### PR TITLE
removed visibility of challenge pref for feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/client-web",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "license": "EUPL-1.2",
       "dependencies": {
         "@apollo/client": "^3.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Alkemio client, enabling users to interact with Challenges hosted on the Alkemio platform.",
   "author": "Alkemio Foundation",
   "repository": {

--- a/src/containers/preferences/challenge/ChallengePreferenceContainer.tsx
+++ b/src/containers/preferences/challenge/ChallengePreferenceContainer.tsx
@@ -3,7 +3,7 @@ import { ApolloError } from '@apollo/client';
 import { ContainerChildProps } from '../../../models/container';
 import { useApolloErrorHandler } from '../../../hooks';
 import { useChallengePreferencesQuery, useUpdatePreferenceOnChallengeMutation } from '../../../hooks/generated/graphql';
-import { ChallengePreferenceType, Preference } from '../../../models/graphql-schema';
+import { ChallengePreferenceType, Preference, PreferenceType } from '../../../models/graphql-schema';
 
 export interface ChallengePreferenceContainerEntities {
   preferences: Preference[];
@@ -28,6 +28,8 @@ export interface ChallengePreferenceContainerProps
   challengeId: string;
 }
 
+const excludedPreferences = [PreferenceType.MembershipFeedbackOnChallengeContext];
+
 const ChallengePreferenceContainer: FC<ChallengePreferenceContainerProps> = ({ children, hubId, challengeId }) => {
   const handleError = useApolloErrorHandler();
   const { data, loading, error } = useChallengePreferencesQuery({
@@ -40,7 +42,9 @@ const ChallengePreferenceContainer: FC<ChallengePreferenceContainerProps> = ({ c
     onError: handleError,
   });
 
-  const preferences = data?.hub?.challenge?.preferences ?? [];
+  const preferences = (data?.hub?.challenge?.preferences ?? []).filter(
+    p => !excludedPreferences.includes(p.definition.type)
+  );
 
   const onUpdate = useCallback(
     (id: string, type: ChallengePreferenceType, checked: boolean) => {


### PR DESCRIPTION
The preference related to providing feedback was for the ESSIF demo, and should not yet be exposed to end users

![image](https://user-images.githubusercontent.com/30729240/162886219-7df8dc5d-2898-4476-befd-7d21882132d0.png)
