### PR TITLE
Release: Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,6 @@
         "rehype-sanitize": "^5.0.1",
         "rehype-stringify": "^9.0.3",
         "relay-compiler": "^13.1.1",
-        "remark-emoji": "^3.0.2",
         "remark-gfm": "^3.0.1",
         "remark-stringify": "^10.0.2",
         "replace-special-characters": "^1.2.5",
@@ -13179,15 +13178,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/emoticon": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.0.1.tgz",
-      "integrity": "sha512-dqx7eA9YaqyvYtUhJwT4rC1HIp82j5ybS1/vQ42ur+jBe17dJMwZE4+gvL1XadSFfxaPFFGt3Xsw+Y8akThDlw==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/encode-utf8": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
@@ -21671,14 +21661,6 @@
         "node": ">=10.5.0"
       }
     },
-    "node_modules/node-emoji": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -26759,19 +26741,6 @@
         "@babel/runtime": "^7.0.0",
         "fbjs": "^3.0.0",
         "invariant": "^2.2.4"
-      }
-    },
-    "node_modules/remark-emoji": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-3.0.2.tgz",
-      "integrity": "sha512-hEgxEv2sBtvhT3tNG/tQeeFY3EbslftaOoG14dDZndLo25fWJ6Fbg4ukFbIotOWWrfXyASjXjyHT+6n366k3mg==",
-      "dependencies": {
-        "emoticon": "^4.0.0",
-        "node-emoji": "^1.11.0",
-        "unist-util-visit": "^4.1.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -38365,7 +38334,7 @@
         "edgedriver": "^5.3.3",
         "geckodriver": "^4.2.0",
         "get-port": "^7.0.0",
-        "got": "^13.0.0",
+        "got": "11.8.5",
         "import-meta-resolve": "^3.0.0",
         "safaridriver": "^0.1.0",
         "wait-port": "^1.0.4"
@@ -41570,11 +41539,6 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
-    "emoticon": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.0.1.tgz",
-      "integrity": "sha512-dqx7eA9YaqyvYtUhJwT4rC1HIp82j5ybS1/vQ42ur+jBe17dJMwZE4+gvL1XadSFfxaPFFGt3Xsw+Y8akThDlw=="
-    },
     "encode-utf8": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
@@ -43010,7 +42974,7 @@
         "@babel/code-frame": "^7.8.3",
         "@types/json-schema": "^7.0.5",
         "chalk": "^4.1.0",
-        "chokidar": "^3.4.2",
+        "chokidar": "^3.5.3",
         "cosmiconfig": "^6.0.0",
         "deepmerge": "^4.2.2",
         "fs-extra": "^9.0.0",
@@ -43567,7 +43531,8 @@
       "dev": true
     },
     "got": {
-      "version": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
       "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dev": true,
       "requires": {
@@ -47629,14 +47594,6 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "dev": true
     },
-    "node-emoji": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
-      "requires": {
-        "lodash": "^4.17.21"
-      }
-    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -51277,16 +51234,6 @@
         "invariant": "^2.2.4"
       }
     },
-    "remark-emoji": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-3.0.2.tgz",
-      "integrity": "sha512-hEgxEv2sBtvhT3tNG/tQeeFY3EbslftaOoG14dDZndLo25fWJ6Fbg4ukFbIotOWWrfXyASjXjyHT+6n366k3mg==",
-      "requires": {
-        "emoticon": "^4.0.0",
-        "node-emoji": "^1.11.0",
-        "unist-util-visit": "^4.1.0"
-      }
-    },
     "remark-gfm": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
@@ -52787,7 +52734,7 @@
             "boolbase": "^1.0.0",
             "css-what": "^3.2.1",
             "domutils": "^1.7.0",
-            "nth-check": "^1.0.2"
+            "nth-check": "^2.0.1"
           }
         },
         "css-what": {
@@ -54306,7 +54253,7 @@
         "@wdio/types": "8.15.0",
         "@wdio/utils": "8.15.4",
         "deepmerge-ts": "^5.1.0",
-        "got": "^ 12.6.1",
+        "got": "11.8.5",
         "ky": "^0.33.0",
         "ws": "^8.8.0"
       },

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "rehype-sanitize": "^5.0.1",
     "rehype-stringify": "^9.0.3",
     "relay-compiler": "^13.1.1",
