### PR TITLE
QR Code always fits in the dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "react-image-file-resizer": "^0.4.7",
         "react-jss": "^10.5.0",
         "react-markdown": "^6.0.2",
+        "react-resize-detector": "^7.0.0",
         "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.0",
         "react-visibility-sensor": "^5.1.1",
@@ -15553,6 +15554,11 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/resize-observer-browser": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
+      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -38461,6 +38467,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-resize-detector": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.0.0.tgz",
+      "integrity": "sha512-Xd1POfpVzH9O3F/xB/0xYy2ijtKjE/z7y4c/aJP593YSzhPy2vDhsNPjes+uQbgL1RezxJajQ679qPs8K5LAFw==",
+      "dependencies": {
+        "@types/resize-observer-browser": "^0.1.6",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
@@ -59987,6 +60006,11 @@
         "@types/react": "*"
       }
     },
+    "@types/resize-observer-browser": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
+      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -77347,6 +77371,15 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-resize-detector": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.0.0.tgz",
+      "integrity": "sha512-Xd1POfpVzH9O3F/xB/0xYy2ijtKjE/z7y4c/aJP593YSzhPy2vDhsNPjes+uQbgL1RezxJajQ679qPs8K5LAFw==",
+      "requires": {
+        "@types/resize-observer-browser": "^0.1.6",
+        "lodash": "^4.17.21"
+      }
     },
     "react-router": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-image-file-resizer": "^0.4.7",
     "react-jss": "^10.5.0",
     "react-markdown": "^6.0.2",
+    "react-resize-detector": "^7.0.0",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
     "react-visibility-sensor": "^5.1.1",

--- a/src/components/composite/dialogs/CredentialDialog.tsx/RequestCredentialDialog.tsx
+++ b/src/components/composite/dialogs/CredentialDialog.tsx/RequestCredentialDialog.tsx
@@ -16,6 +16,7 @@ import TranslationKey from '../../../../types/TranslationKey';
 import { Loading } from '../../../core';
 import { DialogContent, DialogTitle } from '../../../core/dialog';
 import QRCode from '../../../core/QRCode/QRCode';
