### PR TITLE
Fix Topbar SearchBox not being populated on keypress #2789

### DIFF
--- a/src/common/components/composite/layout/TopBar/SearchBar.tsx
+++ b/src/common/components/composite/layout/TopBar/SearchBar.tsx
@@ -25,11 +25,10 @@ const SearchBar = () => {
   const [value, setValue] = useState(getInitialValue);
 
   useLayoutEffect(() => {
-    if (match && query.get(SEARCH_TERMS_PARAM) === getSearchTerms(value)) {
-      return;
+    if (!match) {
+      setValue('');
     }
-    setValue('');
-  }, [match, query, value]);
+  }, [match]);
 
   const isTermValid = useMemo(() => value.length < MINIMUM_TERM_LENGTH, [value]);
 


### PR DESCRIPTION
### Describe the background of your pull request

The topbar searchbox was not accepting any input. On key press, the text field was staying empty.

The problem was introduced here: [3fc957](https://github.com/alkem-io/client-web/commit/3fc957e3914e794140bdeeed0749b54c8463c276)
This piece of code inside useLayoutEffect cleans up the text field if the user leaves the search page. But introducing `value` as a dependency makes the effect to be executed every time the user presses a key.

Debugging it I think the behavior is perfectly fine if we don't check the search terms at all, it's okay to just check if we still are in the search page. The only downside is that the old terms remain in the textbox when the user changes the search terms in the search dialog:
![image](https://user-images.githubusercontent.com/16032487/197475231-33df8b70-e416-4d2a-be6c-a13fd40d2c1f.png)
This doesn't happen in live at the moment.

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
