### PR TITLE
Spaces/Subspaces cards on Spaces page

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1420,6 +1420,7 @@
     "card": {
       "member": "Member",
       "private": "Private",
+      "public": "Public",
       "lead": "Lead"
     },
     "errorblock": {
@@ -1984,7 +1985,8 @@
       },
       "my": {
         "title": "My Challenges",
-        "subtitle": "Here you'll find the challenges that you are contributing to."
+        "subtitle": "Here you'll find the challenges that you are contributing to.",
+        "in": "in"
       },
       "other": {
         "title": "Other Challenges within My Spaces",
@@ -2639,6 +2641,7 @@
       }
     },
     "avatar": {
+      "name": "avatar",
       "contributor": {
         "text": "{{displayName}}'s avatar: {{altText}}"
       }

--- a/src/dev/ui/JourneyCardsDemo.tsx
+++ b/src/dev/ui/JourneyCardsDemo.tsx
@@ -8,6 +8,8 @@ import SpaceCard from '../../domain/journey/space/SpaceCard/SpaceCard';
 import ChallengeCard from '../../domain/journey/challenge/ChallengeCard/ChallengeCard';
 import PageContentBlockHeader from '../../core/ui/content/PageContentBlockHeader';
 import OpportunityCard from '../../domain/journey/opportunity/OpportunityCard/OpportunityCard';
+import SpaceSubspaceCard from '../../domain/journey/space/SpaceSubspaceCard/SpaceSubspaceCard';
+import { ProfileType } from '../../core/apollo/generated/graphql-schema';
 
 const loremIpsum =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
@@ -26,6 +28,60 @@ const JourneyCardsDemo = () => {
           </PageContentBlock>
         </PageContentColumn>
         <PageContentColumn columns={8}>
+          <PageContentBlock>
+            <PageContentBlockHeader title="Explore Spaces Cards" />
+            <PageContentBlockGrid disablePadding cards>
+              <SpaceSubspaceCard
+                banner={{ uri: '/src/domain/journey/defaultVisuals/Card.jpg' }}
+                tagline={loremIpsum}
+                vision={loremIpsum}
+                displayName="Challenge Card"
+                tags={['challenge', 'card']}
+                journeyUri=""
+                spaceDisplayName="Parent Space"
+                spaceUri=""
+                type={ProfileType.Challenge}
+                avatarUris={['', '']}
+              />
+              <SpaceSubspaceCard
+                banner={{ uri: '/src/domain/journey/defaultVisuals/Card.jpg' }}
+                tagline={loremIpsum}
+                vision={loremIpsum}
+                displayName="Really Long Challenge Card Display Name"
+                tags={['challenge', 'card']}
+                journeyUri=""
+                spaceDisplayName=""
+                spaceUri=""
+                type={ProfileType.Space}
+                isPrivate
+                avatarUris={['']}
+              />
+              <SpaceSubspaceCard
+                banner={{ uri: '/src/domain/journey/defaultVisuals/Card.jpg' }}
+                tagline={loremIpsum}
+                vision={loremIpsum}
+                displayName="Really Long Challenge Card Display Name That Doesn't Even Fit On 2 Lines"
+                tags={[
+                  'challenge',
+                  'card',
+                  'that',
+                  'has',
+                  'too',
+                  'many',
+                  'tags',
+                  'they',
+                  'dont even fit',
+                  'on 2 lines',
+                ]}
+                member
+                journeyUri=""
+                spaceDisplayName="Parent Space"
+                spaceUri=""
+                type={ProfileType.Opportunity}
+                avatarUris={['', '', '']}
+              />
+            </PageContentBlockGrid>
+          </PageContentBlock>
           <PageContentBlock>
             <PageContentBlockHeader title="Space Cards" />
             <PageContentBlockGrid disablePadding cards>

--- a/src/domain/journey/common/JourneyCard/JourneyCard.tsx
+++ b/src/domain/journey/common/JourneyCard/JourneyCard.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentType, PropsWithChildren, ReactNode, useState } from 'react';
-import { Box, SvgIconProps } from '@mui/material';
+import { Box, Chip, SvgIconProps } from '@mui/material';
 import { LockOutlined } from '@mui/icons-material';
 import ContributeCard, { ContributeCardProps } from '../../../../core/ui/card/ContributeCard';
 import BadgeCardView from '../../../../core/ui/list/BadgeCardView';
@@ -8,7 +8,6 @@ import { gutters } from '../../../../core/ui/grid/utils';
 import CardContent from '../../../../core/ui/card/CardContent';
 import RouterLink from '../../../../core/ui/link/RouterLink';
 import ExpandableCardFooter from '../../../../core/ui/card/ExpandableCardFooter';
-import CardMemberIcon from '../../../community/membership/CardMemberIcon/CardMemberIcon';
 import CardBanner from '../../../../core/ui/card/CardImageHeader';
 import { useTranslation } from 'react-i18next';
 import { JourneyCardBanner } from './Banner';
@@ -27,6 +26,10 @@ export interface JourneyCardProps extends ContributeCardProps {
   locked?: boolean;
   actions?: ReactNode;
   matchedTerms?: boolean; // TODO pass ComponentType<CardTags> instead
+  visual?: ReactNode;
+  showAccessibility?: boolean;
+  subspace?: boolean;
+  isPrivate?: boolean;
 }
 
 const JourneyCard = ({
@@ -42,6 +45,10 @@ const JourneyCard = ({
   locked,
   actions,
   children,
+  visual,
+  showAccessibility,
+  subspace,
+  isPrivate,
   ...containerProps
 }: PropsWithChildren<JourneyCardProps>) => {
   const { t } = useTranslation();
@@ -60,6 +67,11 @@ const JourneyCard = ({
       } as const)
     : {};
 
+  const isSubspace = subspace ? t('common.subspace') : t('common.space');
+  const accessibilityLabel = member
+    ? t('components.card.member')
+    : `${isPrivate ? t('components.card.private') : t('components.card.public')} ${isSubspace}`;
+
   return (
     <ContributeCard {...containerProps}>
       <Box {...wrapperProps}>
@@ -69,12 +81,20 @@ const JourneyCard = ({
           overlay={
             <>
               {ribbon}
-              {member && <CardMemberIcon top={gutters(ribbon ? 2.0 : 0.5)} />}
+              {showAccessibility && (
+                <Chip
+                  variant="filled"
+                  color="primary"
+                  label={accessibilityLabel}
+                  icon={isPrivate ? <LockOutlined /> : undefined}
+                  sx={{ position: 'absolute', bottom: gutters(0.5), left: gutters(0.5) }}
+                />
+              )}
             </>
           }
         />
         <BadgeCardView
-          visual={<RoundedIcon size="small" component={Icon} />}
+          visual={visual || <RoundedIcon size="small" component={Icon} />}
           visualRight={locked ? <LockOutlined fontSize="small" color="primary" /> : undefined}
           gap={1}
           height={gutters(3)}

--- a/src/domain/journey/space/SpaceSubspaceCard/SpaceSubspaceCard.tsx
+++ b/src/domain/journey/space/SpaceSubspaceCard/SpaceSubspaceCard.tsx
@@ -1,0 +1,86 @@
+import { useTranslation } from 'react-i18next';
+import { HubOutlined } from '@mui/icons-material';
+import { ProfileType, SpaceVisibility } from '../../../../core/apollo/generated/graphql-schema';
+import { BlockTitle, Caption } from '../../../../core/ui/typography';
+import CardRibbon from '../../../../core/ui/card/CardRibbon';
+import CardActions from '../../../../core/ui/card/CardActions';
+import JourneyCard, { JourneyCardProps } from '../../common/JourneyCard/JourneyCard';
+import JourneyCardDescription from '../../common/JourneyCard/JourneyCardDescription';
+import JourneyCardSpacing from '../../common/JourneyCard/JourneyCardSpacing';
+import JourneyCardGoToButton from '../../common/JourneyCard/JourneyCardGoToButton';
+import JourneyCardTagline from '../../common/JourneyCard/JourneyCardTagline';
+import StackedAvatar from './StackedAvatar';
+
+interface SpaceSubspaceCardProps
+  extends Omit<JourneyCardProps, 'header' | 'iconComponent' | 'expansion' | 'journeyTypeName'> {
+  tagline: string;
+  displayName: string;
+  vision: string;
+  member?: boolean;
+  journeyUri: string;
+  type: string;
+  spaceVisibility?: SpaceVisibility;
+  spaceDisplayName?: string;
+  spaceUri?: string;
+  hideJoin?: boolean;
+  isPrivate?: boolean;
+  avatarUris: string[];
+}
+
+const SpaceSubspaceCard = ({
+  displayName,
+  vision,
+  tagline,
+  spaceVisibility,
+  type,
+  spaceDisplayName,
+  avatarUris,
+  ...props
+}: SpaceSubspaceCardProps) => {
+  const { t } = useTranslation();
+
+  const ribbon =
+    spaceVisibility && spaceVisibility !== SpaceVisibility.Active ? (
+      <CardRibbon text={t(`common.enums.space-visibility.${spaceVisibility}` as const)} />
+    ) : undefined;
+
+  const isSubspace = type !== ProfileType.Space;
+
+  return (
+    <JourneyCard
+      iconComponent={HubOutlined}
+      header={
+        <>
+          <BlockTitle noWrap component="dt">
+            {displayName}
+          </BlockTitle>
+          {isSubspace && (
+            <Caption noWrap component="dd" sx={{ color: 'primary.main' }}>
+              {t('pages.challenge-explorer.my.in')}: {spaceDisplayName}
+            </Caption>
+          )}
+        </>
+      }
+      visual={<StackedAvatar uri={avatarUris} />}
+      showAccessibility
+      subspace={isSubspace}
+      expansion={
+        <>
+          <JourneyCardDescription>{vision}</JourneyCardDescription>
+          <JourneyCardSpacing />
+        </>
+      }
+      expansionActions={
+        <CardActions>
+          <JourneyCardGoToButton journeyUri={props.journeyUri} journeyTypeName="space" />
+        </CardActions>
+      }
+      ribbon={ribbon}
+      {...props}
+    >
+      <JourneyCardTagline>{tagline}</JourneyCardTagline>
+    </JourneyCard>
+  );
+};
+
+export default SpaceSubspaceCard;

--- a/src/domain/journey/space/SpaceSubspaceCard/StackedAvatar.tsx
+++ b/src/domain/journey/space/SpaceSubspaceCard/StackedAvatar.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next';
+import { Box, styled } from '@mui/material';
+import { gutters } from '../../../../core/ui/grid/utils';
+
+interface StackedAvatarProps {
+  uri: string[];
+}
+
+const Avatar = styled(Box)(({ theme }) => ({
+  width: theme.spacing(2),
+  height: theme.spacing(2),
+  position: 'absolute',
+  borderRadius: 4,
+  border: '1px solid #FFFFFF',
+  '& > img': {
+    width: theme.spacing(2),
+    height: theme.spacing(2),
+    objectFit: 'cover',
+  },
+}));
+
+const StackedAvatar = ({ uri }: StackedAvatarProps) => {
+  const { t } = useTranslation();
+  return (
+    <Box sx={{ width: gutters(1.5), height: gutters(1.5), position: 'relative', flex: '0 0 10%' }}>
+      {uri.map((u, index) => {
+        return (
+          <Avatar sx={{ zIndex: index, top: `${index * 4}px`, left: `${index * 4}px` }}>
+            <img src={u ? u : '/src/domain/journey/defaultVisuals/Card.jpg'} alt={t('visuals-alt-text.avatar.name')} />
+          </Avatar>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default StackedAvatar;


### PR DESCRIPTION
- Add label on cards for "My Space" "Public Space", "Private Space" (+lock icon), see design
-  Instead of the current Journey icon, show the avatar. In case of a SubSpace, stack Space/Subspace avatars on top of squares with primary color and white border, see design. 1 square behind the avatar for level 1 Subspace, 2 squares behind the avatar for level 2 Subspace
-  In case of subspace, move Space title to be below Subspace title, see design
-  Remove membership status icon top right.