### PR TITLE
Redirect and refetch on Invitation accepted user action

### DIFF
--- a/src/domain/community/invitations/InvitationActionsContainer.tsx
+++ b/src/domain/community/invitations/InvitationActionsContainer.tsx
@@ -18,9 +18,11 @@ interface InvitationActionsContainerProvided {
 
 interface InvitationActionsContainerProps extends SimpleContainerProps<InvitationActionsContainerProvided> {
   onUpdate?: () => void;
+  onAccept?: () => void;
+  onReject?: () => void;
 }
 
-const InvitationActionsContainer = ({ onUpdate, children }: InvitationActionsContainerProps) => {
+const InvitationActionsContainer = ({ onUpdate, onAccept, onReject, children }: InvitationActionsContainerProps) => {
   const { spaceId, permissions } = useSpace();
   const [invitationStateEventMutation] = useInvitationStateEventMutation({
     refetchQueries: compact([
@@ -42,6 +44,9 @@ const InvitationActionsContainer = ({ onUpdate, children }: InvitationActionsCon
         invitationId,
         eventName: 'ACCEPT',
       },
+      onCompleted: () => {
+        onAccept?.();
+      },
     })
   );
 
@@ -50,6 +55,9 @@ const InvitationActionsContainer = ({ onUpdate, children }: InvitationActionsCon
       variables: {
         invitationId,
         eventName: 'REJECT',
+      },
+      onCompleted: () => {
+        onReject?.();
       },
     })
   );


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/5813

On invitation Accept -> refetchPendingInvitations & try to navigate to the Space;
On invitation Reject -> refetchPendingInvitations & open back the pending memberships Dialog;

The changes were applied to the Dashboard Widget's Pending Memberships and the User Menu's Pending Memberships.

There's one more place with similar logic -> Apply button on top of the Space. There's no need for redirection there. 