### PR TITLE
Fix sort order of authenticated-no memberships yet users widgets

### DIFF
--- a/src/main/topLevelPages/myDashboard/MyDashboard.tsx
+++ b/src/main/topLevelPages/myDashboard/MyDashboard.tsx
@@ -29,18 +29,22 @@ export const MyDashboard = () => {
     <HomePageLayout>
       <ReleaseUpdatesDialog />
       <MyMembershipsDialog open={isMyMembershipsDialogOpen} onClose={() => setIsMyMembershipsDialogOpen(false)} />
-      <PageContent gridContainerProps={{ flexDirection: 'row-reverse' }}>
-        {!isAuthenticated && !isLoadingAuthentication ? (
+      {!isAuthenticated && !isLoadingAuthentication ? (
+        <PageContent gridContainerProps={{ flexDirection: 'row-reverse' }}>
           <MyDashboardUnauthenticated />
-        ) : hasSpaceMemberships ? (
+        </PageContent>
+      ) : hasSpaceMemberships ? (
+        <PageContent gridContainerProps={{ flexDirection: 'row-reverse' }}>
           <MyDashboardWithMemberships
             spacesData={spacesData}
             onOpenMembershipsDialog={() => setIsMyMembershipsDialogOpen(true)}
           />
-        ) : (
+        </PageContent>
+      ) : (
+        <PageContent gridContainerProps={{ flexDirection: 'row' }}>
           <MyDashboardWithoutMemberships />
-        )}
-      </PageContent>
+        </PageContent>
+      )}
     </HomePageLayout>
   );
 };

--- a/src/main/topLevelPages/myDashboard/MyDashboardWithoutMemberships.tsx
+++ b/src/main/topLevelPages/myDashboard/MyDashboardWithoutMemberships.tsx
@@ -15,17 +15,17 @@ const MyDashboardWithoutMemberships: FC<MyDashboardWithoutMembershipsProps> = ()
   const columns = useColumns();
   return (
     <>
+      <PageContentColumn columns={8}>
+        <MembershipSuggestions />
+        <ExploreOtherChallenges />
+        <StartingSpace width="100%" />
+      </PageContentColumn>
       <PageContentColumn columns={columns === 12 ? 4 : 8} flexDirection="column" alignSelf="stretch">
         <TipsAndTricks />
         <InnovationLibraryBlock />
         <RecentForumMessages />
       </PageContentColumn>
-      <PageContentColumn columns={8}>
-        <MembershipSuggestions />
-        <ExploreOtherChallenges />
-        <StartingSpace width="100%" />
-        <MoreAboutAlkemio />
-      </PageContentColumn>
+      <MoreAboutAlkemio />
     </>
   );
 };


### PR DESCRIPTION
I've had to swap the order of elements because of this comment:
https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/gh/alkem-io/client-web/5005
