### PR TITLE
Added apollo preflight header

### DIFF
--- a/src/core/apollo/graphqlLinks/httpLink.ts
+++ b/src/core/apollo/graphqlLinks/httpLink.ts
@@ -13,6 +13,7 @@ export const httpLink = (graphQLEndpoint: string, enableWebSockets: boolean) => 
   const uploadLink = createUploadLink({
     uri: graphQLEndpoint,
     credentials: 'include',
+    headers: { 'apollo-require-preflight': true },
   });
   if (enableWebSockets) {
     // if creating the web socket link fails fall back to http only


### PR DESCRIPTION
**This change is required due to the latest package update on the server.**

Passing 'apollo-require-preflight' header when uploading files.
This is required due to theoperation beeing blocked as a potential Cross-Site Request Forgery (CSRF).