### PR TITLE
Image cropping - initial variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/client-web",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "EUPL-1.2",
       "dependencies": {
         "@apollo/client": "^3.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "react-dom": "^17.0.1",
         "react-i18next": "^11.15.1",
         "react-image-crop": "^9.0.5",
+        "react-image-file-resizer": "^0.4.7",
         "react-jss": "^10.5.0",
         "react-markdown": "^6.0.2",
         "react-router-dom": "^5.2.0",
@@ -30311,6 +30312,11 @@
       "peerDependencies": {
         "react": ">=16.13.1"
       }
+    },
+    "node_modules/react-image-file-resizer": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/react-image-file-resizer/-/react-image-file-resizer-0.4.7.tgz",
+      "integrity": "sha512-Dak7Ecrd6WEV5LjqoRYFI49ASn7eB1VTlrw6dri9HeIMS6aJang4nli6q5xeckEMY+7QwgqgWqAQD5tgkm4bJg=="
     },
     "node_modules/react-inspector": {
       "version": "5.1.1",
@@ -61245,6 +61251,11 @@
       "requires": {
         "clsx": "^1.1.1"
       }
+    },
+    "react-image-file-resizer": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/react-image-file-resizer/-/react-image-file-resizer-0.4.7.tgz",
+      "integrity": "sha512-Dak7Ecrd6WEV5LjqoRYFI49ASn7eB1VTlrw6dri9HeIMS6aJang4nli6q5xeckEMY+7QwgqgWqAQD5tgkm4bJg=="
     },
     "react-inspector": {
       "version": "5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "react-copy-to-clipboard": "^5.0.3",
         "react-dom": "^17.0.1",
         "react-i18next": "^11.15.1",
+        "react-image-crop": "^9.0.5",
         "react-jss": "^10.5.0",
         "react-markdown": "^6.0.2",
         "react-router-dom": "^5.2.0",
@@ -30298,6 +30299,17 @@
       "peerDependencies": {
         "i18next": ">= 19.0.0",
         "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/react-image-crop": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-9.0.5.tgz",
+      "integrity": "sha512-J5lbsBMI36GsbkRHXNEo95OjwpxfkUBrEl9Oxb7z5mDC7iamySXYKhkv9QoidkfmI9e8Vj7q3SgNCVfuZHQMQw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-inspector": {
@@ -61224,6 +61236,14 @@
         "@babel/runtime": "^7.14.5",
         "html-escaper": "^2.0.2",
         "html-parse-stringify": "^3.0.1"
+      }
+    },
+    "react-image-crop": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-9.0.5.tgz",
+      "integrity": "sha512-J5lbsBMI36GsbkRHXNEo95OjwpxfkUBrEl9Oxb7z5mDC7iamySXYKhkv9QoidkfmI9e8Vj7q3SgNCVfuZHQMQw==",
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "react-inspector": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Alkemio client, enabling users to interact with the Challenge centric platform.",
   "author": "Cherrytwist Foundation",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-copy-to-clipboard": "^5.0.3",
     "react-dom": "^17.0.1",
     "react-i18next": "^11.15.1",
+    "react-image-crop": "^9.0.5",
     "react-jss": "^10.5.0",
     "react-markdown": "^6.0.2",
     "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-dom": "^17.0.1",
     "react-i18next": "^11.15.1",
     "react-image-crop": "^9.0.5",
+    "react-image-file-resizer": "^0.4.7",
     "react-jss": "^10.5.0",
     "react-markdown": "^6.0.2",
     "react-router-dom": "^5.2.0",

--- a/src/components/composite/common/EditableAvatar.tsx
+++ b/src/components/composite/common/EditableAvatar.tsx
@@ -60,25 +60,8 @@ const EditableAvatar: FC<EditableAvatarProps> = ({ profileId, classes = {}, ...p
             onChange={e => {
               const file = e && e.target && e.target.files && e.target.files[0];
               if (file) {
-                try {
-                  Resizer.imageFileResizer(
-                    file,
-                    400,
-                    400,
-                    'JPEG',
-                    100,
-                    0,
-                    uri => {
-                      setSelectedFile(uri as File);
-                      setDialogOpened(true);
-                    },
-                    'file',
-                    200,
-                    200
-                  );
-                } catch (err) {
-                  console.log(err);
-                }
+                setSelectedFile(file);
+                setDialogOpened(true);
               } //handleAvatarChange(file);
             }}
             small
@@ -112,19 +95,10 @@ const MAX_HEIGHT = 400;
 const CropDialog: FC<CropDialogInterface> = ({ file, onSave, ...rest }) => {
   const [src, setSrc] = useState<string | null>(null);
   const [crop, setCrop] = useState<Partial<Crop>>({ aspect: ASPECT_RATIO });
-  // const [imgUrl, setImgUrl] = useState<string>('');
   const imgRef = useRef<HTMLImageElement>();
 
-  // useEffect(() => {
-  //   return () => {
-
-  //     window.URL.revokeObjectURL(imgUrl);
-  //   };
-  // }, [imgUrl]);
-
-  const onCropChange = (crop: Crop, percentCrop: Crop) => {
+  const onCropChange = (crop: Crop, _percentCrop: Crop) => {
     // You could also use percentCrop:
-    console.log(crop);
     setCrop(crop);
   };
 
@@ -191,14 +165,27 @@ const CropDialog: FC<CropDialogInterface> = ({ file, onSave, ...rest }) => {
     return new Promise<File>((resolve, reject) => {
       canvas.toBlob(
         blob => {
-          if (!blob) {
-            //reject(new Error('Canvas is empty'));
-            console.error('Canvas is empty');
-            return;
+          if (blob) {
+            try {
+              Resizer.imageFileResizer(
+                blob,
+                MAX_WIDTH,
+                MAX_HEIGHT,
+                'JPEG',
+                100,
+                0,
+                uri => {
+                  resolve(new File([uri as Blob], fileName, { type: 'image/jpeg' }));
+                },
+                'blob',
+                200,
+                200
+              );
+            } catch (err) {
+              console.error(err);
+              reject(err);
+            }
           }
-          // const fileUrl = window.URL.createObjectURL(blob);
-          // setImgUrl(fileUrl);
-          resolve(new File([blob], fileName, { type: 'image/jpeg' }));
         },
         'image/jpeg',
         1

--- a/src/components/composite/common/EditableAvatar.tsx
+++ b/src/components/composite/common/EditableAvatar.tsx
@@ -3,13 +3,13 @@ import clsx from 'clsx';
 import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactCrop, { Crop } from 'react-image-crop';
+import 'react-image-crop/dist/ReactCrop.css';
+import Resizer from 'react-image-file-resizer';
 import { useApolloErrorHandler } from '../../../hooks';
 import { useUploadAvatarMutation } from '../../../hooks/generated/graphql';
 import Avatar, { AvatarProps, useAvatarStyles } from '../../core/Avatar';
 import { Spinner } from '../../core/Spinner';
 import UploadButton from '../../core/UploadButton';
-import 'react-image-crop/dist/ReactCrop.css';
-
 interface EditableAvatarProps extends AvatarProps {
   profileId?: string;
 }
@@ -60,8 +60,26 @@ const EditableAvatar: FC<EditableAvatarProps> = ({ profileId, classes = {}, ...p
             onChange={e => {
               const file = e && e.target && e.target.files && e.target.files[0];
               if (file) {
-                setSelectedFile(file);
-                setDialogOpened(true);
+                try {
+                  Resizer.imageFileResizer(
+                    file,
+                    400,
+                    400,
+                    'JPEG',
+                    100,
+                    0,
+                    uri => {
+                      console.log(uri);
+                      setSelectedFile(uri as File);
+                      setDialogOpened(true);
+                    },
+                    'file',
+                    200,
+                    200
+                  );
+                } catch (err) {
+                  console.log(err);
+                }
               } //handleAvatarChange(file);
             }}
             small

--- a/src/components/composite/common/EditableAvatar.tsx
+++ b/src/components/composite/common/EditableAvatar.tsx
@@ -96,6 +96,7 @@ const CropDialog: FC<CropDialogInterface> = ({ file, onSave, ...rest }) => {
   const [src, setSrc] = useState<string | null>(null);
   const [crop, setCrop] = useState<Partial<Crop>>({ aspect: ASPECT_RATIO });
   const imgRef = useRef<HTMLImageElement>();
+  const { t } = useTranslation();
 
   const onCropChange = (crop: Crop, _percentCrop: Crop) => {
     // You could also use percentCrop:
@@ -225,9 +226,9 @@ const CropDialog: FC<CropDialogInterface> = ({ file, onSave, ...rest }) => {
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleClose}>{t('buttons.cancel')}</Button>
         <Button variant="contained" onClick={handleSave}>
-          Save
+          {t('buttons.save')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/components/composite/common/EditableAvatar.tsx
+++ b/src/components/composite/common/EditableAvatar.tsx
@@ -69,7 +69,6 @@ const EditableAvatar: FC<EditableAvatarProps> = ({ profileId, classes = {}, ...p
                     100,
                     0,
                     uri => {
-                      console.log(uri);
                       setSelectedFile(uri as File);
                       setDialogOpened(true);
                     },

--- a/src/components/composite/common/EditableAvatar.tsx
+++ b/src/components/composite/common/EditableAvatar.tsx
@@ -1,12 +1,14 @@
-import { Box } from '@mui/material';
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogProps } from '@mui/material';
 import clsx from 'clsx';
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import ReactCrop, { Crop } from 'react-image-crop';
 import { useApolloErrorHandler } from '../../../hooks';
 import { useUploadAvatarMutation } from '../../../hooks/generated/graphql';
 import Avatar, { AvatarProps, useAvatarStyles } from '../../core/Avatar';
 import { Spinner } from '../../core/Spinner';
 import UploadButton from '../../core/UploadButton';
+import 'react-image-crop/dist/ReactCrop.css';
 
 interface EditableAvatarProps extends AvatarProps {
   profileId?: string;
@@ -16,13 +18,14 @@ const EditableAvatar: FC<EditableAvatarProps> = ({ profileId, classes = {}, ...p
   const { t } = useTranslation();
   const avatarStyles = useAvatarStyles(classes);
   const [uploadAvatar, { loading }] = useUploadAvatarMutation();
-
+  const [dialogOpened, setDialogOpened] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File>();
   const handleError = useApolloErrorHandler();
 
   const handleAvatarChange = useCallback(
-    (file: File) => {
+    async (file: File) => {
       if (profileId) {
-        uploadAvatar({
+        await uploadAvatar({
           variables: {
             file,
             input: {
@@ -56,15 +59,167 @@ const EditableAvatar: FC<EditableAvatarProps> = ({ profileId, classes = {}, ...p
             accept={'image/*'}
             onChange={e => {
               const file = e && e.target && e.target.files && e.target.files[0];
-              if (file) handleAvatarChange(file);
+              if (file) {
+                setSelectedFile(file);
+                setDialogOpened(true);
+              } //handleAvatarChange(file);
             }}
             small
             text={t('buttons.edit-photo')}
           />
         </Box>
       )}
+      {dialogOpened && (
+        <CropDialog
+          open={dialogOpened}
+          file={selectedFile}
+          onClose={() => setDialogOpened(false)}
+          onSave={handleAvatarChange}
+        />
+      )}
     </Box>
   );
 };
 
 export default EditableAvatar;
+
+interface CropDialogInterface extends DialogProps {
+  file?: File;
+  onSave?: (imgFile: File) => Promise<void> | void;
+}
+
+const ASPECT_RATIO = 1 / 1;
+const MAX_WIDTH = 400;
+const MAX_HEIGHT = 400;
+
+const CropDialog: FC<CropDialogInterface> = ({ file, onSave, ...rest }) => {
+  const [src, setSrc] = useState<string | null>(null);
+  const [crop, setCrop] = useState<Partial<Crop>>({ aspect: ASPECT_RATIO });
+  // const [imgUrl, setImgUrl] = useState<string>('');
+  const imgRef = useRef<HTMLImageElement>();
+
+  // useEffect(() => {
+  //   return () => {
+
+  //     window.URL.revokeObjectURL(imgUrl);
+  //   };
+  // }, [imgUrl]);
+
+  const onCropChange = (crop: Crop, percentCrop: Crop) => {
+    // You could also use percentCrop:
+    console.log(crop);
+    setCrop(crop);
+  };
+
+  const onLoad = useCallback((img: HTMLImageElement) => {
+    imgRef.current = img;
+
+    const aspect = ASPECT_RATIO;
+    const width = img.width / aspect < img.height * aspect ? 100 : ((img.height * aspect) / img.width) * 100;
+    const height = img.width / aspect > img.height * aspect ? 100 : (img.width / aspect / img.height) * 100;
+    const y = (100 - height) / 2;
+    const x = (100 - width) / 2;
+
+    setCrop({
+      unit: '%',
+      width,
+      height,
+      x,
+      y,
+      aspect,
+    });
+
+    return false; // Return false if you set crop state in here.
+  }, []);
+
+  useEffect(() => {
+    const reader = new FileReader();
+    const loadFile = () => setSrc(reader.result as string);
+    reader.addEventListener('load', loadFile);
+
+    if (file) {
+      reader.readAsDataURL(file);
+    }
+
+    return () => reader.removeEventListener('load', loadFile);
+  }, [file]);
+
+  const getCroppedImg = (image: HTMLImageElement, crop: Crop, fileName: string) => {
+    const canvas = document.createElement('canvas');
+    const pixelRatio = window.devicePixelRatio;
+    const scaleX = image.naturalWidth / image.width;
+    const scaleY = image.naturalHeight / image.height;
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) throw new Error('Can not create canvas context');
+
+    canvas.width = crop.width * pixelRatio * scaleX;
+    canvas.height = crop.height * pixelRatio * scaleY;
+
+    ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    ctx.imageSmoothingQuality = 'high';
+
+    ctx.drawImage(
+      image,
+      crop.x * scaleX,
+      crop.y * scaleY,
+      crop.width * scaleX,
+      crop.height * scaleY,
+      0,
+      0,
+      crop.width * scaleX,
+      crop.height * scaleY
+    );
+
+    return new Promise<File>((resolve, reject) => {
+      canvas.toBlob(
+        blob => {
+          if (!blob) {
+            //reject(new Error('Canvas is empty'));
+            console.error('Canvas is empty');
+            return;
+          }
+          // const fileUrl = window.URL.createObjectURL(blob);
+          // setImgUrl(fileUrl);
+          resolve(new File([blob], fileName, { type: 'image/jpeg' }));
+        },
+        'image/jpeg',
+        1
+      );
+    });
+  };
+
+  const handleClose = useCallback(() => rest.onClose && rest.onClose({}, 'escapeKeyDown'), [rest.onClose]);
+
+  const handleSave = useCallback(async () => {
+    if (!imgRef.current) return;
+    const newImage = await getCroppedImg(imgRef.current, crop as Crop, 'newFile.jpg');
+    if (onSave) await onSave(newImage);
+    handleClose();
+  }, [crop, getCroppedImg, onSave, handleClose]);
+
+  return (
+    <Dialog
+      fullWidth
+      maxWidth={'md'}
+      sx={{
+        '& img': {
+          width: '100%',
+        },
+      }}
+      {...rest}
+    >
+      <DialogContent>
+        <Box display="flex" justifyContent="center" sx={{ backgroundColor: t => t.palette.grey[800] }}>
+          {src && <ReactCrop src={src} crop={crop} onChange={onCropChange} onImageLoaded={onLoad} />}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button variant="contained" onClick={handleSave}>
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/components/composite/common/EditableAvatar.tsx
+++ b/src/components/composite/common/EditableAvatar.tsx
@@ -106,13 +106,19 @@ const CropDialog: FC<CropDialogInterface> = ({ file, onSave, ...rest }) => {
     imgRef.current = img;
 
     const aspect = ASPECT_RATIO;
-    const width = img.width / aspect < img.height * aspect ? 100 : ((img.height * aspect) / img.width) * 100;
-    const height = img.width / aspect > img.height * aspect ? 100 : (img.width / aspect / img.height) * 100;
-    const y = (100 - height) / 2;
-    const x = (100 - width) / 2;
+    // calculate in ration
+    const widthRatio = img.width / aspect < img.height * aspect ? 1 : (img.height * aspect) / img.width;
+    const heightRatio = img.width / aspect > img.height * aspect ? 1 : img.width / aspect / img.height;
+
+    // calculate in pixels
+    const width = img.width * widthRatio;
+    const height = img.height * heightRatio;
+
+    const y = ((1 - heightRatio) / 2) * img.height;
+    const x = ((1 - widthRatio) / 2) * img.width;
 
     setCrop({
-      unit: '%',
+      unit: 'px',
       width,
       height,
       x,


### PR DESCRIPTION
This is an example of how images can be cropped on the client-side and sent to the backend using the existing API.
![CropAvatar2](https://user-images.githubusercontent.com/3524687/147108491-7821b855-91a0-4fc5-9e76-8bed81e71af4.gif)

The image is not resized to 400x400 and the user should select an area that is less than 400x400 in order for the example to work.

What is left to be done so it can be used:

- [ ] Set the initial crop based on the image size in pixels - the current example uses "%" which is not taken into account when the final image is created. 
- [x] Resize the image to fit into 400x400 px.  [react-image-file-resizer](https://github.com/onurzorluer/react-image-file-resizer) can be used for the resizing or manual resize can be done during the construction of the final image (use the react-image-file-resizer source code)
- [ ] Create a component that can be reused for banners/backgrounds etc. The component should be able to:
  - [ ] accept aspect ration.
  - [ ] define maxHeight/maxWidth of produced image.
  - [ ] handy way of returning the final image. (react-image-file-resizer source code)
