### PR TITLE
switch to updated search api, with dedicated results types per search result type

### DIFF
--- a/src/containers/ContributionDetails/ContributionDetails.graphql
+++ b/src/containers/ContributionDetails/ContributionDetails.graphql
@@ -54,7 +54,6 @@ query opportunityContributionDetails($hubId: UUID_NAMEID!, $opportunityId: UUID_
       id
       nameID
       displayName
-      parentId
       parentNameID
       tagset {
         id

--- a/src/containers/application/PendingApplicationContainer.tsx
+++ b/src/containers/application/PendingApplicationContainer.tsx
@@ -54,7 +54,7 @@ const PendingApplicationContainer: FC<PendingApplicationContainerProps> = ({ ent
   });
   if (opportunityID) {
     const hubNameId = _opportunityNameId?.hub.nameID || '';
-    const challengeNameId = _opportunityNameId?.hub.opportunity.challenge?.nameID || '';
+    const challengeNameId = _opportunityNameId?.hub.opportunity.parentNameID || '';
     const opportunityNameId = _opportunityNameId?.hub.opportunity.nameID || '';
     url = buildOpportunityUrl(hubNameId, challengeNameId, opportunityNameId);
   }

--- a/src/domain/challenge/challenge/containers/ChallengeExplorerContainer.tsx
+++ b/src/domain/challenge/challenge/containers/ChallengeExplorerContainer.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react';
 import { ApolloError } from '@apollo/client';
 import { ContainerChildProps } from '../../../../models/container';
-import { ChallengeExplorerSearchResultFragment } from '../../../../models/graphql-schema';
 import {
   useChallengeExplorerDataQuery,
   useChallengeExplorerPageQuery,
@@ -10,6 +9,7 @@ import {
 import { useApolloErrorHandler, useUserContext } from '../../../../hooks';
 import { ValueType } from '../../../../common/components/core/card-filter/filterFn';
 import { getVisualBannerNarrow } from '../../../../common/utils/visuals.utils';
+import { SearchResultChallengeFragment } from '../../../../models/graphql-schema';
 
 export type SimpleChallenge = {
   id: string;
@@ -137,10 +137,10 @@ export const ChallengeExplorerContainer: FC<ChallengePageContainerProps> = ({ se
 
   // Obtain the data of the challenges returned by the search
   const hubIDsSearch = rawSearchResults?.search.map(
-    result => (result.result as ChallengeExplorerSearchResultFragment)?.hubID
+    result => (result as SearchResultChallengeFragment)?.challenge.hubID
   );
   const challengesIDsSearch = rawSearchResults?.search.map(
-    result => (result.result as ChallengeExplorerSearchResultFragment)?.id
+    result => (result as SearchResultChallengeFragment)?.challenge.id
   );
 
   const { data: searchResultsData, loading: loadingSearchResultsData } = useChallengeExplorerDataQuery({
@@ -167,8 +167,7 @@ export const ChallengeExplorerContainer: FC<ChallengePageContainerProps> = ({ se
         tags: ch.tagset?.tags || [],
         roles: challengeRoles.find(c => c.id === ch.id)?.roles || [],
         matchedTerms:
-          rawSearchResults?.search.find(r => (r.result as ChallengeExplorerSearchResultFragment)?.id === ch.id)
-            ?.terms || [],
+          rawSearchResults?.search.find(r => (r as SearchResultChallengeFragment)?.challenge.id === ch.id)?.terms || [],
       })) || []
   );
 

--- a/src/domain/challenge/challenge/containers/ChallengeExplorerQueries.graphql
+++ b/src/domain/challenge/challenge/containers/ChallengeExplorerQueries.graphql
@@ -13,16 +13,13 @@ query ChallengeExplorerPage($rolesData: RolesUserInput!) {
 
 query ChallengeExplorerSearch($searchData: SearchInput!) {
   search(searchData: $searchData) {
-    result {
-      ...ChallengeExplorerSearchResult
-    }
+    id
+    type
     terms
+    ... on SearchResultChallenge {
+      ...SearchResultChallenge
+    }
   }
-}
-
-fragment ChallengeExplorerSearchResult on Challenge {
-  id
-  hubID
 }
 
 query ChallengeExplorerData($hubIDs: [UUID!], $challengeIDs: [UUID!]) {
@@ -34,7 +31,7 @@ query ChallengeExplorerData($hubIDs: [UUID!], $challengeIDs: [UUID!]) {
       id
       tagline
     }
-    challenges (IDs: $challengeIDs) {
+    challenges(IDs: $challengeIDs) {
       id
       nameID
       displayName

--- a/src/domain/community/application/graphql/queries/nameIds.graphql
+++ b/src/domain/community/application/graphql/queries/nameIds.graphql
@@ -23,10 +23,7 @@ query opportunityNameId($hubId: UUID_NAMEID!, $opportunityId: UUID_NAMEID!) {
     opportunity(ID: $opportunityId) {
       id
       nameID
-      challenge {
-        id
-        nameID
-      }
+      parentNameID
     }
   }
 }

--- a/src/domain/community/community/CommunityUpdates/CommunityUpdatesDashboardSection.tsx
+++ b/src/domain/community/community/CommunityUpdates/CommunityUpdatesDashboardSection.tsx
@@ -4,14 +4,14 @@ import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
 import DashboardGenericSection from '../../../shared/components/DashboardSections/DashboardGenericSection';
 import { useTranslation } from 'react-i18next';
-import { Message, Searchable } from '../../../../models/graphql-schema';
+import { Message } from '../../../../models/graphql-schema';
 import { Box } from '@mui/material';
 import { CommunityUpdatesView } from '../views/CommunityUpdates/CommunityUpdatesView';
 import { Author } from '../../../shared/components/AuthorAvatar/models/author';
 
 const UPDATES_CONTAINER_HEIGHT = 300;
 
-export type SearchableUserCardProps = UserCardProps & Searchable;
+export type SearchableUserCardProps = UserCardProps;
 
 export interface CommunityUpdatesDashboardSectionProps {
   messages?: Message[];

--- a/src/hooks/generated/graphql.ts
+++ b/src/hooks/generated/graphql.ts
@@ -782,12 +782,6 @@ export const MyPrivilegesFragmentDoc = gql`
     myPrivileges
   }
 `;
-export const ChallengeExplorerSearchResultFragmentDoc = gql`
-  fragment ChallengeExplorerSearchResult on Challenge {
-    id
-    hubID
-  }
-`;
 export const ChallengeInfoFragmentDoc = gql`
   fragment ChallengeInfo on Challenge {
     id
@@ -1976,8 +1970,8 @@ export const ActivityLogOnCollaborationFragmentDoc = gql`
   ${ActivityLogChallengeCreatedFragmentDoc}
   ${ActivityLogOpportunityCreatedFragmentDoc}
 `;
-export const ProfileSearchResultFragmentDoc = gql`
-  fragment ProfileSearchResult on Profile {
+export const SearchResultProfileFragmentDoc = gql`
+  fragment SearchResultProfile on Profile {
     id
     location {
       id
@@ -1994,88 +1988,113 @@ export const ProfileSearchResultFragmentDoc = gql`
   }
   ${VisualUriFragmentDoc}
 `;
-export const UserSearchResultFragmentDoc = gql`
-  fragment UserSearchResult on User {
-    id
-    nameID
-    displayName
-    profile {
-      ...ProfileSearchResult
-    }
-  }
-  ${ProfileSearchResultFragmentDoc}
-`;
-export const OrganizationSearchResultFragmentDoc = gql`
-  fragment OrganizationSearchResult on Organization {
-    id
-    nameID
-    displayName
-    profile_: profile {
-      ...ProfileSearchResult
-    }
-  }
-  ${ProfileSearchResultFragmentDoc}
-`;
-export const HubSearchResultFragmentDoc = gql`
-  fragment HubSearchResult on Hub {
-    id
-    nameID
-    displayName
-    context {
+export const SearchResultUserFragmentDoc = gql`
+  fragment SearchResultUser on SearchResultUser {
+    user {
       id
-      tagline
-      visuals {
-        ...VisualUri
+      nameID
+      displayName
+      profile {
+        ...SearchResultProfile
       }
     }
-    tagset {
+  }
+  ${SearchResultProfileFragmentDoc}
+`;
+export const SearchResultOrganizationFragmentDoc = gql`
+  fragment SearchResultOrganization on SearchResultOrganization {
+    organization {
       id
-      tags
+      nameID
+      displayName
+      profile {
+        ...SearchResultProfile
+      }
+    }
+  }
+  ${SearchResultProfileFragmentDoc}
+`;
+export const SearchResultHubFragmentDoc = gql`
+  fragment SearchResultHub on SearchResultHub {
+    hub {
+      id
+      nameID
+      displayName
+      context {
+        id
+        tagline
+        visuals {
+          ...VisualUri
+        }
+      }
+      tagset {
+        id
+        tags
+      }
     }
   }
   ${VisualUriFragmentDoc}
 `;
-export const ChallengeSearchResultFragmentDoc = gql`
-  fragment ChallengeSearchResult on Challenge {
-    id
-    nameID
-    displayName
-    hubID
-    context {
-      id
-      tagline
-      visuals {
-        ...VisualUri
-      }
-    }
-    tagset {
-      id
-      tags
-    }
-  }
-  ${VisualUriFragmentDoc}
-`;
-export const OpportunitySearchResultFragmentDoc = gql`
-  fragment OpportunitySearchResult on Opportunity {
-    id
-    nameID
-    displayName
-    context {
-      id
-      tagline
-      visuals {
-        ...VisualUri
-      }
-    }
-    tagset {
-      id
-      tags
-    }
+export const SearchResultChallengeFragmentDoc = gql`
+  fragment SearchResultChallenge on SearchResultChallenge {
     challenge {
       id
       nameID
       displayName
       hubID
+      context {
+        id
+        tagline
+        visuals {
+          ...VisualUri
+        }
+      }
+      tagset {
+        id
+        tags
+      }
+    }
+    hub {
+      id
+      nameID
+      displayName
+    }
+  }
+  ${VisualUriFragmentDoc}
+`;
+export const SearchResultOpportunityFragmentDoc = gql`
+  fragment SearchResultOpportunity on SearchResultOpportunity {
+    opportunity {
+      id
+      nameID
+      displayName
+      context {
+        id
+        tagline
+        visuals {
+          ...VisualUri
+        }
+      }
+      tagset {
+        id
+        tags
+      }
+      challenge {
+        id
+        nameID
+        displayName
+        hubID
+      }
+    }
+    challenge {
+      id
+      nameID
+      displayName
+    }
+    hub {
+      id
+      nameID
+      displayName
     }
   }
   ${VisualUriFragmentDoc}
@@ -7784,13 +7803,15 @@ export function refetchChallengeExplorerPageQuery(variables: SchemaTypes.Challen
 export const ChallengeExplorerSearchDocument = gql`
   query ChallengeExplorerSearch($searchData: SearchInput!) {
     search(searchData: $searchData) {
-      result {
-        ...ChallengeExplorerSearchResult
-      }
+      id
+      type
       terms
+      ... on SearchResultChallenge {
+        ...SearchResultChallenge
+      }
     }
   }
-  ${ChallengeExplorerSearchResultFragmentDoc}
+  ${SearchResultChallengeFragmentDoc}
 `;
 
 /**
@@ -19139,32 +19160,32 @@ export type UpdatePreferenceOnHubMutationOptions = Apollo.BaseMutationOptions<
 export const SearchDocument = gql`
   query search($searchData: SearchInput!) {
     search(searchData: $searchData) {
+      id
       score
       terms
-      result {
-        ... on User {
-          ...UserSearchResult
-        }
-        ... on Organization {
-          ...OrganizationSearchResult
-        }
-        ... on Hub {
-          ...HubSearchResult
-        }
-        ... on Challenge {
-          ...ChallengeSearchResult
-        }
-        ... on Opportunity {
-          ...OpportunitySearchResult
-        }
+      type
+      ... on SearchResultHub {
+        ...SearchResultHub
+      }
+      ... on SearchResultChallenge {
+        ...SearchResultChallenge
+      }
+      ... on SearchResultOpportunity {
+        ...SearchResultOpportunity
+      }
+      ... on SearchResultUser {
+        ...SearchResultUser
+      }
+      ... on SearchResultOrganization {
+        ...SearchResultOrganization
       }
     }
   }
-  ${UserSearchResultFragmentDoc}
-  ${OrganizationSearchResultFragmentDoc}
-  ${HubSearchResultFragmentDoc}
-  ${ChallengeSearchResultFragmentDoc}
-  ${OpportunitySearchResultFragmentDoc}
+  ${SearchResultHubFragmentDoc}
+  ${SearchResultChallengeFragmentDoc}
+  ${SearchResultOpportunityFragmentDoc}
+  ${SearchResultUserFragmentDoc}
+  ${SearchResultOrganizationFragmentDoc}
 `;
 
 /**

--- a/src/hooks/generated/graphql.ts
+++ b/src/hooks/generated/graphql.ts
@@ -2058,6 +2058,9 @@ export const SearchResultChallengeFragmentDoc = gql`
       id
       nameID
       displayName
+      context {
+        tagline
+      }
     }
   }
   ${VisualUriFragmentDoc}
@@ -2078,12 +2081,6 @@ export const SearchResultOpportunityFragmentDoc = gql`
       tagset {
         id
         tags
-      }
-      challenge {
-        id
-        nameID
-        displayName
-        hubID
       }
     }
     challenge {
@@ -3527,7 +3524,6 @@ export const OpportunityContributionDetailsDocument = gql`
         id
         nameID
         displayName
-        parentId
         parentNameID
         tagset {
           id
@@ -13867,10 +13863,7 @@ export const OpportunityNameIdDocument = gql`
       opportunity(ID: $opportunityId) {
         id
         nameID
-        challenge {
-          id
-          nameID
-        }
+        parentNameID
       }
     }
   }

--- a/src/models/apollo-helpers.ts
+++ b/src/models/apollo-helpers.ts
@@ -1714,15 +1714,93 @@ export type RolesResultOrganizationFieldPolicy = {
   roles?: FieldPolicy<any> | FieldReadFunction<any>;
   userGroups?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SearchResultEntryKeySpecifier = ('result' | 'score' | 'terms' | SearchResultEntryKeySpecifier)[];
-export type SearchResultEntryFieldPolicy = {
-  result?: FieldPolicy<any> | FieldReadFunction<any>;
+export type SearchResultKeySpecifier = ('id' | 'score' | 'terms' | 'type' | SearchResultKeySpecifier)[];
+export type SearchResultFieldPolicy = {
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
   score?: FieldPolicy<any> | FieldReadFunction<any>;
   terms?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SearchableKeySpecifier = ('id' | SearchableKeySpecifier)[];
-export type SearchableFieldPolicy = {
+export type SearchResultBaseKeySpecifier = ('id' | 'score' | 'terms' | 'type' | SearchResultBaseKeySpecifier)[];
+export type SearchResultBaseFieldPolicy = {
   id?: FieldPolicy<any> | FieldReadFunction<any>;
+  score?: FieldPolicy<any> | FieldReadFunction<any>;
+  terms?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type SearchResultChallengeKeySpecifier = (
+  | 'challenge'
+  | 'hub'
+  | 'id'
+  | 'score'
+  | 'terms'
+  | 'type'
+  | SearchResultChallengeKeySpecifier
+)[];
+export type SearchResultChallengeFieldPolicy = {
+  challenge?: FieldPolicy<any> | FieldReadFunction<any>;
+  hub?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  score?: FieldPolicy<any> | FieldReadFunction<any>;
+  terms?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type SearchResultHubKeySpecifier = ('hub' | 'id' | 'score' | 'terms' | 'type' | SearchResultHubKeySpecifier)[];
+export type SearchResultHubFieldPolicy = {
+  hub?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  score?: FieldPolicy<any> | FieldReadFunction<any>;
+  terms?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type SearchResultOpportunityKeySpecifier = (
+  | 'challenge'
+  | 'hub'
+  | 'id'
+  | 'opportunity'
+  | 'score'
+  | 'terms'
+  | 'type'
+  | SearchResultOpportunityKeySpecifier
+)[];
+export type SearchResultOpportunityFieldPolicy = {
+  challenge?: FieldPolicy<any> | FieldReadFunction<any>;
+  hub?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  opportunity?: FieldPolicy<any> | FieldReadFunction<any>;
+  score?: FieldPolicy<any> | FieldReadFunction<any>;
+  terms?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type SearchResultOrganizationKeySpecifier = (
+  | 'id'
+  | 'organization'
+  | 'score'
+  | 'terms'
+  | 'type'
+  | SearchResultOrganizationKeySpecifier
+)[];
+export type SearchResultOrganizationFieldPolicy = {
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  organization?: FieldPolicy<any> | FieldReadFunction<any>;
+  score?: FieldPolicy<any> | FieldReadFunction<any>;
+  terms?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type SearchResultUserKeySpecifier = (
+  | 'id'
+  | 'score'
+  | 'terms'
+  | 'type'
+  | 'user'
+  | SearchResultUserKeySpecifier
+)[];
+export type SearchResultUserFieldPolicy = {
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  score?: FieldPolicy<any> | FieldReadFunction<any>;
+  terms?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
+  user?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type SentryKeySpecifier = ('enabled' | 'endpoint' | 'submitPII' | SentryKeySpecifier)[];
 export type SentryFieldPolicy = {
@@ -2426,13 +2504,33 @@ export type StrictTypedTypePolicies = {
     keyFields?: false | RolesResultOrganizationKeySpecifier | (() => undefined | RolesResultOrganizationKeySpecifier);
     fields?: RolesResultOrganizationFieldPolicy;
   };
-  SearchResultEntry?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
-    keyFields?: false | SearchResultEntryKeySpecifier | (() => undefined | SearchResultEntryKeySpecifier);
-    fields?: SearchResultEntryFieldPolicy;
+  SearchResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | SearchResultKeySpecifier | (() => undefined | SearchResultKeySpecifier);
+    fields?: SearchResultFieldPolicy;
   };
-  Searchable?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
-    keyFields?: false | SearchableKeySpecifier | (() => undefined | SearchableKeySpecifier);
-    fields?: SearchableFieldPolicy;
+  SearchResultBase?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | SearchResultBaseKeySpecifier | (() => undefined | SearchResultBaseKeySpecifier);
+    fields?: SearchResultBaseFieldPolicy;
+  };
+  SearchResultChallenge?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | SearchResultChallengeKeySpecifier | (() => undefined | SearchResultChallengeKeySpecifier);
+    fields?: SearchResultChallengeFieldPolicy;
+  };
+  SearchResultHub?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | SearchResultHubKeySpecifier | (() => undefined | SearchResultHubKeySpecifier);
+    fields?: SearchResultHubFieldPolicy;
+  };
+  SearchResultOpportunity?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | SearchResultOpportunityKeySpecifier | (() => undefined | SearchResultOpportunityKeySpecifier);
+    fields?: SearchResultOpportunityFieldPolicy;
+  };
+  SearchResultOrganization?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | SearchResultOrganizationKeySpecifier | (() => undefined | SearchResultOrganizationKeySpecifier);
+    fields?: SearchResultOrganizationFieldPolicy;
+  };
+  SearchResultUser?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | SearchResultUserKeySpecifier | (() => undefined | SearchResultUserKeySpecifier);
+    fields?: SearchResultUserFieldPolicy;
   };
   Sentry?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | SentryKeySpecifier | (() => undefined | SentryKeySpecifier);

--- a/src/models/apollo-helpers.ts
+++ b/src/models/apollo-helpers.ts
@@ -1280,7 +1280,6 @@ export type NVPFieldPolicy = {
 };
 export type OpportunityKeySpecifier = (
   | 'authorization'
-  | 'challenge'
   | 'collaboration'
   | 'community'
   | 'context'
@@ -1289,7 +1288,6 @@ export type OpportunityKeySpecifier = (
   | 'lifecycle'
   | 'metrics'
   | 'nameID'
-  | 'parentId'
   | 'parentNameID'
   | 'projects'
   | 'tagset'
@@ -1297,7 +1295,6 @@ export type OpportunityKeySpecifier = (
 )[];
 export type OpportunityFieldPolicy = {
   authorization?: FieldPolicy<any> | FieldReadFunction<any>;
-  challenge?: FieldPolicy<any> | FieldReadFunction<any>;
   collaboration?: FieldPolicy<any> | FieldReadFunction<any>;
   community?: FieldPolicy<any> | FieldReadFunction<any>;
   context?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1306,7 +1303,6 @@ export type OpportunityFieldPolicy = {
   lifecycle?: FieldPolicy<any> | FieldReadFunction<any>;
   metrics?: FieldPolicy<any> | FieldReadFunction<any>;
   nameID?: FieldPolicy<any> | FieldReadFunction<any>;
-  parentId?: FieldPolicy<any> | FieldReadFunction<any>;
   parentNameID?: FieldPolicy<any> | FieldReadFunction<any>;
   projects?: FieldPolicy<any> | FieldReadFunction<any>;
   tagset?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/models/graphql-schema.ts
+++ b/src/models/graphql-schema.ts
@@ -2523,8 +2523,6 @@ export type Opportunity = {
   __typename?: 'Opportunity';
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
-  /** The parent Challenge of the Opportunity */
-  challenge?: Maybe<Challenge>;
   /** The collaboration for the Opportunity. */
   collaboration?: Maybe<Collaboration>;
   /** The community for the Opportunity. */
@@ -2541,8 +2539,6 @@ export type Opportunity = {
   metrics?: Maybe<Array<Nvp>>;
   /** A name identifier of the entity, unique within a given scope. */
   nameID: Scalars['NameID'];
-  /** The parent entity (challenge) ID. */
-  parentId?: Maybe<Scalars['String']>;
   /** The parent entity name (challenge) ID. */
   parentNameID?: Maybe<Scalars['String']>;
   /** The set of projects within the context of this Opportunity */
@@ -4484,7 +4480,6 @@ export type OpportunityContributionDetailsQuery = {
       id: string;
       nameID: string;
       displayName: string;
-      parentId?: string | undefined;
       parentNameID?: string | undefined;
       tagset?: { __typename?: 'Tagset'; id: string; name: string; tags: Array<string> } | undefined;
       context?:
@@ -8335,7 +8330,13 @@ export type ChallengeExplorerSearchQuery = {
             | undefined;
           tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
         };
-        hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };
+        hub: {
+          __typename?: 'Hub';
+          id: string;
+          nameID: string;
+          displayName: string;
+          context?: { __typename?: 'Context'; tagline?: string | undefined } | undefined;
+        };
       }
     | { __typename?: 'SearchResultHub'; id: string; type: SearchResultType; terms: Array<string> }
     | { __typename?: 'SearchResultOpportunity'; id: string; type: SearchResultType; terms: Array<string> }
@@ -12307,12 +12308,7 @@ export type OpportunityNameIdQuery = {
     __typename?: 'Hub';
     id: string;
     nameID: string;
-    opportunity: {
-      __typename?: 'Opportunity';
-      id: string;
-      nameID: string;
-      challenge?: { __typename?: 'Challenge'; id: string; nameID: string } | undefined;
-    };
+    opportunity: { __typename?: 'Opportunity'; id: string; nameID: string; parentNameID?: string | undefined };
   };
 };
 
@@ -16551,7 +16547,13 @@ export type SearchQuery = {
             | undefined;
           tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
         };
-        hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };
+        hub: {
+          __typename?: 'Hub';
+          id: string;
+          nameID: string;
+          displayName: string;
+          context?: { __typename?: 'Context'; tagline?: string | undefined } | undefined;
+        };
       }
     | {
         __typename?: 'SearchResultHub';
@@ -16595,9 +16597,6 @@ export type SearchQuery = {
               }
             | undefined;
           tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-          challenge?:
-            | { __typename?: 'Challenge'; id: string; nameID: string; displayName: string; hubID: string }
-            | undefined;
         };
         challenge: { __typename?: 'Challenge'; id: string; nameID: string; displayName: string };
         hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };
@@ -16728,7 +16727,13 @@ export type SearchResultChallengeFragment = {
       | undefined;
     tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
   };
-  hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };
+  hub: {
+    __typename?: 'Hub';
+    id: string;
+    nameID: string;
+    displayName: string;
+    context?: { __typename?: 'Context'; tagline?: string | undefined } | undefined;
+  };
 };
 
 export type SearchResultOpportunityFragment = {
@@ -16747,9 +16752,6 @@ export type SearchResultOpportunityFragment = {
         }
       | undefined;
     tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-    challenge?:
-      | { __typename?: 'Challenge'; id: string; nameID: string; displayName: string; hubID: string }
-      | undefined;
   };
   challenge: { __typename?: 'Challenge'; id: string; nameID: string; displayName: string };
   hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };

--- a/src/models/graphql-schema.ts
+++ b/src/models/graphql-schema.ts
@@ -718,7 +718,7 @@ export type CanvasTemplate = {
   value: Scalars['JSON'];
 };
 
-export type Challenge = Searchable & {
+export type Challenge = {
   __typename?: 'Challenge';
   /** The Agent representing this Challenge. */
   agent?: Maybe<Agent>;
@@ -736,6 +736,7 @@ export type Challenge = Searchable & {
   displayName: Scalars['String'];
   /** The ID of the containing Hub. */
   hubID: Scalars['String'];
+  /** The ID of the entity */
   id: Scalars['UUID'];
   /** The lifeycle for the Challenge. */
   lifecycle?: Maybe<Lifecycle>;
@@ -1551,7 +1552,7 @@ export type Groupable = {
   groups?: Maybe<Array<UserGroup>>;
 };
 
-export type Hub = Searchable & {
+export type Hub = {
   __typename?: 'Hub';
   /** The Agent representing this Hub. */
   agent?: Maybe<Agent>;
@@ -1579,6 +1580,7 @@ export type Hub = Searchable & {
   groupsWithTag: Array<UserGroup>;
   /** The Hub host. */
   host?: Maybe<Organization>;
+  /** The ID of the entity */
   id: Scalars['UUID'];
   /** Metrics about activity within this Hub. */
   metrics?: Maybe<Array<Nvp>>;
@@ -2517,7 +2519,7 @@ export type Nvp = {
   value: Scalars['String'];
 };
 
-export type Opportunity = Searchable & {
+export type Opportunity = {
   __typename?: 'Opportunity';
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
@@ -2531,6 +2533,7 @@ export type Opportunity = Searchable & {
   context?: Maybe<Context>;
   /** The display name. */
   displayName: Scalars['String'];
+  /** The ID of the entity */
   id: Scalars['UUID'];
   /** The lifeycle for the Opportunity. */
   lifecycle?: Maybe<Lifecycle>;
@@ -2573,40 +2576,40 @@ export type OpportunityTemplate = {
   relations?: Maybe<Array<Scalars['String']>>;
 };
 
-export type Organization = Groupable &
-  Searchable & {
-    __typename?: 'Organization';
-    /** The Agent representing this User. */
-    agent?: Maybe<Agent>;
-    /** All Users that are associated with this Organization. */
-    associates?: Maybe<Array<User>>;
-    /** The Authorization for this Organization. */
-    authorization?: Maybe<Authorization>;
-    /** Organization contact email */
-    contactEmail?: Maybe<Scalars['String']>;
-    /** The display name. */
-    displayName: Scalars['String'];
-    /** Domain name; what is verified, eg. alkem.io */
-    domain?: Maybe<Scalars['String']>;
-    /** Group defined on this organization. */
-    group?: Maybe<UserGroup>;
-    /** Groups defined on this organization. */
-    groups?: Maybe<Array<UserGroup>>;
-    id: Scalars['UUID'];
-    /** Legal name - required if hosting an Hub */
-    legalEntityName?: Maybe<Scalars['String']>;
-    /** Metrics about the activity within this Organization. */
-    metrics?: Maybe<Array<Nvp>>;
-    /** A name identifier of the entity, unique within a given scope. */
-    nameID: Scalars['NameID'];
-    /** The preferences for this Organization */
-    preferences: Array<Preference>;
-    /** The profile for this organization. */
-    profile: Profile;
-    verification: OrganizationVerification;
-    /** Organization website */
-    website?: Maybe<Scalars['String']>;
-  };
+export type Organization = Groupable & {
+  __typename?: 'Organization';
+  /** The Agent representing this User. */
+  agent?: Maybe<Agent>;
+  /** All Users that are associated with this Organization. */
+  associates?: Maybe<Array<User>>;
+  /** The Authorization for this Organization. */
+  authorization?: Maybe<Authorization>;
+  /** Organization contact email */
+  contactEmail?: Maybe<Scalars['String']>;
+  /** The display name. */
+  displayName: Scalars['String'];
+  /** Domain name; what is verified, eg. alkem.io */
+  domain?: Maybe<Scalars['String']>;
+  /** Group defined on this organization. */
+  group?: Maybe<UserGroup>;
+  /** Groups defined on this organization. */
+  groups?: Maybe<Array<UserGroup>>;
+  /** The ID of the entity */
+  id: Scalars['UUID'];
+  /** Legal name - required if hosting an Hub */
+  legalEntityName?: Maybe<Scalars['String']>;
+  /** Metrics about the activity within this Organization. */
+  metrics?: Maybe<Array<Nvp>>;
+  /** A name identifier of the entity, unique within a given scope. */
+  nameID: Scalars['NameID'];
+  /** The preferences for this Organization */
+  preferences: Array<Preference>;
+  /** The profile for this organization. */
+  profile: Profile;
+  verification: OrganizationVerification;
+  /** Organization website */
+  website?: Maybe<Scalars['String']>;
+};
 
 export type OrganizationGroupArgs = {
   ID: Scalars['UUID'];
@@ -2876,7 +2879,7 @@ export type Query = {
   /** The roles that that the specified User has. */
   rolesUser: ContributorRoles;
   /** Search the hub for terms supplied */
-  search: Array<SearchResultEntry>;
+  search: Array<SearchResult>;
   /** A particular user, identified by the ID or by email */
   user: User;
   /** Privileges assigned to a User (based on held credentials) given an Authorization defnition. */
@@ -3010,7 +3013,7 @@ export type Relation = {
   type: Scalars['String'];
 };
 
-export type RelayPaginatedUser = Searchable & {
+export type RelayPaginatedUser = {
   __typename?: 'RelayPaginatedUser';
   /** The unique personal identifier (upn) for the account associated with this user profile */
   accountUpn: Scalars['String'];
@@ -3028,6 +3031,7 @@ export type RelayPaginatedUser = Searchable & {
   email: Scalars['String'];
   firstName: Scalars['String'];
   gender: Scalars['String'];
+  /** The ID of the entity */
   id: Scalars['UUID'];
   lastName: Scalars['String'];
   /** A name identifier of the entity, unique within a given scope. */
@@ -3219,18 +3223,106 @@ export type SearchInput = {
   typesFilter?: InputMaybe<Array<Scalars['String']>>;
 };
 
-export type SearchResultEntry = {
-  __typename?: 'SearchResultEntry';
-  /** Each search result contains either a User, UserGroup or Organization */
-  result?: Maybe<Searchable>;
+export type SearchResult = {
+  id: Scalars['UUID'];
   /** The score for this search result; more matches means a higher score. */
-  score?: Maybe<Scalars['Float']>;
+  score: Scalars['Float'];
   /** The terms that were matched for this result */
-  terms?: Maybe<Array<Scalars['String']>>;
+  terms: Array<Scalars['String']>;
+  /** The event type for this Activity. */
+  type: SearchResultType;
 };
 
-export type Searchable = {
+export type SearchResultBase = SearchResult & {
+  __typename?: 'SearchResultBase';
+  /** The unique identifier for this search result. */
   id: Scalars['UUID'];
+  /** The score for this search result; more matches means a higher score. */
+  score: Scalars['Float'];
+  /** The terms that were matched for this result */
+  terms: Array<Scalars['String']>;
+  /** The event type for this Activity. */
+  type: SearchResultType;
+};
+
+export type SearchResultChallenge = SearchResult & {
+  __typename?: 'SearchResultChallenge';
+  /** The Challenge that was found. */
+  challenge: Challenge;
+  /** The Hub that the Challenge is in. */
+  hub: Hub;
+  id: Scalars['UUID'];
+  /** The score for this search result; more matches means a higher score. */
+  score: Scalars['Float'];
+  /** The terms that were matched for this result */
+  terms: Array<Scalars['String']>;
+  /** The event type for this Activity. */
+  type: SearchResultType;
+};
+
+export type SearchResultHub = SearchResult & {
+  __typename?: 'SearchResultHub';
+  /** The Hub that was found. */
+  hub: Hub;
+  id: Scalars['UUID'];
+  /** The score for this search result; more matches means a higher score. */
+  score: Scalars['Float'];
+  /** The terms that were matched for this result */
+  terms: Array<Scalars['String']>;
+  /** The event type for this Activity. */
+  type: SearchResultType;
+};
+
+export type SearchResultOpportunity = SearchResult & {
+  __typename?: 'SearchResultOpportunity';
+  /** The Challenge that the Opportunity is in. */
+  challenge: Challenge;
+  /** The Hub that the Opportunity is in. */
+  hub: Hub;
+  id: Scalars['UUID'];
+  /** The Opportunity that was found. */
+  opportunity: Opportunity;
+  /** The score for this search result; more matches means a higher score. */
+  score: Scalars['Float'];
+  /** The terms that were matched for this result */
+  terms: Array<Scalars['String']>;
+  /** The event type for this Activity. */
+  type: SearchResultType;
+};
+
+export type SearchResultOrganization = SearchResult & {
+  __typename?: 'SearchResultOrganization';
+  id: Scalars['UUID'];
+  /** The Organization that was found. */
+  organization: Organization;
+  /** The score for this search result; more matches means a higher score. */
+  score: Scalars['Float'];
+  /** The terms that were matched for this result */
+  terms: Array<Scalars['String']>;
+  /** The event type for this Activity. */
+  type: SearchResultType;
+};
+
+export enum SearchResultType {
+  Challenge = 'CHALLENGE',
+  Hub = 'HUB',
+  Opportunity = 'OPPORTUNITY',
+  Organization = 'ORGANIZATION',
+  User = 'USER',
+  Usergroup = 'USERGROUP',
+}
+
+export type SearchResultUser = SearchResult & {
+  __typename?: 'SearchResultUser';
+  id: Scalars['UUID'];
+  /** The score for this search result; more matches means a higher score. */
+  score: Scalars['Float'];
+  /** The terms that were matched for this result */
+  terms: Array<Scalars['String']>;
+  /** The event type for this Activity. */
+  type: SearchResultType;
+  /** The User that was found. */
+  user: User;
 };
 
 export type SendMessageOnCalloutInput = {
@@ -3707,7 +3799,7 @@ export type UpdatesSendMessageInput = {
   updatesID: Scalars['UUID'];
 };
 
-export type User = Searchable & {
+export type User = {
   __typename?: 'User';
   /** The unique personal identifier (upn) for the account associated with this user profile */
   accountUpn: Scalars['String'];
@@ -3725,6 +3817,7 @@ export type User = Searchable & {
   email: Scalars['String'];
   firstName: Scalars['String'];
   gender: Scalars['String'];
+  /** The ID of the entity */
   id: Scalars['UUID'];
   lastName: Scalars['String'];
   /** A name identifier of the entity, unique within a given scope. */
@@ -3755,10 +3848,11 @@ export type UserFilterInput = {
   lastName?: InputMaybe<Scalars['String']>;
 };
 
-export type UserGroup = Searchable & {
+export type UserGroup = {
   __typename?: 'UserGroup';
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
+  /** The ID of the entity */
   id: Scalars['UUID'];
   /** The Users that are members of this User Group. */
   members?: Maybe<Array<User>>;
@@ -8218,22 +8312,37 @@ export type ChallengeExplorerSearchQueryVariables = Exact<{
 
 export type ChallengeExplorerSearchQuery = {
   __typename?: 'Query';
-  search: Array<{
-    __typename?: 'SearchResultEntry';
-    terms?: Array<string> | undefined;
-    result?:
-      | { __typename?: 'Challenge'; id: string; hubID: string }
-      | { __typename?: 'Hub' }
-      | { __typename?: 'Opportunity' }
-      | { __typename?: 'Organization' }
-      | { __typename?: 'RelayPaginatedUser' }
-      | { __typename?: 'User' }
-      | { __typename?: 'UserGroup' }
-      | undefined;
-  }>;
+  search: Array<
+    | { __typename?: 'SearchResultBase'; id: string; type: SearchResultType; terms: Array<string> }
+    | {
+        __typename?: 'SearchResultChallenge';
+        id: string;
+        type: SearchResultType;
+        terms: Array<string>;
+        challenge: {
+          __typename?: 'Challenge';
+          id: string;
+          nameID: string;
+          displayName: string;
+          hubID: string;
+          context?:
+            | {
+                __typename?: 'Context';
+                id: string;
+                tagline?: string | undefined;
+                visuals?: Array<{ __typename?: 'Visual'; id: string; uri: string; name: string }> | undefined;
+              }
+            | undefined;
+          tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+        };
+        hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };
+      }
+    | { __typename?: 'SearchResultHub'; id: string; type: SearchResultType; terms: Array<string> }
+    | { __typename?: 'SearchResultOpportunity'; id: string; type: SearchResultType; terms: Array<string> }
+    | { __typename?: 'SearchResultOrganization'; id: string; type: SearchResultType; terms: Array<string> }
+    | { __typename?: 'SearchResultUser'; id: string; type: SearchResultType; terms: Array<string> }
+  >;
 };
-
-export type ChallengeExplorerSearchResultFragment = { __typename?: 'Challenge'; id: string; hubID: string };
 
 export type ChallengeExplorerDataQueryVariables = Exact<{
   hubIDs?: InputMaybe<Array<Scalars['UUID']> | Scalars['UUID']>;
@@ -16418,12 +16527,15 @@ export type SearchQueryVariables = Exact<{
 
 export type SearchQuery = {
   __typename?: 'Query';
-  search: Array<{
-    __typename?: 'SearchResultEntry';
-    score?: number | undefined;
-    terms?: Array<string> | undefined;
-    result?:
-      | {
+  search: Array<
+    | { __typename?: 'SearchResultBase'; id: string; score: number; terms: Array<string>; type: SearchResultType }
+    | {
+        __typename?: 'SearchResultChallenge';
+        id: string;
+        score: number;
+        terms: Array<string>;
+        type: SearchResultType;
+        challenge: {
           __typename?: 'Challenge';
           id: string;
           nameID: string;
@@ -16438,8 +16550,16 @@ export type SearchQuery = {
               }
             | undefined;
           tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-        }
-      | {
+        };
+        hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };
+      }
+    | {
+        __typename?: 'SearchResultHub';
+        id: string;
+        score: number;
+        terms: Array<string>;
+        type: SearchResultType;
+        hub: {
           __typename?: 'Hub';
           id: string;
           nameID: string;
@@ -16453,8 +16573,15 @@ export type SearchQuery = {
               }
             | undefined;
           tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-        }
-      | {
+        };
+      }
+    | {
+        __typename?: 'SearchResultOpportunity';
+        id: string;
+        score: number;
+        terms: Array<string>;
+        type: SearchResultType;
+        opportunity: {
           __typename?: 'Opportunity';
           id: string;
           nameID: string;
@@ -16471,22 +16598,37 @@ export type SearchQuery = {
           challenge?:
             | { __typename?: 'Challenge'; id: string; nameID: string; displayName: string; hubID: string }
             | undefined;
-        }
-      | {
+        };
+        challenge: { __typename?: 'Challenge'; id: string; nameID: string; displayName: string };
+        hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };
+      }
+    | {
+        __typename?: 'SearchResultOrganization';
+        id: string;
+        score: number;
+        terms: Array<string>;
+        type: SearchResultType;
+        organization: {
           __typename?: 'Organization';
           id: string;
           nameID: string;
           displayName: string;
-          profile_: {
+          profile: {
             __typename?: 'Profile';
             id: string;
             location?: { __typename?: 'Location'; id: string; country: string; city: string } | undefined;
             tagsets?: Array<{ __typename?: 'Tagset'; id: string; tags: Array<string> }> | undefined;
             avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
           };
-        }
-      | { __typename?: 'RelayPaginatedUser' }
-      | {
+        };
+      }
+    | {
+        __typename?: 'SearchResultUser';
+        id: string;
+        score: number;
+        terms: Array<string>;
+        type: SearchResultType;
+        user: {
           __typename?: 'User';
           id: string;
           nameID: string;
@@ -16500,43 +16642,48 @@ export type SearchQuery = {
                 avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
               }
             | undefined;
-        }
-      | { __typename?: 'UserGroup' }
-      | undefined;
-  }>;
-};
-
-export type UserSearchResultFragment = {
-  __typename?: 'User';
-  id: string;
-  nameID: string;
-  displayName: string;
-  profile?:
-    | {
-        __typename?: 'Profile';
-        id: string;
-        location?: { __typename?: 'Location'; id: string; country: string; city: string } | undefined;
-        tagsets?: Array<{ __typename?: 'Tagset'; id: string; tags: Array<string> }> | undefined;
-        avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+        };
       }
-    | undefined;
+  >;
 };
 
-export type OrganizationSearchResultFragment = {
-  __typename?: 'Organization';
-  id: string;
-  nameID: string;
-  displayName: string;
-  profile_: {
-    __typename?: 'Profile';
+export type SearchResultUserFragment = {
+  __typename?: 'SearchResultUser';
+  user: {
+    __typename?: 'User';
     id: string;
-    location?: { __typename?: 'Location'; id: string; country: string; city: string } | undefined;
-    tagsets?: Array<{ __typename?: 'Tagset'; id: string; tags: Array<string> }> | undefined;
-    avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+    nameID: string;
+    displayName: string;
+    profile?:
+      | {
+          __typename?: 'Profile';
+          id: string;
+          location?: { __typename?: 'Location'; id: string; country: string; city: string } | undefined;
+          tagsets?: Array<{ __typename?: 'Tagset'; id: string; tags: Array<string> }> | undefined;
+          avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+        }
+      | undefined;
   };
 };
 
-export type ProfileSearchResultFragment = {
+export type SearchResultOrganizationFragment = {
+  __typename?: 'SearchResultOrganization';
+  organization: {
+    __typename?: 'Organization';
+    id: string;
+    nameID: string;
+    displayName: string;
+    profile: {
+      __typename?: 'Profile';
+      id: string;
+      location?: { __typename?: 'Location'; id: string; country: string; city: string } | undefined;
+      tagsets?: Array<{ __typename?: 'Tagset'; id: string; tags: Array<string> }> | undefined;
+      avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+    };
+  };
+};
+
+export type SearchResultProfileFragment = {
   __typename?: 'Profile';
   id: string;
   location?: { __typename?: 'Location'; id: string; country: string; city: string } | undefined;
@@ -16544,54 +16691,68 @@ export type ProfileSearchResultFragment = {
   avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
 };
 
-export type HubSearchResultFragment = {
-  __typename?: 'Hub';
-  id: string;
-  nameID: string;
-  displayName: string;
-  context?:
-    | {
-        __typename?: 'Context';
-        id: string;
-        tagline?: string | undefined;
-        visuals?: Array<{ __typename?: 'Visual'; id: string; uri: string; name: string }> | undefined;
-      }
-    | undefined;
-  tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+export type SearchResultHubFragment = {
+  __typename?: 'SearchResultHub';
+  hub: {
+    __typename?: 'Hub';
+    id: string;
+    nameID: string;
+    displayName: string;
+    context?:
+      | {
+          __typename?: 'Context';
+          id: string;
+          tagline?: string | undefined;
+          visuals?: Array<{ __typename?: 'Visual'; id: string; uri: string; name: string }> | undefined;
+        }
+      | undefined;
+    tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+  };
 };
 
-export type ChallengeSearchResultFragment = {
-  __typename?: 'Challenge';
-  id: string;
-  nameID: string;
-  displayName: string;
-  hubID: string;
-  context?:
-    | {
-        __typename?: 'Context';
-        id: string;
-        tagline?: string | undefined;
-        visuals?: Array<{ __typename?: 'Visual'; id: string; uri: string; name: string }> | undefined;
-      }
-    | undefined;
-  tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+export type SearchResultChallengeFragment = {
+  __typename?: 'SearchResultChallenge';
+  challenge: {
+    __typename?: 'Challenge';
+    id: string;
+    nameID: string;
+    displayName: string;
+    hubID: string;
+    context?:
+      | {
+          __typename?: 'Context';
+          id: string;
+          tagline?: string | undefined;
+          visuals?: Array<{ __typename?: 'Visual'; id: string; uri: string; name: string }> | undefined;
+        }
+      | undefined;
+    tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+  };
+  hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };
 };
 
-export type OpportunitySearchResultFragment = {
-  __typename?: 'Opportunity';
-  id: string;
-  nameID: string;
-  displayName: string;
-  context?:
-    | {
-        __typename?: 'Context';
-        id: string;
-        tagline?: string | undefined;
-        visuals?: Array<{ __typename?: 'Visual'; id: string; uri: string; name: string }> | undefined;
-      }
-    | undefined;
-  tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-  challenge?: { __typename?: 'Challenge'; id: string; nameID: string; displayName: string; hubID: string } | undefined;
+export type SearchResultOpportunityFragment = {
+  __typename?: 'SearchResultOpportunity';
+  opportunity: {
+    __typename?: 'Opportunity';
+    id: string;
+    nameID: string;
+    displayName: string;
+    context?:
+      | {
+          __typename?: 'Context';
+          id: string;
+          tagline?: string | undefined;
+          visuals?: Array<{ __typename?: 'Visual'; id: string; uri: string; name: string }> | undefined;
+        }
+      | undefined;
+    tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+    challenge?:
+      | { __typename?: 'Challenge'; id: string; nameID: string; displayName: string; hubID: string }
+      | undefined;
+  };
+  challenge: { __typename?: 'Challenge'; id: string; nameID: string; displayName: string };
+  hub: { __typename?: 'Hub'; id: string; nameID: string; displayName: string };
 };
 
 export type UserRolesSearchCardsQueryVariables = Exact<{

--- a/src/pages/Search/SearchQueries.graphql
+++ b/src/pages/Search/SearchQueries.graphql
@@ -1,46 +1,50 @@
 query search($searchData: SearchInput!) {
   search(searchData: $searchData) {
+    id
     score
     terms
-    result {
-      ... on User {
-        ...UserSearchResult
-      }
-      ... on Organization {
-        ...OrganizationSearchResult
-      }
-      ... on Hub {
-        ...HubSearchResult
-      }
-      ... on Challenge {
-        ...ChallengeSearchResult
-      }
-      ... on Opportunity {
-        ...OpportunitySearchResult
-      }
+    type
+    ... on SearchResultHub {
+      ...SearchResultHub
+    }
+    ... on SearchResultChallenge {
+      ...SearchResultChallenge
+    }
+    ... on SearchResultOpportunity {
+      ...SearchResultOpportunity
+    }
+    ... on SearchResultUser {
+      ...SearchResultUser
+    }
+    ... on SearchResultOrganization {
+      ...SearchResultOrganization
     }
   }
 }
 
-fragment UserSearchResult on User {
-  id
-  nameID
-  displayName
-  profile {
-    ...ProfileSearchResult
+fragment SearchResultUser on SearchResultUser {
+  user {
+    id
+    nameID
+    displayName
+    profile {
+      ...SearchResultProfile
+    }
   }
 }
 
-fragment OrganizationSearchResult on Organization {
-  id
-  nameID
-  displayName
-  profile_: profile {
-    ...ProfileSearchResult
+fragment SearchResultOrganization on SearchResultOrganization {
+  organization {
+    id
+    nameID
+    displayName
+    profile {
+      ...SearchResultProfile
+    }
   }
 }
 
-fragment ProfileSearchResult on Profile {
+fragment SearchResultProfile on Profile {
   id
   location {
     id
@@ -56,62 +60,82 @@ fragment ProfileSearchResult on Profile {
   }
 }
 
-fragment HubSearchResult on Hub {
-  id
-  nameID
-  displayName
-  context {
+fragment SearchResultHub on SearchResultHub {
+  hub {
     id
-    tagline
-    visuals {
-      ...VisualUri
+    nameID
+    displayName
+    context {
+      id
+      tagline
+      visuals {
+        ...VisualUri
+      }
     }
-  }
-  tagset {
-    id
-    tags
+    tagset {
+      id
+      tags
+    }
   }
 }
 
-fragment ChallengeSearchResult on Challenge {
-  id
-  nameID
-  displayName
-  hubID
-  context {
-    id
-    tagline
-    visuals {
-      ...VisualUri
-    }
-  }
-  tagset {
-    id
-    tags
-  }
-}
-
-
-fragment OpportunitySearchResult on Opportunity {
-  id
-  nameID
-  displayName
-  context {
-    id
-    tagline
-    visuals {
-      ...VisualUri
-    }
-  }
-  tagset {
-    id
-    tags
-  }
+fragment SearchResultChallenge on SearchResultChallenge {
   challenge {
     id
     nameID
     displayName
     hubID
+    context {
+      id
+      tagline
+      visuals {
+        ...VisualUri
+      }
+    }
+    tagset {
+      id
+      tags
+    }
+  }
+  hub {
+    id
+    nameID
+    displayName
+  }
+}
+
+fragment SearchResultOpportunity on SearchResultOpportunity {
+  opportunity {
+    id
+    nameID
+    displayName
+    context {
+      id
+      tagline
+      visuals {
+        ...VisualUri
+      }
+    }
+    tagset {
+      id
+      tags
+    }
+    challenge {
+      id
+      nameID
+      displayName
+      hubID
+    }
+  }
+  challenge {
+    id
+    nameID
+    displayName
+  }
+  hub {
+    id
+    nameID
+    displayName
   }
 }
 

--- a/src/pages/Search/SearchQueries.graphql
+++ b/src/pages/Search/SearchQueries.graphql
@@ -101,6 +101,9 @@ fragment SearchResultChallenge on SearchResultChallenge {
     id
     nameID
     displayName
+    context {
+      tagline
+    }
   }
 }
 
@@ -119,12 +122,6 @@ fragment SearchResultOpportunity on SearchResultOpportunity {
     tagset {
       id
       tags
-    }
-    challenge {
-      id
-      nameID
-      displayName
-      hubID
     }
   }
   challenge {

--- a/src/pages/Search/SearchResultCardChooser.tsx
+++ b/src/pages/Search/SearchResultCardChooser.tsx
@@ -1,32 +1,35 @@
 import React from 'react';
 import Skeleton from '@mui/material/Skeleton';
-import { SearchResultType } from './SearchPage';
 import { useHydrateCard } from './hooks/useHydratedCard';
+import { SearchResultMetaType } from './SearchPage';
+import { SearchResultType } from '../../models/graphql-schema';
 
-const SearchResultCardChooser = ({ result }: { result: SearchResultType | undefined }): React.ReactElement | null => {
+const SearchResultCardChooser = ({
+  result,
+}: {
+  result: SearchResultMetaType | undefined;
+}): React.ReactElement | null => {
   const { hydrateHubCard, hydrateChallengeCard, hydrateOpportunityCard, hydrateUserCard, hydrateOrganizationCard } =
     useHydrateCard(result);
 
-  if (!result || !result.__typename) {
+  if (!result || !result.type) {
     return (
       <Skeleton sx={theme => ({ width: theme.cards.search.width, height: theme.cards.search.contributor.height })} />
     );
   }
 
-  const cardDict: Record<NonNullable<SearchResultType['__typename']>, React.ReactElement | null> = {
-    Hub: hydrateHubCard(),
-    Challenge: hydrateChallengeCard(),
-    Opportunity: hydrateOpportunityCard(),
-    User: hydrateUserCard(),
-    Organization: hydrateOrganizationCard(),
-  };
-
-  const card = cardDict[result.__typename];
-
-  if (card === undefined) {
-    throw new Error(`Unrecognized result typename: ${result.__typename}`);
+  switch (result.type) {
+    case SearchResultType.Hub:
+      return hydrateHubCard();
+    case SearchResultType.Challenge:
+      return hydrateChallengeCard();
+    case SearchResultType.Opportunity:
+      return hydrateOpportunityCard();
+    case SearchResultType.User:
+      return hydrateUserCard();
+    case SearchResultType.Organization:
+      return hydrateOrganizationCard();
   }
-
-  return card;
+  throw new Error(`Unrecognized result typename: ${result.__typename}`);
 };
 export default SearchResultCardChooser;

--- a/src/pages/Search/SearchResultSection.tsx
+++ b/src/pages/Search/SearchResultSection.tsx
@@ -2,13 +2,13 @@ import { FilterConfig, FilterDefinition } from './Filter';
 import React, { FC, useMemo, useState } from 'react';
 import DashboardGenericSection from '../../domain/shared/components/DashboardSections/DashboardGenericSection';
 import { EntityFilter } from './EntityFilter';
-import { SearchResultType } from './SearchPage';
 import CardsLayout from '../../domain/shared/layout/CardsLayout/CardsLayout';
 import SearchResultCardChooser from './SearchResultCardChooser';
+import { SearchResultMetaType } from './SearchPage';
 
 interface ResultSectionProps {
   title: string;
-  results: SearchResultType[] | undefined;
+  results: SearchResultMetaType[] | undefined;
   filterConfig: FilterConfig;
   onFilterChange: (value: FilterDefinition['value']) => void;
   loading?: boolean;

--- a/src/pages/Search/hooks/useHydratedCard.tsx
+++ b/src/pages/Search/hooks/useHydratedCard.tsx
@@ -1,11 +1,10 @@
-import { SearchResultType, SearchResult } from '../SearchPage';
 import {
-  ChallengeSearchResultFragment,
-  HubSearchResultFragment,
-  OpportunitySearchResultFragment,
-  OrganizationSearchResultFragment,
+  SearchResultChallengeFragment,
+  SearchResultHubFragment,
+  SearchResultOpportunityFragment,
+  SearchResultOrganizationFragment,
+  SearchResultUserFragment,
   UserRolesSearchCardsQuery,
-  UserSearchResultFragment,
 } from '../../../models/graphql-schema';
 import React from 'react';
 import {
@@ -24,20 +23,25 @@ import {
 } from '../../../domain/shared/components/search-cards';
 import { RoleType } from '../../../domain/community/contributor/user/constants/RoleType';
 import { getVisualBanner } from '../../../common/utils/visuals.utils';
-import { useHubNameQuery, useUserRolesSearchCardsQuery } from '../../../hooks/generated/graphql';
+import { useUserRolesSearchCardsQuery } from '../../../hooks/generated/graphql';
 import { useUserContext } from '../../../domain/community/contributor/user/hooks/useUserContext';
+import { SearchResultMetaType, SearchResultT } from '../SearchPage';
 
-const _hydrateUserCard = (data: SearchResult<UserSearchResultFragment>): React.ReactElement => {
+const _hydrateUserCard = (data: SearchResultT<SearchResultUserFragment>) => {
+  if (!data?.user) {
+    return null;
+  }
+  const user = data.user;
   // todo extract in func
-  const profile = data?.profile;
+  const profile = user.profile;
   const image = profile?.avatar?.uri;
   const { country, city } = profile?.location ?? {};
-  const url = buildUserProfileUrl(data.nameID);
+  const url = buildUserProfileUrl(user.nameID);
 
   return (
     <SearchUserCard
       image={image}
-      name={data.displayName}
+      name={user.displayName}
       country={country}
       city={city}
       matchedTerms={data.terms}
@@ -47,23 +51,27 @@ const _hydrateUserCard = (data: SearchResult<UserSearchResultFragment>): React.R
 };
 
 const _hydrateOrganizationCard = (
-  data: SearchResult<OrganizationSearchResultFragment>,
+  data: SearchResultT<SearchResultOrganizationFragment>,
   userRoles: UserRolesSearchCardsQuery['rolesUser'] | undefined
 ) => {
+  if (!data?.organization) {
+    return null;
+  }
+  const organization = data.organization;
   // todo extract in func
-  const profile = data.profile_;
+  const profile = data.organization.profile;
   const image = profile?.avatar?.uri;
   const { country, city } = profile?.location ?? {};
-  const url = buildOrganizationUrl(data.nameID);
+  const url = buildOrganizationUrl(organization.nameID);
 
-  const organizationRoles = userRoles?.organizations.find(x => x.id === data.id);
+  const organizationRoles = userRoles?.organizations.find(x => x.id === organization.id);
   const label = organizationRoles?.roles.find(x => x === RoleType.Associate);
 
   return (
     <SearchOrganizationCard
       image={image}
       label={label}
-      name={data.displayName}
+      name={organization.displayName}
       country={country}
       city={city}
       matchedTerms={data.terms}
@@ -73,15 +81,19 @@ const _hydrateOrganizationCard = (
 };
 
 const _hydrateHubCard = (
-  data: SearchResult<HubSearchResultFragment>,
+  data: SearchResultT<SearchResultHubFragment>,
   userRoles: UserRolesSearchCardsQuery['rolesUser'] | undefined
 ) => {
-  const context = data.context;
+  if (!data?.hub) {
+    return null;
+  }
+  const hub = data.hub;
+  const context = hub.context;
   const tagline = context?.tagline;
   const image = getVisualBanner(context?.visuals);
-  const name = data.displayName;
+  const name = hub.displayName;
   const matchedTerms = data.terms;
-  const url = buildHubUrl(data.nameID);
+  const url = buildHubUrl(hub.nameID);
 
   const hubRoles = userRoles?.hubs.find(x => x.id === data.id);
   const label =
@@ -95,35 +107,26 @@ const _hydrateHubCard = (
 };
 
 const useHydrateChallengeCard = (
-  data: SearchResult<ChallengeSearchResultFragment> | undefined,
+  data: SearchResultT<SearchResultChallengeFragment> | undefined,
   userRoles: UserRolesSearchCardsQuery['rolesUser'] | undefined,
   skip: boolean
 ) => {
-  const context = data?.context;
+  if (skip || !data?.challenge || !data?.hub) {
+    return null;
+  }
+  const challenge = data.challenge;
+  const containingHub = data.hub;
+  const context = challenge.context;
   const tagline = context?.tagline;
   const image = getVisualBanner(context?.visuals);
-  const name = data?.displayName;
+  const name = challenge.displayName;
   const matchedTerms = data?.terms ?? [];
-  const hubId = data?.hubID;
-  const nameID = data?.nameID;
+  const hubId = containingHub.id;
+  const hubNameId = containingHub.nameID;
+  const hubDisplayName = containingHub.displayName;
 
-  const { data: hubData } = useHubNameQuery({
-    variables: {
-      hubId: hubId!,
-    },
-    skip: !hubId || skip,
-  });
+  const nameID = challenge.nameID;
 
-  if (skip) {
-    return null;
-  }
-
-  if (!hubData || !name || !nameID) {
-    return null;
-  }
-
-  const hubNameId = hubData.hub.nameID;
-  const hubDisplayName = hubData.hub.displayName;
   const url = buildChallengeUrl(hubNameId, nameID);
 
   const challengeRoles = userRoles?.hubs.find(x => x.id === hubId)?.challenges.find(x => x.id === data?.id);
@@ -145,42 +148,30 @@ const useHydrateChallengeCard = (
 };
 
 const useHydrateOpportunityCard = (
-  data: SearchResult<OpportunitySearchResultFragment> | undefined,
+  data: SearchResultT<SearchResultOpportunityFragment> | undefined,
   userRoles: UserRolesSearchCardsQuery['rolesUser'] | undefined,
   skip: boolean
 ) => {
-  const context = data?.context;
+  if (skip || !data?.opportunity) {
+    return null;
+  }
+  const opportunity = data.opportunity;
+  const containingChallenge = data.challenge;
+  const containingHub = data.hub;
+  const context = opportunity.context;
   const tagline = context?.tagline;
   const image = getVisualBanner(context?.visuals);
-  const name = data?.displayName;
+  const name = opportunity.displayName;
   const matchedTerms = data?.terms ?? [];
-  const challengeNameId = data?.challenge?.nameID;
-  const challengeDisplayName = data?.challenge?.displayName;
-  const hubId = data?.challenge?.hubID;
-  const nameID = data?.nameID;
+  const challengeNameId = containingChallenge.nameID;
+  const challengeDisplayName = containingChallenge.displayName;
+  const hubId = containingHub.id;
+  const hubNameID = containingHub.nameID;
+  const nameID = opportunity.nameID;
 
-  const { data: hubData } = useHubNameQuery({
-    variables: {
-      hubId: hubId!,
-    },
-    skip: !hubId || skip,
-  });
+  const url = buildOpportunityUrl(hubNameID, challengeNameId, nameID);
 
-  if (skip) {
-    return null;
-  }
-
-  if (!hubData || !challengeNameId || !name || !nameID || !challengeDisplayName) {
-    return null;
-  }
-
-  const hubNameId = hubData.hub.nameID;
-
-  const url = buildOpportunityUrl(hubNameId, challengeNameId, nameID);
-
-  const opportunityRoles = userRoles?.hubs
-    .find(x => x.id === data?.challenge?.hubID)
-    ?.opportunities.find(x => x.id === data?.id);
+  const opportunityRoles = userRoles?.hubs.find(x => x.id === hubId)?.opportunities.find(x => x.id === data?.id);
 
   const label =
     opportunityRoles?.roles.find(x => x === RoleType.Lead) || opportunityRoles?.roles.find(x => x === RoleType.Member);
@@ -198,7 +189,7 @@ const useHydrateOpportunityCard = (
   );
 };
 
-export const useHydrateCard = (result: SearchResultType | undefined) => {
+export const useHydrateCard = (result: SearchResultMetaType | undefined) => {
   const { user: userMetadata } = useUserContext();
   const userId = userMetadata?.user?.id;
 
@@ -210,22 +201,22 @@ export const useHydrateCard = (result: SearchResultType | undefined) => {
   });
   const userRoles = rolesData?.rolesUser;
 
-  const hydrateUserCard = () => _hydrateUserCard(result as SearchResult<UserSearchResultFragment>);
+  const hydrateUserCard = () => _hydrateUserCard(result as SearchResultT<SearchResultUserFragment>);
 
   const hydrateOrganizationCard = () =>
-    _hydrateOrganizationCard(result as SearchResult<OrganizationSearchResultFragment>, userRoles);
+    _hydrateOrganizationCard(result as SearchResultT<SearchResultOrganizationFragment>, userRoles);
 
-  const hydrateHubCard = () => _hydrateHubCard(result as SearchResult<HubSearchResultFragment>, userRoles);
+  const hydrateHubCard = () => _hydrateHubCard(result as SearchResultT<SearchResultHubFragment>, userRoles);
 
   const hydrateChallengeCardResult = useHydrateChallengeCard(
-    result as SearchResult<ChallengeSearchResultFragment>,
+    result as SearchResultT<SearchResultChallengeFragment>,
     userRoles,
     !result || !result['hubID']
   );
   const hydrateChallengeCard = () => hydrateChallengeCardResult;
 
   const hydrateOpportunityCardResult = useHydrateOpportunityCard(
-    result as SearchResult<OpportunitySearchResultFragment>,
+    result as SearchResultT<SearchResultOpportunityFragment>,
     userRoles,
     !result || !result['challenge']
   );


### PR DESCRIPTION
Results are now strongly typed per search result type, with additional information directly available. 

This means a lot of follow up queries to the server, e.g. for the hub displayName are no longer needed. This both reduces the code as well as improves the response times for end users

challengesPage: now that challengeSearch results can query the whole hub, then could also remove a second call up for data for the challenges search results. 