### PR TITLE
Whiteboard Autosave + bugfixes on images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
         "replace-special-characters": "^1.2.5",
         "socket.io-client": "^4.7.2",
         "subscriptions-transport-ws": "^0.11.0",
+        "ts-semaphore": "^1.0.0",
         "typescript": "~4.1.3",
         "unified": "^10.0.0",
         "unist-builder": "^3.0.1",
@@ -29359,6 +29360,14 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "devOptional": true
     },
+    "node_modules/ts-semaphore": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ts-semaphore/-/ts-semaphore-1.0.0.tgz",
+      "integrity": "sha512-pVttFT51kQiiq6MzdFGOLhKKIAbcI7CdTtSWMsFDBo02PqLMmTK337mMvGXU7vBL+fdTFFvEeE8lDgImOeHW7g==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -38334,7 +38343,7 @@
         "edgedriver": "^5.3.3",
         "geckodriver": "^4.2.0",
         "get-port": "^7.0.0",
-        "got": "^13.0.0",
+        "got": "11.8.5",
         "import-meta-resolve": "^3.0.0",
         "safaridriver": "^0.1.0",
         "wait-port": "^1.0.4"
@@ -42974,7 +42983,7 @@
         "@babel/code-frame": "^7.8.3",
         "@types/json-schema": "^7.0.5",
         "chalk": "^4.1.0",
-        "chokidar": "^3.4.2",
+        "chokidar": "^3.5.3",
         "cosmiconfig": "^6.0.0",
         "deepmerge": "^4.2.2",
         "fs-extra": "^9.0.0",
@@ -43531,7 +43540,8 @@
       "dev": true
     },
     "got": {
-      "version": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
       "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dev": true,
       "requires": {
@@ -52733,7 +52743,7 @@
             "boolbase": "^1.0.0",
             "css-what": "^3.2.1",
             "domutils": "^1.7.0",
-            "nth-check": "^1.0.2"
+            "nth-check": "^2.0.1"
           }
         },
         "css-what": {
@@ -53237,6 +53247,11 @@
           "devOptional": true
         }
       }
+    },
+    "ts-semaphore": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ts-semaphore/-/ts-semaphore-1.0.0.tgz",
+      "integrity": "sha512-pVttFT51kQiiq6MzdFGOLhKKIAbcI7CdTtSWMsFDBo02PqLMmTK337mMvGXU7vBL+fdTFFvEeE8lDgImOeHW7g=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",
@@ -54252,7 +54267,7 @@
         "@wdio/types": "8.15.0",
         "@wdio/utils": "8.15.4",
         "deepmerge-ts": "^5.1.0",
-        "got": "^ 12.6.1",
+        "got": "11.8.5",
         "ky": "^0.33.0",
         "ws": "^8.8.0"
       },

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "replace-special-characters": "^1.2.5",
     "socket.io-client": "^4.7.2",
     "subscriptions-transport-ws": "^0.11.0",
+    "ts-semaphore": "^1.0.0",
     "typescript": "~4.1.3",
     "unified": "^10.0.0",
     "unist-builder": "^3.0.1",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2059,6 +2059,7 @@
       "add-whiteboard": "Create whiteboard",
       "no-whiteboards": "No whiteboards have been created yet. Be the first to add one.",
       "locked-by": "{{user}} is currently editing this Whiteboard",
+      "savingWhiteboard": "Saving whiteboard...",
       "state": {
         "checkedout": "Someone else is currently editing this Whiteboard"
       },

--- a/src/core/ui/button/FloatingActionButtons.tsx
+++ b/src/core/ui/button/FloatingActionButtons.tsx
@@ -1,9 +1,9 @@
 import { BoxProps, Fade } from '@mui/material';
 import React, { FC, ReactNode } from 'react';
 import ScrollToTop from './ScrollToTop';
-import { PLATFORM_NAVIGATION_MENU_Z_INDEX } from '../../../main/ui/platformNavigation/constants';
 import Gutters from '../grid/Gutters';
 
