### PR TITLE
Fix canvases getting deleted when opening the options combobox #2815

### DIFF
--- a/src/domain/shared/utils/useAsyncInterruptibleCallback.ts
+++ b/src/domain/shared/utils/useAsyncInterruptibleCallback.ts
@@ -57,7 +57,7 @@ const useAsyncInterruptibleCallback = <Args extends unknown[], Result, Fn extend
 
     return Object.assign(interruptible, callback); // carrying extra properties such as flash/cancel on a debounced fn
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [depsValueFromObjectDeps, fn]);
+  }, [depsValueFromObjectDeps]);
 };
 
 export default useAsyncInterruptibleCallback;


### PR DESCRIPTION
### Describe the background of your pull request

Removing this `fn` from the deps list fixed the issue. 
This `useAsyncInterruptibleCallback` is only used in canvases and after this change the canvases behavior turns back to normal.

### Additional context

I think it should be just removed because precisely what we want is to not detect changes in `fn` between renders, we want this callback to be always the same no matter what function is behind it. Not sure if I'm right.

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
