### PR TITLE
added additional text to the verification and recovery pages

### DIFF
--- a/src/i18n/en/translation.en.json
+++ b/src/i18n/en/translation.en.json
@@ -1039,6 +1039,7 @@
         }
       },
       "header": "Password Reset",
+      "message": "Please enter your email address below to recieve a link to reset your password.",
       "buttons": {
         "register": "Register"
       }
@@ -1049,7 +1050,8 @@
           "email": "Email is not valid"
         }
       },
-      "header": "Verify",
+      "header": "Email verification",
+      "message": "Users of Alkemio are required to verify their email address.<br/><br/>Please enter your email address below to recieve a new verification link.",
       "buttons": {
         "register": "Verify"
       }

--- a/src/pages/Authentication/RecoveryPage.tsx
+++ b/src/pages/Authentication/RecoveryPage.tsx
@@ -27,6 +27,9 @@ export const RecoveryPage: FC<RegisterPageProps> = ({ flow }) => {
           <Box marginY={3} textAlign={'center'}>
             <Typography variant={'h3'}>{t('pages.recovery.header')}</Typography>
           </Box>
+          <Box marginY={3} textAlign={'center'}>
+            <Typography variant={'h5'}>{t('pages.recovery.message')}</Typography>
+          </Box>
           <KratosUI flow={recoveryFlow} />
         </Grid>
       </Grid>

--- a/src/pages/Authentication/VerificationPage.tsx
+++ b/src/pages/Authentication/VerificationPage.tsx
@@ -28,6 +28,9 @@ export const VerificationPage: FC<RegisterPageProps> = ({ flow }) => {
           <Box marginY={3} textAlign={'center'}>
             <Typography variant={'h3'}>{t('pages.verification.header')}</Typography>
           </Box>
+          <Box marginY={3} textAlign={'center'}>
+            <Typography variant={'h5'}>{t('pages.verification.message')}</Typography>
+          </Box>
           <KratosUI flow={verificationFlow} />
         </Grid>
       </Grid>


### PR DESCRIPTION
During initial testing at UWV there was feedback that the verificaiton page in particular did not explain to the user where they were. 