### PR TITLE
[POC] Load canvas template into current canvas - do not merge

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -10165,6 +10165,69 @@ export function useCalloutMessageReceivedSubscription(
 export type CalloutMessageReceivedSubscriptionHookResult = ReturnType<typeof useCalloutMessageReceivedSubscription>;
 export type CalloutMessageReceivedSubscriptionResult =
   Apollo.SubscriptionResult<SchemaTypes.CalloutMessageReceivedSubscription>;
+export const GetCanvasTemplateDocument = gql`
+  query getCanvasTemplate($hubId: UUID_NAMEID!) {
+    hub(ID: $hubId) {
+      nameID
+      templates {
+        canvasTemplates {
+          id
+          value
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetCanvasTemplateQuery__
+ *
+ * To run a query within a React component, call `useGetCanvasTemplateQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCanvasTemplateQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCanvasTemplateQuery({
+ *   variables: {
+ *      hubId: // value for 'hubId'
+ *   },
+ * });
+ */
+export function useGetCanvasTemplateQuery(
+  baseOptions: Apollo.QueryHookOptions<SchemaTypes.GetCanvasTemplateQuery, SchemaTypes.GetCanvasTemplateQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SchemaTypes.GetCanvasTemplateQuery, SchemaTypes.GetCanvasTemplateQueryVariables>(
+    GetCanvasTemplateDocument,
+    options
+  );
+}
+
+export function useGetCanvasTemplateLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.GetCanvasTemplateQuery,
+    SchemaTypes.GetCanvasTemplateQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SchemaTypes.GetCanvasTemplateQuery, SchemaTypes.GetCanvasTemplateQueryVariables>(
+    GetCanvasTemplateDocument,
+    options
+  );
+}
+
+export type GetCanvasTemplateQueryHookResult = ReturnType<typeof useGetCanvasTemplateQuery>;
+export type GetCanvasTemplateLazyQueryHookResult = ReturnType<typeof useGetCanvasTemplateLazyQuery>;
+export type GetCanvasTemplateQueryResult = Apollo.QueryResult<
+  SchemaTypes.GetCanvasTemplateQuery,
+  SchemaTypes.GetCanvasTemplateQueryVariables
+>;
+export function refetchGetCanvasTemplateQuery(variables: SchemaTypes.GetCanvasTemplateQueryVariables) {
+  return { query: GetCanvasTemplateDocument, variables: variables };
+}
+
 export const CanvasTemplatesDocument = gql`
   query canvasTemplates($hubId: UUID_NAMEID!) {
     hub(ID: $hubId) {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -12837,6 +12837,24 @@ export type CalloutMessageReceivedSubscription = {
   };
 };
 
+export type GetCanvasTemplateQueryVariables = Exact<{
+  hubId: Scalars['UUID_NAMEID'];
+}>;
+
+export type GetCanvasTemplateQuery = {
+  __typename?: 'Query';
+  hub: {
+    __typename?: 'Hub';
+    nameID: string;
+    templates?:
+      | {
+          __typename?: 'TemplatesSet';
+          canvasTemplates: Array<{ __typename?: 'CanvasTemplate'; id: string; value: string }>;
+        }
+      | undefined;
+  };
+};
+
 export type CanvasDetailsFragment = {
   __typename?: 'Canvas';
   id: string;

--- a/src/domain/collaboration/canvas/CanvasDialog/getCanvasTemplate.graphql
+++ b/src/domain/collaboration/canvas/CanvasDialog/getCanvasTemplate.graphql
@@ -1,0 +1,11 @@
+query getCanvasTemplate($hubId: UUID_NAMEID!) {
+  hub(ID: $hubId) {
+    nameID
+    templates {
+      canvasTemplates {
+        id
+        value
+      }
+    }
+  }
+}

--- a/src/domain/collaboration/canvas/utils/mergeCanvas.ts
+++ b/src/domain/collaboration/canvas/utils/mergeCanvas.ts
@@ -1,0 +1,44 @@
+import { ExcalidrawElement } from '@alkemio/excalidraw/types/element/types';
+import { BinaryFileData, ExcalidrawImperativeAPI } from '@alkemio/excalidraw/types/types';
+import { uniqueId } from 'lodash';
+
+interface CanvasLike {
+  type: string;
+  version: number;
+  source: string;
+  appState: unknown;
+
+  elements: ExcalidrawElement[];
+  files?: Record<BinaryFileData['id'], BinaryFileData>;
+}
+
+const mergeCanvas = (canvasApi: ExcalidrawImperativeAPI, canvasValue: string | undefined) => {
+  if (!canvasApi || !canvasValue) {
+    return;
+  }
+  const parsedCanvas = JSON.parse(canvasValue) as CanvasLike;
+
+  //TODO: This may not be needed
+  if (parsedCanvas.type !== 'excalidraw' || parsedCanvas.version !== 2) {
+    throw new Error('Unable to load canvas');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const fileId in parsedCanvas.files) {
+    canvasApi.addFiles([parsedCanvas.files[fileId]]);
+  }
+
+  const currentElements = canvasApi.getSceneElements();
+  const insertedElements = parsedCanvas.elements?.map(el => ({
+    ...el,
+    id: uniqueId(Math.random().toString()),
+  }));
+
+  const newElements = [...currentElements, ...insertedElements];
+  canvasApi.updateScene({
+    appState: canvasApi.getAppState(),
+    elements: newElements,
+    commitToHistory: true, // TODO: WARNING maybe this needs to be false when collaborative editing
+  });
+};
+
+export default mergeCanvas;

--- a/src/domain/collaboration/canvas/utils/mergeCanvas.ts
+++ b/src/domain/collaboration/canvas/utils/mergeCanvas.ts
@@ -22,14 +22,17 @@ const mergeCanvas = (canvasApi: ExcalidrawImperativeAPI, canvasValue: string | u
   if (parsedCanvas.type !== 'excalidraw' || parsedCanvas.version !== 2) {
     throw new Error('Unable to load canvas');
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   for (const fileId in parsedCanvas.files) {
+    // TODO: maybe there is a way to check if file is already in...
+    // TODO: Confirm: because file ids look like hashes, it would be nice to have each file only once, per file content
     canvasApi.addFiles([parsedCanvas.files[fileId]]);
   }
 
   const currentElements = canvasApi.getSceneElements();
   const insertedElements = parsedCanvas.elements?.map(el => ({
     ...el,
+    // Changing id is required // TODO: generate a better ID, see inside excalidraw how their IDs are being generated
     id: uniqueId(Math.random().toString()),
   }));
 


### PR DESCRIPTION
Finds the first template in the current hub and puts all its contents into the current canvas.

It would be nice to also push all the injected elements to an empty area and not inject them exactly in the same position where they are in the template, (if you inject the same template multiple times it works but elements overlap eachother).
It's not finished, cannot be merged, but It works. so we can estimate it.

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
