### PR TITLE
Fixed Hub cards on Profile page

### DIFF
--- a/src/components/composite/common/cards/ChallengeCard/ChallengeCard.tsx
+++ b/src/components/composite/common/cards/ChallengeCard/ChallengeCard.tsx
@@ -51,7 +51,7 @@ const ChallengeCard: FC<ChallengeCardProps> = ({ challenge, hubNameId, loading =
         mediaUrl: bannerNarrow,
         tags: challenge?.tagset?.tags || [],
         tagsFor: 'challenge',
-        url: url,
+        url,
       }}
       isMember={isMember(id)}
       loading={loading}

--- a/src/containers/ContributionDetails/ContributionDetailsContainer.tsx
+++ b/src/containers/ContributionDetails/ContributionDetailsContainer.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../hooks/generated/graphql';
 import { ContainerProps } from '../../models/container';
 import { ContributionItem } from '../../models/entities/contribution';
-import { buildChallengeUrl, buildOpportunityUrl } from '../../utils/urlBuilders';
+import { buildChallengeUrl, buildHubUrl, buildOpportunityUrl } from '../../utils/urlBuilders';
 import { getVisualBanner } from '../../utils/visuals.utils';
 
 export interface EntityDetailsContainerEntities {
@@ -57,6 +57,7 @@ const ContributionDetailsContainer: FC<EntityDetailsContainerProps> = ({ entitie
         type: 'hub',
         mediaUrl: getVisualBanner(hubData.hub.context?.visuals),
         tags: hubData.hub.tagset?.tags || [],
+        url: buildHubUrl(hubData.hub.nameID),
         domain: {
           communityID: hubData.hub.community?.id,
         },

--- a/src/views/ProfileView/ContributionsView.tsx
+++ b/src/views/ProfileView/ContributionsView.tsx
@@ -15,6 +15,9 @@ export interface ContributionViewProps extends ProfileCardProps {
   loading?: boolean;
 }
 
+const getContributionItemKey = ({ hubId, challengeId, opportunityId }: ContributionItem) =>
+  [hubId, challengeId, opportunityId].filter(id => id).join('/');
+
 const SkeletonItem = () => (
   <Grid item>
     <Skeleton
@@ -49,9 +52,9 @@ export const ContributionsView: FC<ContributionViewProps> = ({ contributions, lo
           </>
         )}
         {!loading &&
-          contributions.map((x, i) => (
-            <Grid item key={i} flexGrow={1} flexBasis={'50%'}>
-              <ContributionDetailsContainer entities={x}>
+          contributions.map(contributionItem => (
+            <Grid item key={getContributionItemKey(contributionItem)}>
+              <ContributionDetailsContainer entities={contributionItem}>
                 {({ details }, state) => <ContributionCardV2 details={details} loading={state.loading} />}
               </ContributionDetailsContainer>
             </Grid>


### PR DESCRIPTION
### Describe the background of your pull request

1. On Profile page, in Contributions, Hub cards are clickable now.
2. Card wrappers no longer stretch to 50% of the parent container's width.

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
