### PR TITLE
MySpaces block in NewMemeberships widget

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -21519,6 +21519,13 @@ export const NewMembershipsDocument = gql`
         createdDate
         state
       }
+      mySpaces {
+        space {
+          id
+          level
+          spaceID: id
+        }
+      }
     }
   }
 `;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -21519,10 +21519,9 @@ export const NewMembershipsDocument = gql`
         createdDate
         state
       }
-      mySpaces {
+      mySpaces(showOnlyMyCreatedSpaces: true) {
         space {
           id
-          level
           spaceID: id
         }
       }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -676,6 +676,7 @@ export enum AuthorizationCredential {
   SpaceAdmin = 'SPACE_ADMIN',
   SpaceLead = 'SPACE_LEAD',
   SpaceMember = 'SPACE_MEMBER',
+  SpaceSubspaceAdmin = 'SPACE_SUBSPACE_ADMIN',
   UserGroupMember = 'USER_GROUP_MEMBER',
   UserSelfManagement = 'USER_SELF_MANAGEMENT',
 }
@@ -3860,7 +3861,7 @@ export type Query = {
   rolesUser: ContributorRoles;
   /** Search the platform for terms supplied */
   search: ISearchResults;
-  /** An space. If no ID is specified then the first Space is returned. */
+  /** Look up a top level Space (i.e. a Space that does not have a parent Space) by the UUID or NameID. */
   space: Space;
   /** The Spaces on this platform; If accessed through an Innovation Hub will return ONLY the Spaces defined in it. */
   spaces: Array<Space>;
@@ -25834,6 +25835,10 @@ export type NewMembershipsQuery = {
       welcomeMessage?: string | undefined;
       createdBy: string;
       createdDate: Date;
+    }>;
+    mySpaces: Array<{
+      __typename?: 'MySpaceResults';
+      space: { __typename?: 'Space'; id: string; level: number; spaceID: string };
     }>;
   };
 };

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -2452,6 +2452,7 @@ export type MeQueryResultsInvitationsArgs = {
 
 export type MeQueryResultsMySpacesArgs = {
   limit?: InputMaybe<Scalars['Float']>;
+  showOnlyMyCreatedSpaces?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type MeQueryResultsSpaceMembershipsArgs = {
@@ -25836,10 +25837,7 @@ export type NewMembershipsQuery = {
       createdBy: string;
       createdDate: Date;
     }>;
-    mySpaces: Array<{
-      __typename?: 'MySpaceResults';
-      space: { __typename?: 'Space'; id: string; level: number; spaceID: string };
-    }>;
+    mySpaces: Array<{ __typename?: 'MySpaceResults'; space: { __typename?: 'Space'; id: string; spaceID: string } }>;
   };
 };
 

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2075,10 +2075,11 @@
           "suggestionsArray": ["Innovation", "Energy", "Inclusive", "3D", "Community", "Transition", "SSI", "Privacy"]
         },
         "newMemberships": {
-          "title": "New Memberships",
+          "title": "Spaces & Subspaces",
           "openInvitations": "Open invitations",
           "noOpenInvitations": "No open invitations",
           "openApplications": "Open applications",
+          "mySpaces": "My Spaces",
           "recentlyJoined": "Recently joined",
           "seeMore": "All pending memberships",
           "seeAll": "See all my memberships",

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
@@ -20,10 +20,9 @@ query NewMemberships {
       createdDate
       state
     }
-    mySpaces {
+    mySpaces(showOnlyMyCreatedSpaces: true) {
       space {
         id
-        level
         spaceID: id
       }
     }

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
@@ -20,5 +20,12 @@ query NewMemberships {
       createdDate
       state
     }
+    mySpaces {
+      space {
+        id
+        level
+        spaceID: id
+      }
+    }
   }
 }

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
@@ -148,9 +148,7 @@ const NewMembershipsBlock = ({
     [invitations, applications]
   );
 
-  // Show only spaces
-  const SPACE_LEVEL = 0;
-  const mySpaces = data?.me.mySpaces?.filter(item => item.space?.level === SPACE_LEVEL) ?? [];
+  const mySpaces = data?.me.mySpaces ?? [];
 
   const [openDialog, setOpenDialog] = useState<PendingMembershipsListDialogDetails | InvitationViewDialogDetails>();
 

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
@@ -148,6 +148,10 @@ const NewMembershipsBlock = ({
     [invitations, applications]
   );
 
+  // Show only spaces
+  const SPACE_LEVEL = 0;
+  const mySpaces = data?.me.mySpaces?.filter(item => item.space?.level === SPACE_LEVEL) ?? [];
+
   const [openDialog, setOpenDialog] = useState<PendingMembershipsListDialogDetails | InvitationViewDialogDetails>();
 
   const closeDialog = () => setOpenDialog(undefined);
@@ -232,6 +236,28 @@ const NewMembershipsBlock = ({
                 </ApplicationHydrator>
               ))}
             </Box>
+          </>
+        )}
+        {mySpaces.length > 0 && (
+          <>
+            <Caption>{t('pages.home.sections.newMemberships.mySpaces')}</Caption>
+            {mySpaces.map(item => (
+              <ApplicationHydrator
+                key={item.space.spaceID}
+                application={{
+                  ...mapApiDataToContributionItem(item.space),
+                }}
+                visualType={VisualType.Avatar}
+              >
+                {({ application: hydratedApplication }) => (
+                  <NewMembershipCard
+                    membership={hydratedApplication}
+                    to={hydratedApplication?.journeyUri}
+                    membershipType="membership"
+                  />
+                )}
+              </ApplicationHydrator>
+            ))}
           </>
         )}
         {recentMemberships.length > 0 && (


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6179

- [x] The existing `NewMemberships` widget (Home Dashboard) was extended to list users' spaces below the pending applications & invitations and above the recent memberships.
- [x] Widget name changed to Spaces & Subspaces;

The server PR: https://github.com/alkem-io/server/pull/3925
allows filtering by `showOnlyMyCreatedSpaces`