### PR TITLE
Clean up CardTags

### DIFF
--- a/src/core/ui/card/CardDescription.tsx
+++ b/src/core/ui/card/CardDescription.tsx
@@ -5,7 +5,7 @@ import WrapperMarkdown from '../markdown/WrapperMarkdown';
 import OverflowGradient, { OverflowGradientProps } from '../overflow/OverflowGradient';
 import stopPropagationFromLinks from '../utils/stopPropagationFromLinks';
 
-const DEFAULT_HEIGHT_GUTTERS = 5;
+export const DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS = 5;
 
 interface CardDescriptionProps extends BoxProps {
   children: string;
@@ -16,7 +16,7 @@ interface CardDescriptionProps extends BoxProps {
 export const CardDescription = ({
   children,
   overflowGradientColor = 'default',
-  heightGutters = DEFAULT_HEIGHT_GUTTERS,
+  heightGutters = DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS,
   ...containerProps
 }: CardDescriptionProps) => {
   return (

--- a/src/core/ui/card/CardDetails.tsx
+++ b/src/core/ui/card/CardDetails.tsx
@@ -4,6 +4,9 @@ import { Box, BoxProps } from '@mui/material';
 const CardDetails = ({ transparent = false, sx, ...boxProps }: { transparent?: boolean } & BoxProps) => {
   const mergedSx = {
     backgroundColor: transparent ? undefined : 'background.default',
+    // To disable margin collapsing because items inside, like CardTags have vertical margin.
+    // (https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
+    overflow: 'hidden',
     ...sx,
   };
 

--- a/src/core/ui/card/CardTags.tsx
+++ b/src/core/ui/card/CardTags.tsx
@@ -4,12 +4,28 @@ import TagsComponent, { TagsComponentProps } from '../../../domain/shared/compon
 
 export interface CardTagsProps extends TagsComponentProps {
   rows?: number;
+  disableIndentation?: boolean;
+  hideIfEmpty?: boolean; // If no tags are passed and this flag is falsey the element will show "No tags available"
 }
 
-const CardTags = ({ rows = 1, ...props }: CardTagsProps) => {
+const CardTags = ({ rows = 1, disableIndentation, hideIfEmpty, tags, ...props }: CardTagsProps) => {
   const heightGutters = rows + (rows - 1) * 0.5;
 
-  return <TagsComponent variant="filled" height={gutters(heightGutters)} marginTop={0.5} color="primary" {...props} />;
+  if (hideIfEmpty && tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <TagsComponent
+      variant="filled"
+      height={gutters(heightGutters)}
+      marginTop={0.5}
+      paddingLeft={disableIndentation ? 0 : 1.5}
+      color="primary"
+      tags={tags}
+      {...props}
+    />
+  );
 };
 
 export default CardTags;

--- a/src/domain/collaboration/InnovationPack/InnovationPackCard/InnovationPackCard.tsx
+++ b/src/domain/collaboration/InnovationPack/InnovationPackCard/InnovationPackCard.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import ContributeCard from '../../../../core/ui/card/ContributeCard';
 import CardHeader from '../../../../core/ui/card/CardHeader';
 import CardDetails from '../../../../core/ui/card/CardDetails';
-import CardDescription from '../../../../core/ui/card/CardDescription';
+import CardDescription, { DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS } from '../../../../core/ui/card/CardDescription';
 import CardTags from '../../../../core/ui/card/CardTags';
 import CardFooter from '../../../../core/ui/card/CardFooter';
 import InnovationPackIcon from '../InnovationPackIcon';
@@ -39,12 +39,16 @@ const InnovationPackCard = ({
   innovationPackUri,
   ...props
 }: InnovationPackCardProps) => {
+  const descriptionHeight = tags.length
+    ? DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS
+    : DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS + 2; // CardTags's height is gutters(2)
+
   return (
     <ContributeCard {...props} to={innovationPackUri}>
       <CardHeader title={displayName} iconComponent={InnovationPackIcon} />
       <CardDetails>
-        <CardDescription>{description ?? ''}</CardDescription>
-        <CardTags tags={tags} paddingX={1.5} marginY={1} />
+        <CardDescription heightGutters={descriptionHeight}>{description ?? ''}</CardDescription>
+        <CardTags tags={tags} marginY={1} hideIfEmpty />
       </CardDetails>
       <CardFooter flexDirection="column" alignItems="stretch" height="auto">
         <Box display="flex" gap={gutters()} height={gutters(2)} alignItems="center" justifyContent="end">

--- a/src/domain/collaboration/callout/post/PostCard.tsx
+++ b/src/domain/collaboration/callout/post/PostCard.tsx
@@ -4,7 +4,7 @@ import { PostIcon } from '../../post/icon/PostIcon';
 import ContributeCard from '../../../../core/ui/card/ContributeCard';
 import CardHeader from '../../../../core/ui/card/CardHeader';
 import CardDetails from '../../../../core/ui/card/CardDetails';
-import CardDescription from '../../../../core/ui/card/CardDescription';
+import CardDescription, { DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS } from '../../../../core/ui/card/CardDescription';
 import CardTags from '../../../../core/ui/card/CardTags';
 import CardFooter from '../../../../core/ui/card/CardFooter';
 import CardFooterDate from '../../../../core/ui/card/CardFooterDate';
@@ -22,7 +22,6 @@ export type PostCardPost = Pick<ContributeTabPostFragment, NeededFields> & {
   createdDate: string | Date; // Apollo says Date while actually it's a string
 };
 
-const DESCRIPTION_HEIGHT_GUTTERS = 5;
 interface PostCardProps {
   post: PostCardPost | undefined;
   onClick: (post: PostCardPost) => void;
@@ -45,7 +44,9 @@ const PostCard = ({ post, onClick }: PostCardProps) => {
     );
   }
   const tags = post.profile.tagset?.tags ?? [];
-  const descriptionHeight = tags.length ? DESCRIPTION_HEIGHT_GUTTERS : DESCRIPTION_HEIGHT_GUTTERS + 2; // <CardTags rows=1> is heightGutters = 2
+  const descriptionHeight = tags.length
+    ? DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS
+    : DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS + 2; // CardTags's height is gutters(2)
 
   return (
     <ContributeCard onClick={handleClick}>
@@ -54,7 +55,7 @@ const PostCard = ({ post, onClick }: PostCardProps) => {
       </CardHeader>
       <CardDetails>
         <CardDescription heightGutters={descriptionHeight}>{post.profile.description!}</CardDescription>
-        {tags.length > 0 ? <CardTags tags={tags} paddingX={1.5} marginY={1} /> : undefined}
+        <CardTags tags={tags} marginY={1} hideIfEmpty />
       </CardDetails>
       <CardFooter>
         {post.createdDate && <CardFooterDate date={post.createdDate} />}

--- a/src/domain/collaboration/post/PostTemplateCard/PostTemplateCard.tsx
+++ b/src/domain/collaboration/post/PostTemplateCard/PostTemplateCard.tsx
@@ -7,7 +7,7 @@ import ContributeCard, { ContributeCardProps } from '../../../../core/ui/card/Co
 import { Caption } from '../../../../core/ui/typography/components';
 import InnovationPackIcon from '../../InnovationPack/InnovationPackIcon';
 import { PostIcon } from '../icon/PostIcon';
-import CardDescription from '../../../../core/ui/card/CardDescription';
+import CardDescription, { DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS } from '../../../../core/ui/card/CardDescription';
 import CardTags from '../../../../core/ui/card/CardTags';
 import CardDetails from '../../../../core/ui/card/CardDetails';
 
@@ -32,6 +32,10 @@ interface PostTemplateCardProps extends ContributeCardProps {
 }
 
 const PostTemplateCard: FC<PostTemplateCardProps> = ({ template, loading, onClick }) => {
+  const tags = template?.tags ?? [];
+  const descriptionHeight =
+    tags.length > 0 ? DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS : DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS + 2;
+
   return (
     <ContributeCard onClick={onClick}>
       <CardHeader title={template?.displayName} iconComponent={PostIcon}>
@@ -41,8 +45,8 @@ const PostTemplateCard: FC<PostTemplateCardProps> = ({ template, loading, onClic
         </CardHeaderCaption>
       </CardHeader>
       <CardDetails>
-        <CardDescription>{template?.description ?? ''}</CardDescription>
-        <CardTags tags={template?.tags ?? []} paddingX={1.5} marginY={1} />
+        <CardDescription heightGutters={descriptionHeight}>{template?.description ?? ''}</CardDescription>
+        <CardTags tags={tags} marginY={1} hideIfEmpty />
       </CardDetails>
       {template?.innovationPack.displayName && (
         <CardSegmentCaption icon={<InnovationPackIcon />}>

--- a/src/domain/collaboration/templates/InnovationFlowTemplateCard/InnovationFlowTemplateCard.tsx
+++ b/src/domain/collaboration/templates/InnovationFlowTemplateCard/InnovationFlowTemplateCard.tsx
@@ -11,12 +11,17 @@ import React from 'react';
 import { InnovationFlowIcon } from '../../../platform/admin/templates/InnovationTemplates/InnovationFlow/InnovationFlowIcon';
 import { SvgIconComponent } from '@mui/icons-material';
 import CardDetails from '../../../../core/ui/card/CardDetails';
-import CardDescription from '../../../../core/ui/card/CardDescription';
+import CardDescription, { DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS } from '../../../../core/ui/card/CardDescription';
 import CardTags from '../../../../core/ui/card/CardTags';
 
 interface InnovationFlowTemplateCardProps extends TemplateCardBaseProps<InnovationFlowTemplate> {}
 
 const InnovationFlowTemplateCard = ({ template, loading, onClick }: InnovationFlowTemplateCardProps) => {
+  const tags = template?.tags ?? [];
+  const descriptionHeight = tags.length
+    ? DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS
+    : DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS + 2;
+
   return (
     <ContributeCard onClick={onClick}>
       <CardHeader title={template?.displayName} iconComponent={InnovationFlowIcon as SvgIconComponent}>
@@ -26,8 +31,8 @@ const InnovationFlowTemplateCard = ({ template, loading, onClick }: InnovationFl
         </CardHeaderCaption>
       </CardHeader>
       <CardDetails>
-        <CardDescription>{template?.description ?? ''}</CardDescription>
-        <CardTags tags={template?.tags ?? []} paddingX={1.5} marginY={1} />
+        <CardDescription heightGutters={descriptionHeight}>{template?.description ?? ''}</CardDescription>
+        <CardTags tags={tags} marginY={1} hideIfEmpty />
       </CardDetails>
       {template?.innovationPack.displayName && (
         <CardSegmentCaption icon={<InnovationPackIcon />}>

--- a/src/domain/community/contributor/ContributorCard/ContributorCard.tsx
+++ b/src/domain/community/contributor/ContributorCard/ContributorCard.tsx
@@ -73,7 +73,7 @@ const ContributorCard = ({
             expansion={
               <>
                 {description && <JourneyCardDescription rows={3}>{description}</JourneyCardDescription>}
-                {matchedTerms ? <CardTags tags={tags} rows={3} /> : undefined}
+                {matchedTerms ? <CardTags tags={tags} rows={3} disableIndentation /> : undefined}
               </>
             }
           />

--- a/src/domain/journey/common/JourneyCard/JourneyCard.tsx
+++ b/src/domain/journey/common/JourneyCard/JourneyCard.tsx
@@ -94,7 +94,7 @@ const JourneyCard = ({
           expansion={expansion}
           actions={actions}
           expansionActions={expansionActions}
-          tags={<Tags tags={tags} />}
+          tags={<Tags tags={tags} disableIndentation />}
         />
       </Box>
     </ContributeCard>

--- a/src/domain/platform/admin/templates/InnovationTemplates/InnovationImportTemplateCard.tsx
+++ b/src/domain/platform/admin/templates/InnovationTemplates/InnovationImportTemplateCard.tsx
@@ -6,7 +6,7 @@ import { TemplateInnovationPackMetaInfo } from '../InnovationPacks/InnovationPac
 import ContributeCard from '../../../../../core/ui/card/ContributeCard';
 import CardHeader from '../../../../../core/ui/card/CardHeader';
 import CardDetails from '../../../../../core/ui/card/CardDetails';
-import CardDescription from '../../../../../core/ui/card/CardDescription';
+import CardDescription, { DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS } from '../../../../../core/ui/card/CardDescription';
 import CardTags from '../../../../../core/ui/card/CardTags';
 import CardHeaderCaption from '../../../../../core/ui/card/CardHeaderCaption';
 import CardSegmentCaption from '../../../../../core/ui/card/CardSegmentCaption';
@@ -16,6 +16,10 @@ import { InnovationFlowIcon } from './InnovationFlow/InnovationFlowIcon';
 interface InnovationImportTemplateCardProps extends TemplateImportCardComponentProps<TemplateInnovationPackMetaInfo> {}
 
 const InnovationImportTemplateCard = ({ template, onClick }: InnovationImportTemplateCardProps) => {
+  const tags = template.profile.tagset?.tags ?? [];
+  const descriptionHeight = tags.length
+    ? DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS
+    : DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS + 2;
   return (
     <ContributeCard onClick={onClick}>
       <CardHeader title={template.profile.displayName} iconComponent={InnovationFlowIcon as SvgIconComponent}>
@@ -24,8 +28,8 @@ const InnovationImportTemplateCard = ({ template, onClick }: InnovationImportTem
         </CardHeaderCaption>
       </CardHeader>
       <CardDetails>
-        <CardDescription>{template.profile.description || ''}</CardDescription>
-        <CardTags tags={template.profile.tagset?.tags ?? []} paddingX={1.5} marginY={1} />
+        <CardDescription heightGutters={descriptionHeight}>{template.profile.description ?? ''}</CardDescription>
+        <CardTags tags={tags} marginY={1} hideIfEmpty />
       </CardDetails>
       <CardSegmentCaption icon={<InnovationPackIcon />}>
         <Caption noWrap>{template.innovationPackProfile.displayName}</Caption>

--- a/src/domain/shared/components/search-cards/SearchContributionPostCard.tsx
+++ b/src/domain/shared/components/search-cards/SearchContributionPostCard.tsx
@@ -4,7 +4,7 @@ import { PostIcon } from '../../../collaboration/post/icon/PostIcon';
 import CardFooterDate from '../../../../core/ui/card/CardFooterDate';
 import MessageCounter from '../../../../core/ui/card/MessageCounter';
 import CardFooter from '../../../../core/ui/card/CardFooter';
-import CardDescription from '../../../../core/ui/card/CardDescription';
+import CardDescription, { DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS } from '../../../../core/ui/card/CardDescription';
 import CardDetails from '../../../../core/ui/card/CardDetails';
 import CardTags from '../../../../core/ui/card/CardTags';
 
@@ -23,11 +23,14 @@ export const SearchContributionCardCard: FC<SearchContributionCardCardProps> = (
   parentSegment,
   ...props
 }) => {
+  const descriptionHeight = tags.length
+    ? DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS
+    : DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS + 2;
   return (
     <SearchBaseContributionCard icon={PostIcon} {...props}>
       <CardDetails paddingBottom={1}>
-        <CardDescription>{description}</CardDescription>
-        <CardTags tags={tags} paddingX={1.5} marginY={1} />
+        <CardDescription heightGutters={descriptionHeight}>{description}</CardDescription>
+        <CardTags tags={tags} marginY={1} hideIfEmpty />
       </CardDetails>
       {parentSegment}
       <CardFooter>


### PR DESCRIPTION
Goes together with #4415 and the PR #4640

The problem itself described in #4562 was only this https://stackoverflow.com/questions/27829250/why-doesnt-a-childs-margin-affect-a-parents-height

But I have taken the chance to refactor a bit. We had in many places that `paddingX={1.5}` for the tags component, I have replaced it with `disableIndent` on the places where we didn't have it. And I have added the param `hideIfEmpty` to handle the `No tags available` problem from inside the tags component to make code on the Cards cleaner