### PR TITLE
Displaying child entities count on Hub/Challenge dashboards

### DIFF
--- a/src/components/composite/common/Activities/ActivitiesV2.tsx
+++ b/src/components/composite/common/Activities/ActivitiesV2.tsx
@@ -10,10 +10,10 @@ export interface ActivitiesV2Props {
 const ActivitiesV2: FC<ActivitiesV2Props> = ({ activity }) => {
   return (
     <Grid container spacing={1} direction="column">
-      {activity.map(({ digit, name }, i) => (
+      {activity.map(({ count, name }, i) => (
         <Grid key={i} item>
           <Box component="span" paddingRight={0.5} fontWeight="bold">
-            {digit}
+            {count}
           </Box>
           {name}
         </Grid>

--- a/src/components/composite/common/ActivityPanel/Activities.tsx
+++ b/src/components/composite/common/ActivityPanel/Activities.tsx
@@ -2,11 +2,13 @@ import { Grid, Skeleton, Theme, useMediaQuery } from '@mui/material';
 import React, { FC } from 'react';
 import CircleTag from '../../../core/CircleTag';
 import Typography from '../../../core/Typography';
+import { ActivityType } from '../../../../models/constants';
 
 export interface ActivityItem {
   name: string;
+  type?: ActivityType;
   isLoading?: boolean;
-  digit: number;
+  count: number;
   color?: 'positive' | 'neutral' | 'primary' | 'neutralMedium';
 }
 
@@ -15,7 +17,7 @@ export const Activities: FC<{ items: ActivityItem[]; asList?: boolean }> = ({ it
   const maxHeightSteps = mediumScreen || asList ? items.length : items.length / 2 + 1;
   return (
     <Grid container spacing={1} direction="column" maxHeight={t => t.spacing(6 * maxHeightSteps)}>
-      {items.map(({ name, isLoading, digit, color }, i) => (
+      {items.map(({ name, isLoading, count, color }, i) => (
         <Grid key={i} item xs={12} md={asList ? 12 : 6}>
           <Grid container justifyContent={'space-between'} alignItems={'center'}>
             <Grid item>
@@ -23,7 +25,7 @@ export const Activities: FC<{ items: ActivityItem[]; asList?: boolean }> = ({ it
               {isLoading && <Skeleton variant="text" sx={{ minWidth: 150 }} />}
             </Grid>
             <Grid item>
-              {!isLoading && <CircleTag text={`${digit}`} color={color || 'neutral'} />}
+              {!isLoading && <CircleTag text={`${count}`} color={color || 'neutral'} />}
               {isLoading && <Skeleton variant="circular" sx={{ height: 36, width: 36 }} />}
             </Grid>
           </Grid>

--- a/src/components/composite/common/ActivityPanel/tempMockActivities.ts
+++ b/src/components/composite/common/ActivityPanel/tempMockActivities.ts
@@ -1,26 +1,26 @@
 const activitiesMock: Array<{
   name: string;
-  digit: number;
+  count: number;
   color?: 'positive' | 'neutral' | 'primary' | 'neutralMedium';
 }> = [
   {
     name: 'challenges',
-    digit: 21,
+    count: 21,
     color: 'neutral',
   },
   {
     name: 'opportunities',
-    digit: 94,
+    count: 94,
     color: 'primary',
   },
   {
     name: 'Projects',
-    digit: 118,
+    count: 118,
     color: 'positive',
   },
   {
     name: 'challenges',
-    digit: 6171,
+    count: 6171,
     color: 'neutralMedium',
   },
 ];

--- a/src/components/composite/common/cards/ChallengeCard/ChallengeCard.tsx
+++ b/src/components/composite/common/cards/ChallengeCard/ChallengeCard.tsx
@@ -35,11 +35,11 @@ const ChallengeCard: FC<ChallengeCardProps> = ({ challenge, hubNameId, loading =
     : [
         {
           name: t('common.opportunities'),
-          digit: getActivityCount(activity, 'opportunities') ?? 0,
+          count: getActivityCount(activity, 'opportunities') ?? 0,
         },
         {
           name: t('common.members'),
-          digit: getActivityCount(activity, 'members') ?? 0,
+          count: getActivityCount(activity, 'members') ?? 0,
         },
       ];
 

--- a/src/components/composite/common/cards/HubCard/HubCard.tsx
+++ b/src/components/composite/common/cards/HubCard/HubCard.tsx
@@ -45,17 +45,17 @@ const HubCard: FC<HubCardProps> = ({ hub, loading = false }) => {
       activities={[
         {
           name: t('common.challenges'),
-          digit: getActivityCount(activity, 'challenges') ?? 0,
+          count: getActivityCount(activity, 'challenges') ?? 0,
           color: 'primary',
         },
         {
           name: t('common.opportunities'),
-          digit: getActivityCount(activity, 'opportunities') ?? 0,
+          count: getActivityCount(activity, 'opportunities') ?? 0,
           color: 'primary',
         },
         {
           name: t('common.members'),
-          digit: getActivityCount(activity, 'members') ?? 0,
+          count: getActivityCount(activity, 'members') ?? 0,
           color: 'positive',
         },
       ]}

--- a/src/components/composite/common/cards/OpportunityCard/OpportunityCard.tsx
+++ b/src/components/composite/common/cards/OpportunityCard/OpportunityCard.tsx
@@ -44,8 +44,8 @@ const OpportunityCard: FC<OpportunityCardProps> = ({ opportunity, hubNameId, cha
       isMember={isMember(opportunity.id)}
       loading={loading}
       activities={[
-        { name: t('common.projects'), digit: getActivityCount(activity, 'projects') ?? 0 },
-        { name: t('common.members'), digit: getActivityCount(activity, 'members') ?? 0 },
+        { name: t('common.projects'), count: getActivityCount(activity, 'projects') ?? 0 },
+        { name: t('common.members'), count: getActivityCount(activity, 'members') ?? 0 },
       ]}
     />
   );

--- a/src/components/composite/search/ChallengeSearchCard.tsx
+++ b/src/components/composite/search/ChallengeSearchCard.tsx
@@ -26,8 +26,8 @@ const ChallengeSearchCardInner: FC<EntitySearchCardProps<ChallengeSearchResultFr
 
   const _activity = challenge?.activity || [];
   const activity: ActivityItem[] = [
-    { name: 'Opportunities', digit: getActivityCount(_activity, 'opportunities') || 0, color: 'primary' },
-    { name: 'Members', digit: getActivityCount(_activity, 'members') || 0, color: 'positive' },
+    { name: 'Opportunities', count: getActivityCount(_activity, 'opportunities') || 0, color: 'primary' },
+    { name: 'Members', count: getActivityCount(_activity, 'members') || 0, color: 'positive' },
   ];
 
   return (

--- a/src/components/composite/search/OpportunitySearchCard.tsx
+++ b/src/components/composite/search/OpportunitySearchCard.tsx
@@ -26,8 +26,8 @@ const OpportunitySearchCardInner: FC<EntitySearchCardProps<OpportunitySearchResu
 
   const _activity = opportunity?.activity || [];
   const activity: ActivityItem[] = [
-    { name: 'Projects', digit: getActivityCount(_activity, 'projects') || 0, color: 'primary' },
-    { name: 'Members', digit: getActivityCount(_activity, 'members') || 0, color: 'positive' },
+    { name: 'Projects', count: getActivityCount(_activity, 'projects') || 0, color: 'primary' },
+    { name: 'Members', count: getActivityCount(_activity, 'members') || 0, color: 'positive' },
   ];
 
   return (

--- a/src/containers/challenge/ChallengePageContainer.tsx
+++ b/src/containers/challenge/ChallengePageContainer.tsx
@@ -9,6 +9,7 @@ import { ContainerProps } from '../../models/container';
 import { Discussion } from '../../models/discussion/discussion';
 import { AuthorizationPrivilege, ChallengeProfileFragment } from '../../models/graphql-schema';
 import getActivityCount from '../../utils/get-activity-count';
+import { ActivityType } from '../../models/constants';
 
 export interface ChallengeContainerEntities {
   hubId: string;
@@ -63,17 +64,18 @@ export const ChallengePageContainer: FC<ChallengePageContainerProps> = ({ childr
     return [
       {
         name: t('common.opportunities'),
-        digit: getActivityCount(_activity, 'opportunities') || 0,
+        type: ActivityType.Opportunity,
+        count: getActivityCount(_activity, 'opportunities') || 0,
         color: 'primary',
       },
       {
         name: t('common.projects'),
-        digit: getActivityCount(_activity, 'projects') || 0,
+        count: getActivityCount(_activity, 'projects') || 0,
         color: 'positive',
       },
       {
         name: t('common.members'),
-        digit: getActivityCount(_activity, 'members') || 0,
+        count: getActivityCount(_activity, 'members') || 0,
         color: 'neutralMedium',
       },
     ];

--- a/src/containers/hub/HubPageContainer.tsx
+++ b/src/containers/hub/HubPageContainer.tsx
@@ -9,6 +9,7 @@ import { AuthorizationPrivilege, ChallengeCardFragment, HubPageFragment } from '
 import getActivityCount from '../../utils/get-activity-count';
 import { useDiscussionsContext } from '../../context/Discussions/DiscussionsProvider';
 import { Discussion } from '../../models/discussion/discussion';
+import { ActivityType } from '../../models/constants';
 
 export interface HubContainerEntities {
   hub?: HubPageFragment;
@@ -56,17 +57,18 @@ export const HubPageContainer: FC<HubPageContainerProps> = ({ children }) => {
     return [
       {
         name: t('common.challenges'),
-        digit: getActivityCount(_activity, 'challenges') || 0,
+        type: ActivityType.Challenge,
+        count: getActivityCount(_activity, 'challenges') || 0,
         color: 'neutral',
       },
       {
         name: t('common.opportunities'),
-        digit: getActivityCount(_activity, 'opportunities') || 0,
+        count: getActivityCount(_activity, 'opportunities') || 0,
         color: 'primary',
       },
       {
         name: t('common.members'),
-        digit: getActivityCount(_activity, 'members') || 0,
+        count: getActivityCount(_activity, 'members') || 0,
         color: 'neutralMedium',
       },
     ];

--- a/src/containers/opportunity/OpportunityPageContainer.tsx
+++ b/src/containers/opportunity/OpportunityPageContainer.tsx
@@ -141,17 +141,17 @@ const OpportunityPageContainer: FC<OpportunityPageContainerProps> = ({ children 
     return [
       {
         name: t('common.projects'),
-        digit: getActivityCount(_activity, 'projects') || 0,
+        count: getActivityCount(_activity, 'projects') || 0,
         color: 'positive',
       },
       {
         name: t('common.interests'),
-        digit: getActivityCount(_activity, 'relations') || 0,
+        count: getActivityCount(_activity, 'relations') || 0,
         color: 'primary',
       },
       {
         name: t('common.members'),
-        digit: getActivityCount(_activity, 'members') || 0,
+        count: getActivityCount(_activity, 'members') || 0,
         color: 'neutralMedium',
       },
     ];

--- a/src/models/constants/common.constants.ts
+++ b/src/models/constants/common.constants.ts
@@ -10,6 +10,17 @@ export enum CommunityType {
   OPPORTUNITY = 'opportunity',
 }
 
+export enum ActivityType {
+  Opportunity = 'opportunities',
+  Project = 'projects',
+  Member = 'members',
+  User = 'users',
+  Organization = 'organizations',
+  Hub = 'hubs',
+  Challenge = 'challenges',
+  Relation = 'relations',
+}
+
 export const APPLICATION_STATE_NEW = 'new';
 export const APPLICATION_STATE_APPROVED = 'approved';
 export const APPLICATION_STATE_REJECTED = 'rejected';

--- a/src/pages/Home/AlkemioActivitySection.tsx
+++ b/src/pages/Home/AlkemioActivitySection.tsx
@@ -22,29 +22,29 @@ const AlkemioActivitySection: FC<{
   ];
   const summary: ActivityItem[] = useMemo(
     () => [
-      { name: t('pages.activity.hubs'), isLoading: loading, digit: hubCount, color: 'primary' },
+      { name: t('pages.activity.hubs'), isLoading: loading, count: hubCount, color: 'primary' },
       {
         name: t('common.challenges'),
         isLoading: loading,
-        digit: challengeCount,
+        count: challengeCount,
         color: 'primary',
       },
       {
         name: t('common.opportunities'),
         isLoading: loading,
-        digit: opportunityCount,
+        count: opportunityCount,
         color: 'primary',
       },
       {
         name: t('common.users'),
         isLoading: loading,
-        digit: userCount,
+        count: userCount,
         color: 'primary',
       },
       {
         name: t('common.organizations'),
         isLoading: loading,
-        digit: orgCount,
+        count: orgCount,
         color: 'primary',
       },
     ],

--- a/src/utils/get-activity-count.ts
+++ b/src/utils/get-activity-count.ts
@@ -1,21 +1,23 @@
 import { Nvp } from '../models/graphql-schema';
+import { ActivityType } from '../models/constants';
+
+export type Activity = Pick<Nvp, 'name' | 'value'>;
+
+type ActivityTypeName = ActivityType[keyof ActivityType];
 
 /***
  * Return a value by activity's name or <i>null</i> otherwise
  * @param activityArray
  * @param name
  */
-const getActivityCount = (activityArray: (Pick<Nvp, 'name' | 'value'> | Nvp)[], name: string): number | null => {
-  if (!Array.isArray(activityArray)) {
-    return null;
-  }
-
-  const activity = activityArray.find(x => x.name === name);
+const getActivityCount = (activityArray: Activity[] | undefined, name: ActivityTypeName): number | null => {
+  const activity = activityArray?.find(x => x.name === name);
 
   if (!activity) {
     return null;
   }
 
-  return activity.value != null ? +activity.value : null;
+  return Number(activity.value);
 };
+
 export default getActivityCount;

--- a/src/views/Challenge/ChallengeDashboardView.tsx
+++ b/src/views/Challenge/ChallengeDashboardView.tsx
@@ -1,5 +1,5 @@
 import Grid from '@mui/material/Grid';
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import ApplicationButton from '../../components/composite/common/ApplicationButton/ApplicationButton';
 import DashboardCommunitySectionV2 from '../../components/composite/common/sections/DashboardCommunitySectionV2';
@@ -18,6 +18,7 @@ import AssociatedOrganizationsView from '../ProfileView/AssociatedOrganizationsV
 import OpportunityCard from '../../components/composite/common/cards/OpportunityCard/OpportunityCard';
 import { CardLayoutContainer, CardLayoutItem } from '../../components/core/CardLayoutContainer/CardLayoutContainer';
 import { getVisualBanner } from '../../utils/visuals.utils';
+import { ActivityType } from '../../models/constants';
 
 const CHALLENGES_NUMBER_IN_SECTION = 2;
 const SPACING = 2;
@@ -32,6 +33,10 @@ export const ChallengeDashboardView: FC<ChallengeDashboardViewProps> = ({ entiti
 
   const { displayName: hubDisplayName, loading: loadingHubContext } = useHub();
   const { hubNameId, hubId, challengeId, challengeNameId, loading: loadingChallengeContext } = useChallenge();
+
+  const opportunitiesCount = useMemo(() => {
+    return entities.activity.find(({ type }) => type === ActivityType.Opportunity)?.count;
+  }, [entities.activity]);
 
   const { challenge, activity, isMember, discussions, permissions } = entities;
 
@@ -98,7 +103,7 @@ export const ChallengeDashboardView: FC<ChallengeDashboardViewProps> = ({ entiti
           />
           <SectionSpacer />
           <DashboardGenericSection
-            headerText={t('pages.challenge.sections.dashboard.opportunities.title')}
+            headerText={`${t('pages.challenge.sections.dashboard.opportunities.title')} (${opportunitiesCount})`}
             helpText={t('pages.challenge.sections.dashboard.opportunities.help-text')}
             navText={t('buttons.see-all')}
             navLink={'opportunities'}

--- a/src/views/Hub/HubDashboardView2.tsx
+++ b/src/views/Hub/HubDashboardView2.tsx
@@ -16,6 +16,7 @@ import ActivityView from '../Activity/ActivityView';
 import AssociatedOrganizationsView from '../ProfileView/AssociatedOrganizationsView';
 import ChallengeCard from '../../components/composite/common/cards/ChallengeCard/ChallengeCard';
 import { CardLayoutContainer, CardLayoutItem } from '../../components/core/CardLayoutContainer/CardLayoutContainer';
+import { ActivityType } from '../../models/constants';
 
 export interface HubDashboardView2Props {
   title?: string;
@@ -60,6 +61,10 @@ const HubDashboardView2: FC<HubDashboardView2Props> = ({
 }) => {
   const { t } = useTranslation();
   const orgNameIds = useMemo(() => (organizationNameId ? [organizationNameId] : []), [organizationNameId]);
+
+  const challengesCount = useMemo(() => {
+    return activity.find(({ type }) => type === ActivityType.Challenge)?.count;
+  }, [activity]);
 
   return (
     <>
@@ -106,7 +111,7 @@ const HubDashboardView2: FC<HubDashboardView2Props> = ({
           <SectionSpacer />
           {challengesReadAccess && (
             <DashboardGenericSection
-              headerText={t('pages.hub.sections.dashboard.challenges.title')}
+              headerText={`${t('pages.hub.sections.dashboard.challenges.title')} (${challengesCount})`}
               helpText={t('pages.hub.sections.dashboard.challenges.help-text')}
               navText={t('buttons.see-all')}
               navLink={'challenges'}


### PR DESCRIPTION
### Describe the background of your pull request

On Hub dashboard, Challenges card title shows the number of challenges.
On Challenge dashboard, Opportunities card title shows the number of opportunities.

### Additional context

To be able to reliably access challenges/opportunities count from a dashboard component,
I added some metadata to the `activity` prop (`ActivityItem` now has `type` property).
This doesn't look as an elegant solution, but the problem is slightly deeper -
we pass pre-formatted data from containers (translations applied), which, to my belief, we shouldn't do.
I think we should consider changing the format activities are passed from containers to the underlying
consumer components.

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
