### PR TITLE
Community Leading organizations bottom padding fixed when empty

### DIFF
--- a/src/views/community/CommunityPageView.tsx
+++ b/src/views/community/CommunityPageView.tsx
@@ -115,27 +115,29 @@ const CommunityPageView: FC<CommunityPageViewProps> = ({
                     {t('pages.community.leading-organizations.no-data')}
                   </Box>
                 )}
-                <Grid container spacing={3}>
-                  {organizations.map((x, i) => (
-                    <Grid
-                      key={i}
-                      item
-                      flexGrow={1}
-                      flexBasis="100%"
-                      maxWidth={{ xs: 'auto', sm: 'auto', md: 'auto', lg: '50%', xl: '50%' }}
-                    >
-                      <OrganizationCard
-                        url={x.url}
-                        members={x.members}
-                        avatar={x.avatar}
-                        name={x.name}
-                        role={x.role}
-                        information={x.information}
-                        verified={x.verified}
-                      />
-                    </Grid>
-                  ))}
-                </Grid>
+                {!!organizations.length && (
+                  <Grid container spacing={3}>
+                    {organizations.map((x, i) => (
+                      <Grid
+                        key={i}
+                        item
+                        flexGrow={1}
+                        flexBasis="100%"
+                        maxWidth={{ xs: 'auto', sm: 'auto', md: 'auto', lg: '50%', xl: '50%' }}
+                      >
+                        <OrganizationCard
+                          url={x.url}
+                          members={x.members}
+                          avatar={x.avatar}
+                          name={x.name}
+                          role={x.role}
+                          information={x.information}
+                          verified={x.verified}
+                        />
+                      </Grid>
+                    ))}
+                  </Grid>
+                )}
               </>
             )}
           </Accordion>


### PR DESCRIPTION
### Fixes a bug:

BUG: "No leading organizations" message is not correctly positioned on "Leading organization" card (1658)

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
