### PR TITLE
Obtain applicationForm questions from Community entity

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -660,9 +660,8 @@ export type ChallengeCreatedFieldPolicy = {
   challenge?: FieldPolicy<any> | FieldReadFunction<any>;
   hubID?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ChallengeTemplateKeySpecifier = ('applications' | 'feedback' | 'name' | ChallengeTemplateKeySpecifier)[];
+export type ChallengeTemplateKeySpecifier = ('feedback' | 'name' | ChallengeTemplateKeySpecifier)[];
 export type ChallengeTemplateFieldPolicy = {
-  applications?: FieldPolicy<any> | FieldReadFunction<any>;
   feedback?: FieldPolicy<any> | FieldReadFunction<any>;
   name?: FieldPolicy<any> | FieldReadFunction<any>;
 };
@@ -776,6 +775,7 @@ export type CommunicationUpdateMessageReceivedFieldPolicy = {
   updatesID?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CommunityKeySpecifier = (
+  | 'applicationForm'
   | 'applications'
   | 'authorization'
   | 'availableLeadUsers'
@@ -792,6 +792,7 @@ export type CommunityKeySpecifier = (
   | CommunityKeySpecifier
 )[];
 export type CommunityFieldPolicy = {
+  applicationForm?: FieldPolicy<any> | FieldReadFunction<any>;
   applications?: FieldPolicy<any> | FieldReadFunction<any>;
   authorization?: FieldPolicy<any> | FieldReadFunction<any>;
   availableLeadUsers?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -975,6 +976,27 @@ export type FileStorageConfigKeySpecifier = ('maxFileSize' | 'mimeTypes' | FileS
 export type FileStorageConfigFieldPolicy = {
   maxFileSize?: FieldPolicy<any> | FieldReadFunction<any>;
   mimeTypes?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type FormKeySpecifier = ('description' | 'id' | 'questions' | FormKeySpecifier)[];
+export type FormFieldPolicy = {
+  description?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  questions?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type FormQuestionKeySpecifier = (
+  | 'explanation'
+  | 'maxLength'
+  | 'question'
+  | 'required'
+  | 'sortOrder'
+  | FormQuestionKeySpecifier
+)[];
+export type FormQuestionFieldPolicy = {
+  explanation?: FieldPolicy<any> | FieldReadFunction<any>;
+  maxLength?: FieldPolicy<any> | FieldReadFunction<any>;
+  question?: FieldPolicy<any> | FieldReadFunction<any>;
+  required?: FieldPolicy<any> | FieldReadFunction<any>;
+  sortOrder?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type GeoKeySpecifier = ('endpoint' | GeoKeySpecifier)[];
 export type GeoFieldPolicy = {
@@ -1267,6 +1289,7 @@ export type MutationKeySpecifier = (
   | 'updateCanvasTemplate'
   | 'updateChallenge'
   | 'updateChallengeInnovationFlow'
+  | 'updateCommunityApplicationForm'
   | 'updateDiscussion'
   | 'updateEcosystemModel'
   | 'updateHub'
@@ -1413,6 +1436,7 @@ export type MutationFieldPolicy = {
   updateCanvasTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   updateChallenge?: FieldPolicy<any> | FieldReadFunction<any>;
   updateChallengeInnovationFlow?: FieldPolicy<any> | FieldReadFunction<any>;
+  updateCommunityApplicationForm?: FieldPolicy<any> | FieldReadFunction<any>;
   updateDiscussion?: FieldPolicy<any> | FieldReadFunction<any>;
   updateEcosystemModel?: FieldPolicy<any> | FieldReadFunction<any>;
   updateHub?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1476,14 +1500,12 @@ export type OpportunityCreatedFieldPolicy = {
 };
 export type OpportunityTemplateKeySpecifier = (
   | 'actorGroups'
-  | 'applications'
   | 'name'
   | 'relations'
   | OpportunityTemplateKeySpecifier
 )[];
 export type OpportunityTemplateFieldPolicy = {
   actorGroups?: FieldPolicy<any> | FieldReadFunction<any>;
-  applications?: FieldPolicy<any> | FieldReadFunction<any>;
   name?: FieldPolicy<any> | FieldReadFunction<any>;
   relations?: FieldPolicy<any> | FieldReadFunction<any>;
 };
@@ -1576,12 +1598,6 @@ export type PlatformFieldPolicy = {
   communication?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   library?: FieldPolicy<any> | FieldReadFunction<any>;
-};
-export type PlatformHubTemplateKeySpecifier = ('applications' | 'aspects' | 'name' | PlatformHubTemplateKeySpecifier)[];
-export type PlatformHubTemplateFieldPolicy = {
-  applications?: FieldPolicy<any> | FieldReadFunction<any>;
-  aspects?: FieldPolicy<any> | FieldReadFunction<any>;
-  name?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type PlatformLocationsKeySpecifier = (
   | 'about'
@@ -2058,7 +2074,6 @@ export type TagsetTemplateFieldPolicy = {
 export type TemplateKeySpecifier = (
   | 'challenges'
   | 'description'
-  | 'hubs'
   | 'name'
   | 'opportunities'
   | 'organizations'
@@ -2068,7 +2083,6 @@ export type TemplateKeySpecifier = (
 export type TemplateFieldPolicy = {
   challenges?: FieldPolicy<any> | FieldReadFunction<any>;
   description?: FieldPolicy<any> | FieldReadFunction<any>;
-  hubs?: FieldPolicy<any> | FieldReadFunction<any>;
   name?: FieldPolicy<any> | FieldReadFunction<any>;
   opportunities?: FieldPolicy<any> | FieldReadFunction<any>;
   organizations?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2581,6 +2595,14 @@ export type StrictTypedTypePolicies = {
     keyFields?: false | FileStorageConfigKeySpecifier | (() => undefined | FileStorageConfigKeySpecifier);
     fields?: FileStorageConfigFieldPolicy;
   };
+  Form?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | FormKeySpecifier | (() => undefined | FormKeySpecifier);
+    fields?: FormFieldPolicy;
+  };
+  FormQuestion?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | FormQuestionKeySpecifier | (() => undefined | FormQuestionKeySpecifier);
+    fields?: FormQuestionFieldPolicy;
+  };
   Geo?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | GeoKeySpecifier | (() => undefined | GeoKeySpecifier);
     fields?: GeoFieldPolicy;
@@ -2676,10 +2698,6 @@ export type StrictTypedTypePolicies = {
   Platform?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | PlatformKeySpecifier | (() => undefined | PlatformKeySpecifier);
     fields?: PlatformFieldPolicy;
-  };
-  PlatformHubTemplate?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
-    keyFields?: false | PlatformHubTemplateKeySpecifier | (() => undefined | PlatformHubTemplateKeySpecifier);
-    fields?: PlatformHubTemplateFieldPolicy;
   };
   PlatformLocations?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | PlatformLocationsKeySpecifier | (() => undefined | PlatformLocationsKeySpecifier);

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -3728,17 +3728,21 @@ export function refetchChallengeActivityQuery(variables: SchemaTypes.ChallengeAc
 }
 
 export const ChallengeApplicationTemplateDocument = gql`
-  query challengeApplicationTemplate {
-    configuration {
-      template {
-        challenges {
-          name
-          applications {
-            name
+  query challengeApplicationTemplate($hubId: UUID_NAMEID!, $challengeId: UUID_NAMEID!) {
+    hub(ID: $hubId) {
+      id
+      challenge(ID: $challengeId) {
+        id
+        community {
+          id
+          applicationForm {
+            description
             questions {
               required
               question
               sortOrder
+              explanation
+              maxLength
             }
           }
         }
@@ -3759,11 +3763,13 @@ export const ChallengeApplicationTemplateDocument = gql`
  * @example
  * const { data, loading, error } = useChallengeApplicationTemplateQuery({
  *   variables: {
+ *      hubId: // value for 'hubId'
+ *      challengeId: // value for 'challengeId'
  *   },
  * });
  */
 export function useChallengeApplicationTemplateQuery(
-  baseOptions?: Apollo.QueryHookOptions<
+  baseOptions: Apollo.QueryHookOptions<
     SchemaTypes.ChallengeApplicationTemplateQuery,
     SchemaTypes.ChallengeApplicationTemplateQueryVariables
   >
@@ -3797,7 +3803,7 @@ export type ChallengeApplicationTemplateQueryResult = Apollo.QueryResult<
   SchemaTypes.ChallengeApplicationTemplateQueryVariables
 >;
 export function refetchChallengeApplicationTemplateQuery(
-  variables?: SchemaTypes.ChallengeApplicationTemplateQueryVariables
+  variables: SchemaTypes.ChallengeApplicationTemplateQueryVariables
 ) {
   return { query: ChallengeApplicationTemplateDocument, variables: variables };
 }
@@ -5465,18 +5471,19 @@ export function refetchHubActivityQuery(variables: SchemaTypes.HubActivityQueryV
 }
 
 export const HubApplicationTemplateDocument = gql`
-  query hubApplicationTemplate {
-    configuration {
-      template {
-        hubs {
-          name
-          applications {
-            name
-            questions {
-              required
-              question
-              sortOrder
-            }
+  query hubApplicationTemplate($hubId: UUID_NAMEID!) {
+    hub(ID: $hubId) {
+      id
+      community {
+        id
+        applicationForm {
+          id
+          description
+          questions {
+            required
+            question
+            explanation
+            sortOrder
           }
         }
       }
@@ -5496,11 +5503,12 @@ export const HubApplicationTemplateDocument = gql`
  * @example
  * const { data, loading, error } = useHubApplicationTemplateQuery({
  *   variables: {
+ *      hubId: // value for 'hubId'
  *   },
  * });
  */
 export function useHubApplicationTemplateQuery(
-  baseOptions?: Apollo.QueryHookOptions<
+  baseOptions: Apollo.QueryHookOptions<
     SchemaTypes.HubApplicationTemplateQuery,
     SchemaTypes.HubApplicationTemplateQueryVariables
   >
@@ -5531,7 +5539,7 @@ export type HubApplicationTemplateQueryResult = Apollo.QueryResult<
   SchemaTypes.HubApplicationTemplateQuery,
   SchemaTypes.HubApplicationTemplateQueryVariables
 >;
-export function refetchHubApplicationTemplateQuery(variables?: SchemaTypes.HubApplicationTemplateQueryVariables) {
+export function refetchHubApplicationTemplateQuery(variables: SchemaTypes.HubApplicationTemplateQueryVariables) {
   return { query: HubApplicationTemplateDocument, variables: variables };
 }
 

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -1066,7 +1066,7 @@ export type CommunicationUpdateMessageReceived = {
 export type Community = Groupable & {
   __typename?: 'Community';
   /** The Form used for Applications to this community. */
-  applicationForm: Form;
+  applicationForm?: Maybe<Form>;
   /** Application available for this community. */
   applications?: Maybe<Array<Application>>;
   /** The authorization rules for the entity */
@@ -5684,18 +5684,20 @@ export type ChallengeApplicationTemplateQuery = {
         | {
             __typename?: 'Community';
             id: string;
-            applicationForm: {
-              __typename?: 'Form';
-              description?: string | undefined;
-              questions: Array<{
-                __typename?: 'FormQuestion';
-                required: boolean;
-                question: string;
-                sortOrder: number;
-                explanation: string;
-                maxLength: number;
-              }>;
-            };
+            applicationForm?:
+              | {
+                  __typename?: 'Form';
+                  description?: string | undefined;
+                  questions: Array<{
+                    __typename?: 'FormQuestion';
+                    required: boolean;
+                    question: string;
+                    sortOrder: number;
+                    explanation: string;
+                    maxLength: number;
+                  }>;
+                }
+              | undefined;
           }
         | undefined;
     };
@@ -8049,18 +8051,20 @@ export type HubApplicationTemplateQuery = {
       | {
           __typename?: 'Community';
           id: string;
-          applicationForm: {
-            __typename?: 'Form';
-            id: string;
-            description?: string | undefined;
-            questions: Array<{
-              __typename?: 'FormQuestion';
-              required: boolean;
-              question: string;
-              explanation: string;
-              sortOrder: number;
-            }>;
-          };
+          applicationForm?:
+            | {
+                __typename?: 'Form';
+                id: string;
+                description?: string | undefined;
+                questions: Array<{
+                  __typename?: 'FormQuestion';
+                  required: boolean;
+                  question: string;
+                  explanation: string;
+                  sortOrder: number;
+                }>;
+              }
+            | undefined;
         }
       | undefined;
   };

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -875,8 +875,6 @@ export enum ChallengePreferenceType {
 
 export type ChallengeTemplate = {
   __typename?: 'ChallengeTemplate';
-  /** Application templates. */
-  applications?: Maybe<Array<ApplicationTemplate>>;
   /** Feedback templates. */
   feedback?: Maybe<Array<FeedbackTemplate>>;
   /** Challenge template name. */
@@ -1067,6 +1065,8 @@ export type CommunicationUpdateMessageReceived = {
 
 export type Community = Groupable & {
   __typename?: 'Community';
+  /** The Form used for Applications to this community. */
+  applicationForm: Form;
   /** Application available for this community. */
   applications?: Maybe<Array<Application>>;
   /** The authorization rules for the entity */
@@ -1764,6 +1764,30 @@ export type FileStorageConfig = {
   mimeTypes: Array<Scalars['String']>;
 };
 
+export type Form = {
+  __typename?: 'Form';
+  /** A description of the purpose of this Form. */
+  description?: Maybe<Scalars['Markdown']>;
+  /** The ID of the entity */
+  id: Scalars['UUID'];
+  /** The set of Questions in this Form. */
+  questions: Array<FormQuestion>;
+};
+
+export type FormQuestion = {
+  __typename?: 'FormQuestion';
+  /** The explation text to clarify the question. */
+  explanation: Scalars['String'];
+  /** The maxiumum length of the answer, in characters, up to a limit of 512. */
+  maxLength: Scalars['Float'];
+  /** The question to be answered */
+  question: Scalars['String'];
+  /** Whether this Question requires an answer or not. */
+  required: Scalars['Boolean'];
+  /** The sort order of this question in a wider set of questions. */
+  sortOrder: Scalars['Float'];
+};
+
 export type Geo = {
   __typename?: 'Geo';
   /** Endpoint where geo information is consumed from. */
@@ -2265,6 +2289,8 @@ export type Mutation = {
   updateChallenge: Challenge;
   /** Updates the Innovation Flow on the specified Challenge. */
   updateChallengeInnovationFlow: Challenge;
+  /** Update the Application Form used by this Community. */
+  updateCommunityApplicationForm: Community;
   /** Updates the specified Discussion. */
   updateDiscussion: Discussion;
   /** Updates the specified EcosystemModel. */
@@ -2787,6 +2813,10 @@ export type MutationUpdateChallengeInnovationFlowArgs = {
   challengeData: UpdateChallengeInnovationFlowInput;
 };
 
+export type MutationUpdateCommunityApplicationFormArgs = {
+  applicationFormData: UpdateCommunityApplicationFormInput;
+};
+
 export type MutationUpdateDiscussionArgs = {
   updateData: UpdateDiscussionInput;
 };
@@ -2921,8 +2951,6 @@ export type OpportunityTemplate = {
   __typename?: 'OpportunityTemplate';
   /** Template actor groups. */
   actorGroups?: Maybe<Array<Scalars['String']>>;
-  /** Application templates. */
-  applications?: Maybe<Array<ApplicationTemplate>>;
   /** Template opportunity name. */
   name: Scalars['String'];
   /** Template relations. */
@@ -3056,16 +3084,6 @@ export type Platform = {
   id: Scalars['UUID'];
   /** The Innovation Library for the platform */
   library: Library;
-};
-
-export type PlatformHubTemplate = {
-  __typename?: 'PlatformHubTemplate';
-  /** Application templates. */
-  applications?: Maybe<Array<ApplicationTemplate>>;
-  /** Hub aspect templates. */
-  aspects?: Maybe<Array<HubAspectTemplate>>;
-  /** Hub template name. */
-  name: Scalars['String'];
 };
 
 export type PlatformLocations = {
@@ -3869,8 +3887,6 @@ export type Template = {
   challenges: Array<ChallengeTemplate>;
   /** Template description. */
   description: Scalars['String'];
-  /** Hub templates. */
-  hubs: Array<PlatformHubTemplate>;
   /** Template name. */
   name: Scalars['String'];
   /** Opportunity templates. */
@@ -4096,6 +4112,11 @@ export type UpdateChallengePreferenceInput = {
   value: Scalars['String'];
 };
 
+export type UpdateCommunityApplicationFormInput = {
+  communityID: Scalars['UUID'];
+  formData: UpdateFormInput;
+};
+
 export type UpdateContextInput = {
   background?: InputMaybe<Scalars['Markdown']>;
   impact?: InputMaybe<Scalars['Markdown']>;
@@ -4121,6 +4142,24 @@ export type UpdateDiscussionInput = {
 export type UpdateEcosystemModelInput = {
   ID: Scalars['UUID'];
   description?: InputMaybe<Scalars['String']>;
+};
+
+export type UpdateFormInput = {
+  description: Scalars['Markdown'];
+  questions: Array<UpdateFormQuestionInput>;
+};
+
+export type UpdateFormQuestionInput = {
+  /** The explation text to clarify the question. */
+  explanation: Scalars['String'];
+  /** The maxiumum length of the answer, in characters, up to a limit of 512. */
+  maxLength: Scalars['Float'];
+  /** The question to be answered */
+  question: Scalars['String'];
+  /** Whether an answer is required for this Question. */
+  required: Scalars['Boolean'];
+  /** The sort order of this question in a wider set of questions. */
+  sortOrder: Scalars['Float'];
 };
 
 export type UpdateHubInput = {
@@ -5628,30 +5667,37 @@ export type ChallengeActivityQuery = {
   };
 };
 
-export type ChallengeApplicationTemplateQueryVariables = Exact<{ [key: string]: never }>;
+export type ChallengeApplicationTemplateQueryVariables = Exact<{
+  hubId: Scalars['UUID_NAMEID'];
+  challengeId: Scalars['UUID_NAMEID'];
+}>;
 
 export type ChallengeApplicationTemplateQuery = {
   __typename?: 'Query';
-  configuration: {
-    __typename?: 'Config';
-    template: {
-      __typename?: 'Template';
-      challenges: Array<{
-        __typename?: 'ChallengeTemplate';
-        name: string;
-        applications?:
-          | Array<{
-              __typename?: 'ApplicationTemplate';
-              name: string;
+  hub: {
+    __typename?: 'Hub';
+    id: string;
+    challenge: {
+      __typename?: 'Challenge';
+      id: string;
+      community?:
+        | {
+            __typename?: 'Community';
+            id: string;
+            applicationForm: {
+              __typename?: 'Form';
+              description?: string | undefined;
               questions: Array<{
-                __typename?: 'QuestionTemplate';
+                __typename?: 'FormQuestion';
                 required: boolean;
                 question: string;
-                sortOrder?: number | undefined;
+                sortOrder: number;
+                explanation: string;
+                maxLength: number;
               }>;
-            }>
-          | undefined;
-      }>;
+            };
+          }
+        | undefined;
     };
   };
 };
@@ -7990,31 +8036,33 @@ export type HubActivityQuery = {
   };
 };
 
-export type HubApplicationTemplateQueryVariables = Exact<{ [key: string]: never }>;
+export type HubApplicationTemplateQueryVariables = Exact<{
+  hubId: Scalars['UUID_NAMEID'];
+}>;
 
 export type HubApplicationTemplateQuery = {
   __typename?: 'Query';
-  configuration: {
-    __typename?: 'Config';
-    template: {
-      __typename?: 'Template';
-      hubs: Array<{
-        __typename?: 'PlatformHubTemplate';
-        name: string;
-        applications?:
-          | Array<{
-              __typename?: 'ApplicationTemplate';
-              name: string;
-              questions: Array<{
-                __typename?: 'QuestionTemplate';
-                required: boolean;
-                question: string;
-                sortOrder?: number | undefined;
-              }>;
-            }>
-          | undefined;
-      }>;
-    };
+  hub: {
+    __typename?: 'Hub';
+    id: string;
+    community?:
+      | {
+          __typename?: 'Community';
+          id: string;
+          applicationForm: {
+            __typename?: 'Form';
+            id: string;
+            description?: string | undefined;
+            questions: Array<{
+              __typename?: 'FormQuestion';
+              required: boolean;
+              question: string;
+              explanation: string;
+              sortOrder: number;
+            }>;
+          };
+        }
+      | undefined;
   };
 };
 

--- a/src/domain/challenge/challenge/graphql/queries/challengeApplicationTemplate.graphql
+++ b/src/domain/challenge/challenge/graphql/queries/challengeApplicationTemplate.graphql
@@ -1,14 +1,18 @@
-query challengeApplicationTemplate {
-  configuration {
-    template {
-      challenges {
-        name
-        applications {
-          name
+query challengeApplicationTemplate($hubId: UUID_NAMEID!, $challengeId: UUID_NAMEID!) {
+  hub(ID: $hubId) {
+    id
+    challenge(ID: $challengeId) {
+      id
+      community {
+        id
+        applicationForm {
+          description
           questions {
             required
             question
             sortOrder
+            explanation
+            maxLength
           }
         }
       }

--- a/src/domain/challenge/hub/graphql/queries/hubApplicationTemplate.graphql
+++ b/src/domain/challenge/hub/graphql/queries/hubApplicationTemplate.graphql
@@ -1,15 +1,16 @@
-query hubApplicationTemplate {
-  configuration {
-    template {
-      hubs {
-        name
-        applications {
-          name
-          questions {
-            required
-            question
-            sortOrder
-          }
+query hubApplicationTemplate($hubId: UUID_NAMEID!) {
+  hub(ID: $hubId) {
+    id
+    community {
+      id
+      applicationForm {
+        id
+        description
+        questions {
+          required
+          question
+          explanation
+          sortOrder
         }
       }
     }

--- a/src/domain/community/application/containers/useApplicationCommunityQuery.ts
+++ b/src/domain/community/application/containers/useApplicationCommunityQuery.ts
@@ -61,7 +61,7 @@ export const useApplicationCommunityQuery = (type: ApplicationTypeEnum) => {
         displayName: hubData?.hub.displayName || '',
         avatar: getVisualAvatar(hubData?.hub.context?.visuals),
         tagline: hubData?.hub.context?.tagline || '',
-        questions: hubTemplateData?.configuration.template.hubs[0].applications?.[0].questions || [],
+        questions: hubTemplateData?.hub.community?.applicationForm?.questions || [],
         backUrl: buildHubUrl(hubNameId),
       };
     }
@@ -71,7 +71,7 @@ export const useApplicationCommunityQuery = (type: ApplicationTypeEnum) => {
         displayName: challengeData?.hub.challenge.displayName || '',
         avatar: getVisualAvatar(challengeData?.hub.challenge.context?.visuals),
         tagline: challengeData?.hub.challenge.context?.tagline || '',
-        questions: challengeTemplateData?.configuration.template.challenges[0].applications?.[0].questions || [],
+        questions: challengeTemplateData?.hub.challenge.community?.applicationForm?.questions || [],
         backUrl: buildChallengeUrl(hubNameId, challengeNameId),
       };
     }

--- a/src/domain/community/application/containers/useApplicationCommunityQuery.ts
+++ b/src/domain/community/application/containers/useApplicationCommunityQuery.ts
@@ -32,6 +32,10 @@ export const useApplicationCommunityQuery = (type: ApplicationTypeEnum) => {
     error: challengeTemplateError,
   } = useChallengeApplicationTemplateQuery({
     skip: type !== ApplicationTypeEnum.challenge,
+    variables: {
+      hubId: hubNameId,
+      challengeId: challengeNameId,
+    },
   });
 
   const {
@@ -52,6 +56,9 @@ export const useApplicationCommunityQuery = (type: ApplicationTypeEnum) => {
     error: hubTemplateError,
   } = useHubApplicationTemplateQuery({
     skip: type !== ApplicationTypeEnum.hub,
+    variables: {
+      hubId: hubNameId,
+    },
   });
 
   const result = useMemo(() => {


### PR DESCRIPTION
Retrieve the applicationForm to use for a Community directly from a Community, rather than from global configuration.

queries are updated, and queries are updated to request the relevant application form. 