### PR TITLE
Max length to the tagline input field #2211

### DIFF
--- a/src/components/Admin/Common/InputField.tsx
+++ b/src/components/Admin/Common/InputField.tsx
@@ -11,6 +11,8 @@ interface InputFieldProps {
   disabled?: boolean;
   required?: boolean;
   helpText?: string;
+  maxLength?: number;
+  withCounter?: boolean;
   loading?: boolean;
 }
 
@@ -22,6 +24,8 @@ const InputField: FC<InputFieldProps> = ({
   disabled = false,
   required,
   helpText,
+  maxLength,
+  withCounter,
   loading,
 }) => {
   const styles = useProfileStyles();
@@ -38,6 +42,8 @@ const InputField: FC<InputFieldProps> = ({
         multiline={!!rows && rows > 1}
         rows={rows}
         helpText={helpText}
+        maxLength={maxLength}
+        withCounter={withCounter}
         loading={loading}
       />
     </Grid>

--- a/src/components/Admin/HubEditForm.tsx
+++ b/src/components/Admin/HubEditForm.tsx
@@ -16,6 +16,7 @@ import InputField from './Common/InputField';
 import { EmptyLocation, Location } from '../../domain/location/Location';
 import { formatLocation } from '../../domain/location/LocationUtils';
 import { LocationSegment } from '../../domain/location/LocationSegment';
+import { SMALL_TEXT_LENGTH } from '../../models/constants/field-length.constants';
 
 interface Props {
   context?: Context;
@@ -135,7 +136,13 @@ const HubEditForm: FC<Props> = ({
                 placeholder={t('components.editHubForm.host.title')}
               />
             </Grid>
-            <InputField name="tagline" label={t('components.contextSegment.tagline')} rows={3} />
+            <InputField
+              name="tagline"
+              label={t('components.contextSegment.tagline')}
+              rows={3}
+              maxLength={SMALL_TEXT_LENGTH}
+              withCounter
+            />
             <LocationSegment cols={2} cityFieldName="location.city" countryFieldName="location.country" />
             <Grid item xs={12}>
               <Typography variant={'h4'} color={'primary'}>

--- a/src/components/composite/forms/FormikInputField.tsx
+++ b/src/components/composite/forms/FormikInputField.tsx
@@ -1,4 +1,4 @@
-import { TextField, TextFieldProps } from '@mui/material';
+import { Box, styled, TextField, TextFieldProps, Typography } from '@mui/material';
 import { DistributiveOmit } from '@mui/types';
 import { useField } from 'formik';
 import React, { FC } from 'react';
@@ -16,8 +16,16 @@ type InputFieldProps = DistributiveOmit<TextFieldProps, 'variant'> & {
   placeholder?: string;
   autoComplete?: string;
   helpText?: string;
+  maxLength?: number;
+  withCounter?: boolean;
   loading?: boolean;
 };
+
+const CharacterCounter = styled(Typography)(({ theme }) => ({
+  position: 'absolute',
+  right: 0,
+  top: theme.spacing(-2),
+}));
 
 export const FormikInputField: FC<InputFieldProps> = ({
   title,
@@ -30,6 +38,8 @@ export const FormikInputField: FC<InputFieldProps> = ({
   autoComplete,
   InputProps,
   helpText,
+  maxLength,
+  withCounter,
   loading,
   ...rest
 }) => {
@@ -46,38 +56,47 @@ export const FormikInputField: FC<InputFieldProps> = ({
   };
 
   return (
-    <TextField
-      name={name}
-      placeholder={placeholder}
-      label={title}
-      onBlur={field.onBlur}
-      onChange={handleOnChange}
-      value={field.value || ''}
-      variant={'outlined'}
-      InputLabelProps={{ shrink: true }}
-      error={meta.touched && Boolean(meta.error)}
-      helperText={
-        meta.touched &&
-        tErr(meta.error as TranslationKey, {
-          field: title,
-        })
-      }
-      required={required}
-      disabled={loading || disabled}
-      autoComplete={autoComplete}
-      fullWidth
-      InputProps={{
-        ...InputProps,
-        endAdornment: (
-          <>
-            {loading && <CircularProgress size={20} />}
-            {helpText && <HelpButton helpText={helpText} />}
-          </>
-        ),
-        readOnly: readOnly,
-      }}
-      {...rest}
-    />
+    <>
+      <TextField
+        name={name}
+        placeholder={placeholder}
+        label={title}
+        onBlur={field.onBlur}
+        onChange={handleOnChange}
+        value={field.value || ''}
+        variant={'outlined'}
+        InputLabelProps={{ shrink: true }}
+        error={meta.touched && Boolean(meta.error)}
+        helperText={
+          meta.touched &&
+          tErr(meta.error as TranslationKey, {
+            field: title,
+          })
+        }
+        required={required}
+        disabled={loading || disabled}
+        autoComplete={autoComplete}
+        fullWidth
+        InputProps={{
+          ...InputProps,
+          endAdornment: (
+            <>
+              {loading && <CircularProgress size={20} />}
+              {helpText && <HelpButton helpText={helpText} />}
+            </>
+          ),
+          readOnly: readOnly,
+        }}
+        {...rest}
+      />
+      {withCounter && (
+        <Box sx={{ position: 'relative' }}>
+          <CharacterCounter variant="caption">
+            {`${field.value?.length ? field.value?.length : 0}` + (maxLength ? `/${maxLength}` : '')}
+          </CharacterCounter>
+        </Box>
+      )}
+    </>
   );
 };
 export default FormikInputField;


### PR DESCRIPTION
### Describe the background of your pull request

Adds a character counter to the TextArea for the tagline and sets the maxlength.
It's still in draft because the task is blocked, we need set the limit in the dto serverside and change the column width on the context table but first we have to see if we have any context in Live with already more than 128 chars length

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
