### PR TITLE
Added privilege check for InnovationFlow Settings Dialog

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -8406,6 +8406,10 @@ export const ChallengeInnovationFlowStatesAllowedValuesDocument = gql`
             id
             state
           }
+          authorization {
+            id
+            myPrivileges
+          }
           profile {
             id
             tagsets {
@@ -8490,6 +8494,10 @@ export const OpportunityInnovationFlowStatesAllowedValuesDocument = gql`
           lifecycle {
             id
             state
+          }
+          authorization {
+            id
+            myPrivileges
           }
           profile {
             id

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -12692,6 +12692,9 @@ export type ChallengeInnovationFlowStatesAllowedValuesQuery = {
             __typename?: 'InnovationFlow';
             id: string;
             lifecycle?: { __typename?: 'Lifecycle'; id: string; state?: string | undefined } | undefined;
+            authorization?:
+              | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
             profile: {
               __typename?: 'Profile';
               id: string;
@@ -12723,6 +12726,9 @@ export type OpportunityInnovationFlowStatesAllowedValuesQuery = {
             __typename?: 'InnovationFlow';
             id: string;
             lifecycle?: { __typename?: 'Lifecycle'; id: string; state?: string | undefined } | undefined;
+            authorization?:
+              | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
             profile: {
               __typename?: 'Profile';
               id: string;

--- a/src/domain/collaboration/InnovationFlow/InnovationFlowStates/InnovationFlowStates.graphql
+++ b/src/domain/collaboration/InnovationFlow/InnovationFlowStates/InnovationFlowStates.graphql
@@ -9,6 +9,10 @@ query ChallengeInnovationFlowStatesAllowedValues($spaceId: UUID_NAMEID!, $challe
           id
           state
         }
+        authorization {
+          id
+          myPrivileges
+        }
         profile {
           id
           tagsets {
@@ -22,7 +26,7 @@ query ChallengeInnovationFlowStatesAllowedValues($spaceId: UUID_NAMEID!, $challe
   }
 }
 
-query OpportunityInnovationFlowStatesAllowedValues($spaceId: UUID_NAMEID!,  $opportunityId: UUID_NAMEID!) {
+query OpportunityInnovationFlowStatesAllowedValues($spaceId: UUID_NAMEID!, $opportunityId: UUID_NAMEID!) {
   space(ID: $spaceId) {
     id
     opportunity(ID: $opportunityId) {
@@ -32,6 +36,10 @@ query OpportunityInnovationFlowStatesAllowedValues($spaceId: UUID_NAMEID!,  $opp
         lifecycle {
           id
           state
+        }
+        authorization {
+          id
+          myPrivileges
         }
         profile {
           id

--- a/src/domain/collaboration/InnovationFlow/InnovationFlowStates/useInnovationFlowStates.ts
+++ b/src/domain/collaboration/InnovationFlow/InnovationFlowStates/useInnovationFlowStates.ts
@@ -1,5 +1,6 @@
 import { useChallengeInnovationFlowStatesAllowedValuesQuery } from '../../../../core/apollo/generated/apollo-hooks';
 import { useOpportunityInnovationFlowStatesAllowedValuesQuery } from '../../../../core/apollo/generated/apollo-hooks';
+import { AuthorizationPrivilege } from '../../../../core/apollo/generated/graphql-schema';
 interface UseInnovationFlowStatesParams {
   spaceId: string;
   challengeId: string | undefined;
@@ -11,6 +12,7 @@ export const INNOVATION_FLOW_STATES_TAGSET_NAME = 'flow-state';
 interface UseInnovationFlowStatesProvided {
   innovationFlowStates: string[] | undefined;
   currentInnovationFlowState: string | undefined;
+  canEdit: boolean;
 }
 
 const useInnovationFlowStates = ({
@@ -22,6 +24,7 @@ const useInnovationFlowStates = ({
     throw new Error('You need to provide either challenge or opportunity id!');
   }
 
+  let canEdit = false;
   const skipChallenge: boolean = !(challengeId && !opportunityId);
   const challengeFlowStates = useChallengeInnovationFlowStatesAllowedValuesQuery({
     variables: {
@@ -46,6 +49,8 @@ const useInnovationFlowStates = ({
       tagset => tagset.name === INNOVATION_FLOW_STATES_TAGSET_NAME
     );
     currentInnovationFlowState = flowStatesData?.space.challenge.innovationFlow?.lifecycle?.state;
+    const myPrivilleges = flowStatesData?.space.challenge.innovationFlow?.authorization?.myPrivileges;
+    canEdit = myPrivilleges?.includes(AuthorizationPrivilege.Update);
   }
 
   if (opportunityId) {
@@ -54,6 +59,8 @@ const useInnovationFlowStates = ({
       tagset => tagset.name === INNOVATION_FLOW_STATES_TAGSET_NAME
     );
     currentInnovationFlowState = flowStatesData?.space.opportunity.innovationFlow?.lifecycle?.state;
+    const myPrivilleges = flowStatesData?.space.opportunity.innovationFlow?.authorization?.myPrivileges;
+    canEdit = myPrivilleges?.includes(AuthorizationPrivilege.Update);
   }
 
   const flowStates = flowStatesTagset?.allowedValues;
@@ -61,6 +68,7 @@ const useInnovationFlowStates = ({
   return {
     innovationFlowStates: flowStates,
     currentInnovationFlowState,
+    canEdit: canEdit,
   };
 };
 

--- a/src/domain/collaboration/callout/JourneyCalloutsTabView/JourneyCalloutsTabView.tsx
+++ b/src/domain/collaboration/callout/JourneyCalloutsTabView/JourneyCalloutsTabView.tsx
@@ -32,7 +32,7 @@ const JourneyCalloutsTabView = ({ journeyTypeName, scrollToCallout }: JourneyCal
     throw new Error('Must be within a Space');
   }
 
-  const { innovationFlowStates, currentInnovationFlowState } = useInnovationFlowStates({
+  const { innovationFlowStates, currentInnovationFlowState, canEdit } = useInnovationFlowStates({
     spaceId: spaceNameId,
     challengeId: challengeNameId!,
     opportunityId: opportunityNameId,
@@ -69,6 +69,7 @@ const JourneyCalloutsTabView = ({ journeyTypeName, scrollToCallout }: JourneyCal
   const { t } = useTranslation();
 
   const handleSelectInnovationFlowState = (state: InnovationFlowState) => setSelectedInnovationFlowState(state);
+  const showInnovationFlowStatesSettingsDialog = canEdit;
 
   return (
     <>
@@ -124,7 +125,7 @@ const JourneyCalloutsTabView = ({ journeyTypeName, scrollToCallout }: JourneyCal
                 selectedState={selectedInnovationFlowState}
                 states={innovationFlowStates}
                 onSelectState={handleSelectInnovationFlowState}
-                showSettings
+                showSettings={showInnovationFlowStatesSettingsDialog}
               />
             )}
             <CalloutsGroupView


### PR DESCRIPTION
There are multiple considerations here, hence the draft:
- We need to be provided with a good UX for web / mobile how this should look like so we don't re-iterate over it 5 times. It looks quite bad when the user doesn't have privileges, when the classification tagsets are long, when they are many etc... It needs proper thinking
- I am checking `UPDATE` privilege on the InnovationFlow State. However, this might not be the best course of action, as the settings dialog manages both the metadata / profile for the InnovationFlow (in that case, the privilege is the correct one) but it also can alter / update `Classification Tagsets` that are actually bound to `Callouts` and not the `Innovation Flow`. One option would be to check whether we can update the `Challenge` / `Opportunity`, but that also seems incorrect. @techsmyth  - any guidance here?