### PR TITLE
Hide calendar if no events and no admin

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -82,7 +82,7 @@
     "past-events": "Past Events",
     "show-calendar": "Show calendar",
     "defaultEventDescription": "$t(common.location):\n\n$t(common.url):\n\n$t(common.description):",
-    "admins-only": "Since there are no events, this block is only visible for admins and leads"
+    "adminsOnly": "Since there are no events, this block is only visible for admins and leads"
   },
   "buttons": {
     "leave": "Leave",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -81,7 +81,8 @@
     "no-upcoming-events": "Currently, there are no upcoming events to be displayed",
     "past-events": "Past Events",
     "show-calendar": "Show calendar",
-    "defaultEventDescription": "$t(common.location):\n\n$t(common.url):\n\n$t(common.description):"
+    "defaultEventDescription": "$t(common.location):\n\n$t(common.url):\n\n$t(common.description):",
+    "admins-only": "Since there are no events, this block is only visible for admins and leads"
   },
   "buttons": {
     "leave": "Leave",

--- a/src/domain/shared/components/DashboardSections/DashboardCalendarSection.tsx
+++ b/src/domain/shared/components/DashboardSections/DashboardCalendarSection.tsx
@@ -112,7 +112,7 @@ const DashboardCalendarSection: FC<DashboardCalendarSectionProps> = ({ journeyId
         )}
         {!loading && !isCalendarView && (
           <>
-            {events.length === 0 && <Text>{t('calendar.admins-only')}</Text>}
+            {events.length === 0 && <Text>{t('calendar.adminsOnly')}</Text>}
             {events.map(event => (
               <CalendarEventView key={event.id} {...event} />
             ))}

--- a/src/domain/shared/components/DashboardSections/DashboardCalendarSection.tsx
+++ b/src/domain/shared/components/DashboardSections/DashboardCalendarSection.tsx
@@ -19,6 +19,7 @@ import PageContentBlockFooter from '../../../../core/ui/content/PageContentBlock
 import FullCalendar, { INTERNAL_DATE_FORMAT } from '../../../timeline/calendar/components/FullCalendar';
 import { HIGHLIGHT_PARAM_NAME } from '../../../timeline/calendar/CalendarDialog';
 import { useQueryParams } from '../../../../core/routing/useQueryParams';
+import { AuthorizationPrivilege } from '../../../../core/apollo/generated/graphql-schema';
 import { JourneyTypeName } from '../../../journey/JourneyTypeName';
 
 const MAX_NUMBER_OF_EVENTS = 3;
@@ -97,7 +98,11 @@ const DashboardCalendarSection: FC<DashboardCalendarSectionProps> = ({ journeyId
     navigate(`${EntityPageSection.Dashboard}/calendar?${nextUrlParams}`);
   };
 
-  return (
+  const alwaysShowEvents = spaceData?.space.collaboration?.timeline?.calendar.authorization?.myPrivileges?.includes(
+    AuthorizationPrivilege.Create
+  );
+
+  return events.length > 0 || alwaysShowEvents ? (
     <PageContentBlock disableGap={isCalendarView}>
       <PageContentBlockHeaderWithDialogAction title={t('common.events')} onDialogOpen={openDialog} />
       <Box display="flex" flexDirection="column" gap={gutters()}>
@@ -107,7 +112,7 @@ const DashboardCalendarSection: FC<DashboardCalendarSectionProps> = ({ journeyId
         )}
         {!loading && !isCalendarView && (
           <>
-            {events.length === 0 && <Text>{t('calendar.no-data')}</Text>}
+            {events.length === 0 && <Text>{t('calendar.admins-only')}</Text>}
             {events.map(event => (
               <CalendarEventView key={event.id} {...event} />
             ))}
@@ -121,6 +126,8 @@ const DashboardCalendarSection: FC<DashboardCalendarSectionProps> = ({ journeyId
         />
       </PageContentBlockFooter>
     </PageContentBlock>
+  ) : (
+    <></>
   );
 };
 


### PR DESCRIPTION
Hiding Events block when there are no events if the viewer is no admin or a lead. If they are, showing the updated message.