### PR TITLE
npm version fix 7.5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
     - node_modules
 before_install:
-  - npm i -g npm@latest
+  - npm i -g npm@7.5.6
 install:
   - npm install
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV REACT_APP_BUILD_REVISION=${ARG_BUILD_REVISION}
 # where available (npm@5+)
 COPY package*.json ./
 
-RUN npm i -g npm@latest
+RUN npm i -g npm@7.5.6
 RUN npm install
 
 # Everything for now


### PR DESCRIPTION
Builds will likely fail without this (based on transitive dependencies). Fixing the version so we update on our own cadence.

There is NPM@8 out now.