### PR TITLE
Changed how graphql error links are handling errors

### DIFF
--- a/src/utils/graphql-links/error-link.ts
+++ b/src/utils/graphql-links/error-link.ts
@@ -1,10 +1,14 @@
 import { onError } from '@apollo/client/link/error';
 import { logger } from '../../services/logging/winston/logger';
 
+/**
+ * This function is called after the GraphQL operation completes and execution is moving back up your link chain
+ * The function should not return a value unless you want to retry the operation.
+ */
 export const errorLink = (errorLogging = false) =>
-  onError(({ graphQLErrors, networkError, forward, operation }) => {
+  onError(({ graphQLErrors, networkError }) => {
     if (!errorLogging) {
-      return forward(operation);
+      return;
     }
 
     const errors: Error[] = [];
@@ -19,6 +23,4 @@ export const errorLink = (errorLogging = false) =>
     }
 
     errors.forEach(e => logger.error(e));
-
-    return forward(operation);
   });

--- a/src/utils/graphql-links/redirect-link.ts
+++ b/src/utils/graphql-links/redirect-link.ts
@@ -12,10 +12,13 @@ import { AUTH_LOGIN_PATH } from '../../models/constants';
  * the response has been redirected
  * and the response source url matches the auth login page.
  * The browser is redirected to the login page if the above criteria are met.
+ *
+ * This function is called after the GraphQL operation completes and execution is moving back up your link chain.
+ * The function should not return a value unless you want to retry the operation.
  */
-export const redirectLink = onError(({ networkError, forward, operation }) => {
+export const redirectLink = onError(({ networkError }) => {
   if (!networkError) {
-    return forward(operation);
+    return;
   }
 
   const parseError = networkError as ServerParseError;
@@ -29,7 +32,5 @@ export const redirectLink = onError(({ networkError, forward, operation }) => {
       logger.info(`[ServerParseError]: Redirecting to ${response.url}...`);
     }
   }
-
-  return forward(operation);
 });
 export default redirectLink;


### PR DESCRIPTION
### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

- Error link must not return a value if you don't want retry mechanics involved - [more info here](https://www.apollographql.com/docs/react/api/link/apollo-link-error/).
- A Duplicate request is normal due to how **fetchPolicy** `network-only/cache-and-network` is behaving - more information is provided in [this github comment](https://github.com/apollographql/apollo-client/issues/7777#issuecomment-789941223) and the issue as a whole.

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
