### PR TITLE
Try fixing log in issue

### DIFF
--- a/src/core/auth/authentication/pages/LoginSuccessPage.tsx
+++ b/src/core/auth/authentication/pages/LoginSuccessPage.tsx
@@ -1,18 +1,19 @@
 import { FC, useEffect } from 'react';
 import { STORAGE_KEY_RETURN_URL } from '../constants/authentication.constants';
+import { useReturnUrl } from '../utils/SignUpReturnUrl';
 
 interface LoginSuccessPageProps {}
 
 export const LoginSuccessPage: FC<LoginSuccessPageProps> = () => {
+  const returnUrl = useReturnUrl();
   useEffect(() => {
-    const redirectUrl = sessionStorage.getItem(STORAGE_KEY_RETURN_URL) ?? '/';
-
-    window.location.replace(redirectUrl);
-
-    return () => {
-      sessionStorage.removeItem(STORAGE_KEY_RETURN_URL);
-    };
-  }, []);
+    if (returnUrl) {
+      window.location.replace(returnUrl);
+      return () => {
+        sessionStorage.removeItem(STORAGE_KEY_RETURN_URL);
+      };
+    }
+  }, [returnUrl]);
 
   return null;
 };

--- a/src/core/auth/authentication/pages/SignUp.tsx
+++ b/src/core/auth/authentication/pages/SignUp.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import AuthPageContentContainer from '../../../../domain/shared/layout/AuthPageContentContainer';
 import SubHeading from '../../../../domain/shared/components/Text/SubHeading';
 import Paragraph from '../../../../domain/shared/components/Text/Paragraph';
@@ -8,7 +8,12 @@ import { EmailOutlined } from '@mui/icons-material';
 import { Theme } from '@mui/material/styles';
 import AuthActionButton from '../components/Button';
 import { useNavigate } from 'react-router-dom';
-import { _AUTH_REGISTER_PATH, _AUTH_LOGIN_PATH } from '../constants/authentication.constants';
+import {
+  _AUTH_REGISTER_PATH,
+  _AUTH_LOGIN_PATH,
+  PARAM_NAME_RETURN_URL,
+  STORAGE_KEY_RETURN_URL,
+} from '../constants/authentication.constants';
 import useKratosFlow, { FlowTypeName } from '../hooks/useKratosFlow';
 import produce from 'immer';
 import KratosUI from '../components/KratosUI';
@@ -22,6 +27,7 @@ import { UiContainer } from '@ory/kratos-client';
 import { KRATOS_INPUT_NAME_CSRF, KRATOS_TRAIT_NAME_ACCEPTED_TERMS } from '../components/Kratos/constants';
 import { isInputNode } from '../components/Kratos/helpers';
 import { useStoreSignUpReturnUrl } from '../utils/SignUpReturnUrl';
+import { useQueryParams } from '../../../routing/useQueryParams';
 
 const EmailIcon = () => {
   const size = (theme: Theme) => theme.spacing(3);
@@ -66,6 +72,14 @@ const SignUp = () => {
   const signIn = () => {
     navigate(_AUTH_LOGIN_PATH);
   };
+
+  const params = useQueryParams();
+  const returnUrl = params.get(PARAM_NAME_RETURN_URL);
+  useEffect(() => {
+    if (returnUrl) {
+      sessionStorage.setItem(STORAGE_KEY_RETURN_URL, returnUrl);
+    }
+  }, [returnUrl]);
 
   useStoreSignUpReturnUrl();
 

--- a/src/core/auth/authentication/utils/SignUpReturnUrl.ts
+++ b/src/core/auth/authentication/utils/SignUpReturnUrl.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { ROUTE_HOME } from '../../../../domain/platform/routes/constants';
 import { STORAGE_KEY_RETURN_URL } from '../constants/authentication.constants';
 import { useConfig } from '../../../../domain/platform/config/useConfig';
+import { env } from '../../../../types/env';
 
 const STORAGE_KEY_SIGN_UP_RETURN_URL = 'signUpReturnUrl';
 
@@ -10,8 +11,14 @@ const storeSignUpReturnUrl = (returnUrl: string) => {
 };
 
 export const useReturnUrl = () => {
-  const { platform } = useConfig();
-  const defaultReturnUrl = `https://${platform?.domain}${ROUTE_HOME}`;
+  const { platform, loading } = useConfig();
+  let defaultReturnUrl = '';
+  if (platform?.domain === 'localhost') {
+    defaultReturnUrl = `//${env?.REACT_APP_ALKEMIO_DOMAIN}${ROUTE_HOME}`;
+  } else if (platform && !loading) {
+    defaultReturnUrl = `https://${platform?.domain}${ROUTE_HOME}`;
+  }
+
   return useRef(sessionStorage.getItem(STORAGE_KEY_RETURN_URL)).current ?? defaultReturnUrl;
 };
 


### PR DESCRIPTION
- In `SignUp` I am saving the returnUrl. I think THIS will fix almost everything. Because we were only saving returnUrl when signing In, and not Up. This code is copied from `LoginRoute.tsx`

In case we get to a success login without the `returnUrl` set in the session, like for example on social logins:
- On `LoginSuccessPage` I am changing the redirect (`window.location.replace`) to wait read the redirect url from the sessionStorage, and if it's not there, read it from the platform. That is asynchronous so maybe it needs to wait.

- on `SignUpReturnUrl.ts` I had a mistake in my previous PR. It wasn't working well for localhost. With this it reads the domain from the env. Why not read it always from the env? Because we need to read the `config.platform.domain` from the server when we are in an Innovation Hub. The `env.REACT_APP_ALKEMIO_DOMAIN` of `demo.alkem.io` for example is just `alkem.io`.