### PR TITLE
Updated gql definitions to work with server-2158

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -180,14 +180,19 @@
           "order": 0,
           "hidden": false
         },
+        "GLOBAL_ADMIN_HUBS": {
+          "name": "Global Admin Hubs",
+          "order": 1,
+          "hidden": false
+        },
         "GLOBAL_ADMIN_COMMUNITY": {
           "name": "Global Community Admin",
-          "order": 1,
+          "order": 2,
           "hidden": false
         },
         "GLOBAL_ADMIN_CHALLENGES": {
           "name": "Global Challenges Admin",
-          "order": 2,
+          "order": 3,
           "hidden": false
         },
         "GLOBAL_REGISTERED": {
@@ -197,77 +202,77 @@
         },
         "HUB_ADMIN": {
           "name": "Hub Admin",
-          "order": 3,
+          "order": 4,
           "hidden": false
         },
         "HUB_HOST": {
           "name": "Hub Host",
-          "order": 4,
+          "order": 5,
           "hidden": true
         },
         "HUB_MEMBER": {
           "name": "Hub Member",
-          "order": 5,
+          "order": 6,
           "hidden": true
         },
         "CHALLENGE_ADMIN": {
           "name": "Challenge Admin",
-          "order": 6,
+          "order": 7,
           "hidden": false
         },
         "CHALLENGE_LEAD": {
           "name": "Challenge Lead",
-          "order": 7,
+          "order": 8,
           "hidden": true
         },
         "CHALLENGE_MEMBER": {
           "name": "Challenge Member",
-          "order": 8,
+          "order": 9,
           "hidden": true
         },
         "OPPORTUNITY_ADMIN": {
           "name": "Opportunity Admin",
-          "order": 9,
+          "order": 10,
           "hidden": true
         },
         "OPPORTUNITY_MEMBER": {
           "name": "Opportunity Member",
-          "order": 10,
+          "order": 11,
           "hidden": true
         },
         "OPPORTUNITY_LEAD": {
           "name": "Opportunity Lead",
-          "order": 11,
+          "order": 12,
           "hidden": true
         },
         "ORGANIZATION_OWNER": {
           "name": "Organization Owner",
-          "order": 11,
+          "order": 13,
           "hidden": false
         },
         "ORGANIZATION_ADMIN": {
           "name": "Organization Admin",
-          "order": 12,
+          "order": 14,
           "hidden": false
         },
         "ORGANIZATION_MEMBER": {
           "name": "Organization Member",
-          "order": 13,
+          "order": 15,
           "hidden": true
         },
         "USER_SELF_MANAGEMENT": {
           "name": "User Self Management",
-          "order": 14,
+          "order": 16,
           "hidden": true
         },
         "COMMUNITY_MEMBER": {
           "name": "Community Member",
-          "order": 15,
+          "order": 17,
           "hidden": true
         },
         "USER_GROUP_MEMBER": {
           "name": "User Group Member",
-          "order": 16,
+          "order": 18,
           "hidden": true
         }
       },

