### PR TITLE
Change previewImage proportions

### DIFF
--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialogTemplatesLibrary.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialogTemplatesLibrary.tsx
@@ -28,7 +28,7 @@ const WhiteboardDialogTemplatesLibrary: FC<WhiteboardDialogTemplatesLibraryProps
   return (
     <>
       {editModeEnabled && (
-        <Box height={gutters()} display="flex" alignItems="center">
+        <Box height={gutters()} display="flex" alignItems="center" marginLeft={gutters()}>
           {columns <= 4 ? (
             <IconButton color="primary" onClick={() => setIsOpen(true)} aria-label={t('buttons.find-template')}>
               <LibraryIcon fontSize="small" />

--- a/src/domain/collaboration/whiteboard/WhiteboardPreviewImages/getWhiteboardPreviewDimensions.ts
+++ b/src/domain/collaboration/whiteboard/WhiteboardPreviewImages/getWhiteboardPreviewDimensions.ts
@@ -22,8 +22,6 @@ const getWhiteboardPreviewDimensions =
       };
     }
 
-    const { minScale = 0 } = params;
-
     // deriving dimensions from visual, but not bigger than the whiteboard content
     let height = Math.min(params.maxHeight, contentHeight);
     let width = Math.min(params.maxWidth, contentWidth);
@@ -31,7 +29,7 @@ const getWhiteboardPreviewDimensions =
     // ensuring the whole content fits
     const scaleV = height / contentHeight;
     const scaleH = width / contentWidth;
-    const scale = Math.max(Math.min(scaleV, scaleH), minScale);
+    const scale = Math.max(scaleV, scaleH);
 
     // removing blank paddings
     if (scaleH > scale) {


### PR DESCRIPTION
Instead of taking the smallest of the scales to fit all the content, we can take the big scale and crop the image with css

Also added a small margin to the button `Find template` button: 
![image](https://github.com/alkem-io/client-web/assets/16032487/b7cdef0f-5cca-4cda-988b-005fe860daac)