+import { makeStyles } from '@mui/styles';
 
 interface RequestCredentialDialogProps {
   entities: {
@@ -39,8 +40,28 @@ interface RequestCredentialDialogProps {
   };
 }
 
+const useStyles = makeStyles({
+  dialogPaper: {
+    height: '100vh',
+  },
+  dialogContent: {
+    overflowX: 'hidden',
+    display: 'flex',
+    flexFlow: 'column nowrap',
+  },
+  slideContent: {
+    flexGrow: 1,
+    display: 'flex',
+    flexFlow: 'column nowrap',
+  },
+  qrCode: {
+    flexGrow: 1,
+  },
+});
+
 const RequestCredentialDialog: FC<RequestCredentialDialogProps> = ({ entities, actions, options, state }) => {
   const { t } = useTranslation();
+  const styles = useStyles();
   const { credentialMetadata } = entities;
 
   const containerRef = useRef(null);
@@ -63,7 +84,7 @@ const RequestCredentialDialog: FC<RequestCredentialDialogProps> = ({ entities, a
   }, [options.show]);
 
   return (
-    <Dialog open={options.show} aria-labelledby="confirmation-dialog">
+    <Dialog open={options.show} aria-labelledby="confirmation-dialog" classes={{ paper: styles.dialogPaper }}>
       <DialogTitle
         id="credential-request-dialog-title"
         onClose={() => {
@@ -74,7 +95,7 @@ const RequestCredentialDialog: FC<RequestCredentialDialogProps> = ({ entities, a
       >
         {title}
       </DialogTitle>
-      <DialogContent ref={containerRef} sx={{ minHeight: 400, overflow: 'hidden' }}>
+      <DialogContent ref={containerRef} className={styles.dialogContent}>
         <Slide direction="right" unmountOnExit in={!Boolean(token) && !loadingToken} container={containerRef.current}>
           <Box>
             <DialogContentText>{content}</DialogContentText>
@@ -95,12 +116,12 @@ const RequestCredentialDialog: FC<RequestCredentialDialogProps> = ({ entities, a
           </Box>
         </Slide>
         <Slide direction="left" unmountOnExit in={Boolean(token) || loadingToken} container={containerRef.current}>
-          <Box>
+          <Box className={styles.slideContent}>
             <DialogContentText>
               Scan the QR code to share the credential with your cloud hosted wallet
             </DialogContentText>
             {loadingToken && <Loading text="Generating credential request" />}
-            {!loadingToken && token?.jwt && <QRCode value={token?.jwt} />}
+            {!loadingToken && token?.jwt && <QRCode value={token.jwt} className={styles.qrCode} />}
           </Box>
         </Slide>
       </DialogContent>

--- a/src/components/composite/dialogs/QRCodeDialog/QRCodeDialog.tsx
+++ b/src/components/composite/dialogs/QRCodeDialog/QRCodeDialog.tsx
@@ -5,6 +5,7 @@ import TranslationKey from '../../../../types/TranslationKey';
 import { Loading } from '../../../core';
 import { DialogContent, DialogTitle } from '../../../core/dialog';
 import QRCode from '../../../core/QRCode/QRCode';
+import { makeStyles } from '@mui/styles';
 
 interface QRCodeDialogProps {
   entities: {
@@ -12,7 +13,7 @@ interface QRCodeDialogProps {
     title?: string | React.ReactNode;
     contentId?: TranslationKey;
     content?: string;
-    qrValue?: string | null;
+    qrValue: string | null;
   };
   actions: {
     onCancel: () => void;
@@ -26,8 +27,22 @@ interface QRCodeDialogProps {
   };
 }
 
+const useStyles = makeStyles({
+  paper: {
+    height: '100vh',
+  },
+  content: {
+    display: 'flex',
+    flexFlow: 'column nowrap',
+  },
+  qrCode: {
+    flexGrow: 1,
+  },
+});
+
 const QRCodeDialog: FC<QRCodeDialogProps> = ({ entities, actions, options, state }) => {
   const { t } = useTranslation();
+  const styles = useStyles();
 
   const title = entities.titleId ? t(entities.titleId) : entities.title;
   if (!title) {
@@ -39,14 +54,14 @@ const QRCodeDialog: FC<QRCodeDialogProps> = ({ entities, actions, options, state
   }
 
   return (
-    <Dialog open={options.show} aria-labelledby="confirmation-dialog">
+    <Dialog open={options.show} aria-labelledby="confirmation-dialog" classes={{ paper: styles.paper }}>
       <DialogTitle id="confirmation-dialog-title" onClose={actions.onCancel}>
         {title}
       </DialogTitle>
-      <DialogContent>
+      <DialogContent className={styles.content}>
         {content}
         {state?.isLoading && <Loading text="Generating credential request" />}
-        {!state?.isLoading && <QRCode value={entities.qrValue} />}
+        {!state?.isLoading && <QRCode value={entities.qrValue} className={styles.qrCode} />}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/core/QRCode/QRCode.tsx
+++ b/src/components/core/QRCode/QRCode.tsx
@@ -1,21 +1,52 @@
 import qrcode from 'qrcode';
 import React, { FC, useEffect, useRef } from 'react';
+import { makeStyles } from '@mui/styles';
+import { useResizeDetector } from 'react-resize-detector';
+import clsx from 'clsx';
 
-export const QRCode: FC<{ value?: string | null }> = ({ value }) => {
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+});
+
+interface QRCodeProps {
+  value: string | null;
+  className?: string;
+}
+
+export const QRCode: FC<QRCodeProps> = ({ value, className }) => {
   const container = useRef<HTMLDivElement>(null);
+  const styles = useStyles();
+
+  const { height, width } = useResizeDetector({
+    targetRef: container,
+  });
+
   useEffect(() => {
     async function loadCanvas() {
-      if (container.current && value) {
+      if (container.current && value && typeof height !== 'undefined' && typeof width !== 'undefined') {
         const canvas = await qrcode.toCanvas(value);
-        container.current.innerHTML = '';
+        const size = Math.min(height, width);
+        canvas.style.height = `${size}px`;
+        canvas.style.width = `${size}px`;
         container.current.append(canvas);
       }
     }
 
     loadCanvas();
-  }, [value, container]);
 
-  return <div ref={container} style={{ display: 'flex', justifyContent: 'center' }} />;
+    return () => {
+      if (container.current) {
+        container.current.innerHTML = '';
+      }
+    };
+  }, [value, container.current, height, width]);
+
+  return <div ref={container} className={clsx(styles.container, className)} />;
 };
 
 export default QRCode;


### PR DESCRIPTION
### Describe the background of your pull request

1. QR Code for the SSI always fits in the pop-up dialog.
2. Share Credentials dialog buttons are always visible.

### Additional context

Resizing canvases with the sole means of CSS is tricky or almost impossible, so I decided to go with `react-resize-detector` and do it programmatically. One possible workaround could be using `svg` (the `qrcode` library allows to do so), but it turned out not to be much easier while `svg` is also somewhat heavier for the browser to render.

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
