### PR TITLE
Update privilege check

### DIFF
--- a/src/domain/shared/components/DashboardSections/DashboardCalendarSection.tsx
+++ b/src/domain/shared/components/DashboardSections/DashboardCalendarSection.tsx
@@ -98,7 +98,7 @@ const DashboardCalendarSection: FC<DashboardCalendarSectionProps> = ({ journeyId
     navigate(`${EntityPageSection.Dashboard}/calendar?${nextUrlParams}`);
   };
 
-  const alwaysShowEvents = spaceData?.space.collaboration?.timeline?.calendar.authorization?.myPrivileges?.includes(
+  const alwaysShowEvents = collaboration?.timeline?.calendar.authorization?.myPrivileges?.includes(
     AuthorizationPrivilege.Create
   );
 


### PR DESCRIPTION
Hiding Events block when there are no events. When there are no events, only show this block to admins and leads.