### PR TITLE
Change the spaces page layout columns ratio on desktop

### DIFF
--- a/src/core/ui/content/ContentColumn.tsx
+++ b/src/core/ui/content/ContentColumn.tsx
@@ -1,20 +1,14 @@
 import React, { forwardRef } from 'react';
-import { useColumns } from '../grid/GridContext';
 import PageContentColumn from './PageContentColumn';
-import { GRID_COLUMNS_MOBILE } from '../grid/constants';
 import { BoxProps } from '@mui/material';
 
+// GRID COLUMNS - INFO_COLUMNS => 12 - 3
 const CONTENT_COLUMNS = 9;
 
-const ContentColumn = forwardRef<HTMLDivElement, BoxProps>(({ children, ...props }, ref) => {
-  const fullWidthColumns = useColumns();
-  const columnsToUse = fullWidthColumns === GRID_COLUMNS_MOBILE ? GRID_COLUMNS_MOBILE : CONTENT_COLUMNS;
-
-  return (
-    <PageContentColumn columns={columnsToUse} {...props} ref={ref}>
-      {children}
-    </PageContentColumn>
-  );
-});
+const ContentColumn = forwardRef<HTMLDivElement, BoxProps>(({ children, ...props }, ref) => (
+  <PageContentColumn columns={CONTENT_COLUMNS} {...props} ref={ref}>
+    {children}
+  </PageContentColumn>
+));
 
 export default ContentColumn;

--- a/src/core/ui/content/ContentColumn.tsx
+++ b/src/core/ui/content/ContentColumn.tsx
@@ -1,0 +1,20 @@
+import React, { forwardRef } from 'react';
+import { useColumns } from '../grid/GridContext';
+import PageContentColumn from './PageContentColumn';
+import { GRID_COLUMNS_MOBILE } from '../grid/constants';
+import { BoxProps } from '@mui/material';
+
+const CONTENT_COLUMNS = 9;
+
+const ContentColumn = forwardRef<HTMLDivElement, BoxProps>(({ children, ...props }, ref) => {
+  const fullWidthColumns = useColumns();
+  const columnsToUse = fullWidthColumns === GRID_COLUMNS_MOBILE ? GRID_COLUMNS_MOBILE : CONTENT_COLUMNS;
+
+  return (
+    <PageContentColumn columns={columnsToUse} {...props} ref={ref}>
+      {children}
+    </PageContentColumn>
+  );
+});
+
+export default ContentColumn;

--- a/src/core/ui/content/InfoColumn.tsx
+++ b/src/core/ui/content/InfoColumn.tsx
@@ -4,11 +4,12 @@ import { BoxProps } from '@mui/material';
 import PageContentColumn from './PageContentColumn';
 import { GRID_COLUMNS_MOBILE } from '../grid/constants';
 
