### PR TITLE
Events calendar configured for sub/sub/spaces

### DIFF
--- a/src/domain/journey/subspace/layout/SubspaceDialog.ts
+++ b/src/domain/journey/subspace/layout/SubspaceDialog.ts
@@ -5,7 +5,7 @@ export enum SubspaceDialog {
   Subspaces = 'Subspaces',
   Contributors = 'Contributors',
   Activity = 'Activity',
-  Events = 'Events',
+  Events = 'calendar',
   Share = 'Share',
   ManageFlow = 'ManageFlow',
   Settings = 'Settings',

--- a/src/domain/journey/subspace/layout/SubspaceDialog.ts
+++ b/src/domain/journey/subspace/layout/SubspaceDialog.ts
@@ -5,7 +5,7 @@ export enum SubspaceDialog {
   Subspaces = 'Subspaces',
   Contributors = 'Contributors',
   Activity = 'Activity',
-  Events = 'calendar',
+  Timeline = 'calendar',
   Share = 'Share',
   ManageFlow = 'ManageFlow',
   Settings = 'Settings',

--- a/src/domain/journey/subspace/routing/SubspaceRoute.tsx
+++ b/src/domain/journey/subspace/routing/SubspaceRoute.tsx
@@ -5,7 +5,6 @@ import { Error404 } from '../../../../core/pages/Errors/Error404';
 import { nameOfUrl } from '../../../../main/routing/urlParams';
 import { OpportunityProvider } from '../../opportunity/context/OpportunityProvider';
 import { CommunityContextProvider } from '../../../community/community/CommunityContext';
-import ChallengeDashboardPage from '../pages/SubspaceDashboardPage';
 import { NotFoundPageLayout } from '../../common/EntityPageLayout';
 import { routes } from '../routes/challengeRoutes';
 import CalloutRoute from '../../../collaboration/callout/routing/CalloutRoute';
@@ -28,6 +27,11 @@ const SubspaceRoute = () => {
         <Route path={SubspaceDialog.Index} element={<SubspaceHomePage dialog={SubspaceDialog.Index} />} />
         <Route path={SubspaceDialog.Subspaces} element={<SubspaceHomePage dialog={SubspaceDialog.Subspaces} />} />
         <Route path={SubspaceDialog.Contributors} element={<SubspaceHomePage dialog={SubspaceDialog.Contributors} />} />
+        <Route path={SubspaceDialog.Events} element={<SubspaceHomePage dialog={SubspaceDialog.Events} />} />
+        <Route
+          path={`${SubspaceDialog.Events}/:${nameOfUrl.calendarEventNameId}`}
+          element={<SubspaceHomePage dialog={SubspaceDialog.Events} />}
+        />
 
         {/* Redirecting legacy dashboard links to Subspace Home */}
         <Route path={routes.Dashboard} element={<Navigate replace to="/" />} />
@@ -35,10 +39,6 @@ const SubspaceRoute = () => {
         <Route path={routes.About} element={<ChallengeAboutPage />} />
         <Route path={routes.Subsubspaces} element={<ChallengeOpportunitiesPage />} />
         <Route path={`${routes.Collaboration}/:${nameOfUrl.calloutNameId}`} element={<SubspaceCalloutPage />} />
-        <Route
-          path={`${routes.Dashboard}/calendar/:${nameOfUrl.calendarEventNameId}`}
-          element={<ChallengeDashboardPage dialog="calendar" />}
-        />
         <Route path={`${routes.Collaboration}/:${nameOfUrl.calloutNameId}`} element={<SubspaceCalloutPage />} />
         <Route
           path={`${routes.Collaboration}/:${nameOfUrl.calloutNameId}/*`}

--- a/src/domain/journey/subspace/routing/SubspaceRoute.tsx
+++ b/src/domain/journey/subspace/routing/SubspaceRoute.tsx
@@ -27,10 +27,10 @@ const SubspaceRoute = () => {
         <Route path={SubspaceDialog.Index} element={<SubspaceHomePage dialog={SubspaceDialog.Index} />} />
         <Route path={SubspaceDialog.Subspaces} element={<SubspaceHomePage dialog={SubspaceDialog.Subspaces} />} />
         <Route path={SubspaceDialog.Contributors} element={<SubspaceHomePage dialog={SubspaceDialog.Contributors} />} />
-        <Route path={SubspaceDialog.Events} element={<SubspaceHomePage dialog={SubspaceDialog.Events} />} />
+        <Route path={SubspaceDialog.Timeline} element={<SubspaceHomePage dialog={SubspaceDialog.Timeline} />} />
         <Route
-          path={`${SubspaceDialog.Events}/:${nameOfUrl.calendarEventNameId}`}
-          element={<SubspaceHomePage dialog={SubspaceDialog.Events} />}
+          path={`${SubspaceDialog.Timeline}/:${nameOfUrl.calendarEventNameId}`}
+          element={<SubspaceHomePage dialog={SubspaceDialog.Timeline} />}
         />
 
         {/* Redirecting legacy dashboard links to Subspace Home */}

--- a/src/domain/journey/subspace/subspaceHome/SubspaceHomePage.tsx
+++ b/src/domain/journey/subspace/subspaceHome/SubspaceHomePage.tsx
@@ -90,7 +90,7 @@ const SubspaceHomePage = ({ dialog }: SubspaceHomePageProps) => {
                 />
                 <DialogDef
                   dialogType={SubspaceDialog.Events}
-                  label={t(`spaceDialog.${SubspaceDialog.Events}` as const)}
+                  label={t('spaceDialog.Events')}
                   icon={CalendarMonthOutlined}
                 />
                 <DialogDef

--- a/src/domain/journey/subspace/subspaceHome/SubspaceHomePage.tsx
+++ b/src/domain/journey/subspace/subspaceHome/SubspaceHomePage.tsx
@@ -89,7 +89,7 @@ const SubspaceHomePage = ({ dialog }: SubspaceHomePageProps) => {
                   icon={HistoryOutlined}
                 />
                 <DialogDef
-                  dialogType={SubspaceDialog.Events}
+                  dialogType={SubspaceDialog.Timeline}
                   label={t('spaceDialog.Events')}
                   icon={CalendarMonthOutlined}
                 />

--- a/src/domain/journey/subspace/subspaceHome/dialogs/SubspaceDialogs.tsx
+++ b/src/domain/journey/subspace/subspaceHome/dialogs/SubspaceDialogs.tsx
@@ -6,6 +6,8 @@ import { UseCalloutsProvided } from '../../../../collaboration/callout/useCallou
 import { SubspaceDialog } from '../../layout/SubspaceDialog';
 import SubspacesListDialog from '../../dialogs/SubspacesListDialog';
 import ContributorsToggleDialog from '../../dialogs/ContributorsToggleDialog';
+import CalendarDialog from '../../../../timeline/calendar/CalendarDialog';
+import { useParams } from 'react-router-dom';
 
 export interface SubspaceDialogsProps {
   dialogOpen: SubspaceDialog | undefined;
@@ -17,6 +19,8 @@ export interface SubspaceDialogsProps {
 const SubspaceDialogs = ({ dialogOpen, journeyUrl, callouts, journeyId }: SubspaceDialogsProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { calendarEventNameId } = useParams();
+
   if (!dialogOpen || !journeyId || !journeyUrl) {
     return null;
   }
@@ -40,6 +44,13 @@ const SubspaceDialogs = ({ dialogOpen, journeyUrl, callouts, journeyId }: Subspa
         journeyId={journeyId}
         open={dialogOpen === SubspaceDialog.Contributors}
         onClose={() => navigate(journeyUrl)}
+      />
+      <CalendarDialog
+        journeyId={journeyId}
+        open={dialogOpen === SubspaceDialog.Events}
+        onClose={() => navigate(journeyUrl)}
+        parentPath={journeyUrl}
+        calendarEventNameId={calendarEventNameId}
       />
     </>
   );

--- a/src/domain/journey/subspace/subspaceHome/dialogs/SubspaceDialogs.tsx
+++ b/src/domain/journey/subspace/subspaceHome/dialogs/SubspaceDialogs.tsx
@@ -47,7 +47,7 @@ const SubspaceDialogs = ({ dialogOpen, journeyUrl, callouts, journeyId }: Subspa
       />
       <CalendarDialog
         journeyId={journeyId}
-        open={dialogOpen === SubspaceDialog.Events}
+        open={dialogOpen === SubspaceDialog.Timeline}
         onClose={() => navigate(journeyUrl)}
         parentPath={journeyUrl}
         calendarEventNameId={calendarEventNameId}

--- a/src/domain/timeline/calendar/CalendarDialog.tsx
+++ b/src/domain/timeline/calendar/CalendarDialog.tsx
@@ -183,6 +183,7 @@ const CalendarDialog: FC<CalendarDialogProps> = ({ open, journeyId, onClose, par
                   events={events}
                   onClose={handleClose}
                   highlightedDay={highlightedDay}
+                  parentPath={parentPath}
                   actions={
                     privileges.canCreateEvents && (
                       <IconButton onClick={() => setIsCreatingEvent(true)} size="large" sx={{ padding: 0 }}>

--- a/src/domain/timeline/calendar/views/CalendarEventsList.tsx
+++ b/src/domain/timeline/calendar/views/CalendarEventsList.tsx
@@ -6,7 +6,6 @@ import DialogHeader, { DialogHeaderProps } from '../../../../core/ui/dialog/Dial
 import GridProvider from '../../../../core/ui/grid/GridProvider';
 import { gutters } from '../../../../core/ui/grid/utils';
 import { BlockSectionTitle, BlockTitle, Caption } from '../../../../core/ui/typography';
-import { EntityPageSection } from '../../../shared/layout/EntityPageSection';
 import CalendarEventCard from './CalendarEventCard';
 import Gutters from '../../../../core/ui/grid/Gutters';
 import ScrollerWithGradient from '../../../../core/ui/overflow/ScrollerWithGradient';
@@ -20,7 +19,6 @@ import useScrollToElement from '../../../shared/utils/scroll/useScrollToElement'
 import useCurrentBreakpoint from '../../../../core/ui/utils/useCurrentBreakpoint';
 import { HIGHLIGHT_PARAM_NAME } from '../CalendarDialog';
 import { useQueryParams } from '../../../../core/routing/useQueryParams';
-import { normalizeLink } from '../../../../core/utils/links';
 
 interface CalendarEventsListProps {
   events: {
@@ -35,20 +33,26 @@ interface CalendarEventsListProps {
   }[];
   highlightedDay?: Date | null;
   actions?: ReactNode;
+  parentPath?: string;
   onClose?: DialogHeaderProps['onClose'];
 }
 
-const CalendarEventsList = ({ events, highlightedDay, actions, onClose }: CalendarEventsListProps) => {
+const CalendarEventsList = ({ events, highlightedDay, actions, parentPath = '', onClose }: CalendarEventsListProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const urlQueryParams = useQueryParams();
   const breakpoint = useCurrentBreakpoint();
+  const calendarPath = parentPath
+    ? parentPath.indexOf('calendar') > -1
+      ? `${parentPath}`
+      : `${parentPath}/calendar`
+    : '';
 
   const [scrollToElement, scrollTo] = useState<string>();
   const { scrollable } = useScrollToElement(scrollToElement, { enabled: Boolean(scrollToElement), method: 'element' });
 
-  const handleClickOnEvent = (url: string) => {
-    navigate(normalizeLink(url));
+  const handleClickOnEvent = (nameID: string) => {
+    navigate(`${calendarPath}/${nameID}`);
   };
 
   const { futureEvents = [], pastEvents = [] } = useMemo(() => {
@@ -83,7 +87,7 @@ const CalendarEventsList = ({ events, highlightedDay, actions, onClose }: Calend
     if (date) {
       const nextUrlParams = new URLSearchParams(urlQueryParams.toString());
       nextUrlParams.set(HIGHLIGHT_PARAM_NAME, dayjs(date).format(INTERNAL_DATE_FORMAT));
-      navigate(`${EntityPageSection.Dashboard}/calendar?${nextUrlParams}`, { replace: true });
+      navigate(`${calendarPath}?${nextUrlParams}`, { replace: true });
     }
     if (events.length > 0) {
       // Scroll again in case url hasn't changed but user has scrolled out of the view
@@ -112,7 +116,7 @@ const CalendarEventsList = ({ events, highlightedDay, actions, onClose }: Calend
                   ref={scrollable(event.nameID)}
                   highlighted={dayjs(event.startDate).startOf('day').isSame(highlightedDay)}
                   event={event}
-                  onClick={() => handleClickOnEvent(event.profile.url)}
+                  onClick={() => handleClickOnEvent(event.nameID)}
                 />
               ))}
               {sortedPastEvents.length > 0 && (
@@ -124,7 +128,7 @@ const CalendarEventsList = ({ events, highlightedDay, actions, onClose }: Calend
                       ref={scrollable(event.nameID)}
                       highlighted={dayjs(event.startDate).startOf('day').isSame(highlightedDay)}
                       event={event}
-                      onClick={() => handleClickOnEvent(event.profile.url)}
+                      onClick={() => handleClickOnEvent(event.nameID)}
                     />
                   ))}
                 </>


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/5983

### Description

The Events (former DashboardCalendar) dialog was configured to support routing of its components on Space, subspace and subsubspace levels.

As subspaces now lack `dashboard/` in the path, changes were applied to support both `/dashboard/calendar` and only `/calendar` paths. 