### PR TITLE
Release: Canvas, Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/client-web",
-      "version": "0.35.2",
+      "version": "0.35.3",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/excalidraw": "0.13.0-alkemio-7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "description": "Alkemio client, enabling users to interact with Challenges hosted on the Alkemio platform.",
   "author": "Alkemio Foundation",
   "repository": {

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -1706,6 +1706,11 @@ export const OrganizationInfoFragmentDoc = gql`
         ...fullLocation
       }
     }
+    metrics {
+      id
+      name
+      value
+    }
     associates @include(if: $includeAssociates) {
       id
       nameID

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -1248,6 +1248,16 @@ export const CollaborationWithCalloutsFragmentDoc = gql`
   }
   ${CalloutFragmentDoc}
 `;
+export const CanvasTemplateProviderProfileFragmentDoc = gql`
+  fragment CanvasTemplateProviderProfile on Profile {
+    id
+    displayName
+    visual(type: AVATAR) {
+      ...VisualUri
+    }
+  }
+  ${VisualUriFragmentDoc}
+`;
 export const CanvasValueFragmentDoc = gql`
   fragment CanvasValue on Canvas {
     id
@@ -10391,6 +10401,321 @@ export function useCalloutMessageReceivedSubscription(
 export type CalloutMessageReceivedSubscriptionHookResult = ReturnType<typeof useCalloutMessageReceivedSubscription>;
 export type CalloutMessageReceivedSubscriptionResult =
   Apollo.SubscriptionResult<SchemaTypes.CalloutMessageReceivedSubscription>;
+export const HubCanvasTemplatesLibraryDocument = gql`
+  query HubCanvasTemplatesLibrary($hubId: UUID_NAMEID!) {
+    hub(ID: $hubId) {
+      id
+      templates {
+        id
+        canvasTemplates {
+          ...CanvasTemplate
+        }
+      }
+      host {
+        id
+        nameID
+        profile {
+          ...CanvasTemplateProviderProfile
+        }
+      }
+    }
+  }
+  ${CanvasTemplateFragmentDoc}
+  ${CanvasTemplateProviderProfileFragmentDoc}
+`;
+
+/**
+ * __useHubCanvasTemplatesLibraryQuery__
+ *
+ * To run a query within a React component, call `useHubCanvasTemplatesLibraryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHubCanvasTemplatesLibraryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHubCanvasTemplatesLibraryQuery({
+ *   variables: {
+ *      hubId: // value for 'hubId'
+ *   },
+ * });
+ */
+export function useHubCanvasTemplatesLibraryQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    SchemaTypes.HubCanvasTemplatesLibraryQuery,
+    SchemaTypes.HubCanvasTemplatesLibraryQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    SchemaTypes.HubCanvasTemplatesLibraryQuery,
+    SchemaTypes.HubCanvasTemplatesLibraryQueryVariables
+  >(HubCanvasTemplatesLibraryDocument, options);
+}
+
+export function useHubCanvasTemplatesLibraryLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.HubCanvasTemplatesLibraryQuery,
+    SchemaTypes.HubCanvasTemplatesLibraryQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SchemaTypes.HubCanvasTemplatesLibraryQuery,
+    SchemaTypes.HubCanvasTemplatesLibraryQueryVariables
+  >(HubCanvasTemplatesLibraryDocument, options);
+}
+
+export type HubCanvasTemplatesLibraryQueryHookResult = ReturnType<typeof useHubCanvasTemplatesLibraryQuery>;
+export type HubCanvasTemplatesLibraryLazyQueryHookResult = ReturnType<typeof useHubCanvasTemplatesLibraryLazyQuery>;
+export type HubCanvasTemplatesLibraryQueryResult = Apollo.QueryResult<
+  SchemaTypes.HubCanvasTemplatesLibraryQuery,
+  SchemaTypes.HubCanvasTemplatesLibraryQueryVariables
+>;
+export function refetchHubCanvasTemplatesLibraryQuery(variables: SchemaTypes.HubCanvasTemplatesLibraryQueryVariables) {
+  return { query: HubCanvasTemplatesLibraryDocument, variables: variables };
+}
+
+export const HubCanvasTemplateValueDocument = gql`
+  query HubCanvasTemplateValue($hubId: UUID_NAMEID!, $canvasTemplateId: UUID!) {
+    hub(ID: $hubId) {
+      id
+      templates {
+        id
+        canvasTemplate(ID: $canvasTemplateId) {
+          ...CanvasTemplate
+          value
+        }
+      }
+    }
+  }
+  ${CanvasTemplateFragmentDoc}
+`;
+
+/**
+ * __useHubCanvasTemplateValueQuery__
+ *
+ * To run a query within a React component, call `useHubCanvasTemplateValueQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHubCanvasTemplateValueQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHubCanvasTemplateValueQuery({
+ *   variables: {
+ *      hubId: // value for 'hubId'
+ *      canvasTemplateId: // value for 'canvasTemplateId'
+ *   },
+ * });
+ */
+export function useHubCanvasTemplateValueQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    SchemaTypes.HubCanvasTemplateValueQuery,
+    SchemaTypes.HubCanvasTemplateValueQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SchemaTypes.HubCanvasTemplateValueQuery, SchemaTypes.HubCanvasTemplateValueQueryVariables>(
+    HubCanvasTemplateValueDocument,
+    options
+  );
+}
+
+export function useHubCanvasTemplateValueLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.HubCanvasTemplateValueQuery,
+    SchemaTypes.HubCanvasTemplateValueQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SchemaTypes.HubCanvasTemplateValueQuery, SchemaTypes.HubCanvasTemplateValueQueryVariables>(
+    HubCanvasTemplateValueDocument,
+    options
+  );
+}
+
+export type HubCanvasTemplateValueQueryHookResult = ReturnType<typeof useHubCanvasTemplateValueQuery>;
+export type HubCanvasTemplateValueLazyQueryHookResult = ReturnType<typeof useHubCanvasTemplateValueLazyQuery>;
+export type HubCanvasTemplateValueQueryResult = Apollo.QueryResult<
+  SchemaTypes.HubCanvasTemplateValueQuery,
+  SchemaTypes.HubCanvasTemplateValueQueryVariables
+>;
+export function refetchHubCanvasTemplateValueQuery(variables: SchemaTypes.HubCanvasTemplateValueQueryVariables) {
+  return { query: HubCanvasTemplateValueDocument, variables: variables };
+}
+
+export const PlatformCanvasTemplatesLibraryDocument = gql`
+  query PlatformCanvasTemplatesLibrary {
+    platform {
+      id
+      library {
+        id
+        innovationPacks {
+          id
+          nameID
+          displayName
+          provider {
+            id
+            profile {
+              ...CanvasTemplateProviderProfile
+            }
+          }
+          templates {
+            id
+            canvasTemplates {
+              ...CanvasTemplate
+            }
+          }
+        }
+      }
+    }
+  }
+  ${CanvasTemplateProviderProfileFragmentDoc}
+  ${CanvasTemplateFragmentDoc}
+`;
+
+/**
+ * __usePlatformCanvasTemplatesLibraryQuery__
+ *
+ * To run a query within a React component, call `usePlatformCanvasTemplatesLibraryQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePlatformCanvasTemplatesLibraryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePlatformCanvasTemplatesLibraryQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function usePlatformCanvasTemplatesLibraryQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    SchemaTypes.PlatformCanvasTemplatesLibraryQuery,
+    SchemaTypes.PlatformCanvasTemplatesLibraryQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    SchemaTypes.PlatformCanvasTemplatesLibraryQuery,
+    SchemaTypes.PlatformCanvasTemplatesLibraryQueryVariables
+  >(PlatformCanvasTemplatesLibraryDocument, options);
+}
+
+export function usePlatformCanvasTemplatesLibraryLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.PlatformCanvasTemplatesLibraryQuery,
+    SchemaTypes.PlatformCanvasTemplatesLibraryQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SchemaTypes.PlatformCanvasTemplatesLibraryQuery,
+    SchemaTypes.PlatformCanvasTemplatesLibraryQueryVariables
+  >(PlatformCanvasTemplatesLibraryDocument, options);
+}
+
+export type PlatformCanvasTemplatesLibraryQueryHookResult = ReturnType<typeof usePlatformCanvasTemplatesLibraryQuery>;
+export type PlatformCanvasTemplatesLibraryLazyQueryHookResult = ReturnType<
+  typeof usePlatformCanvasTemplatesLibraryLazyQuery
+>;
+export type PlatformCanvasTemplatesLibraryQueryResult = Apollo.QueryResult<
+  SchemaTypes.PlatformCanvasTemplatesLibraryQuery,
+  SchemaTypes.PlatformCanvasTemplatesLibraryQueryVariables
+>;
+export function refetchPlatformCanvasTemplatesLibraryQuery(
+  variables?: SchemaTypes.PlatformCanvasTemplatesLibraryQueryVariables
+) {
+  return { query: PlatformCanvasTemplatesLibraryDocument, variables: variables };
+}
+
+export const PlatformCanvasTemplateValueDocument = gql`
+  query PlatformCanvasTemplateValue($innovationPackId: UUID!, $canvasTemplateId: UUID!) {
+    platform {
+      id
+      library {
+        id
+        innovationPack(ID: $innovationPackId) {
+          id
+          nameID
+          displayName
+          provider {
+            id
+            profile {
+              ...CanvasTemplateProviderProfile
+            }
+          }
+          templates {
+            id
+            canvasTemplate(ID: $canvasTemplateId) {
+              ...CanvasTemplate
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+  ${CanvasTemplateProviderProfileFragmentDoc}
+  ${CanvasTemplateFragmentDoc}
+`;
+
+/**
+ * __usePlatformCanvasTemplateValueQuery__
+ *
+ * To run a query within a React component, call `usePlatformCanvasTemplateValueQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePlatformCanvasTemplateValueQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePlatformCanvasTemplateValueQuery({
+ *   variables: {
+ *      innovationPackId: // value for 'innovationPackId'
+ *      canvasTemplateId: // value for 'canvasTemplateId'
+ *   },
+ * });
+ */
+export function usePlatformCanvasTemplateValueQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    SchemaTypes.PlatformCanvasTemplateValueQuery,
+    SchemaTypes.PlatformCanvasTemplateValueQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    SchemaTypes.PlatformCanvasTemplateValueQuery,
+    SchemaTypes.PlatformCanvasTemplateValueQueryVariables
+  >(PlatformCanvasTemplateValueDocument, options);
+}
+
+export function usePlatformCanvasTemplateValueLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.PlatformCanvasTemplateValueQuery,
+    SchemaTypes.PlatformCanvasTemplateValueQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SchemaTypes.PlatformCanvasTemplateValueQuery,
+    SchemaTypes.PlatformCanvasTemplateValueQueryVariables
+  >(PlatformCanvasTemplateValueDocument, options);
+}
+
+export type PlatformCanvasTemplateValueQueryHookResult = ReturnType<typeof usePlatformCanvasTemplateValueQuery>;
+export type PlatformCanvasTemplateValueLazyQueryHookResult = ReturnType<typeof usePlatformCanvasTemplateValueLazyQuery>;
+export type PlatformCanvasTemplateValueQueryResult = Apollo.QueryResult<
+  SchemaTypes.PlatformCanvasTemplateValueQuery,
+  SchemaTypes.PlatformCanvasTemplateValueQueryVariables
+>;
+export function refetchPlatformCanvasTemplateValueQuery(
+  variables: SchemaTypes.PlatformCanvasTemplateValueQueryVariables
+) {
+  return { query: PlatformCanvasTemplateValueDocument, variables: variables };
+}
+
 export const CanvasTemplatesDocument = gql`
   query canvasTemplates($hubId: UUID_NAMEID!) {
     hub(ID: $hubId) {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -16447,6 +16447,7 @@ export type OrganizationInfoFragment = {
         }
       | undefined;
   };
+  metrics?: Array<{ __typename?: 'NVP'; id: string; name: string; value: string }> | undefined;
   associates?:
     | Array<{
         __typename?: 'User';
@@ -16512,6 +16513,7 @@ export type OrganizationInfoQuery = {
           }
         | undefined;
     };
+    metrics?: Array<{ __typename?: 'NVP'; id: string; name: string; value: string }> | undefined;
     associates?:
       | Array<{
           __typename?: 'User';

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -12645,6 +12645,198 @@ export type CalloutMessageReceivedSubscription = {
   };
 };
 
+export type HubCanvasTemplatesLibraryQueryVariables = Exact<{
+  hubId: Scalars['UUID_NAMEID'];
+}>;
+
+export type HubCanvasTemplatesLibraryQuery = {
+  __typename?: 'Query';
+  hub: {
+    __typename?: 'Hub';
+    id: string;
+    templates?:
+      | {
+          __typename?: 'TemplatesSet';
+          id: string;
+          canvasTemplates: Array<{
+            __typename?: 'CanvasTemplate';
+            id: string;
+            info: {
+              __typename?: 'TemplateInfo';
+              id: string;
+              title: string;
+              description: string;
+              tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+              visual?: { __typename?: 'Visual'; id: string; uri: string } | undefined;
+            };
+          }>;
+        }
+      | undefined;
+    host?:
+      | {
+          __typename?: 'Organization';
+          id: string;
+          nameID: string;
+          profile: {
+            __typename?: 'Profile';
+            id: string;
+            displayName: string;
+            visual?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+          };
+        }
+      | undefined;
+  };
+};
+
+export type HubCanvasTemplateValueQueryVariables = Exact<{
+  hubId: Scalars['UUID_NAMEID'];
+  canvasTemplateId: Scalars['UUID'];
+}>;
+
+export type HubCanvasTemplateValueQuery = {
+  __typename?: 'Query';
+  hub: {
+    __typename?: 'Hub';
+    id: string;
+    templates?:
+      | {
+          __typename?: 'TemplatesSet';
+          id: string;
+          canvasTemplate?:
+            | {
+                __typename?: 'CanvasTemplate';
+                value: string;
+                id: string;
+                info: {
+                  __typename?: 'TemplateInfo';
+                  id: string;
+                  title: string;
+                  description: string;
+                  tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+                  visual?: { __typename?: 'Visual'; id: string; uri: string } | undefined;
+                };
+              }
+            | undefined;
+        }
+      | undefined;
+  };
+};
+
+export type PlatformCanvasTemplatesLibraryQueryVariables = Exact<{ [key: string]: never }>;
+
+export type PlatformCanvasTemplatesLibraryQuery = {
+  __typename?: 'Query';
+  platform: {
+    __typename?: 'Platform';
+    id: string;
+    library: {
+      __typename?: 'Library';
+      id: string;
+      innovationPacks: Array<{
+        __typename?: 'InnovatonPack';
+        id: string;
+        nameID: string;
+        displayName: string;
+        provider?:
+          | {
+              __typename?: 'Organization';
+              id: string;
+              profile: {
+                __typename?: 'Profile';
+                id: string;
+                displayName: string;
+                visual?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+              };
+            }
+          | undefined;
+        templates?:
+          | {
+              __typename?: 'TemplatesSet';
+              id: string;
+              canvasTemplates: Array<{
+                __typename?: 'CanvasTemplate';
+                id: string;
+                info: {
+                  __typename?: 'TemplateInfo';
+                  id: string;
+                  title: string;
+                  description: string;
+                  tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+                  visual?: { __typename?: 'Visual'; id: string; uri: string } | undefined;
+                };
+              }>;
+            }
+          | undefined;
+      }>;
+    };
+  };
+};
+
+export type PlatformCanvasTemplateValueQueryVariables = Exact<{
+  innovationPackId: Scalars['UUID'];
+  canvasTemplateId: Scalars['UUID'];
+}>;
+
+export type PlatformCanvasTemplateValueQuery = {
+  __typename?: 'Query';
+  platform: {
+    __typename?: 'Platform';
+    id: string;
+    library: {
+      __typename?: 'Library';
+      id: string;
+      innovationPack?:
+        | {
+            __typename?: 'InnovatonPack';
+            id: string;
+            nameID: string;
+            displayName: string;
+            provider?:
+              | {
+                  __typename?: 'Organization';
+                  id: string;
+                  profile: {
+                    __typename?: 'Profile';
+                    id: string;
+                    displayName: string;
+                    visual?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+                  };
+                }
+              | undefined;
+            templates?:
+              | {
+                  __typename?: 'TemplatesSet';
+                  id: string;
+                  canvasTemplate?:
+                    | {
+                        __typename?: 'CanvasTemplate';
+                        value: string;
+                        id: string;
+                        info: {
+                          __typename?: 'TemplateInfo';
+                          id: string;
+                          title: string;
+                          description: string;
+                          tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+                          visual?: { __typename?: 'Visual'; id: string; uri: string } | undefined;
+                        };
+                      }
+                    | undefined;
+                }
+              | undefined;
+          }
+        | undefined;
+    };
+  };
+};
+
+export type CanvasTemplateProviderProfileFragment = {
+  __typename?: 'Profile';
+  id: string;
+  displayName: string;
+  visual?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+};
+
 export type CanvasDetailsFragment = {
   __typename?: 'Canvas';
   id: string;

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -91,6 +91,7 @@
     "confirm-choice": "Confirm Choice",
     "confirm": "Confirm",
     "change-template": "Change template",
+    "find-template": "Find template",
     "change": "Change",
     "library": "Library",
     "share": "Share",
@@ -106,7 +107,8 @@
     "moveUp": "Move up",
     "moveDown": "Move down",
     "moveToTop": "Move to top",
-    "moveToBottom": "Move to bottom"
+    "moveToBottom": "Move to bottom",
+    "use": "Use"
   },
   "tooltips": {
     "click-more-info": "Click for more information",
@@ -568,7 +570,13 @@
     "banner-narrow": "Banner narrow"
   },
   "canvas-templates": {
-    "canvas-template": "Whiteboard template"
+    "template-library": "Template Library",
+    "filter-placeholder": "Search Templates...",
+    "canvas-template": "Whiteboard template",
+    "hub-templates": "Templates selected by the host of this community",
+    "load-platform-templates": "Or click here to browse through all platform templates",
+    "platform-templates": "Platform Templates",
+    "error-importing": "Error importing Canvas Template"
   },
   "innovation-templates": {
     "innovation-template": "Innovation Flow template",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1845,7 +1845,8 @@
   },
   "associates-view": {
     "less": "show less",
-    "more": "...plus {{count}} more"
+    "more": "...plus {{count}} more",
+    "sign-in": "Please sign in to see the users that are associated with this organization."
   },
   "hubs-filter": {
     "current-filter": "Current filter: ",

--- a/src/core/ui/dialog/DialogHeader.tsx
+++ b/src/core/ui/dialog/DialogHeader.tsx
@@ -1,17 +1,18 @@
 import React, { PropsWithChildren, ReactNode } from 'react';
 import { Close } from '@mui/icons-material';
-import { Box, IconButton } from '@mui/material';
+import { Box, BoxProps, IconButton } from '@mui/material';
 import ActionsBar from '../actions/ActionsBar/ActionsBar';
 
 export interface DialogHeaderProps {
   actions?: ReactNode;
   onClose?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  titleContainerProps?: BoxProps;
 }
 
-const DialogHeader = ({ actions, onClose, children }: PropsWithChildren<DialogHeaderProps>) => {
+const DialogHeader = ({ actions, onClose, titleContainerProps, children }: PropsWithChildren<DialogHeaderProps>) => {
   return (
     <Box display="flex" alignItems="start" padding={1}>
-      <Box flexGrow={1} flexShrink={1} minWidth={0} display="flex" flexDirection="column" gap={1} padding={1}>
+      <Box flexGrow={1} flexShrink={1} minWidth={0} display="flex" gap={1} padding={1} {...titleContainerProps}>
         {children}
       </Box>
       <ActionsBar>

--- a/src/core/ui/dialog/DialogIcon.tsx
+++ b/src/core/ui/dialog/DialogIcon.tsx
@@ -1,0 +1,25 @@
+import { FC } from 'react';
+import { Box, BoxProps, useTheme } from '@mui/material';
+import { gutters } from '../grid/utils';
+
+interface DialogIconProps extends BoxProps {}
+
+const DialogIcon: FC<DialogIconProps> = ({ ...props }) => {
+  const theme = useTheme();
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      width={gutters(2)}
+      height={gutters(2)}
+      bgcolor={theme.palette.primary.main}
+      color={theme.palette.primary.contrastText}
+      borderRadius="5px"
+      {...props}
+    />
+  );
+};
+
+export default DialogIcon;

--- a/src/core/ui/forms/MarkdownInput/MarkdownValidator.ts
+++ b/src/core/ui/forms/MarkdownInput/MarkdownValidator.ts
@@ -1,9 +1,19 @@
 import { TextFieldMaxLength } from '../field-length.constants';
 import { string } from 'yup';
 import { MessageWithPayload } from '../../../../domain/shared/i18n/ValidationMessageTranslation';
+import TranslationKey from '../../../../types/TranslationKey';
+import { ValidationMessageWithPayload } from '../../../../domain/shared/i18n/ValidationMessageTranslation/ValidationMessageWithPayload';
+
+const translationKey: TranslationKey = 'components.wysiwyg-editor.validation.maxLength';
 
 const MarkdownValidator = (maxLength: TextFieldMaxLength) => {
-  return string().max(maxLength, MessageWithPayload('components.wysiwyg-editor.validation.maxLength'));
+  return string().max(maxLength, MessageWithPayload(translationKey));
+};
+
+export const isMarkdownMaxLengthError = (
+  error: string | ValidationMessageWithPayload
+): error is ValidationMessageWithPayload => {
+  return typeof error !== 'string' && error.message === translationKey;
 };
 
 export default MarkdownValidator;

--- a/src/core/ui/forms/field-length.constants.ts
+++ b/src/core/ui/forms/field-length.constants.ts
@@ -13,7 +13,7 @@ export const LIFECYCLE_DEFINITION_LENGTH = 8388608;
 export type TextFieldMaxLength = typeof MID_TEXT_LENGTH | typeof LONG_TEXT_LENGTH | typeof VERY_LONG_TEXT_LENGTH;
 
 export const MarkdownFieldMaxLength: Record<TextFieldMaxLength, number> = {
-  [MID_TEXT_LENGTH]: 200,
-  [LONG_TEXT_LENGTH]: 500,
-  [VERY_LONG_TEXT_LENGTH]: 2000,
+  [MID_TEXT_LENGTH]: 500,
+  [LONG_TEXT_LENGTH]: 2000,
+  [VERY_LONG_TEXT_LENGTH]: 8000,
 };

--- a/src/core/utils/links.ts
+++ b/src/core/utils/links.ts
@@ -9,7 +9,12 @@ export const hasDomainLike = (link: string) => getDomainLikeRegexp().test(link);
 export const hasSameHost = (link: string) => link.startsWith(window.location.host);
 
 export const normalizeLink = (link: string) => {
-  if (isAbsoluteUrl(link) && hasSameOrigin(link)) {
+  if (
+    isAbsoluteUrl(link) &&
+    hasSameOrigin(link) &&
+    // Keep file attachment urls in absolute format, they are not handled by React Router anyway
+    !isFileAttachmentUrl(link)
+  ) {
     return link.slice(window.origin.length) || '/';
   } else {
     if (process.env.NODE_ENV === 'development' && link.startsWith('localhost')) {
@@ -30,4 +35,15 @@ export const normalizeLink = (link: string) => {
 export const makeAbsoluteUrl = (link: string) => {
   if (isAbsoluteUrl(link)) return link;
   return `${window.location.origin}${link.startsWith('/') ? '' : '/'}${link}`;
+};
+
+export const isFileAttachmentUrl = (link: string) => {
+  let path = link;
+  if (isAbsoluteUrl(link)) {
+    if (!hasSameOrigin(link)) {
+      return false;
+    }
+    path = link.slice(window.origin.length);
+  }
+  return path.startsWith('/ipfs/');
 };

--- a/src/domain/collaboration/CalloutBlock/CalloutLayout.tsx
+++ b/src/domain/collaboration/CalloutBlock/CalloutLayout.tsx
@@ -166,6 +166,7 @@ const CalloutLayout = ({
             <ShareButton url={callout.url} entityTypeName="callout" />
           </>
         }
+        titleContainerProps={{ flexDirection: 'column' }}
       >
         {hasCalloutDetails && (
           <Authorship authorAvatarUri={callout.authorAvatarUri} date={callout.publishedAt}>

--- a/src/domain/collaboration/canvas/CanvasDialog/CanvasDialog.tsx
+++ b/src/domain/collaboration/canvas/CanvasDialog/CanvasDialog.tsx
@@ -20,16 +20,21 @@ import CanvasWhiteboard from '../../../../common/components/composite/entities/C
 import { ExportedDataState } from '@alkemio/excalidraw/types/data/types';
 import getCanvasBannerCardDimensions from '../utils/getCanvasBannerCardDimensions';
 import Authorship from '../../../../core/ui/authorship/Authorship';
-import { PageTitle } from '../../../../core/ui/typography';
 import DialogHeader from '../../../../core/ui/dialog/DialogHeader';
 import { Box, Button, ButtonProps } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 import { Actions } from '../../../../core/ui/actions/Actions';
 import { gutters } from '../../../../core/ui/grid/utils';
 import FlexSpacer from '../../../../core/ui/utils/FlexSpacer';
-import FormikInputField from '../../../../common/components/composite/forms/FormikInputField';
 import canvasSchema from '../validation/canvasSchema';
 import isCanvasValueEqual from '../utils/isCanvasValueEqual';
+import FormikInputField from '../../../../common/components/composite/forms/FormikInputField';
+import { PageTitle } from '../../../../core/ui/typography';
+import CanvasTemplatesLibrary from '../CanvasTemplatesLibrary/CanvasTemplatesLibrary';
+import { CanvasTemplateWithValue } from '../CanvasTemplatesLibrary/CanvasTemplate';
+import mergeCanvas from '../utils/mergeCanvas';
+import { error as logError } from '../../../../services/logging/sentry/log';
+import { useNotification } from '../../../../core/ui/notifications/useNotification';
 
 interface CanvasWithValue extends Omit<CanvasValueFragment, 'id'>, Partial<CanvasDetailsFragment> {}
 
@@ -97,6 +102,7 @@ const CanvasDialog = <Canvas extends CanvasWithValue>({
   state,
 }: CanvasDialogProps<Canvas>) => {
   const { t } = useTranslation();
+  const notify = useNotification();
   const { canvas, lockedBy } = entities;
   const excalidrawApiRef = useRef<ExcalidrawAPIRefValue>(null);
 
@@ -191,6 +197,18 @@ const CanvasDialog = <Canvas extends CanvasWithValue>({
     actions.onCancel(canvas!);
   };
 
+  const handleImportTemplate = async (template: CanvasTemplateWithValue) => {
+    const canvasApi = await excalidrawApiRef.current?.readyPromise;
+    if (canvasApi && options.canEdit && options.checkedOutByMe) {
+      try {
+        mergeCanvas(canvasApi, template.value);
+      } catch (err) {
+        notify(t('canvas-templates.error-importing'), 'error');
+        logError(new Error(`Error importing canvas template ${template.id}: '${err}'`));
+      }
+    }
+  };
+
   const currentAction: CanvasAction = options.checkedOutByMe ? 'save-and-checkin' : 'checkout';
 
   const formikRef = useRef<FormikProps<{ displayName: string }>>(null);
@@ -230,15 +248,22 @@ const CanvasDialog = <Canvas extends CanvasWithValue>({
       <Formik innerRef={formikRef} initialValues={initialValues} onSubmit={() => {}} validationSchema={canvasSchema}>
         {({ isValid }) => (
           <>
-            <DialogHeader actions={options.headerActions} onClose={onClose}>
+            <DialogHeader
+              actions={options.headerActions}
+              onClose={onClose}
+              titleContainerProps={{ flexDirection: options.checkedOutByMe ? 'row' : 'column' }}
+            >
               {options.checkedOutByMe ? (
-                <Box
-                  component={FormikInputField}
-                  title={t('fields.displayName')}
-                  name="displayName"
-                  size="small"
-                  maxWidth={gutters(50)}
-                />
+                <>
+                  <Box
+                    component={FormikInputField}
+                    title={t('fields.displayName')}
+                    name="displayName"
+                    size="small"
+                    maxWidth={gutters(30)}
+                  />
+                  <CanvasTemplatesLibrary onSelectTemplate={handleImportTemplate} />
+                </>
               ) : (
                 <>
                   <Authorship authorAvatarUri={canvas?.createdBy?.profile.visual?.uri} date={canvas?.createdDate}>

--- a/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplate.ts
+++ b/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplate.ts
@@ -1,0 +1,46 @@
+import {
+  CanvasTemplateFragment,
+  CanvasTemplateProviderProfileFragment,
+} from '../../../../core/apollo/generated/graphql-schema';
+import { Identifiable } from '../../../shared/types/Identifiable';
+
+export interface CanvasTemplate extends Identifiable {
+  displayName: string;
+  description: string;
+  visualUri: string | undefined;
+  tags: string[] | undefined;
+  provider: {
+    displayName: string | undefined;
+    avatarUri: string | undefined;
+  };
+  innovationPack: {
+    id: string | undefined;
+    displayName: string | undefined;
+  };
+}
+
+export interface CanvasTemplateWithValue extends CanvasTemplate {
+  value: string;
+}
+
+export const CanvasTemplateMapper = (
+  template: CanvasTemplateFragment,
+  provider?: CanvasTemplateProviderProfileFragment,
+  innovationPack?: { id: string; displayName: string }
+): CanvasTemplate => {
+  return {
+    id: template.id,
+    displayName: template.info.title,
+    description: template.info.description,
+    tags: template.info.tagset?.tags,
+    provider: {
+      displayName: provider?.displayName,
+      avatarUri: provider?.visual?.uri,
+    },
+    innovationPack: {
+      id: innovationPack?.id,
+      displayName: innovationPack?.displayName,
+    },
+    visualUri: template.info.visual?.uri,
+  };
+};

--- a/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplateCard.tsx
+++ b/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplateCard.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from '@mui/material';
+import { FC } from 'react';
+import CardHeader from '../../../../core/ui/card/CardHeader';
+import CardHeaderCaption from '../../../../core/ui/card/CardHeaderCaption';
+import CardImage from '../../../../core/ui/card/CardImage';
+import CardSegmentCaption from '../../../../core/ui/card/CardSegmentCaption';
+import ContributeCard from '../../../../core/ui/card/ContributeCard';
+import { Caption } from '../../../../core/ui/typography/components';
+import { InnovationPackIcon } from '../../../platform/admin/templates/InnovationPacks/InnovationPackIcon';
+import { CanvasIcon } from '../icon/CanvasIcon';
+import { CanvasTemplate } from './CanvasTemplate';
+
+interface CanvasTemplateCardProps {
+  template: CanvasTemplate | undefined;
+  loading?: boolean;
+  onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+}
+
+const CanvasTemplateCard: FC<CanvasTemplateCardProps> = ({ template, loading, onClick }) => {
+  return (
+    <ContributeCard onClick={onClick}>
+      <CardHeader title={template?.displayName} iconComponent={CanvasIcon}>
+        {loading && <Skeleton />}
+        <CardHeaderCaption noWrap logoUrl={template?.provider?.avatarUri}>
+          {template?.provider?.displayName}
+        </CardHeaderCaption>
+      </CardHeader>
+      <CardImage src={template?.visualUri} alt={template?.displayName} defaultImageSvg={<CanvasIcon />} />
+      {template?.innovationPack.displayName && (
+        <CardSegmentCaption icon={<InnovationPackIcon />}>
+          <Caption noWrap>{template?.innovationPack.displayName}</Caption>
+        </CardSegmentCaption>
+      )}
+      {loading && <Skeleton />}
+    </ContributeCard>
+  );
+};
+
+export default CanvasTemplateCard;

--- a/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplatesLibrary.graphql
+++ b/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplatesLibrary.graphql
@@ -1,0 +1,92 @@
+query HubCanvasTemplatesLibrary($hubId: UUID_NAMEID!) {
+  hub(ID: $hubId) {
+    id
+    templates {
+      id
+      canvasTemplates {
+        ...CanvasTemplate
+      }
+    }
+    host {
+      id
+      nameID
+      profile {
+        ...CanvasTemplateProviderProfile
+      }
+    }
+  }
+}
+
+query HubCanvasTemplateValue($hubId: UUID_NAMEID!, $canvasTemplateId: UUID!) {
+  hub(ID: $hubId) {
+    id
+    templates {
+      id
+      canvasTemplate(ID: $canvasTemplateId) {
+        ...CanvasTemplate
+        value
+      }
+    }
+  }
+}
+
+query PlatformCanvasTemplatesLibrary {
+  platform {
+    id
+    library {
+      id
+      innovationPacks {
+        id
+        nameID
+        displayName
+        provider {
+          id
+          profile {
+            ...CanvasTemplateProviderProfile
+          }
+        }
+        templates {
+          id
+          canvasTemplates {
+            ...CanvasTemplate
+          }
+        }
+      }
+    }
+  }
+}
+
+query PlatformCanvasTemplateValue($innovationPackId: UUID!, $canvasTemplateId: UUID!) {
+  platform {
+    id
+    library {
+      id
+      innovationPack(ID: $innovationPackId) {
+        id
+        nameID
+        displayName
+        provider {
+          id
+          profile {
+            ...CanvasTemplateProviderProfile
+          }
+        }
+        templates {
+          id
+          canvasTemplate(ID: $canvasTemplateId) {
+            ...CanvasTemplate
+            value
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment CanvasTemplateProviderProfile on Profile {
+  id
+  displayName
+  visual(type: AVATAR) {
+    ...VisualUri
+  }
+}

--- a/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplatesLibrary.tsx
+++ b/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplatesLibrary.tsx
@@ -1,0 +1,212 @@
+import { Button, Dialog, DialogContent, Link } from '@mui/material';
+import { FC, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LibraryIcon } from '../../../../common/icons/LibraryIcon';
+import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt';
+import { CanvasTemplate, CanvasTemplateMapper, CanvasTemplateWithValue } from './CanvasTemplate';
+import CanvasTemplatesLibraryGallery from './CanvasTemplatesLibraryGallery';
+import CanvasTemplatesLibraryPreview from './CanvasTemplatesLibraryPreview';
+import {
+  useHubCanvasTemplatesLibraryQuery,
+  usePlatformCanvasTemplatesLibraryLazyQuery,
+  useHubCanvasTemplateValueLazyQuery,
+  usePlatformCanvasTemplateValueLazyQuery,
+} from '../../../../core/apollo/generated/apollo-hooks';
+import { useHub } from '../../../challenge/hub/HubContext/useHub';
+import { BlockTitle, Caption } from '../../../../core/ui/typography';
+import { compact } from 'lodash';
+import Gutters from '../../../../core/ui/grid/Gutters';
+import DialogHeader from '../../../../core/ui/dialog/DialogHeader';
+import DialogIcon from '../../../../core/ui/dialog/DialogIcon';
+import { ImageSearch as ImageSearchIcon } from '@mui/icons-material';
+import MultipleSelect from '../../../platform/search/MultipleSelect';
+
+export interface CanvasTemplatesLibraryProps {
+  onSelectTemplate: (template: CanvasTemplateWithValue) => void;
+}
+
+const CanvasTemplatesLibrary: FC<CanvasTemplatesLibraryProps> = ({ onSelectTemplate }) => {
+  const { t } = useTranslation();
+  const { hubId } = useHub();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const handleClose = () => {
+    setDialogOpen(false);
+    handleClosePreview();
+  };
+  const [filter, setFilter] = useState<string[]>([]);
+
+  // Show gallery or show preview of this template:
+  const [previewTemplate, setPreviewTemplate] = useState<CanvasTemplateWithValue>();
+
+  // Hub Templates:
+  const { data: hubData, loading: loadingHubTemplates } = useHubCanvasTemplatesLibraryQuery({
+    variables: {
+      hubId,
+    },
+  });
+
+  const [fetchCanvasTemplateValueHub, { loading: loadingHubTemplateValue }] = useHubCanvasTemplateValueLazyQuery();
+
+  const hubTemplates = useMemo(
+    () =>
+      hubData?.hub.templates?.canvasTemplates.map<CanvasTemplate>(template =>
+        CanvasTemplateMapper(template, hubData?.hub.host?.profile)
+      ),
+    [hubData]
+  );
+
+  const handlePreviewTemplateHub = async (template: CanvasTemplate) => {
+    const { data } = await fetchCanvasTemplateValueHub({
+      variables: {
+        hubId,
+        canvasTemplateId: template.id,
+      },
+    });
+    const templateValue = data?.hub.templates?.canvasTemplate;
+    if (templateValue) {
+      setPreviewTemplate({
+        ...CanvasTemplateMapper(templateValue, hubData?.hub.host?.profile),
+        value: templateValue.value,
+      });
+    }
+  };
+
+  // Platform Templates:
+  const [fetchPlatformTemplates, { data: platformData, loading: loadingPlatformTemplates }] =
+    usePlatformCanvasTemplatesLibraryLazyQuery();
+
+  const [fetchCanvasTemplateValuePlatform, { loading: loadingPlatformTemplateValue }] =
+    usePlatformCanvasTemplateValueLazyQuery();
+
+  const platformTemplates = useMemo(
+    () =>
+      platformData?.platform.library.innovationPacks.flatMap(ip =>
+        compact(
+          ip.templates?.canvasTemplates.map<CanvasTemplate>(template =>
+            CanvasTemplateMapper(template, ip.provider?.profile, ip)
+          )
+        )
+      ),
+    [platformData]
+  );
+
+  const handlePreviewTemplatePlatform = async (template: CanvasTemplate) => {
+    const { data } = await fetchCanvasTemplateValuePlatform({
+      variables: {
+        innovationPackId: template.innovationPack.id!,
+        canvasTemplateId: template.id,
+      },
+    });
+
+    const ip = data?.platform.library.innovationPack;
+    const templateValue = ip?.templates?.canvasTemplate;
+    if (templateValue) {
+      setPreviewTemplate({
+        ...CanvasTemplateMapper(templateValue, ip?.provider?.profile, ip),
+        value: templateValue.value,
+      });
+    }
+  };
+
+  const handleClosePreview = () => {
+    setPreviewTemplate(undefined);
+  };
+
+  const handleSelectTemplate = () => {
+    if (previewTemplate) {
+      onSelectTemplate(previewTemplate);
+      handleClose();
+    }
+  };
+
+  const loading =
+    loadingHubTemplates || loadingHubTemplateValue || loadingPlatformTemplates || loadingPlatformTemplateValue;
+  const loadingPreview = loadingHubTemplateValue || loadingPlatformTemplateValue;
+
+  return (
+    <>
+      <Button variant="outlined" startIcon={<LibraryIcon />} onClick={() => setDialogOpen(true)}>
+        {t('buttons.find-template')}
+      </Button>
+      <Dialog
+        open={dialogOpen}
+        aria-labelledby="canvas-template-dialog"
+        onClose={handleClose}
+        PaperProps={{ sx: { backgroundColor: 'background.default', width: theme => theme.spacing(150) } }}
+        maxWidth={false}
+        fullWidth
+      >
+        <DialogHeader onClose={handleClose} titleContainerProps={{ alignItems: 'center' }}>
+          <DialogIcon>
+            <LibraryIcon />
+          </DialogIcon>
+          {t('canvas-templates.template-library')}
+          <MultipleSelect
+            onChange={terms => setFilter(terms)}
+            value={filter}
+            minLength={2}
+            containerProps={{
+              marginLeft: 'auto',
+            }}
+            inputProps={{ size: 'small' }}
+          />
+        </DialogHeader>
+        <DialogContent>
+          {!previewTemplate && !loadingPreview ? (
+            <Gutters>
+              <BlockTitle>{t('canvas-templates.hub-templates')}</BlockTitle>
+              <CanvasTemplatesLibraryGallery
+                canvases={hubTemplates}
+                filter={filter}
+                onPreviewTemplate={template => handlePreviewTemplateHub(template)}
+                loading={loadingHubTemplates}
+              />
+              {!platformTemplates && !loadingPlatformTemplates ? (
+                <Link
+                  component={Caption}
+                  onClick={() => fetchPlatformTemplates()}
+                  display="flex"
+                  alignItems="center"
+                  gap={1}
+                  sx={{ cursor: 'pointer' }}
+                >
+                  <ImageSearchIcon /> {t('canvas-templates.load-platform-templates')}
+                </Link>
+              ) : (
+                <>
+                  <BlockTitle>{t('canvas-templates.platform-templates')}</BlockTitle>
+                  <CanvasTemplatesLibraryGallery
+                    canvases={platformTemplates}
+                    filter={filter}
+                    onPreviewTemplate={template => handlePreviewTemplatePlatform(template)}
+                    loading={loadingPlatformTemplates}
+                  />
+                </>
+              )}
+            </Gutters>
+          ) : (
+            <CanvasTemplatesLibraryPreview
+              template={previewTemplate}
+              loading={loadingPreview}
+              onClose={handleClosePreview}
+              actions={
+                <Button
+                  startIcon={<SystemUpdateAltIcon />}
+                  variant="contained"
+                  sx={{ marginLeft: theme => theme.spacing(1) }}
+                  disabled={loading}
+                  onClick={handleSelectTemplate}
+                >
+                  {t('buttons.use')}
+                </Button>
+              }
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default CanvasTemplatesLibrary;

--- a/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplatesLibraryGallery.tsx
+++ b/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplatesLibraryGallery.tsx
@@ -1,0 +1,63 @@
+import React, { FC, useMemo } from 'react';
+import { Box, BoxProps, Skeleton } from '@mui/material';
+import { CanvasTemplate } from './CanvasTemplate';
+import CanvasTemplateCard from './CanvasTemplateCard';
+import { useTranslation } from 'react-i18next';
+import GridProvider from '../../../../core/ui/grid/GridProvider';
+import CardsLayout from '../../../../core/ui/card/CardsLayout/CardsLayout';
+import { Text } from '../../../../core/ui/typography';
+import { gutters } from '../../../../core/ui/grid/utils';
+import { times } from 'lodash';
+
+const GallerySkeleton: FC<BoxProps> = props => {
+  return (
+    <Box display="flex" gap={2} height={gutters(8)} {...props}>
+      {times(4, i => (
+        <Skeleton key={i} sx={{ flexGrow: 1 }} />
+      ))}
+    </Box>
+  );
+};
+
+export interface CanvasTemplatesLibraryGalleryProps {
+  canvases: CanvasTemplate[] | undefined;
+  filter?: string[];
+  onPreviewTemplate: (template: CanvasTemplate) => void;
+  loading?: boolean;
+}
+
+const CanvasTemplatesLibraryGallery = ({
+  canvases,
+  filter,
+  onPreviewTemplate,
+  loading,
+}: CanvasTemplatesLibraryGalleryProps) => {
+  const { t } = useTranslation();
+
+  const templates = useMemo(() => {
+    return canvases?.filter(canvas => {
+      if (!filter || filter.length === 0) return true;
+      const canvasString =
+        `${canvas.displayName} ${canvas.provider.displayName} ${canvas.innovationPack.displayName}`.toLowerCase();
+      return filter.some(term => canvasString.includes(term.toLowerCase()));
+    });
+  }, [canvases, filter]);
+
+  return (
+    <GridProvider columns={12} force>
+      {(loading || !templates) && <GallerySkeleton />}
+      {!loading && templates && (
+        <CardsLayout items={templates} deps={[templates]} disablePadding cards={false}>
+          {template => (
+            <CanvasTemplateCard key={template.id} template={template} onClick={() => onPreviewTemplate(template)} />
+          )}
+        </CardsLayout>
+      )}
+      {!loading && templates && templates.length === 0 && (
+        <Text>{t('pages.admin.generic.sections.templates.import.no-templates')}</Text>
+      )}
+    </GridProvider>
+  );
+};
+
+export default CanvasTemplatesLibraryGallery;

--- a/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplatesLibraryPreview.tsx
+++ b/src/domain/collaboration/canvas/CanvasTemplatesLibrary/CanvasTemplatesLibraryPreview.tsx
@@ -1,0 +1,79 @@
+import { Box, Button, Grid, Skeleton, useTheme } from '@mui/material';
+import { FC, ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CanvasTemplateWithValue } from './CanvasTemplate';
+import CanvasTemplateCard from './CanvasTemplateCard';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import GridProvider from '../../../../core/ui/grid/GridProvider';
+import { BlockSectionTitle } from '../../../../core/ui/typography/components';
+import WrapperMarkdown from '../../../../core/ui/markdown/WrapperMarkdown';
+import TagsComponent from '../../../shared/components/TagsComponent/TagsComponent';
+import CanvasWhiteboard from '../../../../common/components/composite/entities/Canvas/CanvasWhiteboard';
+
+export interface CanvasTemplatesLibraryPreviewProps {
+  onClose: () => void;
+  template?: CanvasTemplateWithValue;
+  loading?: boolean;
+  importedTemplateValue?: string | undefined;
+  actions?: ReactNode;
+}
+
+const CanvasTemplatesLibraryPreview: FC<CanvasTemplatesLibraryPreviewProps> = ({
+  template,
+  loading,
+  actions,
+  onClose,
+}) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12} sm={3} sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+        <GridProvider columns={3}>
+          <CanvasTemplateCard template={template} loading={loading} />
+        </GridProvider>
+        <Box sx={{ display: 'flex', marginY: theme.spacing(2), justifyContent: 'end' }}>
+          <Button startIcon={<ArrowBackIcon />} variant="text" onClick={() => onClose()}>
+            {t('buttons.back')}
+          </Button>
+          {actions}
+        </Box>
+      </Grid>
+      <Grid item xs={12} sm={9}>
+        <Box>
+          <BlockSectionTitle>{t('common.description')}</BlockSectionTitle>
+          <WrapperMarkdown>{template?.description || ''}</WrapperMarkdown>
+          {loading && <Skeleton />}
+        </Box>
+        <Box>
+          <BlockSectionTitle>{t('common.tags')}</BlockSectionTitle>
+          <TagsComponent tags={template?.tags ?? []} />
+          {loading && <Skeleton />}
+        </Box>
+        <Box height={theme.spacing(40)}>
+          {template?.value ? (
+            <CanvasWhiteboard
+              entities={{
+                canvas: template,
+              }}
+              actions={{}}
+              options={{
+                viewModeEnabled: true,
+                UIOptions: {
+                  canvasActions: {
+                    export: false,
+                  },
+                },
+              }}
+            />
+          ) : (
+            <Skeleton height={theme.spacing(40)} />
+          )}
+        </Box>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default CanvasTemplatesLibraryPreview;

--- a/src/domain/collaboration/canvas/utils/mergeCanvas.ts
+++ b/src/domain/collaboration/canvas/utils/mergeCanvas.ts
@@ -1,0 +1,117 @@
+import { ExcalidrawElement } from '@alkemio/excalidraw/types/element/types';
+import { BinaryFileData, ExcalidrawImperativeAPI } from '@alkemio/excalidraw/types/types';
+import { v4 as uuidv4 } from 'uuid';
+
+class CanvasMergeError extends Error {}
+
+interface CanvasLike {
+  type: string;
+  version: number;
+  elements: ExcalidrawElement[];
+  files?: Record<BinaryFileData['id'], BinaryFileData>;
+}
+
+const isCanvasLike = (parsedObject: unknown): parsedObject is CanvasLike => {
+  if (!parsedObject) {
+    return false;
+  }
+
+  const canvas = parsedObject as Record<string, unknown>;
+  if (canvas['type'] !== 'excalidraw' || canvas['version'] !== 2) {
+    return false;
+  }
+  if (!canvas['elements'] || !Array.isArray(canvas['elements'])) {
+    return false;
+  }
+  // At least we have something that looks like a canvas
+  return true;
+};
+
+interface BoundingBox {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+const getBoundingBox = (canvasElements?: readonly ExcalidrawElement[]): BoundingBox => {
+  if (!canvasElements || canvasElements.length === 0) {
+    return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+  }
+
+  const [firstElement, ...elements] = canvasElements;
+
+  const box = {
+    minX: firstElement.x,
+    minY: firstElement.y,
+    maxX: firstElement.x + firstElement.width,
+    maxY: firstElement.y + firstElement.height,
+  };
+
+  elements.forEach(element => {
+    box.minX = Math.min(element.x, box.minX);
+    box.minY = Math.min(element.y, box.minY);
+    box.maxX = Math.max(element.x + element.width, box.maxX);
+    box.maxY = Math.max(element.y + element.height, box.maxY);
+  });
+  return box;
+};
+
+const calculateInsertionPoint = (canvasA: BoundingBox, canvasB: BoundingBox): { x: number; y: number } => {
+  // Center the canvasB vertically in reference to canvasA
+  // minY - height / 2
+  const aY = canvasA.minY + (canvasA.maxY - canvasA.minY) / 2;
+  const bY = canvasB.minY + (canvasB.maxY - canvasB.minY) / 2;
+  // Displace middle of canvasB to middle of canvasA
+  const y = aY - bY;
+
+  // Displace all elements of canvasB to the right of canvasA + 10% of the width of canvasA
+  const x = -canvasB.minX + canvasA.maxX + 0.1 * (canvasA.maxX - canvasA.minX);
+
+  return { x, y };
+};
+
+const mergeCanvas = (canvasApi: ExcalidrawImperativeAPI, canvasValue: string) => {
+  let parsedCanvas: unknown;
+  try {
+    parsedCanvas = JSON.parse(canvasValue);
+  } catch (err) {
+    throw new CanvasMergeError(`Unable to parse canvas value: ${err}`);
+  }
+
+  if (!isCanvasLike(parsedCanvas)) throw new CanvasMergeError('Canvas verification failed');
+
+  try {
+    // Insert missing files into current canvas:
+    const currentFiles = canvasApi.getFiles();
+    for (const fileId in parsedCanvas.files) {
+      if (!currentFiles[fileId]) {
+        canvasApi.addFiles([parsedCanvas.files[fileId]]);
+      }
+    }
+
+    const currentElements = canvasApi.getSceneElements();
+
+    const currentElementsBBox = getBoundingBox(currentElements);
+    const insertedCanvasBBox = getBoundingBox(parsedCanvas.elements);
+    const displacement = calculateInsertionPoint(currentElementsBBox, insertedCanvasBBox);
+
+    const insertedElements = parsedCanvas.elements?.map(el => ({
+      ...el,
+      id: uuidv4(),
+      x: el.x + displacement.x,
+      y: el.y + displacement.y,
+    }));
+
+    const newElements = [...currentElements, ...insertedElements];
+    canvasApi.updateScene({
+      elements: newElements,
+      commitToHistory: true, // TODO: WARNING maybe this needs to be false when collaborative editing
+    });
+    canvasApi.zoomToFit();
+    return true;
+  } catch (err) {
+    throw new CanvasMergeError(`Unable to merge canvases: ${err}`);
+  }
+};
+
+export default mergeCanvas;

--- a/src/domain/community/contributor/organization/OrganizationPageContainer/OrganizationPageContainer.tsx
+++ b/src/domain/community/contributor/organization/OrganizationPageContainer/OrganizationPageContainer.tsx
@@ -35,6 +35,7 @@ export interface OrganizationContainerEntities {
   contributions: ContributionItem[];
   permissions: {
     canEdit: boolean;
+    canReadUsers: boolean;
   };
   website?: string;
   handleSendMessage: (text: string) => Promise<void>;
@@ -57,7 +58,7 @@ export interface OrganizationPageContainerProps
 const NO_PRIVILEGES = [];
 
 export const OrganizationPageContainer: FC<OrganizationPageContainerProps> = ({ children }) => {
-  const { organizationId, organizationNameId, loading, organization } = useOrganization();
+  const { organizationId, organizationNameId, loading, organization, canReadUsers } = useOrganization();
 
   const usersWithRoles = useUserCardRoleName((organization?.associates || []) as User[], organizationId);
 
@@ -103,6 +104,7 @@ export const OrganizationPageContainer: FC<OrganizationPageContainerProps> = ({ 
 
   const permissions = {
     canEdit: organizationPrivileges.includes(AuthorizationPrivilege.Update),
+    canReadUsers,
   };
 
   const associates = useMemo<ContributorCardProps[]>(() => {

--- a/src/domain/community/contributor/organization/context/OrganizationInfoFragment.graphql
+++ b/src/domain/community/contributor/organization/context/OrganizationInfoFragment.graphql
@@ -33,6 +33,11 @@ fragment OrganizationInfo on Organization {
       ...fullLocation
     }
   }
+  metrics {
+    id
+    name
+    value
+  }
   associates @include(if: $includeAssociates) {
     id
     nameID

--- a/src/domain/community/contributor/organization/context/OrganizationProvider.tsx
+++ b/src/domain/community/contributor/organization/context/OrganizationProvider.tsx
@@ -8,12 +8,14 @@ interface OrganizationContextProps {
   organization?: OrganizationInfoFragment;
   organizationId: string;
   organizationNameId: string;
+  canReadUsers: boolean;
   displayName: string;
   loading: boolean;
 }
 
 const OrganizationContext = React.createContext<OrganizationContextProps>({
   loading: true,
+  canReadUsers: false,
   organizationId: '',
   organizationNameId: '',
   displayName: '',
@@ -39,6 +41,7 @@ const OrganizationProvider: FC = ({ children }) => {
         organization,
         organizationId: organization?.id || '',
         organizationNameId: organization?.nameID || organizationId,
+        canReadUsers: canReadUsers ?? false,
         displayName,
         loading,
       }}

--- a/src/domain/community/contributor/organization/views/OrganizationPageView.tsx
+++ b/src/domain/community/contributor/organization/views/OrganizationPageView.tsx
@@ -14,6 +14,8 @@ import {
 } from '../../../profile/views/ProfileView';
 import PageContent from '../../../../../core/ui/content/PageContent';
 import PageContentColumn from '../../../../../core/ui/content/PageContentColumn';
+import getMetricCount from '../../../../platform/metrics/utils/getMetricCount';
+import { MetricType } from '../../../../platform/metrics/MetricType';
 
 interface OrganizationPageViewProps {
   entities: OrganizationContainerEntities;
@@ -50,13 +52,15 @@ export const OrganizationPageView: FC<OrganizationPageViewProps> = ({ entities }
     [organization, tagsets, socialLinks, links, t]
   );
 
+  const associatesCount = getMetricCount(organization?.metrics, MetricType.Associate);
+
   return (
     <PageContent>
       <PageContentColumn columns={4}>
         <OrganizationProfileView entity={entity} permissions={permissions} />
       </PageContentColumn>
       <PageContentColumn columns={8}>
-        <AssociatesView associates={associates} />
+        <AssociatesView associates={associates} totalCount={associatesCount} canReadUsers={permissions.canReadUsers} />
         <ContributionsView
           title={t('components.contributions.title')}
           helpText={t('components.contributions.help')}

--- a/src/domain/community/profile/views/ProfileView/AssociatesView.tsx
+++ b/src/domain/community/profile/views/ProfileView/AssociatesView.tsx
@@ -6,15 +6,23 @@ import ContributorCard, {
 } from '../../../../../common/components/composite/common/cards/ContributorCard/ContributorCard';
 import PageContentBlock from '../../../../../core/ui/content/PageContentBlock';
 import PageContentBlockHeader from '../../../../../core/ui/content/PageContentBlockHeader';
+import { BlockSectionTitle } from '../../../../../core/ui/typography';
 
 const ASSOCIATE_CARDS_COUNT = 12;
 
 interface AssociatesViewProps {
+  canReadUsers: boolean;
   associates: ContributorCardProps[];
+  totalCount: number;
   count?: number;
 }
 
-export const AssociatesView: FC<AssociatesViewProps> = ({ associates, count = ASSOCIATE_CARDS_COUNT }) => {
+export const AssociatesView: FC<AssociatesViewProps> = ({
+  canReadUsers,
+  associates,
+  totalCount,
+  count = ASSOCIATE_CARDS_COUNT,
+}) => {
   const { t } = useTranslation();
   const [showAll, setShowAll] = useState(false);
   const toggleShowAll = () => setShowAll(prevValue => !prevValue);
@@ -27,21 +35,30 @@ export const AssociatesView: FC<AssociatesViewProps> = ({ associates, count = AS
 
   return (
     <PageContentBlock>
-      <PageContentBlockHeader title={t('components.associates.title', { count: associates.length })} />
+      <PageContentBlockHeader title={t('components.associates.title', { count: totalCount })} />
+
       <Grid container spacing={2} columns={{ xs: 6, sm: 12 }}>
-        {associatesToShow.map(associate => (
-          <Grid key={associate.id} item xs={2}>
-            <ContributorCard {...associate} />
+        {canReadUsers ? (
+          <>
+            {associatesToShow.map(associate => (
+              <Grid key={associate.id} item xs={2}>
+                <ContributorCard {...associate} />
+              </Grid>
+            ))}
+            <Grid item container justifyContent="flex-end">
+              {usersCount > 0 && (
+                <Link component="button" onClick={toggleShowAll}>
+                  {!showAll && t('associates-view.more', { count: usersCount })}
+                  {showAll && t('associates-view.less')}
+                </Link>
+              )}
+            </Grid>
+          </>
+        ) : (
+          <Grid item>
+            <BlockSectionTitle>{t('associates-view.sign-in')}</BlockSectionTitle>
           </Grid>
-        ))}
-        <Grid item container justifyContent="flex-end">
-          {usersCount > 0 && (
-            <Link component="button" onClick={toggleShowAll}>
-              {!showAll && t('associates-view.more', { count: usersCount })}
-              {showAll && t('associates-view.less')}
-            </Link>
-          )}
-        </Grid>
+        )}
       </Grid>
     </PageContentBlock>
   );

--- a/src/domain/platform/admin/templates/AspectTemplates/AspectImportTemplateCard.tsx
+++ b/src/domain/platform/admin/templates/AspectTemplates/AspectImportTemplateCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TemplateImportCardComponentProps } from '../InnovationPacks/ImportTemplatesDialogGalleryStep';
 import { AspectIcon } from '../../../../collaboration/aspect/icon/AspectIcon';
-import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
+import { InnovationPackIcon } from '../InnovationPacks/InnovationPackIcon';
 import { TemplateInnovationPackMetaInfo } from '../InnovationPacks/InnovationPack';
 import ContributeCard from '../../../../../core/ui/card/ContributeCard';
 import CardHeader from '../../../../../core/ui/card/CardHeader';
@@ -26,7 +26,7 @@ const AspectImportTemplateCard = ({ template, onClick }: AspectImportTemplateCar
         <CardDescription>{template.info.description}</CardDescription>
         <CardTags tags={template.info.tagset?.tags ?? []} paddingX={1.5} marginY={1} />
       </CardDetails>
-      <CardSegmentCaption icon={<Inventory2OutlinedIcon />}>
+      <CardSegmentCaption icon={<InnovationPackIcon />}>
         <Caption noWrap>{template.innovationPackDisplayName}</Caption>
       </CardSegmentCaption>
     </ContributeCard>

--- a/src/domain/platform/admin/templates/CanvasTemplates/CanvasImportTemplateCard.tsx
+++ b/src/domain/platform/admin/templates/CanvasTemplates/CanvasImportTemplateCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TemplateImportCardComponentProps } from '../InnovationPacks/ImportTemplatesDialogGalleryStep';
 import { getVisualBannerNarrow } from '../../../../common/visual/utils/visuals.utils';
 import { CanvasIcon } from '../../../../collaboration/canvas/icon/CanvasIcon';
-import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
+import { InnovationPackIcon } from '../InnovationPacks/InnovationPackIcon';
 import { TemplateInnovationPackMetaInfo } from '../InnovationPacks/InnovationPack';
 import ContributeCard from '../../../../../core/ui/card/ContributeCard';
 import CardHeader from '../../../../../core/ui/card/CardHeader';
@@ -26,7 +26,7 @@ const CanvasImportTemplateCard = ({ template, onClick }: CanvasImportTemplateCar
         alt={template.info.title}
         defaultImageSvg={<CanvasIcon />}
       />
-      <CardSegmentCaption icon={<Inventory2OutlinedIcon />}>
+      <CardSegmentCaption icon={<InnovationPackIcon />}>
         <Caption noWrap>{template.innovationPackDisplayName}</Caption>
       </CardSegmentCaption>
     </ContributeCard>

--- a/src/domain/platform/admin/templates/InnovationPacks/InnovationPackIcon.tsx
+++ b/src/domain/platform/admin/templates/InnovationPacks/InnovationPackIcon.tsx
@@ -1,0 +1,3 @@
+import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
+
+export const InnovationPackIcon = Inventory2OutlinedIcon;

--- a/src/domain/platform/admin/templates/InnovationTemplates/InnovationImportTemplateCard.tsx
+++ b/src/domain/platform/admin/templates/InnovationTemplates/InnovationImportTemplateCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TemplateImportCardComponentProps } from '../InnovationPacks/ImportTemplatesDialogGalleryStep';
 import AutoGraphIcon from '@mui/icons-material/AutoGraph';
-import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
+import { InnovationPackIcon } from '../InnovationPacks/InnovationPackIcon';
 import { TemplateInnovationPackMetaInfo } from '../InnovationPacks/InnovationPack';
 import ContributeCard from '../../../../../core/ui/card/ContributeCard';
 import CardHeader from '../../../../../core/ui/card/CardHeader';
@@ -26,7 +26,7 @@ const InnovationImportTemplateCard = ({ template, onClick }: InnovationImportTem
         <CardDescription>{template.info.description}</CardDescription>
         <CardTags tags={template.info.tagset?.tags ?? []} paddingX={1.5} marginY={1} />
       </CardDetails>
-      <CardSegmentCaption icon={<Inventory2OutlinedIcon />}>
+      <CardSegmentCaption icon={<InnovationPackIcon />}>
         <Caption noWrap>{template.innovationPackDisplayName}</Caption>
       </CardSegmentCaption>
     </ContributeCard>

--- a/src/domain/platform/search/MultipleSelect.tsx
+++ b/src/domain/platform/search/MultipleSelect.tsx
@@ -1,5 +1,5 @@
 import SearchIcon from '@mui/icons-material/Search';
-import Box from '@mui/material/Box';
+import Box, { BoxProps } from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import React, { ChangeEventHandler, FC, KeyboardEventHandler, Ref, useState } from 'react';
@@ -20,7 +20,9 @@ export interface MultipleSelectProps {
   inputProps?: {
     inputRef?: Ref<HTMLInputElement | null>;
     onBlur?: InputBaseProps['onBlur'];
+    size?: InputBaseProps['size'];
   };
+  containerProps?: BoxProps;
 }
 
 const filterTerms = (values: string[] | undefined) => {
@@ -59,6 +61,7 @@ const MultipleSelect: FC<MultipleSelectProps> = ({
   minLength = 2,
   autoFocus,
   inputProps,
+  containerProps,
   children,
 }) => {
   const { t } = useTranslation();
@@ -119,7 +122,7 @@ const MultipleSelect: FC<MultipleSelectProps> = ({
   };
 
   return (
-    <Box>
+    <Box {...containerProps}>
       <Tooltip
         id="overlay-example"
         title={t('pages.search.max-tags-reached', { max: MAX_TERMS_SEARCH })}


### PR DESCRIPTION
## Canvas
  - Now `Users` can create a canvas from content in the `Library`

## Fixes
  - Restored old field length limits, added logging to Sentry if limits are exceeded
  - Attachment URLs now stay as absolute URLs
  - Associates count is being read from metrics

