### PR TITLE
Email Verification page: friendlier message if link expired

### DIFF
--- a/src/components/Authentication/Kratos/messages.ts
+++ b/src/components/Authentication/Kratos/messages.ts
@@ -1,0 +1,36 @@
+import { UiText } from '@ory/kratos-client/api';
+import { has } from 'lodash';
+
+/**
+ * A message from Kratos is received in the form of an object with an id property. Kratos docs say:
+ * This ID will not change and can be used to translate the message or use your own message content.
+ * See https://www.ory.sh/docs/kratos/concepts/ui-user-interface
+ */
+
+const messages = {
+  '4070005': 'verification-flow-expired',
+};
+
+export default messages;
+
+interface T {
+  (
+    path: string,
+    replacement?:
+      | {
+          [key: string]: string | number;
+        }
+      | undefined
+  ): string;
+}
+
+export const KratosFriendlierMessageMapper =
+  (t: T) =>
+  (kratosMessage: UiText): string => {
+    if (has(messages, kratosMessage.id)) {
+      const label = messages[kratosMessage.id];
+      const replacement = kratosMessage.context as Record<string, string | number>;
+      return t(`kratos.messages.${label}`, replacement);
+    }
+    return kratosMessage.text;
+  };

--- a/src/components/Authentication/KratosUI.tsx
+++ b/src/components/Authentication/KratosUI.tsx
@@ -23,6 +23,7 @@ import KratosCheckbox from './Kratos/KratosCheckbox';
 import KratosHidden from './Kratos/KratosHidden';
 import KratosInput from './Kratos/KratosInput';
 import { KratosInputExtraProps } from './Kratos/KratosProps';
+import { KratosFriendlierMessageMapper } from './Kratos/messages';
 
 type FormType =
   | SubmitSelfServiceLoginFlowBody
@@ -52,11 +53,14 @@ const toAlertVariant = (type: string) => {
 };
 
 const KratosMessages: FC<{ messages?: Array<UiText> }> = ({ messages }) => {
+  const { t } = useTranslation();
+  const getFriendlierMessage = useMemo(() => KratosFriendlierMessageMapper(t), []);
+
   return (
     <>
-      {messages?.map(x => (
-        <Alert key={x.id} severity={toAlertVariant(x.type)}>
-          {x.text}
+      {messages?.map(message => (
+        <Alert key={message.id} severity={toAlertVariant(message.type)}>
+          {getFriendlierMessage(message)}
         </Alert>
       ))}
     </>
@@ -165,6 +169,8 @@ export const KratosUI: FC<KratosUIProps> = ({ resetPasswordComponent, flow, ...r
       return doc.body;
     }
   };
+
+  console.log(ui.messages);
 
   return (
     <KratosUIProvider {...rest}>

--- a/src/i18n/en/translation.en.json
+++ b/src/i18n/en/translation.en.json
@@ -1134,7 +1134,10 @@
       }
     },
     "loading-flow": "Loading flow",
-    "loading-error": "Loading error"
+    "loading-error": "Loading error",
+    "messages": {
+      "verification-flow-expired": "The verification link has expired. Please request a fresh one by submitting you email once again."
+    }
   },
   "dashboard-updates-section": {
     "title": "Updates ({{count}})",


### PR DESCRIPTION
### Describe the background of your pull request

Email Verification page shows a friendlier message if the verification link has expired. The message points to the next action the user has to take in order to get his email verified.

### Additional context

I introduced a map between Kratos message codes and corresponding i18n labels. But we may consider putting Kratos codes in translations directly and using `t.exists()` to check if the mapping exists.

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