+// GRID COLUMNS - CONTENT_COLUMNS => 12 - 9
 const INFO_COLUMNS = 3;
 
 const InfoColumn = forwardRef<HTMLDivElement, BoxProps>(({ children, ...props }, ref) => {
-  const fullWidthColumns = useColumns();
-  const columnsToUse = fullWidthColumns === GRID_COLUMNS_MOBILE ? GRID_COLUMNS_MOBILE : INFO_COLUMNS;
+  const availableColumns = useColumns();
+  const columnsToUse = availableColumns === GRID_COLUMNS_MOBILE ? GRID_COLUMNS_MOBILE : INFO_COLUMNS;
 
   return (
     <PageContentColumn columns={columnsToUse} {...props} ref={ref}>

--- a/src/core/ui/content/InfoColumn.tsx
+++ b/src/core/ui/content/InfoColumn.tsx
@@ -1,0 +1,20 @@
+import React, { forwardRef } from 'react';
+import { useColumns } from '../grid/GridContext';
+import { BoxProps } from '@mui/material';
+import PageContentColumn from './PageContentColumn';
+import { GRID_COLUMNS_MOBILE } from '../grid/constants';
+
+const INFO_COLUMNS = 3;
+
+const InfoColumn = forwardRef<HTMLDivElement, BoxProps>(({ children, ...props }, ref) => {
+  const fullWidthColumns = useColumns();
+  const columnsToUse = fullWidthColumns === GRID_COLUMNS_MOBILE ? GRID_COLUMNS_MOBILE : INFO_COLUMNS;
+
+  return (
+    <PageContentColumn columns={columnsToUse} {...props} ref={ref}>
+      {children}
+    </PageContentColumn>
+  );
+});
+
+export default InfoColumn;

--- a/src/core/ui/themes/default/Theme.ts
+++ b/src/core/ui/themes/default/Theme.ts
@@ -10,11 +10,6 @@ const AVATAR_SIZE_XS = 4;
 const AVATAR_SIZE = 7;
 const AVATAR_SIZE_LG = 9;
 
-// page layout grid constants
-export const SIDEBAR_COLUMNS = 3;
-export const CONTENT_COLUMNS = 9;
-export const COLUMNS_MOBILE = 4;
-
 const defaultTheme = createTheme();
 
 export const themeOptions: ThemeOptions = {

--- a/src/core/ui/themes/default/Theme.ts
+++ b/src/core/ui/themes/default/Theme.ts
@@ -10,6 +10,12 @@ const AVATAR_SIZE_XS = 4;
 const AVATAR_SIZE = 7;
 const AVATAR_SIZE_LG = 9;
 
+// page layout constants
+export const SIDEBAR_COLUMNS = 3;
+export const SIDEBAR_COLUMNS_MOBILE = 4;
+export const CONTENT_COLUMNS = 9;
+export const CONTENT_COLUMNS_MOBILE = 8;
+
 const defaultTheme = createTheme();
 
 export const themeOptions: ThemeOptions = {

--- a/src/core/ui/themes/default/Theme.ts
+++ b/src/core/ui/themes/default/Theme.ts
@@ -10,11 +10,10 @@ const AVATAR_SIZE_XS = 4;
 const AVATAR_SIZE = 7;
 const AVATAR_SIZE_LG = 9;
 
-// page layout constants
+// page layout grid constants
 export const SIDEBAR_COLUMNS = 3;
-export const SIDEBAR_COLUMNS_MOBILE = 4;
 export const CONTENT_COLUMNS = 9;
-export const CONTENT_COLUMNS_MOBILE = 8;
+export const COLUMNS_MOBILE = 4;
 
 const defaultTheme = createTheme();
 

--- a/src/domain/collaboration/KnowledgeBase/KnowedgeBasePage.tsx
+++ b/src/domain/collaboration/KnowledgeBase/KnowedgeBasePage.tsx
@@ -1,12 +1,9 @@
 import React, { PropsWithChildren } from 'react';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { Theme } from '@mui/material';
 import usePageLayoutByEntity from '../../shared/utils/usePageLayoutByEntity';
 import { JourneyTypeName } from '../../journey/JourneyTypeName';
 import { EntityPageSection } from '../../shared/layout/EntityPageSection';
 import MembershipBackdrop from '../../shared/components/Backdrops/MembershipBackdrop';
 import PageContent from '../../../core/ui/content/PageContent';
-import PageContentColumn from '../../../core/ui/content/PageContentColumn';
 import { ContributeCreationBlock } from '../../journey/common/tabs/Contribute/ContributeCreationBlock';
 import PageContentBlock from '../../../core/ui/content/PageContentBlock';
 import PageContentBlockHeader from '../../../core/ui/content/PageContentBlockHeader';
@@ -21,7 +18,8 @@ import CalloutsGroupView from '../callout/CalloutsInContext/CalloutsGroupView';
 import CalloutCreationDialog from '../callout/creationDialog/CalloutCreationDialog';
 import KnowledgeBaseContainer from './KnowledgeBaseContainer';
 import { useRouteResolver } from '../../../main/routing/resolvers/RouteResolver';
-import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../core/ui/themes/default/Theme';
+import InfoColumn from '../../../core/ui/content/InfoColumn';
+import ContentColumn from '../../../core/ui/content/ContentColumn';
 
 interface KnowledgeBasePageProps {
   journeyTypeName: JourneyTypeName;
@@ -33,8 +31,6 @@ const KnowledgeBasePage = ({ journeyTypeName }: PropsWithChildren<KnowledgeBaseP
   const { journeyId } = useRouteResolver();
 
   const { t } = useTranslation();
-
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
 
   const buildCalloutTitle = (callout: TypedCallout) => {
     return <EllipsableWithCount count={callout.activity}>{callout.framing.profile.displayName}</EllipsableWithCount>;
@@ -70,7 +66,7 @@ const KnowledgeBasePage = ({ journeyTypeName }: PropsWithChildren<KnowledgeBaseP
           <>
             <MembershipBackdrop show={!loading && !canReadCallout} blockName={t(`common.${journeyTypeName}` as const)}>
               <PageContent>
-                <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+                <InfoColumn>
                   <ContributeCreationBlock canCreate={canCreateCallout} handleCreate={handleCreate} />
                   <PageContentBlock>
                     <PageContentBlockHeader
@@ -93,9 +89,9 @@ const KnowledgeBasePage = ({ journeyTypeName }: PropsWithChildren<KnowledgeBaseP
                       loading={loading}
                     />
                   </PageContentBlock>
-                </PageContentColumn>
+                </InfoColumn>
 
-                <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
+                <ContentColumn>
                   <CalloutsGroupView
                     callouts={groupedCallouts[CalloutGroupName.Knowledge]}
                     canCreateCallout={canCreateCallout}
@@ -107,7 +103,7 @@ const KnowledgeBasePage = ({ journeyTypeName }: PropsWithChildren<KnowledgeBaseP
                     onCalloutUpdate={refetchCallout}
                     groupName={CalloutGroupName.Knowledge}
                   />
-                </PageContentColumn>
+                </ContentColumn>
               </PageContent>
             </MembershipBackdrop>
             <CalloutCreationDialog

--- a/src/domain/collaboration/KnowledgeBase/KnowedgeBasePage.tsx
+++ b/src/domain/collaboration/KnowledgeBase/KnowedgeBasePage.tsx
@@ -21,12 +21,7 @@ import CalloutsGroupView from '../callout/CalloutsInContext/CalloutsGroupView';
 import CalloutCreationDialog from '../callout/creationDialog/CalloutCreationDialog';
 import KnowledgeBaseContainer from './KnowledgeBaseContainer';
 import { useRouteResolver } from '../../../main/routing/resolvers/RouteResolver';
-import {
-  CONTENT_COLUMNS,
-  CONTENT_COLUMNS_MOBILE,
-  SIDEBAR_COLUMNS,
-  SIDEBAR_COLUMNS_MOBILE,
-} from '../../../core/ui/themes/default/Theme';
+import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../core/ui/themes/default/Theme';
 
 interface KnowledgeBasePageProps {
   journeyTypeName: JourneyTypeName;
@@ -75,7 +70,7 @@ const KnowledgeBasePage = ({ journeyTypeName }: PropsWithChildren<KnowledgeBaseP
           <>
             <MembershipBackdrop show={!loading && !canReadCallout} blockName={t(`common.${journeyTypeName}` as const)}>
               <PageContent>
-                <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+                <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
                   <ContributeCreationBlock canCreate={canCreateCallout} handleCreate={handleCreate} />
                   <PageContentBlock>
                     <PageContentBlockHeader
@@ -100,7 +95,7 @@ const KnowledgeBasePage = ({ journeyTypeName }: PropsWithChildren<KnowledgeBaseP
                   </PageContentBlock>
                 </PageContentColumn>
 
-                <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
+                <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
                   <CalloutsGroupView
                     callouts={groupedCallouts[CalloutGroupName.Knowledge]}
                     canCreateCallout={canCreateCallout}

--- a/src/domain/collaboration/KnowledgeBase/KnowedgeBasePage.tsx
+++ b/src/domain/collaboration/KnowledgeBase/KnowedgeBasePage.tsx
@@ -1,4 +1,6 @@
 import React, { PropsWithChildren } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material';
 import usePageLayoutByEntity from '../../shared/utils/usePageLayoutByEntity';
 import { JourneyTypeName } from '../../journey/JourneyTypeName';
 import { EntityPageSection } from '../../shared/layout/EntityPageSection';
@@ -19,6 +21,12 @@ import CalloutsGroupView from '../callout/CalloutsInContext/CalloutsGroupView';
 import CalloutCreationDialog from '../callout/creationDialog/CalloutCreationDialog';
 import KnowledgeBaseContainer from './KnowledgeBaseContainer';
 import { useRouteResolver } from '../../../main/routing/resolvers/RouteResolver';
+import {
+  CONTENT_COLUMNS,
+  CONTENT_COLUMNS_MOBILE,
+  SIDEBAR_COLUMNS,
+  SIDEBAR_COLUMNS_MOBILE,
+} from '../../../core/ui/themes/default/Theme';
 
 interface KnowledgeBasePageProps {
   journeyTypeName: JourneyTypeName;
@@ -30,6 +38,8 @@ const KnowledgeBasePage = ({ journeyTypeName }: PropsWithChildren<KnowledgeBaseP
   const { journeyId } = useRouteResolver();
 
   const { t } = useTranslation();
+
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
 
   const buildCalloutTitle = (callout: TypedCallout) => {
     return <EllipsableWithCount count={callout.activity}>{callout.framing.profile.displayName}</EllipsableWithCount>;
@@ -65,7 +75,7 @@ const KnowledgeBasePage = ({ journeyTypeName }: PropsWithChildren<KnowledgeBaseP
           <>
             <MembershipBackdrop show={!loading && !canReadCallout} blockName={t(`common.${journeyTypeName}` as const)}>
               <PageContent>
-                <PageContentColumn columns={4}>
+                <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
                   <ContributeCreationBlock canCreate={canCreateCallout} handleCreate={handleCreate} />
                   <PageContentBlock>
                     <PageContentBlockHeader
@@ -90,7 +100,7 @@ const KnowledgeBasePage = ({ journeyTypeName }: PropsWithChildren<KnowledgeBaseP
                   </PageContentBlock>
                 </PageContentColumn>
 
-                <PageContentColumn columns={8}>
+                <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
                   <CalloutsGroupView
                     callouts={groupedCallouts[CalloutGroupName.Knowledge]}
                     canCreateCallout={canCreateCallout}

--- a/src/domain/collaboration/callout/JourneyCalloutsTabView/JourneyCalloutsTabView.tsx
+++ b/src/domain/collaboration/callout/JourneyCalloutsTabView/JourneyCalloutsTabView.tsx
@@ -17,12 +17,7 @@ import { OrderUpdate, TypedCallout } from '../useCallouts/useCallouts';
 import calloutIcons from '../utils/calloutIcons';
 import JourneyCalloutsListItemTitle from './JourneyCalloutsListItemTitle';
 import { InnovationFlowState } from '../../InnovationFlow/InnovationFlow';
-import {
-  CONTENT_COLUMNS,
-  CONTENT_COLUMNS_MOBILE,
-  SIDEBAR_COLUMNS,
-  SIDEBAR_COLUMNS_MOBILE,
-} from '../../../../core/ui/themes/default/Theme';
+import { CONTENT_COLUMNS, COLUMNS_MOBILE, SIDEBAR_COLUMNS } from '../../../../core/ui/themes/default/Theme';
 
 interface JourneyCalloutsTabViewProps {
   collaborationId: string | undefined;
@@ -80,7 +75,7 @@ const JourneyCalloutsTabView = ({
     <>
       <MembershipBackdrop show={!loading && !allCallouts} blockName={t(`common.${journeyTypeName}` as const)}>
         <PageContent>
-          <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+          <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
             <ContributeInnovationFlowBlock collaborationId={collaborationId} journeyTypeName={journeyTypeName} />
             <PageContentBlock>
               <PageContentBlockHeader
@@ -124,7 +119,7 @@ const JourneyCalloutsTabView = ({
             />
           </PageContentColumn>
 
-          <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
+          <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
             {innovationFlowStates &&
               currentInnovationFlowState &&
               selectedInnovationFlowState &&

--- a/src/domain/collaboration/callout/JourneyCalloutsTabView/JourneyCalloutsTabView.tsx
+++ b/src/domain/collaboration/callout/JourneyCalloutsTabView/JourneyCalloutsTabView.tsx
@@ -1,10 +1,7 @@
 import { useTranslation } from 'react-i18next';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { Theme } from '@mui/material';
 import PageContent from '../../../../core/ui/content/PageContent';
 import PageContentBlock from '../../../../core/ui/content/PageContentBlock';
 import PageContentBlockHeader from '../../../../core/ui/content/PageContentBlockHeader';
-import PageContentColumn from '../../../../core/ui/content/PageContentColumn';
 import LinksList from '../../../../core/ui/list/LinksList';
 import useStateWithAsyncDefault from '../../../../core/utils/useStateWithAsyncDefault';
 import { JourneyTypeName } from '../../../journey/JourneyTypeName';
@@ -17,7 +14,8 @@ import { OrderUpdate, TypedCallout } from '../useCallouts/useCallouts';
 import calloutIcons from '../utils/calloutIcons';
 import JourneyCalloutsListItemTitle from './JourneyCalloutsListItemTitle';
 import { InnovationFlowState } from '../../InnovationFlow/InnovationFlow';
-import { CONTENT_COLUMNS, COLUMNS_MOBILE, SIDEBAR_COLUMNS } from '../../../../core/ui/themes/default/Theme';
+import InfoColumn from '../../../../core/ui/content/InfoColumn';
+import ContentColumn from '../../../../core/ui/content/ContentColumn';
 
 interface JourneyCalloutsTabViewProps {
   collaborationId: string | undefined;
@@ -69,13 +67,11 @@ const JourneyCalloutsTabView = ({
 
   const contributeLeftCalloutsIds = groupedCallouts[CalloutGroupName.Contribute_1]?.map(callout => callout.id) ?? [];
 
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
-
   return (
     <>
       <MembershipBackdrop show={!loading && !allCallouts} blockName={t(`common.${journeyTypeName}` as const)}>
         <PageContent>
-          <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+          <InfoColumn>
             <ContributeInnovationFlowBlock collaborationId={collaborationId} journeyTypeName={journeyTypeName} />
             <PageContentBlock>
               <PageContentBlockHeader
@@ -117,9 +113,9 @@ const JourneyCalloutsTabView = ({
               groupName={CalloutGroupName.Contribute_1}
               flowState={selectedInnovationFlowState}
             />
-          </PageContentColumn>
+          </InfoColumn>
 
-          <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
+          <ContentColumn>
             {innovationFlowStates &&
               currentInnovationFlowState &&
               selectedInnovationFlowState &&
@@ -153,7 +149,7 @@ const JourneyCalloutsTabView = ({
               createButtonPlace="top"
               flowState={selectedInnovationFlowState}
             />
-          </PageContentColumn>
+          </ContentColumn>
         </PageContent>
       </MembershipBackdrop>
     </>

--- a/src/domain/collaboration/callout/JourneyCalloutsTabView/JourneyCalloutsTabView.tsx
+++ b/src/domain/collaboration/callout/JourneyCalloutsTabView/JourneyCalloutsTabView.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from 'react-i18next';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material';
 import PageContent from '../../../../core/ui/content/PageContent';
 import PageContentBlock from '../../../../core/ui/content/PageContentBlock';
 import PageContentBlockHeader from '../../../../core/ui/content/PageContentBlockHeader';
@@ -15,6 +17,12 @@ import { OrderUpdate, TypedCallout } from '../useCallouts/useCallouts';
 import calloutIcons from '../utils/calloutIcons';
 import JourneyCalloutsListItemTitle from './JourneyCalloutsListItemTitle';
 import { InnovationFlowState } from '../../InnovationFlow/InnovationFlow';
+import {
+  CONTENT_COLUMNS,
+  CONTENT_COLUMNS_MOBILE,
+  SIDEBAR_COLUMNS,
+  SIDEBAR_COLUMNS_MOBILE,
+} from '../../../../core/ui/themes/default/Theme';
 
 interface JourneyCalloutsTabViewProps {
   collaborationId: string | undefined;
@@ -66,11 +74,13 @@ const JourneyCalloutsTabView = ({
 
   const contributeLeftCalloutsIds = groupedCallouts[CalloutGroupName.Contribute_1]?.map(callout => callout.id) ?? [];
 
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
+
   return (
     <>
       <MembershipBackdrop show={!loading && !allCallouts} blockName={t(`common.${journeyTypeName}` as const)}>
         <PageContent>
-          <PageContentColumn columns={4}>
+          <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
             <ContributeInnovationFlowBlock collaborationId={collaborationId} journeyTypeName={journeyTypeName} />
             <PageContentBlock>
               <PageContentBlockHeader
@@ -114,7 +124,7 @@ const JourneyCalloutsTabView = ({
             />
           </PageContentColumn>
 
-          <PageContentColumn columns={8}>
+          <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
             {innovationFlowStates &&
               currentInnovationFlowState &&
               selectedInnovationFlowState &&

--- a/src/domain/journey/common/tabs/About/OpportunityAboutView.tsx
+++ b/src/domain/journey/common/tabs/About/OpportunityAboutView.tsx
@@ -37,7 +37,8 @@ import InnovationFlowChips from '../../../../collaboration/InnovationFlow/Innova
 import useMetricsItems from '../../../../platform/metrics/utils/useMetricsItems';
 import OpportunityMetrics from '../../../opportunity/utils/useOpportunityMetricsItems';
 import { Metric } from '../../../../platform/metrics/utils/getMetricCount';
-import { COLUMNS_MOBILE, CONTENT_COLUMNS, SIDEBAR_COLUMNS } from '../../../../../core/ui/themes/default/Theme';
+import InfoColumn from '../../../../../core/ui/content/InfoColumn';
+import ContentColumn from '../../../../../core/ui/content/ContentColumn';
 
 export interface OpportunityAboutViewProps extends EntityDashboardContributors, EntityDashboardLeads {
   challengeId: string | undefined;
@@ -132,8 +133,6 @@ const OpportunityAboutView: FC<OpportunityAboutViewProps> = ({
     who,
   } as const;
 
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
-
   const hasExtendedApplicationButton = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
 
   const shareUpdatesUrl = buildUpdatesUrl(opportunityUrl);
@@ -159,7 +158,7 @@ const OpportunityAboutView: FC<OpportunityAboutViewProps> = ({
             );
           }}
         </OpportunityApplicationButtonContainer>
-        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+        <InfoColumn>
           <PageContentBlock accent>
             <PageContentBlockHeader title={name} />
             <Tagline>{tagline}</Tagline>
@@ -201,8 +200,8 @@ const OpportunityAboutView: FC<OpportunityAboutViewProps> = ({
               <ActivityView activity={metricsItems} loading={loading} />
             </PageContentBlock>
           )}
-        </PageContentColumn>
-        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
+        </InfoColumn>
+        <ContentColumn>
           <FixedHeightContentBlock>
             <PageContentBlockHeaderWithDialogAction
               title={t(`context.${journeyTypeName}.vision.title` as const)}
@@ -244,7 +243,7 @@ const OpportunityAboutView: FC<OpportunityAboutViewProps> = ({
               <ActivityView activity={metricsItems} loading={loading} />
             </PageContentBlock>
           )}
-        </PageContentColumn>
+        </ContentColumn>
       </PageContent>
       <DialogWithGrid open={isDialogOpen} columns={12} onClose={closeDialog}>
         <DialogHeader title={t('common.context')} onClose={closeDialog} />

--- a/src/domain/journey/common/tabs/About/OpportunityAboutView.tsx
+++ b/src/domain/journey/common/tabs/About/OpportunityAboutView.tsx
@@ -37,6 +37,7 @@ import InnovationFlowChips from '../../../../collaboration/InnovationFlow/Innova
 import useMetricsItems from '../../../../platform/metrics/utils/useMetricsItems';
 import OpportunityMetrics from '../../../opportunity/utils/useOpportunityMetricsItems';
 import { Metric } from '../../../../platform/metrics/utils/getMetricCount';
+import { COLUMNS_MOBILE, CONTENT_COLUMNS, SIDEBAR_COLUMNS } from '../../../../../core/ui/themes/default/Theme';
 
 export interface OpportunityAboutViewProps extends EntityDashboardContributors, EntityDashboardLeads {
   challengeId: string | undefined;
@@ -131,6 +132,8 @@ const OpportunityAboutView: FC<OpportunityAboutViewProps> = ({
     who,
   } as const;
 
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
+
   const hasExtendedApplicationButton = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
 
   const shareUpdatesUrl = buildUpdatesUrl(opportunityUrl);
@@ -156,7 +159,7 @@ const OpportunityAboutView: FC<OpportunityAboutViewProps> = ({
             );
           }}
         </OpportunityApplicationButtonContainer>
-        <PageContentColumn columns={4}>
+        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
           <PageContentBlock accent>
             <PageContentBlockHeader title={name} />
             <Tagline>{tagline}</Tagline>
@@ -199,7 +202,7 @@ const OpportunityAboutView: FC<OpportunityAboutViewProps> = ({
             </PageContentBlock>
           )}
         </PageContentColumn>
-        <PageContentColumn columns={8}>
+        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
           <FixedHeightContentBlock>
             <PageContentBlockHeaderWithDialogAction
               title={t(`context.${journeyTypeName}.vision.title` as const)}

--- a/src/domain/journey/common/tabs/Dashboard/JourneyDashboardView.tsx
+++ b/src/domain/journey/common/tabs/Dashboard/JourneyDashboardView.tsx
@@ -35,12 +35,7 @@ import FullWidthButton from '../../../../../core/ui/button/FullWidthButton';
 import { InfoOutlined } from '@mui/icons-material';
 import RouterLink from '../../../../../core/ui/link/RouterLink';
 import { RECENT_ACTIVITIES_LIMIT_EXPANDED } from '../../journeyDashboard/constants';
-import {
-  CONTENT_COLUMNS,
-  CONTENT_COLUMNS_MOBILE,
-  SIDEBAR_COLUMNS,
-  SIDEBAR_COLUMNS_MOBILE,
-} from '../../../../../core/ui/themes/default/Theme';
+import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../../../core/ui/themes/default/Theme';
 
 export interface JourneyDashboardViewProps
   extends EntityDashboardContributors,
@@ -132,7 +127,7 @@ const JourneyDashboardView = ({
   return (
     <PageContent>
       {ribbon}
-      <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+      <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
         {welcome}
         <FullWidthButton
           startIcon={<InfoOutlined />}
@@ -184,7 +179,7 @@ const JourneyDashboardView = ({
         />
       </PageContentColumn>
 
-      <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
+      <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
         <DashboardRecentContributionsBlock
           halfWidth={(callouts.groupedCallouts[CalloutGroupName.Home_2]?.length ?? 0) > 0}
           readUsersAccess={readUsersAccess}

--- a/src/domain/journey/common/tabs/Dashboard/JourneyDashboardView.tsx
+++ b/src/domain/journey/common/tabs/Dashboard/JourneyDashboardView.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material';
 import {
   CalloutGroupName,
   CalloutsQueryVariables,
@@ -33,6 +35,12 @@ import FullWidthButton from '../../../../../core/ui/button/FullWidthButton';
 import { InfoOutlined } from '@mui/icons-material';
 import RouterLink from '../../../../../core/ui/link/RouterLink';
 import { RECENT_ACTIVITIES_LIMIT_EXPANDED } from '../../journeyDashboard/constants';
+import {
+  CONTENT_COLUMNS,
+  CONTENT_COLUMNS_MOBILE,
+  SIDEBAR_COLUMNS,
+  SIDEBAR_COLUMNS_MOBILE,
+} from '../../../../../core/ui/themes/default/Theme';
 
 export interface JourneyDashboardViewProps
   extends EntityDashboardContributors,
@@ -119,10 +127,12 @@ const JourneyDashboardView = ({
 
   const translatedJourneyTypeName = t(`common.${journeyTypeName}` as const);
 
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
+
   return (
     <PageContent>
       {ribbon}
-      <PageContentColumn columns={4}>
+      <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
         {welcome}
         <FullWidthButton
           startIcon={<InfoOutlined />}
@@ -174,7 +184,7 @@ const JourneyDashboardView = ({
         />
       </PageContentColumn>
 
-      <PageContentColumn columns={8}>
+      <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
         <DashboardRecentContributionsBlock
           halfWidth={(callouts.groupedCallouts[CalloutGroupName.Home_2]?.length ?? 0) > 0}
           readUsersAccess={readUsersAccess}

--- a/src/domain/journey/common/tabs/Dashboard/JourneyDashboardView.tsx
+++ b/src/domain/journey/common/tabs/Dashboard/JourneyDashboardView.tsx
@@ -1,7 +1,5 @@
 import React, { ReactNode, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { Theme } from '@mui/material';
 import {
   CalloutGroupName,
   CalloutsQueryVariables,
@@ -17,7 +15,6 @@ import { EntityPageSection } from '../../../../shared/layout/EntityPageSection';
 import { ActivityLogResultType } from '../../../../collaboration/activity/ActivityLog/ActivityComponent';
 import ShareButton from '../../../../shared/components/ShareDialog/ShareButton';
 import PageContent from '../../../../../core/ui/content/PageContent';
-import PageContentColumn from '../../../../../core/ui/content/PageContentColumn';
 import SeeMore from '../../../../../core/ui/content/SeeMore';
 import { JourneyTypeName } from '../../../JourneyTypeName';
 import DashboardCalendarSection from '../../../../shared/components/DashboardSections/DashboardCalendarSection';
@@ -35,7 +32,8 @@ import FullWidthButton from '../../../../../core/ui/button/FullWidthButton';
 import { InfoOutlined } from '@mui/icons-material';
 import RouterLink from '../../../../../core/ui/link/RouterLink';
 import { RECENT_ACTIVITIES_LIMIT_EXPANDED } from '../../journeyDashboard/constants';
-import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../../../core/ui/themes/default/Theme';
+import InfoColumn from '../../../../../core/ui/content/InfoColumn';
+import ContentColumn from '../../../../../core/ui/content/ContentColumn';
 
 export interface JourneyDashboardViewProps
   extends EntityDashboardContributors,
@@ -122,12 +120,10 @@ const JourneyDashboardView = ({
 
   const translatedJourneyTypeName = t(`common.${journeyTypeName}` as const);
 
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
-
   return (
     <PageContent>
       {ribbon}
-      <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+      <InfoColumn>
         {welcome}
         <FullWidthButton
           startIcon={<InfoOutlined />}
@@ -177,9 +173,9 @@ const JourneyDashboardView = ({
           onCalloutUpdate={callouts.refetchCallout}
           groupName={CalloutGroupName.Home_1}
         />
-      </PageContentColumn>
+      </InfoColumn>
 
-      <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
+      <ContentColumn>
         <DashboardRecentContributionsBlock
           halfWidth={(callouts.groupedCallouts[CalloutGroupName.Home_2]?.length ?? 0) > 0}
           readUsersAccess={readUsersAccess}
@@ -208,7 +204,7 @@ const JourneyDashboardView = ({
             }
           }}
         />
-      </PageContentColumn>
+      </ContentColumn>
     </PageContent>
   );
 };

--- a/src/domain/journey/common/tabs/Subentities/ChildJourneyView.tsx
+++ b/src/domain/journey/common/tabs/Subentities/ChildJourneyView.tsx
@@ -22,12 +22,7 @@ import Loading from '../../../../../core/ui/loading/Loading';
 import PageContentBlockSeamless from '../../../../../core/ui/content/PageContentBlockSeamless';
 import JourneyFilter from '../../JourneyFilter/JourneyFilter';
 import { Identifiable } from '../../../../../core/utils/Identifiable';
-import {
-  CONTENT_COLUMNS,
-  CONTENT_COLUMNS_MOBILE,
-  SIDEBAR_COLUMNS,
-  SIDEBAR_COLUMNS_MOBILE,
-} from '../../../../../core/ui/themes/default/Theme';
+import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../../../core/ui/themes/default/Theme';
 
 export interface JourneySubentitiesState {
   loading: boolean;
@@ -79,7 +74,7 @@ const ChildJourneyView = <ChildEntity extends BaseChildEntity>({
   return (
     <MembershipBackdrop show={!childEntityReadAccess} blockName={getJourneyChildrenTranslation(t, journeyTypeName)}>
       <PageContent>
-        <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
           <ChildJourneyCreate
             journeyTypeName={journeyTypeName}
             canCreateSubentity={childEntityCreateAccess}
@@ -107,7 +102,7 @@ const ChildJourneyView = <ChildEntity extends BaseChildEntity>({
           </PageContentBlock>
           {childrenLeft}
         </PageContentColumn>
-        <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
+        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
           {state.loading && <Loading />}
           {!state.loading && childEntities.length === 0 && (
             <PageContentBlockSeamless>

--- a/src/domain/journey/common/tabs/Subentities/ChildJourneyView.tsx
+++ b/src/domain/journey/common/tabs/Subentities/ChildJourneyView.tsx
@@ -3,15 +3,12 @@ import { ReactElement, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import AddOutlinedIcon from '@mui/icons-material/AddOutlined';
 import { Button } from '@mui/material';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { Theme } from '@mui/material';
 import { ValueType } from '../../../../../core/utils/filtering/filterFn';
 import ErrorBlock from '../../../../../core/ui/error/ErrorBlock';
 import getJourneyChildrenTranslation from '../../../childJourney/getJourneyChildrenTranslation';
 import PageContent from '../../../../../core/ui/content/PageContent';
 import PageContentBlock from '../../../../../core/ui/content/PageContentBlock';
 import PageContentBlockHeader from '../../../../../core/ui/content/PageContentBlockHeader';
-import PageContentColumn from '../../../../../core/ui/content/PageContentColumn';
 import LinksList from '../../../../../core/ui/list/LinksList';
 import { Caption } from '../../../../../core/ui/typography';
 import MembershipBackdrop from '../../../../shared/components/Backdrops/MembershipBackdrop';
@@ -22,7 +19,8 @@ import Loading from '../../../../../core/ui/loading/Loading';
 import PageContentBlockSeamless from '../../../../../core/ui/content/PageContentBlockSeamless';
 import JourneyFilter from '../../JourneyFilter/JourneyFilter';
 import { Identifiable } from '../../../../../core/utils/Identifiable';
-import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../../../core/ui/themes/default/Theme';
+import InfoColumn from '../../../../../core/ui/content/InfoColumn';
+import ContentColumn from '../../../../../core/ui/content/ContentColumn';
 
 export interface JourneySubentitiesState {
   loading: boolean;
@@ -69,12 +67,10 @@ const ChildJourneyView = <ChildEntity extends BaseChildEntity>({
 }: ChildJourneyViewProps<ChildEntity>) => {
   const { t } = useTranslation();
 
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
-
   return (
     <MembershipBackdrop show={!childEntityReadAccess} blockName={getJourneyChildrenTranslation(t, journeyTypeName)}>
       <PageContent>
-        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+        <InfoColumn>
           <ChildJourneyCreate
             journeyTypeName={journeyTypeName}
             canCreateSubentity={childEntityCreateAccess}
@@ -101,8 +97,8 @@ const ChildJourneyView = <ChildEntity extends BaseChildEntity>({
             />
           </PageContentBlock>
           {childrenLeft}
-        </PageContentColumn>
-        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
+        </InfoColumn>
+        <ContentColumn>
           {state.loading && <Loading />}
           {!state.loading && childEntities.length === 0 && (
             <PageContentBlockSeamless>
@@ -147,7 +143,7 @@ const ChildJourneyView = <ChildEntity extends BaseChildEntity>({
           )}
           {childrenRight}
           {state.error && <ErrorBlock blockName={t(`common.${journeyTypeName}` as const)} />}
-        </PageContentColumn>
+        </ContentColumn>
       </PageContent>
     </MembershipBackdrop>
   );

--- a/src/domain/journey/common/tabs/Subentities/ChildJourneyView.tsx
+++ b/src/domain/journey/common/tabs/Subentities/ChildJourneyView.tsx
@@ -1,6 +1,10 @@
 import { ApolloError } from '@apollo/client';
 import { ReactElement, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import AddOutlinedIcon from '@mui/icons-material/AddOutlined';
+import { Button } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material';
 import { ValueType } from '../../../../../core/utils/filtering/filterFn';
 import ErrorBlock from '../../../../../core/ui/error/ErrorBlock';
 import getJourneyChildrenTranslation from '../../../childJourney/getJourneyChildrenTranslation';
@@ -17,9 +21,13 @@ import ChildJourneyCreate from './ChildJourneyCreate';
 import Loading from '../../../../../core/ui/loading/Loading';
 import PageContentBlockSeamless from '../../../../../core/ui/content/PageContentBlockSeamless';
 import JourneyFilter from '../../JourneyFilter/JourneyFilter';
-import AddOutlinedIcon from '@mui/icons-material/AddOutlined';
-import { Button } from '@mui/material';
 import { Identifiable } from '../../../../../core/utils/Identifiable';
+import {
+  CONTENT_COLUMNS,
+  CONTENT_COLUMNS_MOBILE,
+  SIDEBAR_COLUMNS,
+  SIDEBAR_COLUMNS_MOBILE,
+} from '../../../../../core/ui/themes/default/Theme';
 
 export interface JourneySubentitiesState {
   loading: boolean;
@@ -66,10 +74,12 @@ const ChildJourneyView = <ChildEntity extends BaseChildEntity>({
 }: ChildJourneyViewProps<ChildEntity>) => {
   const { t } = useTranslation();
 
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
+
   return (
     <MembershipBackdrop show={!childEntityReadAccess} blockName={getJourneyChildrenTranslation(t, journeyTypeName)}>
       <PageContent>
-        <PageContentColumn columns={4}>
+        <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
           <ChildJourneyCreate
             journeyTypeName={journeyTypeName}
             canCreateSubentity={childEntityCreateAccess}
@@ -97,7 +107,7 @@ const ChildJourneyView = <ChildEntity extends BaseChildEntity>({
           </PageContentBlock>
           {childrenLeft}
         </PageContentColumn>
-        <PageContentColumn columns={8}>
+        <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
           {state.loading && <Loading />}
           {!state.loading && childEntities.length === 0 && (
             <PageContentBlockSeamless>

--- a/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPage.tsx
+++ b/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPage.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { Box, Theme } from '@mui/material';
+import { Box } from '@mui/material';
 import { EntityPageSection } from '../../../shared/layout/EntityPageSection';
 import PageContent from '../../../../core/ui/content/PageContent';
-import PageContentColumn from '../../../../core/ui/content/PageContentColumn';
 import { useUrlParams } from '../../../../core/routing/useUrlParams';
 import CalloutsGroupView from '../../../collaboration/callout/CalloutsInContext/CalloutsGroupView';
 import EntityDashboardLeadsSection from '../../../community/community/EntityDashboardLeadsSection/EntityDashboardLeadsSection';
@@ -31,7 +29,8 @@ import DialogWithGrid from '../../../../core/ui/dialog/DialogWithGrid';
 import { useRouteResolver } from '../../../../main/routing/resolvers/RouteResolver';
 import CommunityGuidelinesBlock from '../../../community/community/CommunityGuidelines/CommunityGuidelinesBlock';
 import { useSpace } from '../SpaceContext/useSpace';
-import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../../core/ui/themes/default/Theme';
+import InfoColumn from '../../../../core/ui/content/InfoColumn';
+import ContentColumn from '../../../../core/ui/content/ContentColumn';
 
 const SpaceCommunityPage = () => {
   const { spaceNameId } = useUrlParams();
@@ -90,8 +89,6 @@ const SpaceCommunityPage = () => {
 
   const [isActivitiesDialogOpen, setIsActivitiesDialogOpen] = useState(false);
 
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
-
   useEffect(() => {
     if (isActivitiesDialogOpen) {
       fetchMoreActivities(RECENT_ACTIVITIES_LIMIT_EXPANDED);
@@ -103,7 +100,7 @@ const SpaceCommunityPage = () => {
       <SpaceCommunityContainer spaceId={spaceId}>
         {({ callouts }) => (
           <PageContent>
-            <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+            <InfoColumn>
               <EntityDashboardLeadsSection
                 usersHeader={t('community.host')}
                 organizationsHeader={t('pages.space.sections.dashboard.organization')}
@@ -132,8 +129,8 @@ const SpaceCommunityPage = () => {
                 onCalloutUpdate={callouts.refetchCallout}
                 groupName={CalloutGroupName.Community_1}
               />
-            </PageContentColumn>
-            <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
+            </InfoColumn>
+            <ContentColumn>
               <CommunityContributorsBlockWide users={memberUsers} organizations={memberOrganizations} />
               <PageContentBlock>
                 <PageContentBlockHeader title={t('common.activity')} />
@@ -166,7 +163,7 @@ const SpaceCommunityPage = () => {
                 onCalloutUpdate={callouts.refetchCallout}
                 groupName={CalloutGroupName.Community_2}
               />
-            </PageContentColumn>
+            </ContentColumn>
           </PageContent>
         )}
       </SpaceCommunityContainer>

--- a/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPage.tsx
+++ b/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPage.tsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Box, Theme } from '@mui/material';
 import { EntityPageSection } from '../../../shared/layout/EntityPageSection';
 import PageContent from '../../../../core/ui/content/PageContent';
 import PageContentColumn from '../../../../core/ui/content/PageContentColumn';
@@ -10,7 +13,6 @@ import {
   DirectMessageDialog,
   MessageReceiverChipData,
 } from '../../../communication/messaging/DirectMessaging/DirectMessageDialog';
-import { useTranslation } from 'react-i18next';
 import PageContentBlockHeader from '../../../../core/ui/content/PageContentBlockHeader';
 import { ActivityComponent } from '../../../collaboration/activity/ActivityLog/ActivityComponent';
 import PageContentBlock from '../../../../core/ui/content/PageContentBlock';
@@ -26,10 +28,15 @@ import { RECENT_ACTIVITIES_LIMIT_EXPANDED } from '../../common/journeyDashboard/
 import SeeMore from '../../../../core/ui/content/SeeMore';
 import DialogHeader from '../../../../core/ui/dialog/DialogHeader';
 import DialogWithGrid from '../../../../core/ui/dialog/DialogWithGrid';
-import { Box } from '@mui/material';
 import { useRouteResolver } from '../../../../main/routing/resolvers/RouteResolver';
 import CommunityGuidelinesBlock from '../../../community/community/CommunityGuidelines/CommunityGuidelinesBlock';
 import { useSpace } from '../SpaceContext/useSpace';
+import {
+  CONTENT_COLUMNS,
+  CONTENT_COLUMNS_MOBILE,
+  SIDEBAR_COLUMNS,
+  SIDEBAR_COLUMNS_MOBILE,
+} from '../../../../core/ui/themes/default/Theme';
 
 const SpaceCommunityPage = () => {
   const { spaceNameId } = useUrlParams();
@@ -88,6 +95,8 @@ const SpaceCommunityPage = () => {
 
   const [isActivitiesDialogOpen, setIsActivitiesDialogOpen] = useState(false);
 
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
+
   useEffect(() => {
     if (isActivitiesDialogOpen) {
       fetchMoreActivities(RECENT_ACTIVITIES_LIMIT_EXPANDED);
@@ -99,7 +108,7 @@ const SpaceCommunityPage = () => {
       <SpaceCommunityContainer spaceId={spaceId}>
         {({ callouts }) => (
           <PageContent>
-            <PageContentColumn columns={4}>
+            <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
               <EntityDashboardLeadsSection
                 usersHeader={t('community.host')}
                 organizationsHeader={t('pages.space.sections.dashboard.organization')}
@@ -129,7 +138,7 @@ const SpaceCommunityPage = () => {
                 groupName={CalloutGroupName.Community_1}
               />
             </PageContentColumn>
-            <PageContentColumn columns={8}>
+            <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
               <CommunityContributorsBlockWide users={memberUsers} organizations={memberOrganizations} />
               <PageContentBlock>
                 <PageContentBlockHeader title={t('common.activity')} />

--- a/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPage.tsx
+++ b/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPage.tsx
@@ -31,12 +31,7 @@ import DialogWithGrid from '../../../../core/ui/dialog/DialogWithGrid';
 import { useRouteResolver } from '../../../../main/routing/resolvers/RouteResolver';
 import CommunityGuidelinesBlock from '../../../community/community/CommunityGuidelines/CommunityGuidelinesBlock';
 import { useSpace } from '../SpaceContext/useSpace';
-import {
-  CONTENT_COLUMNS,
-  CONTENT_COLUMNS_MOBILE,
-  SIDEBAR_COLUMNS,
-  SIDEBAR_COLUMNS_MOBILE,
-} from '../../../../core/ui/themes/default/Theme';
+import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../../core/ui/themes/default/Theme';
 
 const SpaceCommunityPage = () => {
   const { spaceNameId } = useUrlParams();
@@ -108,7 +103,7 @@ const SpaceCommunityPage = () => {
       <SpaceCommunityContainer spaceId={spaceId}>
         {({ callouts }) => (
           <PageContent>
-            <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+            <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
               <EntityDashboardLeadsSection
                 usersHeader={t('community.host')}
                 organizationsHeader={t('pages.space.sections.dashboard.organization')}
@@ -138,7 +133,7 @@ const SpaceCommunityPage = () => {
                 groupName={CalloutGroupName.Community_1}
               />
             </PageContentColumn>
-            <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
+            <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
               <CommunityContributorsBlockWide users={memberUsers} organizations={memberOrganizations} />
               <PageContentBlock>
                 <PageContentBlockHeader title={t('common.activity')} />

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
@@ -32,12 +32,7 @@ import MembershipContainer from '../../../community/membership/membershipContain
 import RouterLink from '../../../../core/ui/link/RouterLink';
 import { EntityPageSection } from '../../../shared/layout/EntityPageSection';
 import { RECENT_ACTIVITIES_LIMIT_EXPANDED } from '../../common/journeyDashboard/constants';
-import {
-  CONTENT_COLUMNS,
-  CONTENT_COLUMNS_MOBILE,
-  SIDEBAR_COLUMNS,
-  SIDEBAR_COLUMNS_MOBILE,
-} from '../../../../core/ui/themes/default/Theme';
+import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../../core/ui/themes/default/Theme';
 
 interface SpaceWelcomeBlockContributor {
   profile: SpaceWelcomeBlockContributorProfileFragment;
@@ -138,7 +133,7 @@ const SpaceDashboardView = ({
             );
           }}
         </ApplicationButtonContainer>
-        <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
           <JourneyDashboardWelcomeBlock
             vision={vision}
             leadUsers={leadUsers}
@@ -179,7 +174,7 @@ const SpaceDashboardView = ({
           />
         </PageContentColumn>
 
-        <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
+        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
           <DashboardRecentContributionsBlock
             halfWidth={(callouts.groupedCallouts[CalloutGroupName.Home_2]?.length ?? 0) > 0}
             readUsersAccess={readUsersAccess}

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
@@ -12,7 +12,6 @@ import {
 import DashboardUpdatesSection from '../../../shared/components/DashboardSections/DashboardUpdatesSection';
 import { ActivityLogResultType } from '../../../collaboration/activity/ActivityLog/ActivityComponent';
 import PageContent from '../../../../core/ui/content/PageContent';
-import PageContentColumn from '../../../../core/ui/content/PageContentColumn';
 import { JourneyTypeName } from '../../JourneyTypeName';
 import DashboardCalendarSection from '../../../shared/components/DashboardSections/DashboardCalendarSection';
 import ApplicationButtonContainer from '../../../community/application/containers/ApplicationButtonContainer';
@@ -32,7 +31,8 @@ import MembershipContainer from '../../../community/membership/membershipContain
 import RouterLink from '../../../../core/ui/link/RouterLink';
 import { EntityPageSection } from '../../../shared/layout/EntityPageSection';
 import { RECENT_ACTIVITIES_LIMIT_EXPANDED } from '../../common/journeyDashboard/constants';
-import { CONTENT_COLUMNS, SIDEBAR_COLUMNS, COLUMNS_MOBILE } from '../../../../core/ui/themes/default/Theme';
+import InfoColumn from '../../../../core/ui/content/InfoColumn';
+import ContentColumn from '../../../../core/ui/content/ContentColumn';
 
 interface SpaceWelcomeBlockContributor {
   profile: SpaceWelcomeBlockContributorProfileFragment;
@@ -100,8 +100,6 @@ const SpaceDashboardView = ({
 }: SpaceDashboardViewProps) => {
   const { t } = useTranslation();
 
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
-
   const hasExtendedApplicationButton = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
 
   const translatedJourneyTypeName = t(`common.${journeyTypeName}` as const);
@@ -121,7 +119,7 @@ const SpaceDashboardView = ({
             }
 
             return (
-              <PageContentColumn columns={12}>
+              <InfoColumn>
                 <ApplicationButton
                   {...applicationButtonProps}
                   loading={loading}
@@ -129,11 +127,11 @@ const SpaceDashboardView = ({
                   extended={hasExtendedApplicationButton}
                   journeyTypeName="space"
                 />
-              </PageContentColumn>
+              </InfoColumn>
             );
           }}
         </ApplicationButtonContainer>
-        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
+        <InfoColumn>
           <JourneyDashboardWelcomeBlock
             vision={vision}
             leadUsers={leadUsers}
@@ -172,9 +170,9 @@ const SpaceDashboardView = ({
             onCalloutUpdate={callouts.refetchCallout}
             groupName={CalloutGroupName.Home_1}
           />
-        </PageContentColumn>
+        </InfoColumn>
 
-        <PageContentColumn columns={isMobile ? COLUMNS_MOBILE : CONTENT_COLUMNS}>
+        <ContentColumn>
           <DashboardRecentContributionsBlock
             halfWidth={(callouts.groupedCallouts[CalloutGroupName.Home_2]?.length ?? 0) > 0}
             readUsersAccess={readUsersAccess}
@@ -203,7 +201,7 @@ const SpaceDashboardView = ({
               }
             }}
           />
-        </PageContentColumn>
+        </ContentColumn>
       </PageContent>
     </>
   );

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
@@ -32,6 +32,12 @@ import MembershipContainer from '../../../community/membership/membershipContain
 import RouterLink from '../../../../core/ui/link/RouterLink';
 import { EntityPageSection } from '../../../shared/layout/EntityPageSection';
 import { RECENT_ACTIVITIES_LIMIT_EXPANDED } from '../../common/journeyDashboard/constants';
+import {
+  CONTENT_COLUMNS,
+  CONTENT_COLUMNS_MOBILE,
+  SIDEBAR_COLUMNS,
+  SIDEBAR_COLUMNS_MOBILE,
+} from '../../../../core/ui/themes/default/Theme';
 
 interface SpaceWelcomeBlockContributor {
   profile: SpaceWelcomeBlockContributorProfileFragment;
@@ -99,6 +105,8 @@ const SpaceDashboardView = ({
 }: SpaceDashboardViewProps) => {
   const { t } = useTranslation();
 
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
+
   const hasExtendedApplicationButton = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
 
   const translatedJourneyTypeName = t(`common.${journeyTypeName}` as const);
@@ -130,7 +138,7 @@ const SpaceDashboardView = ({
             );
           }}
         </ApplicationButtonContainer>
-        <PageContentColumn columns={4}>
+        <PageContentColumn columns={isMobile ? SIDEBAR_COLUMNS_MOBILE : SIDEBAR_COLUMNS}>
           <JourneyDashboardWelcomeBlock
             vision={vision}
             leadUsers={leadUsers}
@@ -171,7 +179,7 @@ const SpaceDashboardView = ({
           />
         </PageContentColumn>
 
-        <PageContentColumn columns={8}>
+        <PageContentColumn columns={isMobile ? CONTENT_COLUMNS_MOBILE : CONTENT_COLUMNS}>
           <DashboardRecentContributionsBlock
             halfWidth={(callouts.groupedCallouts[CalloutGroupName.Home_2]?.length ?? 0) > 0}
             readUsersAccess={readUsersAccess}


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/5749
The page layout columns change in Spaces and Subspaces on non-mobile res:
old 4 + 8, new 3 + 9 (sidebar + content) 

Note that we're keeping the current 4 on mobile. 


