### PR TITLE
Fix references disappearing bug

### DIFF
--- a/src/domain/shared/components/References/CreateReferencesDialog.tsx
+++ b/src/domain/shared/components/References/CreateReferencesDialog.tsx
@@ -66,6 +66,11 @@ const CreateReferencesDialog: FC<CreateReferencesDialogProps> = ({
     onClose();
   };
 
+  const handleSave = (currentReferences: CreateReferenceFormValues[]) => {
+    setHangingReferenceIds([]);
+    onSave(currentReferences);
+  };
+
   useEffect(() => {
     const run = async () => {
       const newId = await onAddMore();
@@ -198,7 +203,7 @@ const CreateReferencesDialog: FC<CreateReferencesDialogProps> = ({
                   </Box>
                   <Actions paddingX={gutters()} justifyContent="space-between">
                     <Button onClick={handleOnClose}>{t('buttons.cancel')}</Button>
-                    <Button variant="contained" onClick={() => onSave(currentReferences)}>
+                    <Button variant="contained" onClick={() => handleSave(currentReferences)}>
                       {t('buttons.save')}
                     </Button>
                   </Actions>


### PR DESCRIPTION
The fix is just the `setHangingReferenceIds([]);` on save. the rest of changes are just lintin fixes by VSCode