-    "remark-emoji": "^3.0.2",
     "remark-gfm": "^3.0.1",
     "remark-stringify": "^10.0.2",
     "replace-special-characters": "^1.2.5",

--- a/src/core/auth/authentication/components/Kratos/KratosInput.tsx
+++ b/src/core/auth/authentication/components/Kratos/KratosInput.tsx
@@ -38,7 +38,11 @@ export const KratosInput: FC<KratosInputProps> = ({ node, autoCapitalize, autoCo
       ...InputProps,
       endAdornment: (
         <InputAdornment position="end">
-          <IconButton onClick={() => setInputType(isInputTextObscured ? 'text' : 'password')} size="small">
+          <IconButton
+            onClick={() => setInputType(isInputTextObscured ? 'text' : 'password')}
+            title={isInputTextObscured ? t('kratos.fields.ShowPassword') : t('kratos.fields.HidePassword')}
+            size="small"
+          >
             {isInputTextObscured ? <VisibilityIcon /> : <VisibilityOffIcon />}
           </IconButton>
         </InputAdornment>

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2254,6 +2254,8 @@
     "fields": {
       "ID": "ID",
       "Password": "Password",
+      "ShowPassword": "Show Password",
+      "HidePassword": "Hide Password",
       "E-Mail": "E-Mail",
       "Email": "$t(kratos.fields.E-Mail)",
       "First Name": "First Name",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1039,7 +1039,7 @@
         "post-template-label": "Choose Post template"
       },
       "publish-dialog": {
-        "text": "You are about to publish {{calloutDisplayName}}.\nDo you want members of this community, **who have their notifications for these actions turned on**, to receive a notification?",
+        "text": "You are about to publish {{calloutDisplayName}}.\nDo you want members of this community, <b>who have their notifications for these actions turned on</b>, to receive a notification?",
         "checkbox-label": "Yes, notify the community."
       }
     },

--- a/src/core/ui/markdown/WrapperMarkdown.tsx
+++ b/src/core/ui/markdown/WrapperMarkdown.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactMarkdown, { Options as ReactMarkdownOptions } from 'react-markdown';
 import gfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
-import emoji from 'remark-emoji';
 import components from './components';
 import PlainText from './PlainText';
 import { MarkdownOptions, MarkdownOptionsProvider } from './MarkdownOptionsContext';
@@ -27,7 +26,7 @@ export const WrapperMarkdown = ({
     >
       <ReactMarkdown
         components={components}
-        remarkPlugins={[gfm, [emoji, { padSpaceAfter: false, emoticon: true }], [PlainText, { enabled: flat }]]}
+        remarkPlugins={[gfm, [PlainText, { enabled: flat }]]}
         rehypePlugins={
           flat ? undefined : ([rehypeRaw, { passThrough: allowedNodeTypes }] as MarkdownProps['rehypePlugins'])
         }

--- a/src/core/ui/menu/NavigatableMenuItem.tsx
+++ b/src/core/ui/menu/NavigatableMenuItem.tsx
@@ -16,7 +16,7 @@ const NavigatableMenuItem = ({
   onClick,
   children,
 }: PropsWithChildren<NavigatableMenuItemProps>) => {
-  const menuItemProps = route ? { component: RouterLink, to: route } : {};
+  const menuItemProps = route ? { component: RouterLink, to: route, blank: false } : {};
 
   return (
     <MenuItem {...menuItemProps} onClick={onClick} sx={{ paddingX: gutters() }}>

--- a/src/core/ui/typography/components.tsx
+++ b/src/core/ui/typography/components.tsx
@@ -1,4 +1,4 @@
-import { lighten, Typography } from '@mui/material';
+import { lighten, Typography, TypographyProps } from '@mui/material';
 import provideStaticProps from '../../utils/provideStaticProps';
 
 /**
@@ -12,7 +12,10 @@ export const BlockTitle = provideStaticProps(Typography, { variant: 'h3' }) as t
 
 export const BlockSectionTitle = provideStaticProps(Typography, { variant: 'h4' }) as typeof Typography;
 
-export const Tagline = provideStaticProps(Typography, { variant: 'subtitle1' }) as typeof Typography;
+export const Tagline = provideStaticProps(Typography, {
+  variant: 'subtitle1',
+  component: 'h3',
+} as TypographyProps) as typeof Typography;
 
 export const Text = provideStaticProps(Typography, { variant: 'body1' }) as typeof Typography;
 

--- a/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
+++ b/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useLayoutEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog/Dialog';
 import {
   PostTemplateCardFragment,
@@ -215,7 +215,17 @@ const CalloutCreationDialog: FC<CalloutCreationDialogProps> = ({
             </DialogHeader>
             <DialogContent>
               <Gutters>
-                {t('components.callout-creation.publish-dialog.text', { calloutDisplayName: callout.displayName })}
+                <Box>
+                  <Trans
+                    i18nKey="components.callout-creation.publish-dialog.text"
+                    values={{
+                      calloutDisplayName: callout.displayName,
+                    }}
+                    components={{
+                      b: <strong />,
+                    }}
+                  />
+                </Box>
                 <FormControlLabel
                   control={
                     <Checkbox checked={sendNotification} onChange={() => setSendNotification(!sendNotification)} />

--- a/src/domain/community/user/layout/UserPageBanner.tsx
+++ b/src/domain/community/user/layout/UserPageBanner.tsx
@@ -48,7 +48,7 @@ const UserPageBanner = () => {
       entityId={userId}
       profile={profile}
       onSendMessage={handleSendMessage}
-      settingsUri={isCurrentUser ? buildUserProfileSettingsUrl(user!.user.nameID) : undefined}
+      settingsUri={user && isCurrentUser ? buildUserProfileSettingsUrl(user.user.nameID) : undefined}
       loading={loading}
     />
   );

--- a/src/domain/journey/common/JourneyUnauthorizedDialog/JourneyUnauthorizedDialog.tsx
+++ b/src/domain/journey/common/JourneyUnauthorizedDialog/JourneyUnauthorizedDialog.tsx
@@ -39,6 +39,13 @@ const JourneyUnauthorizedDialog = ({
 
   const applicationButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
 
+  // applicationButtonRef.current.disabled needs to be defined and false
+  // or just an anchor
+  const showRibbon = () =>
+    applicationButtonRef.current != null &&
+    (applicationButtonRef.current instanceof HTMLAnchorElement ||
+      (applicationButtonRef.current instanceof HTMLButtonElement && !applicationButtonRef.current.disabled));
+
   return (
     <JourneyAboutDialog
       open={!disabled && !privilegesLoading && !authorized}
@@ -56,12 +63,14 @@ const JourneyUnauthorizedDialog = ({
         </ApplicationButtonContainer>
       }
       ribbon={
-        <PageContentRibbon onClick={() => applicationButtonRef.current?.click()} sx={{ cursor: 'pointer' }}>
-          <Box display="flex" gap={gutters(0.5)} alignItems="center" justifyContent="center">
-            <LockOutlined fontSize="small" />
-            {t('components.journeyUnauthorizedDialog.message')}
-          </Box>
-        </PageContentRibbon>
+        showRibbon() && (
+          <PageContentRibbon onClick={() => applicationButtonRef.current?.click()} sx={{ cursor: 'pointer' }}>
+            <Box display="flex" gap={gutters(0.5)} alignItems="center" justifyContent="center">
+              <LockOutlined fontSize="small" />
+              {t('components.journeyUnauthorizedDialog.message')}
+            </Box>
+          </PageContentRibbon>
+        )
       }
       journeyTypeName={journeyTypeName}
       {...aboutDialogProps}

--- a/src/main/guidance/chatWidget/ChatWidget.tsx
+++ b/src/main/guidance/chatWidget/ChatWidget.tsx
@@ -142,6 +142,14 @@ const Feedback = ({ answerId }: FeedbackProps) => {
   );
 };
 
+export const useInitialChatWidgetMessage = () => {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    addResponseMessage(t('chatbot.intro'));
+  }, []);
+};
+
 const ChatWidget = () => {
   const [newMessage, setNewMessage] = useState(null);
   const { t, i18n } = useTranslation();
@@ -150,10 +158,6 @@ const ChatWidget = () => {
     skip: !newMessage,
     fetchPolicy: 'network-only',
   });
-
-  useEffect(() => {
-    addResponseMessage(t('chatbot.intro'));
-  }, []);
 
   useEffect(() => {
     if (data && !loading) {

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -20,6 +20,7 @@ import { fontFamilySourceSans, subHeading } from './core/ui/typography/themeTypo
 import { ApmProvider, ApmUserSetter } from './core/analytics/apm/context';
 import { UserGeoProvider } from './core/analytics/geo';
 import { SentryTransactionScopeContextProvider } from './core/analytics/SentryTransactionScopeContext';
+import { useInitialChatWidgetMessage } from './main/guidance/chatWidget/ChatWidget';
 
 const useGlobalStyles = makeStyles(theme => ({
   '@global': {
@@ -66,42 +67,46 @@ const GlobalStyles: FC = ({ children }) => {
   return <>{children}</>;
 };
 
-const Root: FC = () => (
-  <StyledEngineProvider injectFirst>
-    <RootThemeProvider>
-      <GlobalStyles>
-        <CookiesProvider>
-          <ConfigProvider url={publicGraphQLEndpoint}>
-            <ServerMetadataProvider url={publicGraphQLEndpoint}>
-              <SentryTransactionScopeContextProvider>
-                <SentryErrorBoundaryProvider>
-                  <GlobalStateProvider>
-                    <BrowserRouter>
-                      <AuthenticationProvider>
-                        <UserGeoProvider>
-                          <ApmProvider>
-                            <AlkemioApolloProvider apiUrl={privateGraphQLEndpoint}>
-                              <NavigationProvider>
-                                <UserProvider>
-                                  <ApmUserSetter />
-                                  <ScrollToTop />
-                                  <TopLevelRoutes />
-                                </UserProvider>
-                              </NavigationProvider>
-                            </AlkemioApolloProvider>
-                          </ApmProvider>
-                        </UserGeoProvider>
-                      </AuthenticationProvider>
-                    </BrowserRouter>
-                  </GlobalStateProvider>
-                </SentryErrorBoundaryProvider>
-              </SentryTransactionScopeContextProvider>
-            </ServerMetadataProvider>
-          </ConfigProvider>
-        </CookiesProvider>
-      </GlobalStyles>
-    </RootThemeProvider>
-  </StyledEngineProvider>
-);
+const Root: FC = () => {
+  useInitialChatWidgetMessage();
+
+  return (
+    <StyledEngineProvider injectFirst>
+      <RootThemeProvider>
+        <GlobalStyles>
+          <CookiesProvider>
+            <ConfigProvider url={publicGraphQLEndpoint}>
+              <ServerMetadataProvider url={publicGraphQLEndpoint}>
+                <SentryTransactionScopeContextProvider>
+                  <SentryErrorBoundaryProvider>
+                    <GlobalStateProvider>
+                      <BrowserRouter>
+                        <AuthenticationProvider>
+                          <UserGeoProvider>
+                            <ApmProvider>
+                              <AlkemioApolloProvider apiUrl={privateGraphQLEndpoint}>
+                                <NavigationProvider>
+                                  <UserProvider>
+                                    <ApmUserSetter />
+                                    <ScrollToTop />
+                                    <TopLevelRoutes />
+                                  </UserProvider>
+                                </NavigationProvider>
+                              </AlkemioApolloProvider>
+                            </ApmProvider>
+                          </UserGeoProvider>
+                        </AuthenticationProvider>
+                      </BrowserRouter>
+                    </GlobalStateProvider>
+                  </SentryErrorBoundaryProvider>
+                </SentryTransactionScopeContextProvider>
+              </ServerMetadataProvider>
+            </ConfigProvider>
+          </CookiesProvider>
+        </GlobalStyles>
+      </RootThemeProvider>
+    </StyledEngineProvider>
+  );
+};
 
 export default Root;


### PR DESCRIPTION
## Fixes
  - Made `tagline` `H3` by default
  - `ChatGuidance` widget initial message to appear only once
  - Fixed an issue where an error was thrown when a `User` refreshes its `Profile/Settings/Membership` page
  - Removed `remark-emoji` package in markdown
  - Added title to `ShowPassword` button
  - `Sign up / Log in` not opening in new tab now
  - Removed `click here to apply` on private spaces where users could not apply