+const NAVIGATION_FLOATING_ACTION_BUTTONS_Z_INDEX = 1200; // Dialogs are 1300
 export interface FloatingActionButtonsProps extends BoxProps {
   visible?: boolean;
   floatingActions?: ReactNode;
@@ -18,7 +18,7 @@ const FloatingActionButtons: FC<FloatingActionButtonsProps> = ({ visible = true,
         right={0}
         justifyContent="center"
         alignItems="center"
-        zIndex={PLATFORM_NAVIGATION_MENU_Z_INDEX + 1}
+        zIndex={NAVIGATION_FLOATING_ACTION_BUTTONS_Z_INDEX}
         maxHeight="100vh"
         {...boxProps}
       >

--- a/src/core/ui/button/FloatingActionButtons.tsx
+++ b/src/core/ui/button/FloatingActionButtons.tsx
@@ -3,7 +3,7 @@ import React, { FC, ReactNode } from 'react';
 import ScrollToTop from './ScrollToTop';
 import Gutters from '../grid/Gutters';
 
-const NAVIGATION_FLOATING_ACTION_BUTTONS_Z_INDEX = 1200; // Dialogs are 1300
+const FLOATING_ACTION_BUTTONS_Z_INDEX = 1200; // Dialogs are 1300
 export interface FloatingActionButtonsProps extends BoxProps {
   visible?: boolean;
   floatingActions?: ReactNode;
@@ -18,7 +18,7 @@ const FloatingActionButtons: FC<FloatingActionButtonsProps> = ({ visible = true,
         right={0}
         justifyContent="center"
         alignItems="center"
-        zIndex={NAVIGATION_FLOATING_ACTION_BUTTONS_Z_INDEX}
+        zIndex={FLOATING_ACTION_BUTTONS_Z_INDEX}
         maxHeight="100vh"
         {...boxProps}
       >

--- a/src/domain/collaboration/callout/whiteboard/WhiteboardCallout.tsx
+++ b/src/domain/collaboration/callout/whiteboard/WhiteboardCallout.tsx
@@ -120,8 +120,9 @@ const WhiteboardCallout = forwardRef<HTMLDivElement, WhiteboardCalloutProps>(
                     displayName: '',
                     storageBucket: {
                       // TODO: When creating a whiteboard a StorageBucketId is needed if we want to allow image uploading
-                      // in this case we are passing the parent's callout storageBucketId
-                      id: callout.framing.profile.storageBucket.id,
+                      // For now we are allowing files attached to the newly created whiteboards, so we can pass
+                      // an empty string here, and allowFilesAttached = true in the options
+                      id: '',
                     },
                   },
                   content: callout.contributionDefaults.whiteboardContent ?? '',
@@ -149,6 +150,7 @@ const WhiteboardCallout = forwardRef<HTMLDivElement, WhiteboardCalloutProps>(
                 show: showCreateWhiteboardDialog,
                 canEdit: true,
                 checkedOutByMe: true,
+                allowFilesAttached: true,
                 fullscreen,
               }}
               state={{}}

--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardRtDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardRtDialog.tsx
@@ -69,7 +69,7 @@ interface WhiteboardDialogProps<Whiteboard extends WhiteboardRtWithContent> {
   };
   actions: {
     onCancel: (whiteboard: WhiteboardRtWithoutContent<Whiteboard>) => void;
-    onUpdate: (whiteboard: Whiteboard, previewImages?: WhiteboardPreviewImage[]) => void;
+    onUpdate: (whiteboard: Whiteboard, previewImages?: WhiteboardPreviewImage[]) => Promise<boolean>;
   };
   options: {
     show: boolean;
@@ -159,9 +159,12 @@ const WhiteboardRtDialog = <Whiteboard extends WhiteboardRtWithContent>({
     storageBucketId: whiteboard?.profile?.storageBucket.id ?? '',
   });
 
-  const handleUpdate = async (whiteboard: WhiteboardRtWithContent, state: RelevantExcalidrawState | undefined) => {
+  const handleUpdate = async (
+    whiteboard: WhiteboardRtWithContent,
+    state: RelevantExcalidrawState | undefined
+  ): Promise<boolean> => {
     if (!state) {
-      return;
+      return false;
     }
     const { appState, elements, files } = await filesManager.removeAllExcalidrawAttachments(state);
 
@@ -170,7 +173,7 @@ const WhiteboardRtDialog = <Whiteboard extends WhiteboardRtWithContent>({
     const content = serializeAsJSON(elements, appState, files ?? {}, 'local');
 
     if (!formikRef.current?.isValid) {
-      return;
+      return false;
     }
 
     const displayName = formikRef.current?.values.displayName ?? whiteboard?.profile?.displayName;
@@ -307,9 +310,7 @@ const WhiteboardRtDialog = <Whiteboard extends WhiteboardRtWithContent>({
                       },
                     }}
                     actions={{
-                      onUpdate: state => {
-                        handleUpdate(whiteboard, state);
-                      },
+                      onUpdate: state => handleUpdate(whiteboard, state),
                       onSavedToDatabase: () => {
                         refetchLastSaved({
                           whiteboardId: whiteboard.id,

--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardRtDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardRtDialog.tsx
@@ -54,7 +54,7 @@ const LastSavedCaption = ({ date, saving }: { date: Date | undefined; saving: bo
 
   return saving ? (
     <Caption title={`${date.toLocaleDateString()} ${date.toLocaleTimeString()}`}>
-      <CircularProgress size={gutters(0.5)(theme)} />
+      <CircularProgress size={gutters(0.5)(theme)} sx={{ marginRight: gutters(0.5) }} />
       {t('pages.whiteboard.savingWhiteboard')}
     </Caption>
   ) : (

--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardRtDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardRtDialog.tsx
@@ -185,7 +185,7 @@ const WhiteboardRtDialog = <Whiteboard extends WhiteboardRtWithContent>({
       if (!whiteboard || !whiteboardApi) {
         return;
       }
-      const content = JSON.parse(whiteboard?.content) as RelevantExcalidrawState;
+      const content = JSON.parse(whiteboard.content) as RelevantExcalidrawState;
       const state = {
         ...content,
         elements: whiteboardApi.getSceneElements(),

--- a/src/domain/collaboration/whiteboard/WhiteboardsManagement/WhiteboardRtManagementView.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardsManagement/WhiteboardRtManagementView.tsx
@@ -35,6 +35,7 @@ export interface ContextViewState {
   creatingWhiteboard?: boolean;
   changingWhiteboardLockState?: boolean;
   updatingWhiteboard?: boolean;
+  updatingWhiteboardContent?: boolean;
   error?: ApolloError;
 }
 

--- a/src/domain/collaboration/whiteboard/containers/WhiteboardRtActionsContainer.tsx
+++ b/src/domain/collaboration/whiteboard/containers/WhiteboardRtActionsContainer.tsx
@@ -5,7 +5,7 @@ import {
   WhiteboardRtDetailsFragment,
   WhiteboardRtContentFragment,
 } from '../../../../core/apollo/generated/graphql-schema';
-import { WhiteboardPreviewImage, useUploadWhiteboardVisuals } from '../WhiteboardPreviewImages/WhiteboardPreviewImages';
+import { WhiteboardPreviewImage } from '../WhiteboardPreviewImages/WhiteboardPreviewImages';
 
 export interface IWhiteboardRtActions {
   onUpdate: (
@@ -19,14 +19,14 @@ export interface WhiteboardRtActionsContainerState {
   deletingWhiteboard?: boolean;
   changingWhiteboardLockState?: boolean;
   updatingWhiteboard?: boolean;
+  updatingWhiteboardContent?: boolean;
 }
 
 export interface WhiteboardRtActionsContainerProps
   extends ContainerChildProps<{}, IWhiteboardRtActions, WhiteboardRtActionsContainerState> {}
 
 const WhiteboardRtActionsContainer: FC<WhiteboardRtActionsContainerProps> = ({ children }) => {
-  const [updateWhiteboardContent, { loading: updatingWhiteboard }] = useUpdateWhiteboardContentRtMutation({});
-  const { uploadVisuals, loading: uploadingVisuals } = useUploadWhiteboardVisuals();
+  const [updateWhiteboardContent, { loading: updatingWhiteboardContent }] = useUpdateWhiteboardContentRtMutation({});
 
   const handleUpdateWhiteboardContent = useCallback(
     async (whiteboard: WhiteboardRtContentFragment & WhiteboardRtDetailsFragment) => {
@@ -40,7 +40,7 @@ const WhiteboardRtActionsContainer: FC<WhiteboardRtActionsContainerProps> = ({ c
       });
       return !result.errors || result.errors.length === 0;
     },
-    [updateWhiteboardContent, uploadVisuals]
+    [updateWhiteboardContent]
   );
 
   const actions = useMemo<IWhiteboardRtActions>(
@@ -55,7 +55,7 @@ const WhiteboardRtActionsContainer: FC<WhiteboardRtActionsContainerProps> = ({ c
       {children(
         {},
         {
-          updatingWhiteboard: updatingWhiteboard || uploadingVisuals,
+          updatingWhiteboardContent,
         },
         actions
       )}

--- a/src/domain/collaboration/whiteboard/containers/WhiteboardRtActionsContainer.tsx
+++ b/src/domain/collaboration/whiteboard/containers/WhiteboardRtActionsContainer.tsx
@@ -11,7 +11,7 @@ export interface IWhiteboardRtActions {
   onUpdate: (
     whiteboard: WhiteboardRtContentFragment & WhiteboardRtDetailsFragment,
     previewImages?: WhiteboardPreviewImage[]
-  ) => Promise<void>;
+  ) => Promise<boolean>;
 }
 
 export interface WhiteboardRtActionsContainerState {
@@ -30,7 +30,7 @@ const WhiteboardRtActionsContainer: FC<WhiteboardRtActionsContainerProps> = ({ c
 
   const handleUpdateWhiteboardContent = useCallback(
     async (whiteboard: WhiteboardRtContentFragment & WhiteboardRtDetailsFragment) => {
-      await updateWhiteboardContent({
+      const result = await updateWhiteboardContent({
         variables: {
           input: {
             ID: whiteboard.id,
@@ -38,6 +38,7 @@ const WhiteboardRtActionsContainer: FC<WhiteboardRtActionsContainerProps> = ({ c
           },
         },
       });
+      return !result.errors || result.errors.length === 0;
     },
     [updateWhiteboardContent, uploadVisuals]
   );

--- a/src/domain/collaboration/whiteboard/utils/isWhiteboardContentEqual.ts
+++ b/src/domain/collaboration/whiteboard/utils/isWhiteboardContentEqual.ts
@@ -1,7 +1,6 @@
 import { isEqual, omit } from 'lodash';
 
-const WHITEBOARD_PROP_SOURCE = 'source';
-
+const IGNORED_PROPERTIES = ['source', 'appState'];
 const isWhiteboardContentEqual = (lWhiteboardContent: string | undefined, rWhiteboardContent: string | undefined) => {
   if (!lWhiteboardContent && !rWhiteboardContent) {
     return true;
@@ -11,7 +10,7 @@ const isWhiteboardContentEqual = (lWhiteboardContent: string | undefined, rWhite
   }
   const lParsedContent = JSON.parse(lWhiteboardContent);
   const rParsedContent = JSON.parse(rWhiteboardContent);
-  return isEqual(omit(lParsedContent, WHITEBOARD_PROP_SOURCE), omit(rParsedContent, WHITEBOARD_PROP_SOURCE));
+  return isEqual(omit(lParsedContent, IGNORED_PROPERTIES), omit(rParsedContent, IGNORED_PROPERTIES));
 };
 
 export default isWhiteboardContentEqual;

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
@@ -42,7 +42,7 @@ export interface WhiteboardWhiteboardEntities {
 }
 
 export interface WhiteboardWhiteboardActions {
-  onUpdate?: (state: ExportedDataState) => void;
+  onUpdate?: (state: ExportedDataState) => Promise<boolean>;
   onSavedToDatabase?: () => void;
 }
 
@@ -207,6 +207,15 @@ const CollaborativeExcalidrawWrapper = forwardRef<ExcalidrawAPIRefValue | null, 
             collabAPIRef={collabRef}
             onSavedToDatabase={actions.onSavedToDatabase}
             filesManager={filesManager}
+            onSaveRequest={async () => {
+              const state = {
+                ...(data as ExportedDataState),
+                elements: excalidrawAPI.getSceneElements(),
+                appState: excalidrawAPI.getAppState(),
+              };
+              const result = await actions.onUpdate?.(state);
+              return result ?? false;
+            }}
           />
         )}
       </div>

--- a/src/domain/common/whiteboard/excalidraw/collab/Collab.tsx
+++ b/src/domain/common/whiteboard/excalidraw/collab/Collab.tsx
@@ -49,6 +49,7 @@ interface PublicProps {
   collabAPIRef?: MutableRefObject<CollabAPI | null> | RefCallback<CollabAPI | null>;
   onSavedToDatabase?: () => void; // Someone in your room saved the whiteboard to the database
   filesManager: WhiteboardFilesManager;
+  onSaveRequest: () => Promise<boolean>;
 }
 
 type Props = PublicProps;
@@ -73,7 +74,7 @@ class Collab extends PureComponent<Props, CollabState> {
       username: props.username,
       activeRoomLink: '',
     };
-    this.portal = new Portal(this, props.filesManager);
+    this.portal = new Portal({ collab: this, filesManager: props.filesManager, onSaveRequest: props.onSaveRequest });
     this.excalidrawAPI = props.excalidrawAPI;
     this.filesManager = props.filesManager;
     this.activeIntervalId = null;

--- a/src/domain/common/whiteboard/excalidraw/collab/Portal.tsx
+++ b/src/domain/common/whiteboard/excalidraw/collab/Portal.tsx
@@ -48,16 +48,15 @@ class Portal {
       this.collab.setCollaborators(clients);
     });
 
-    // TODO: cleanup here
+    // TODO: Remove these console.logs when this is stable
     this.socket.on('save-request', async callback => {
-      console.log('save-request received');
+      console.log('Save Request recevied from the server');
       const result = await this.onSaveRequest();
-      console.log('saved successfully: ', result);
-      console.log(callback);
       if (typeof callback === 'function') {
-        callback({ savedSuccesfully: result });
+        console.log('Returning save result to the server: ', result);
+        callback({ success: result });
       } else {
-        console.error('cant acknowledge of successful save');
+        console.error('Cannot acknowledge save result:', result);
       }
     });
 

--- a/src/domain/common/whiteboard/excalidraw/collab/Portal.tsx
+++ b/src/domain/common/whiteboard/excalidraw/collab/Portal.tsx
@@ -7,17 +7,24 @@ import { BroadcastedExcalidrawElement } from './reconciliation';
 import { Socket } from 'socket.io-client';
 import { BinaryFileDataWithUrl, WhiteboardFilesManager } from '../useWhiteboardFilesManager';
 
+interface PortalProps {
+  collab: TCollabClass;
+  filesManager: WhiteboardFilesManager;
+  onSaveRequest: () => Promise<boolean>;
+}
 class Portal {
   collab: TCollabClass;
   filesManager: WhiteboardFilesManager;
+  onSaveRequest: () => Promise<boolean>;
   socket: Socket | null = null;
   socketInitialized: boolean = false; // we don't want the socket to emit any updates until it is fully initialized
   roomId: string | null = null;
   broadcastedElementVersions: Map<string, number> = new Map();
 
-  constructor(collab: TCollabClass, filesManager: WhiteboardFilesManager) {
+  constructor({ collab, filesManager, onSaveRequest }: PortalProps) {
     this.collab = collab;
     this.filesManager = filesManager;
+    this.onSaveRequest = onSaveRequest;
   }
 
   open(socket: Socket, id: string) {
@@ -39,6 +46,19 @@ class Portal {
     });
     this.socket.on('room-user-change', (clients: string[]) => {
       this.collab.setCollaborators(clients);
+    });
+
+    // TODO: cleanup here
+    this.socket.on('save-request', async callback => {
+      console.log('save-request received');
+      const result = await this.onSaveRequest();
+      console.log('saved successfully: ', result);
+      console.log(callback);
+      if (typeof callback === 'function') {
+        callback({ savedSuccesfully: result });
+      } else {
+        console.error('cant acknowledge of successful save');
+      }
     });
 
     return socket;

--- a/src/domain/common/whiteboard/excalidraw/collab/Portal.tsx
+++ b/src/domain/common/whiteboard/excalidraw/collab/Portal.tsx
@@ -54,15 +54,8 @@ class Portal {
         result = await this.onSaveRequest();
       } catch (ex) {
         result = false;
-        // eslint-disable-next-line no-console
-        console.error('Error saving whiteboard content', ex);
       } finally {
-        if (typeof callback === 'function') {
-          callback({ success: result });
-        } else {
-          // eslint-disable-next-line no-console
-          console.error('Cannot acknowledge save result:', result);
-        }
+        callback({ success: result });
       }
     });
 

--- a/src/domain/common/whiteboard/excalidraw/collab/Portal.tsx
+++ b/src/domain/common/whiteboard/excalidraw/collab/Portal.tsx
@@ -48,15 +48,21 @@ class Portal {
       this.collab.setCollaborators(clients);
     });
 
-    // TODO: Remove these console.logs when this is stable
     this.socket.on('save-request', async callback => {
-      console.log('Save Request recevied from the server');
-      const result = await this.onSaveRequest();
-      if (typeof callback === 'function') {
-        console.log('Returning save result to the server: ', result);
-        callback({ success: result });
-      } else {
-        console.error('Cannot acknowledge save result:', result);
+      let result: boolean = false;
+      try {
+        result = await this.onSaveRequest();
+      } catch (ex) {
+        result = false;
+        // eslint-disable-next-line no-console
+        console.error('Error saving whiteboard content', ex);
+      } finally {
+        if (typeof callback === 'function') {
+          callback({ success: result });
+        } else {
+          // eslint-disable-next-line no-console
+          console.error('Cannot acknowledge save result:', result);
+        }
       }
     });
 

--- a/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
+++ b/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
@@ -242,6 +242,12 @@ const useWhiteboardFilesManager = ({
    * Finds a file in the fileStore and prepares it to be sent:
    * - Ensures that it has a url
    * - Removes dataURL
+   *
+   * A Semaphore is required in this function because it can be called multiple times in parallel by Collab.syncFiles
+   * Multiple upload requests were triggered because those `await uploadFileToStorage` were taking longer
+   * than the next call to this function from syncFiles.
+   * The semaphore ensures that the second call to this function will wait for the upload to finish
+   * and then the first condition will evaluate to `true` because the file will be already in the fileStore.
    */
   const removeExcalidrawAttachment = (
     file: BinaryFileData & { url?: string }

--- a/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
+++ b/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
@@ -240,10 +240,7 @@ const useWhiteboardFilesManager = ({
   const removeExcalidrawAttachment = async (
     file: BinaryFileData & { url?: string }
   ): Promise<BinaryFileDataWithUrl | undefined> => {
-    if (file.url) {
-      // The url was already set, just copy it and remove dataURL to the output:
-      return { ...file, dataURL: '' } as BinaryFileDataWithUrl;
-    } else if (fileStore[file.id]) {
+    if (fileStore[file.id]) {
       // The file is in the fileStore, so it has been uploaded at some point, take the url from there:
       return { ...file, dataURL: '', url: fileStore[file.id].url } as BinaryFileDataWithUrl;
     } else if (file.dataURL && storageBucketId) {
@@ -254,8 +251,9 @@ const useWhiteboardFilesManager = ({
       log('Uploaded ', file.id, file, fileObject, id, url);
       return { ...file, url, dataURL: '' } as BinaryFileDataWithUrl;
     } else if (file.dataURL && !storageBucketId && allowFallbackToAttached) {
-      // no storageBucket was supplied, but allowFallbackToAttached was true, so we'll allow this file to be attached in the json for now
-      return { ...file } as BinaryFileDataWithUrl;
+      // no storageBucket was supplied, but allowFallbackToAttached is true, so we'll allow this file to be attached in the json for now
+      const { url, ...fileWithoutUrl } = file;
+      return { ...fileWithoutUrl } as BinaryFileDataWithUrl; // forced to cast because we are allowing attachments
     } else {
       console.error('File without url or dataURL. IGNORED', file);
     }


### PR DESCRIPTION
Implemented AutoSaving functionality
Socket.IO sends frequently a new type of message `save-request` and that triggers a call to onSaveRequest which will save the current whiteboardContent to the database and callback the server with a `{ success: true }` response.

- Helped bugfixing (it's not a full fix) server #3451. With these changes https://github.com/alkem-io/client-web/pull/5182/commits/6c3d6af003eebb97443dfb9f499b3eadab7bf87d all the files pasted from another whiteboard will have their urls ignored and will be re-uploaded.
- Also bugfixed #5190 adding a semaphore (using a newly installed npm package ts-semaphore) to the function `removeExcalidrawAttachment` and turning `fileStore` into a `ref` and not in a State.
- Turning fileStore into a ref was in mind before, I think it should be a ref. But being a State causes a re-render everytime we add a new image to the fileStore, which is required. So I needed to add this new state `fileStoreVersion`.