### PR TITLE
For member joined show the new member, not the person that triggered it

### DIFF
--- a/src/domain/shared/components/ActivityLog/views/ActivityMemberJoinedView.tsx
+++ b/src/domain/shared/components/ActivityLog/views/ActivityMemberJoinedView.tsx
@@ -12,7 +12,6 @@ interface ActivityMemberJoinedViewProps extends ActivityViewProps {
 }
 
 export const ActivityMemberJoinedView: FC<ActivityMemberJoinedViewProps> = ({
-  author,
   loading,
   createdDate,
   journeyTypeName,
@@ -40,7 +39,7 @@ export const ActivityMemberJoinedView: FC<ActivityMemberJoinedViewProps> = ({
         <ActivityDescriptionByType
           activityType="member-joined"
           {...{
-            author,
+            author: member, // Important to show the user that joined, not the person that triggered it
             createdDate,
             journeyTypeName,
             journeyLocation,

--- a/src/domain/shared/components/ActivityLog/views/ActivityMemberJoinedView.tsx
+++ b/src/domain/shared/components/ActivityLog/views/ActivityMemberJoinedView.tsx
@@ -34,7 +34,7 @@ export const ActivityMemberJoinedView: FC<ActivityMemberJoinedViewProps> = ({
 
   return (
     <ActivityBaseView
-      author={author}
+      author={member} // Important to show the user that joined, not the person that triggered it
       loading={loading}
       title={
         <ActivityDescriptionByType


### PR DESCRIPTION
Avoids having the admin showing up in activity