### PR TITLE
Pick up post-verification URL from kratos config if present

### DIFF
--- a/src/core/auth/authentication/pages/VerificationPage.tsx
+++ b/src/core/auth/authentication/pages/VerificationPage.tsx
@@ -42,7 +42,7 @@ export const VerificationPage: FC<RegisterPageProps> = ({ flow }) => {
         if (!continueButton) {
           return;
         }
-        (continueButton as UiNodeAnchor).attributes.href = returnUrl;
+        (continueButton as UiNodeAnchor).attributes.href = verificationFlow.ui.action ?? returnUrl;
       })
     );
   }, [verificationFlow]);


### PR DESCRIPTION
- default to the next action URL provided by kratos
- if not present, default to what we currently have