### PR TITLE
Fix: User cannot create application to challenge

### DIFF
--- a/src/routing/application/EcoverseApplyRoute.tsx
+++ b/src/routing/application/EcoverseApplyRoute.tsx
@@ -19,6 +19,7 @@ export const EcoverseApplyRoute: FC<Props> = ({ paths }) => {
     variables: {
       ecoverseId: ecoverseId,
     },
+    errorPolicy: 'all',
   });
   const communityId = ecoverseInfoData?.ecoverse.community?.id || '';
   const ecoverseName = ecoverseInfoData?.ecoverse.displayName || '';


### PR DESCRIPTION
Main issue was that if the user does not have privileges to read data that is selected in the community query together with public data, the public data was omitted. This was fixed in alkem-io/server#1323 the only required is to use `errorPolicy: 'all'` or `errorPolicy: 'ignore'` when querying data.