### PR TITLE
Fix mentions with spaces

### DIFF
--- a/src/domain/shared/components/Comments/FormikCommentInputField.tsx
+++ b/src/domain/shared/components/Comments/FormikCommentInputField.tsx
@@ -29,7 +29,7 @@ import TranslationKey from '../../../../types/TranslationKey';
 import { ProfileChipView } from '../../../community/contributor/ProfileChip/ProfileChipView';
 import { useValidationMessageTranslation } from '../../i18n/ValidationMessageTranslation';
 
-const MAX_USERS_MENTIONABLE = 5;
+const MAX_USERS_LISTED = 30;
 const POPPER_Z_INDEX = 1400; // Dialogs are 1300
 
 interface MentionableUser extends SuggestionDataItem {
@@ -55,6 +55,8 @@ const SuggestionsContainer: FC<PropsWithChildren<SuggestionsContainerProps>> = (
         <Box
           sx={theme => ({
             width: gutters(17)(theme),
+            maxHeight: gutters(20)(theme),
+            overflowY: 'auto',
             '& li': {
               listStyle: 'none',
               margin: 0,
@@ -129,7 +131,7 @@ export const CommentsInput: FC<InputBaseComponentProps> = forwardRef<HTMLDivElem
       }
       const filter = { email: search, firstName: search, lastName: search };
       queryUsers({
-        variables: { filter, first: MAX_USERS_MENTIONABLE },
+        variables: { filter, first: MAX_USERS_LISTED },
         onCompleted: data => {
           const users = data?.usersPaginated.users ?? [];
           const mentionableUsers = users
@@ -194,6 +196,7 @@ export const CommentsInput: FC<InputBaseComponentProps> = forwardRef<HTMLDivElem
           maxLength={maxLength}
           onBlur={() => helper.setTouched(true)}
           forceSuggestionsAboveCursor
+          allowSpaceInQuery
           customSuggestionsContainer={children => (
             <SuggestionsContainer anchorElement={popperAnchor}>{children}</SuggestionsContainer>
           )}


### PR DESCRIPTION
PARTIAL SOLUTION
A serverside tweak should be made to handle search terms with spaces

### Describe the background of your pull request
This PR adds a scrollbar to the list of mentionable users, increases the max number of retrieved users to 30, and makes `react-mentions` component allow spaces in the mentioning.

Do not merge, this requires discussion


### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