--- a/src/domain/admin/components/Organization/OrganizationForm.tsx
+++ b/src/domain/admin/components/Organization/OrganizationForm.tsx
@@ -32,6 +32,7 @@ const EmptyOrganization: Organization = {
   id: '',
   nameID: '',
   displayName: '',
+  authorization: undefined,
   contactEmail: undefined,
   domain: '',
   legalEntityName: '',

--- a/src/domain/shared/components/ActivityLog/ActivityLogComponent.tsx
+++ b/src/domain/shared/components/ActivityLog/ActivityLogComponent.tsx
@@ -49,9 +49,9 @@ interface ActivityViewChooserProps extends ActivityLogViewProps {
 const ActivityViewChooser = ({ type, ...rest }: ActivityViewChooserProps): React.ReactElement<ActivityLogViewProps> => {
   const lookup: Record<ActivityEventType, ComponentType<ActivityLogViewProps> | null> = {
     [ActivityEventType.CalloutPublished]: ActivityLogCalloutPublishedView,
-    [ActivityEventType.CanvasCreated]: ActivityLogCanvasCreatedView,
+    [ActivityEventType.CalloutCanvasCreated]: ActivityLogCanvasCreatedView,
     [ActivityEventType.CardComment]: ActivityCardCommentCreatedView,
-    [ActivityEventType.CardCreated]: ActivityLogCardCreatedView,
+    [ActivityEventType.CalloutCardCreated]: ActivityLogCardCreatedView,
     [ActivityEventType.DiscussionComment]: ActivityLogDiscussionCommentCreatedView,
     [ActivityEventType.MemberJoined]: ActivityLogMemberJoinedView,
   };

--- a/src/domain/shared/components/ActivityLog/ActivityLogComponent.tsx
+++ b/src/domain/shared/components/ActivityLog/ActivityLogComponent.tsx
@@ -49,9 +49,9 @@ interface ActivityViewChooserProps extends ActivityLogViewProps {
 const ActivityViewChooser = ({ type, ...rest }: ActivityViewChooserProps): React.ReactElement<ActivityLogViewProps> => {
   const lookup: Record<ActivityEventType, ComponentType<ActivityLogViewProps> | null> = {
     [ActivityEventType.CalloutPublished]: ActivityLogCalloutPublishedView,
-    [ActivityEventType.CalloutCanvasCreated]: ActivityLogCanvasCreatedView,
+    [ActivityEventType.CanvasCreated]: ActivityLogCanvasCreatedView,
     [ActivityEventType.CardComment]: ActivityCardCommentCreatedView,
-    [ActivityEventType.CalloutCardCreated]: ActivityLogCardCreatedView,
+    [ActivityEventType.CardCreated]: ActivityLogCardCreatedView,
     [ActivityEventType.DiscussionComment]: ActivityLogDiscussionCommentCreatedView,
     [ActivityEventType.MemberJoined]: ActivityLogMemberJoinedView,
   };

--- a/src/models/apollo-helpers.ts
+++ b/src/models/apollo-helpers.ts
@@ -263,6 +263,7 @@ export type CalloutKeySpecifier = (
   | 'displayName'
   | 'id'
   | 'nameID'
+  | 'sortOrder'
   | 'state'
   | 'type'
   | 'visibility'
@@ -277,6 +278,7 @@ export type CalloutFieldPolicy = {
   displayName?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   nameID?: FieldPolicy<any> | FieldReadFunction<any>;
+  sortOrder?: FieldPolicy<any> | FieldReadFunction<any>;
   state?: FieldPolicy<any> | FieldReadFunction<any>;
   type?: FieldPolicy<any> | FieldReadFunction<any>;
   visibility?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -285,6 +287,17 @@ export type CalloutAspectCreatedKeySpecifier = ('aspect' | 'calloutID' | Callout
 export type CalloutAspectCreatedFieldPolicy = {
   aspect?: FieldPolicy<any> | FieldReadFunction<any>;
   calloutID?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type CalloutMessageReceivedKeySpecifier = (
+  | 'calloutID'
+  | 'commentsID'
+  | 'message'
+  | CalloutMessageReceivedKeySpecifier
+)[];
+export type CalloutMessageReceivedFieldPolicy = {
+  calloutID?: FieldPolicy<any> | FieldReadFunction<any>;
+  commentsID?: FieldPolicy<any> | FieldReadFunction<any>;
+  message?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CanvasKeySpecifier = (
   | 'authorization'
@@ -790,6 +803,7 @@ export type MutationKeySpecifier = (
   | 'assignUserAsCommunityMember'
   | 'assignUserAsGlobalAdmin'
   | 'assignUserAsGlobalCommunityAdmin'
+  | 'assignUserAsGlobalHubsAdmin'
   | 'assignUserAsHubAdmin'
   | 'assignUserAsOpportunityAdmin'
   | 'assignUserAsOrganizationAdmin'
@@ -868,6 +882,7 @@ export type MutationKeySpecifier = (
   | 'removeUserAsCommunityMember'
   | 'removeUserAsGlobalAdmin'
   | 'removeUserAsGlobalCommunityAdmin'
+  | 'removeUserAsGlobalHubsAdmin'
   | 'removeUserAsHubAdmin'
   | 'removeUserAsOpportunityAdmin'
   | 'removeUserAsOrganizationAdmin'
@@ -918,6 +933,7 @@ export type MutationFieldPolicy = {
   assignUserAsCommunityMember?: FieldPolicy<any> | FieldReadFunction<any>;
   assignUserAsGlobalAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
   assignUserAsGlobalCommunityAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
+  assignUserAsGlobalHubsAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
   assignUserAsHubAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
   assignUserAsOpportunityAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
   assignUserAsOrganizationAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -996,6 +1012,7 @@ export type MutationFieldPolicy = {
   removeUserAsCommunityMember?: FieldPolicy<any> | FieldReadFunction<any>;
   removeUserAsGlobalAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
   removeUserAsGlobalCommunityAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
+  removeUserAsGlobalHubsAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
   removeUserAsHubAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
   removeUserAsOpportunityAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
   removeUserAsOrganizationAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1494,6 +1511,7 @@ export type ServiceMetadataFieldPolicy = {
 export type SubscriptionKeySpecifier = (
   | 'aspectCommentsMessageReceived'
   | 'calloutAspectCreated'
+  | 'calloutMessageReceived'
   | 'canvasContentUpdated'
   | 'communicationDiscussionMessageReceived'
   | 'communicationDiscussionUpdated'
@@ -1504,6 +1522,7 @@ export type SubscriptionKeySpecifier = (
 export type SubscriptionFieldPolicy = {
   aspectCommentsMessageReceived?: FieldPolicy<any> | FieldReadFunction<any>;
   calloutAspectCreated?: FieldPolicy<any> | FieldReadFunction<any>;
+  calloutMessageReceived?: FieldPolicy<any> | FieldReadFunction<any>;
   canvasContentUpdated?: FieldPolicy<any> | FieldReadFunction<any>;
   communicationDiscussionMessageReceived?: FieldPolicy<any> | FieldReadFunction<any>;
   communicationDiscussionUpdated?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1790,6 +1809,10 @@ export type StrictTypedTypePolicies = {
   CalloutAspectCreated?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | CalloutAspectCreatedKeySpecifier | (() => undefined | CalloutAspectCreatedKeySpecifier);
     fields?: CalloutAspectCreatedFieldPolicy;
+  };
+  CalloutMessageReceived?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | CalloutMessageReceivedKeySpecifier | (() => undefined | CalloutMessageReceivedKeySpecifier);
+    fields?: CalloutMessageReceivedFieldPolicy;
   };
   Canvas?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | CanvasKeySpecifier | (() => undefined | CanvasKeySpecifier);

--- a/src/models/graphql-schema.ts
+++ b/src/models/graphql-schema.ts
@@ -42,10 +42,10 @@ export type Activity = {
 };
 
 export enum ActivityEventType {
+  CalloutCanvasCreated = 'CALLOUT_CANVAS_CREATED',
+  CalloutCardCreated = 'CALLOUT_CARD_CREATED',
   CalloutPublished = 'CALLOUT_PUBLISHED',
-  CanvasCreated = 'CANVAS_CREATED',
   CardComment = 'CARD_COMMENT',
-  CardCreated = 'CARD_CREATED',
   DiscussionComment = 'DISCUSSION_COMMENT',
   MemberJoined = 'MEMBER_JOINED',
 }
@@ -247,6 +247,10 @@ export type AssignGlobalCommunityAdminInput = {
   userID: Scalars['UUID_NAMEID_EMAIL'];
 };
 
+export type AssignGlobalHubsAdminInput = {
+  userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
 export type AssignHubAdminInput = {
   hubID: Scalars['UUID_NAMEID'];
   userID: Scalars['UUID_NAMEID_EMAIL'];
@@ -320,6 +324,7 @@ export enum AuthorizationCredential {
   ChallengeMember = 'CHALLENGE_MEMBER',
   GlobalAdmin = 'GLOBAL_ADMIN',
   GlobalAdminCommunity = 'GLOBAL_ADMIN_COMMUNITY',
+  GlobalAdminHubs = 'GLOBAL_ADMIN_HUBS',
   GlobalRegistered = 'GLOBAL_REGISTERED',
   HubAdmin = 'HUB_ADMIN',
   HubHost = 'HUB_HOST',
@@ -356,6 +361,7 @@ export type AuthorizationPolicyRuleVerifiedCredential = {
 };
 
 export enum AuthorizationPrivilege {
+  AuthorizationReset = 'AUTHORIZATION_RESET',
   CommunityApply = 'COMMUNITY_APPLY',
   CommunityContextReview = 'COMMUNITY_CONTEXT_REVIEW',
   CommunityJoin = 'COMMUNITY_JOIN',
@@ -369,6 +375,8 @@ export enum AuthorizationPrivilege {
   CreateRelation = 'CREATE_RELATION',
   Delete = 'DELETE',
   Grant = 'GRANT',
+  GrantGlobalAdmins = 'GRANT_GLOBAL_ADMINS',
+  PlatformAdmin = 'PLATFORM_ADMIN',
   Read = 'READ',
   ReadUsers = 'READ_USERS',
   Update = 'UPDATE',
@@ -394,6 +402,8 @@ export type Callout = {
   id: Scalars['UUID'];
   /** A name identifier of the entity, unique within a given scope. */
   nameID: Scalars['NameID'];
+  /** The sorting order for this Callout. */
+  sortOrder: Scalars['Float'];
   /** State of the Callout. */
   state: CalloutState;
   /** The Callout type, e.g. Card, Canvas, Discussion */
@@ -420,6 +430,16 @@ export type CalloutAspectCreated = {
   aspect: Aspect;
   /** The identifier for the Callout on which the aspect was created. */
   calloutID: Scalars['String'];
+};
+
+export type CalloutMessageReceived = {
+  __typename?: 'CalloutMessageReceived';
+  /** The identifier for the Callout. */
+  calloutID: Scalars['String'];
+  /** The identifier for the Comments. */
+  commentsID: Scalars['String'];
+  /** The message that has been sent. */
+  message: Message;
 };
 
 export enum CalloutState {
@@ -895,6 +915,8 @@ export type CreateCalloutOnCollaborationInput = {
   displayName: Scalars['String'];
   /** A readable identifier, unique within the containing scope. */
   nameID?: InputMaybe<Scalars['NameID']>;
+  /** The sort order to assign to this Callout. */
+  sortOrder?: InputMaybe<Scalars['Float']>;
   /** State of the callout. */
   state?: InputMaybe<CalloutState>;
   /** Callout type. */
@@ -1512,6 +1534,8 @@ export type Mutation = {
   assignUserAsGlobalAdmin: User;
   /** Assigns a User as a Global Community Admin. */
   assignUserAsGlobalCommunityAdmin: User;
+  /** Assigns a User as a Global Hubs Admin. */
+  assignUserAsGlobalHubsAdmin: User;
   /** Assigns a User as an Hub Admin. */
   assignUserAsHubAdmin: User;
   /** Assigns a User as an Opportunity Admin. */
@@ -1668,6 +1692,8 @@ export type Mutation = {
   removeUserAsGlobalAdmin: User;
   /** Removes a User from being a Global Community Admin. */
   removeUserAsGlobalCommunityAdmin: User;
+  /** Removes a User from being a Global Hubs Admin. */
+  removeUserAsGlobalHubsAdmin: User;
   /** Removes a User from being an Hub Admin. */
   removeUserAsHubAdmin: User;
   /** Removes a User from being an Opportunity Admin. */
@@ -1784,6 +1810,10 @@ export type MutationAssignUserAsGlobalAdminArgs = {
 
 export type MutationAssignUserAsGlobalCommunityAdminArgs = {
   membershipData: AssignGlobalCommunityAdminInput;
+};
+
+export type MutationAssignUserAsGlobalHubsAdminArgs = {
+  membershipData: AssignGlobalHubsAdminInput;
 };
 
 export type MutationAssignUserAsHubAdminArgs = {
@@ -2090,6 +2120,10 @@ export type MutationRemoveUserAsGlobalCommunityAdminArgs = {
   membershipData: RemoveGlobalCommunityAdminInput;
 };
 
+export type MutationRemoveUserAsGlobalHubsAdminArgs = {
+  membershipData: RemoveGlobalHubsAdminInput;
+};
+
 export type MutationRemoveUserAsHubAdminArgs = {
   membershipData: RemoveHubAdminInput;
 };
@@ -2298,7 +2332,7 @@ export type Organization = Groupable &
     activity?: Maybe<Array<Nvp>>;
     /** The Agent representing this User. */
     agent?: Maybe<Agent>;
-    /** The authorization rules for the entity */
+    /** The Authorization for this Organization. */
     authorization?: Maybe<Authorization>;
     /** Organization contact email */
     contactEmail?: Maybe<Scalars['String']>;
@@ -2726,7 +2760,7 @@ export type RelayPaginatedUser = Searchable & {
   accountUpn: Scalars['String'];
   /** The Agent representing this User. */
   agent?: Maybe<Agent>;
-  /** The authorization rules for the entity */
+  /** The Authorization for this User. */
   authorization?: Maybe<Authorization>;
   /** The Community rooms this user is a member of */
   communityRooms?: Maybe<Array<CommunicationRoom>>;
@@ -2797,6 +2831,10 @@ export type RemoveGlobalAdminInput = {
 };
 
 export type RemoveGlobalCommunityAdminInput = {
+  userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
+export type RemoveGlobalHubsAdminInput = {
   userID: Scalars['UUID_NAMEID_EMAIL'];
 };
 
@@ -2966,6 +3004,8 @@ export type Subscription = {
   aspectCommentsMessageReceived: AspectCommentsMessageReceived;
   /** Receive new Update messages on Communities the currently authenticated User is a member of. */
   calloutAspectCreated: CalloutAspectCreated;
+  /** Receive comments on Callouts */
+  calloutMessageReceived: CalloutMessageReceived;
   /** Receive updated content of a canvas */
   canvasContentUpdated: CanvasContentUpdated;
   /** Receive new Discussion messages */
@@ -2984,6 +3024,10 @@ export type SubscriptionAspectCommentsMessageReceivedArgs = {
 
 export type SubscriptionCalloutAspectCreatedArgs = {
   calloutID: Scalars['UUID'];
+};
+
+export type SubscriptionCalloutMessageReceivedArgs = {
+  calloutIDs: Array<Scalars['UUID']>;
 };
 
 export type SubscriptionCanvasContentUpdatedArgs = {
@@ -3124,6 +3168,8 @@ export type UpdateCalloutInput = {
   displayName?: InputMaybe<Scalars['String']>;
   /** A display identifier, unique within the containing scope. Note: updating the nameID will affect URL on the client. */
   nameID?: InputMaybe<Scalars['NameID']>;
+  /** The sort order to assign to this Callout. */
+  sortOrder?: InputMaybe<Scalars['Float']>;
   /** State of the callout. */
   state?: InputMaybe<CalloutState>;
   /** Callout type. */
@@ -3378,7 +3424,7 @@ export type User = Searchable & {
   accountUpn: Scalars['String'];
   /** The Agent representing this User. */
   agent?: Maybe<Agent>;
-  /** The authorization rules for the entity */
+  /** The Authorization for this User. */
   authorization?: Maybe<Authorization>;
   /** The Community rooms this user is a member of */
   communityRooms?: Maybe<Array<CommunicationRoom>>;

--- a/src/models/graphql-schema.ts
+++ b/src/models/graphql-schema.ts
@@ -42,10 +42,10 @@ export type Activity = {
 };
 
 export enum ActivityEventType {
-  CalloutCanvasCreated = 'CALLOUT_CANVAS_CREATED',
-  CalloutCardCreated = 'CALLOUT_CARD_CREATED',
   CalloutPublished = 'CALLOUT_PUBLISHED',
+  CanvasCreated = 'CANVAS_CREATED',
   CardComment = 'CARD_COMMENT',
+  CardCreated = 'CARD_CREATED',
   DiscussionComment = 'DISCUSSION_COMMENT',
   MemberJoined = 'MEMBER_JOINED',
 }


### PR DESCRIPTION
- Works with server-2158
- Fixed authorization fields regression (they should be optional)
- Fixed updated enum fields 