### PR TITLE
Add inheritMembershipRights admin option to subspaces

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1873,7 +1873,8 @@
           "memberActions": {
             "title": "Member Actions",
             "createBlocks": "<b>Create Blocks</b>: allow members to create blocks for collaboration tools & posts. If you deactivate this, members will still be able to contribute to existing posts and calls, but will not be able to create new blocks.",
-            "createSubspaces": "<b>Create Subspaces</b>: allow members to create Subspaces in this Space. If you deactivate this, you can still create Subspaces yourself and add other people as an admin inside the Subspace."
+            "createSubspaces": "<b>Create Subspaces</b>: allow members to create Subspaces in this Space. If you deactivate this, you can still create Subspaces yourself and add other people as an admin inside the Subspace.",
+            "inheritRights": "Allow Space members to contribute."
           }
         }
       },

--- a/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsView.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsView.tsx
@@ -142,6 +142,40 @@ export const SpaceSettingsView: FC<SpaceSettingsViewProps> = ({ journeyId, journ
     }
   };
 
+  const getMemberActions = () => {
+    const spaceActions = {
+      allowMembersToCreateCallouts: {
+        checked:
+          currentSettings.collaboration?.allowMembersToCreateCallouts ??
+          defaultSpaceSettings.collaboration.allowMembersToCreateCallouts,
+        label: <Trans i18nKey="pages.admin.space.settings.memberActions.createBlocks" components={{ b: <strong /> }} />,
+      },
+      allowMembersToCreateSubspaces: {
+        checked:
+          currentSettings.collaboration?.allowMembersToCreateSubspaces ??
+          defaultSpaceSettings.collaboration.allowMembersToCreateSubspaces,
+        label: (
+          <Trans i18nKey="pages.admin.space.settings.memberActions.createSubspaces" components={{ b: <strong /> }} />
+        ),
+      },
+    };
+
+    if (isSubspace) {
+      // show inheritMembershipRights only for subspaces
+      return {
+        ...spaceActions,
+        inheritMembershipRights: {
+          checked:
+            currentSettings.collaboration?.inheritMembershipRights ??
+            defaultSpaceSettings.collaboration.inheritMembershipRights,
+          label: <Trans i18nKey="pages.admin.space.settings.memberActions.inheritRights" />,
+        },
+      };
+    }
+
+    return spaceActions;
+  };
+
   return (
     <PageContent background="transparent">
       {!loading && (
@@ -237,30 +271,7 @@ export const SpaceSettingsView: FC<SpaceSettingsViewProps> = ({ journeyId, journ
           <PageContentBlock>
             <BlockTitle>{t('pages.admin.space.settings.memberActions.title')}</BlockTitle>
             <SwitchSettingsGroup
-              options={{
-                allowMembersToCreateCallouts: {
-                  checked:
-                    currentSettings.collaboration?.allowMembersToCreateCallouts ??
-                    defaultSpaceSettings.collaboration.allowMembersToCreateCallouts,
-                  label: (
-                    <Trans
-                      i18nKey="pages.admin.space.settings.memberActions.createBlocks"
-                      components={{ b: <strong /> }}
-                    />
-                  ),
-                },
-                allowMembersToCreateSubspaces: {
-                  checked:
-                    currentSettings.collaboration?.allowMembersToCreateSubspaces ??
-                    defaultSpaceSettings.collaboration.allowMembersToCreateSubspaces,
-                  label: (
-                    <Trans
-                      i18nKey="pages.admin.space.settings.memberActions.createSubspaces"
-                      components={{ b: <strong /> }}
-                    />
-                  ),
-                },
-              }}
+              options={getMemberActions()}
               onChange={async (setting, newValue) => {
                 await handleUpdateSettings({
                   collaborationSettings: {


### PR DESCRIPTION
### Describe the background of your pull request
https://github.com/alkem-io/client-web/issues/6107

This admin action `inheritMembershipRights` was added to the subspace options. 
Please, double-check and confirm that this should be the one to replace the former "Allow space memebers to contribute".
