### PR TITLE
Handling nullish subEntity in useSubscriptionToSubEntity

### DIFF
--- a/src/domain/shared/subscriptions/useSubscribeToMore.ts
+++ b/src/domain/shared/subscriptions/useSubscribeToMore.ts
@@ -17,7 +17,7 @@ export interface Options {
 
 const useSubscribeToMore = <QueryData, SubscriptionData, SubscriptionVariables = undefined>(
   subscribeToMore: SubscribeToMore<QueryData>,
-  options: SubscribeToMoreOptions<QueryData, SubscriptionVariables, SubscriptionData> & Options
+  options: SubscribeToMoreOptions<QueryData, SubscriptionVariables | null, SubscriptionData> & Options
 ) => {
   const handleError = useApolloErrorHandler();
   const { isFeatureEnabled } = useConfig();

--- a/src/domain/shared/subscriptions/useSubscribeToMore.ts
+++ b/src/domain/shared/subscriptions/useSubscribeToMore.ts
@@ -3,7 +3,6 @@ import { useApolloErrorHandler, useConfig, useUserContext } from '../../../hooks
 import { FEATURE_SUBSCRIPTIONS } from '../../../models/constants';
 import { ApolloError, SubscribeToMoreOptions } from '@apollo/client';
 import getDepsValueFromObject from '../utils/getDepsValueFromObject';
-// import getEntriesSortedFlat from '../utils/getEntriesSortedFlat';
 
 export interface SubscribeToMore<QueryData> {
   <SubscriptionData, SubscriptionVariables>(
@@ -17,7 +16,7 @@ export interface Options {
 
 const useSubscribeToMore = <QueryData, SubscriptionData, SubscriptionVariables = undefined>(
   subscribeToMore: SubscribeToMore<QueryData>,
-  options: SubscribeToMoreOptions<QueryData, SubscriptionVariables | null, SubscriptionData> & Options
+  options: SubscribeToMoreOptions<QueryData, SubscriptionVariables, SubscriptionData> & Options
 ) => {
   const handleError = useApolloErrorHandler();
   const { isFeatureEnabled } = useConfig();

--- a/src/domain/shared/subscriptions/useSubscriptionToSubEntity.ts
+++ b/src/domain/shared/subscriptions/useSubscriptionToSubEntity.ts
@@ -40,7 +40,7 @@ const createUseSubscriptionToSubEntityHook =
 
     const variables = subEntity && options.getSubscriptionVariables?.(subEntity);
 
-    const skip = subscriptionOptions.skip || !subEntity;
+    const skip = subscriptionOptions.skip || typeof subEntity === 'undefined';
 
     return useSubscribeToMore<QueryData, SubEntitySubscription, SubEntitySubscriptionVariables>(subscribeToMore, {
       document: options.subscriptionDocument,

--- a/src/domain/shared/subscriptions/useSubscriptionToSubEntity.ts
+++ b/src/domain/shared/subscriptions/useSubscriptionToSubEntity.ts
@@ -5,7 +5,7 @@ import useSubscribeToMore, { Options, SubscribeToMore } from './useSubscribeToMo
 interface CreateUseSubscriptionToSubEntityOptions<SubEntity, SubEntitySubscriptionVariables, SubEntitySubscription> {
   subscriptionDocument: TypedDocumentNode<SubEntitySubscription, SubEntitySubscriptionVariables>;
   getSubscriptionVariables?: (subEntity: SubEntity) => SubEntitySubscriptionVariables | undefined;
-  updateSubEntity: (subEntity: SubEntity | undefined, subscriptionData: SubEntitySubscription) => void;
+  updateSubEntity: (subEntity: SubEntity | undefined | null, subscriptionData: SubEntitySubscription) => void;
 }
 
 /**
@@ -32,7 +32,7 @@ const createUseSubscriptionToSubEntityHook =
   ) =>
   <QueryData>(
     parentEntity: QueryData | undefined,
-    getSubEntity: (data: QueryData | undefined) => SubEntity | undefined,
+    getSubEntity: (data: QueryData | undefined) => SubEntity | undefined | null,
     subscribeToMore: SubscribeToMore<QueryData>,
     subscriptionOptions: Options = { skip: false }
   ) => {
@@ -40,7 +40,7 @@ const createUseSubscriptionToSubEntityHook =
 
     const variables = subEntity && options.getSubscriptionVariables?.(subEntity);
 
-    const skip = subscriptionOptions.skip || typeof subEntity === 'undefined';
+    const skip = subscriptionOptions.skip || !subEntity;
 
     return useSubscribeToMore<QueryData, SubEntitySubscription, SubEntitySubscriptionVariables>(subscribeToMore, {
       document: options.subscriptionDocument,

--- a/src/domain/shared/subscriptions/useSubscriptionToSubEntity.ts
+++ b/src/domain/shared/subscriptions/useSubscriptionToSubEntity.ts
@@ -32,13 +32,13 @@ const createUseSubscriptionToSubEntityHook =
   ) =>
   <QueryData>(
     parentEntity: QueryData | undefined,
-    getSubEntity: (data: QueryData | undefined) => SubEntity | undefined | null,
+    getSubEntity: (data: QueryData | undefined) => SubEntity | undefined,
     subscribeToMore: SubscribeToMore<QueryData>,
     subscriptionOptions: Options = { skip: false }
   ) => {
     const subEntity = getSubEntity(parentEntity);
 
-    const variables = subEntity && options.getSubscriptionVariables?.(subEntity);
+    const variables = subEntity ? options.getSubscriptionVariables?.(subEntity) : undefined;
 
     const skip = subscriptionOptions.skip || !subEntity;
 

--- a/src/domain/shared/utils/getDepsValueFromObject.ts
+++ b/src/domain/shared/utils/getDepsValueFromObject.ts
@@ -5,8 +5,8 @@ import { sortBy } from 'lodash';
  * Use like that: useEffect(() => {}, [dep1, dep2, getDepsValueFromObject(object)]);
  * @param object
  */
-const getDepsValueFromObject = <Object extends {}>(object: Object | undefined): string => {
-  if (typeof object === 'undefined') {
+const getDepsValueFromObject = <Object extends {}>(object: Object | undefined | null): string => {
+  if (typeof object === 'undefined' || object === null) {
     return '';
   }
   const entries = Object.entries(object) as [keyof Object, Object[keyof Object]][];

--- a/src/domain/shared/utils/getDepsValueFromObject.ts
+++ b/src/domain/shared/utils/getDepsValueFromObject.ts
@@ -6,7 +6,7 @@ import { sortBy } from 'lodash';
  * @param object
  */
 const getDepsValueFromObject = <Object extends {}>(object: Object | undefined | null): string => {
-  if (typeof object === 'undefined' || object === null) {
+  if (!object) {
     return '';
   }
   const entries = Object.entries(object) as [keyof Object, Object[keyof Object]][];

--- a/src/domain/shared/utils/getDepsValueFromObject.ts
+++ b/src/domain/shared/utils/getDepsValueFromObject.ts
@@ -5,7 +5,7 @@ import { sortBy } from 'lodash';
  * Use like that: useEffect(() => {}, [dep1, dep2, getDepsValueFromObject(object)]);
  * @param object
  */
-const getDepsValueFromObject = <Object extends {}>(object: Object | undefined | null): string => {
+const getDepsValueFromObject = <Object extends {}>(object: Object | undefined): string => {
   if (!object) {
     return '';
   }


### PR DESCRIPTION
### Describe the background of your pull request

Fixes #2179 

Not sure if this is the fix. Maybe if object is null we don't even want to subscribe at all. Need to discuss it tomorrow.
I have seen that from useSubscribeToMore.ts a null was coming in the argument object.

### Additional context



### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
