### PR TITLE
Restrict the access to /admin routes to PLATFORM_ADMINS only

### DIFF
--- a/src/core/routing/NonAdminRedirect.tsx
+++ b/src/core/routing/NonAdminRedirect.tsx
@@ -7,7 +7,9 @@ import useHasPlatformLevelPrivilege from '../../domain/community/user/PlatformLe
 const NonAdminRedirect: FC = ({ children }) => {
   const { pathname } = useLocation();
 
-  const [isAdmin, { loading: isLoadingPrivileges }] = useHasPlatformLevelPrivilege(AuthorizationPrivilege.Admin);
+  const [isAdmin, { loading: isLoadingPrivileges }] = useHasPlatformLevelPrivilege(
+    AuthorizationPrivilege.PlatformAdmin
+  );
 
   if (isLoadingPrivileges) {
     return <Loading text="Loading user configuration" />;


### PR DESCRIPTION
Relates to # 3 in https://github.com/alkem-io/client-web/issues/6109