### PR TITLE
removed opportunities from being displayed as part of hub metrics; 

### DIFF
--- a/src/domain/challenge/hub/Metrics/HubMetrics.ts
+++ b/src/domain/challenge/hub/Metrics/HubMetrics.ts
@@ -8,11 +8,6 @@ const HubMetrics: MetricsItemSpec[] = [
     color: 'neutral',
   },
   {
-    label: 'common.opportunities',
-    type: MetricType.Opportunity,
-    color: 'primary',
-  },
-  {
     label: 'common.members',
     type: MetricType.Member,
     color: 'neutralMedium',


### PR DESCRIPTION
very confusing when displaying dialog on private hub that a new user does not have access to.

Came up today in a meeting; WDC was open that they should not be exposed to that information in that box. 


