### PR TITLE
Draft innovation hub with account

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -5,6 +5,7 @@ export type APMFieldPolicy = {
   rumEnabled?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type AccountKeySpecifier = (
+  | 'agent'
   | 'authorization'
   | 'defaults'
   | 'host'
@@ -15,6 +16,7 @@ export type AccountKeySpecifier = (
   | AccountKeySpecifier
 )[];
 export type AccountFieldPolicy = {
+  agent?: FieldPolicy<any> | FieldReadFunction<any>;
   authorization?: FieldPolicy<any> | FieldReadFunction<any>;
   defaults?: FieldPolicy<any> | FieldReadFunction<any>;
   host?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -864,6 +866,7 @@ export type CommunityKeySpecifier = (
   | 'memberUsers'
   | 'myMembershipStatus'
   | 'myRoles'
+  | 'myRolesImplicit'
   | 'organizationsInRole'
   | 'policy'
   | 'usersInRole'
@@ -886,6 +889,7 @@ export type CommunityFieldPolicy = {
   memberUsers?: FieldPolicy<any> | FieldReadFunction<any>;
   myMembershipStatus?: FieldPolicy<any> | FieldReadFunction<any>;
   myRoles?: FieldPolicy<any> | FieldReadFunction<any>;
+  myRolesImplicit?: FieldPolicy<any> | FieldReadFunction<any>;
   organizationsInRole?: FieldPolicy<any> | FieldReadFunction<any>;
   policy?: FieldPolicy<any> | FieldReadFunction<any>;
   usersInRole?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -965,9 +969,11 @@ export type ContributorRolesFieldPolicy = {
   organizations?: FieldPolicy<any> | FieldReadFunction<any>;
   spaces?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CredentialKeySpecifier = ('id' | 'resourceID' | 'type' | CredentialKeySpecifier)[];
+export type CredentialKeySpecifier = ('expires' | 'id' | 'issuer' | 'resourceID' | 'type' | CredentialKeySpecifier)[];
 export type CredentialFieldPolicy = {
+  expires?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
+  issuer?: FieldPolicy<any> | FieldReadFunction<any>;
   resourceID?: FieldPolicy<any> | FieldReadFunction<any>;
   type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
@@ -1157,6 +1163,7 @@ export type InnovationFlowTemplateFieldPolicy = {
   states?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type InnovationHubKeySpecifier = (
+  | 'account'
   | 'authorization'
   | 'id'
   | 'nameID'
@@ -1168,6 +1175,7 @@ export type InnovationHubKeySpecifier = (
   | InnovationHubKeySpecifier
 )[];
 export type InnovationHubFieldPolicy = {
+  account?: FieldPolicy<any> | FieldReadFunction<any>;
   authorization?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   nameID?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1199,6 +1207,7 @@ export type InvitationKeySpecifier = (
   | 'createdBy'
   | 'createdDate'
   | 'id'
+  | 'invitedToParent'
   | 'lifecycle'
   | 'updatedDate'
   | 'user'
@@ -1210,6 +1219,7 @@ export type InvitationFieldPolicy = {
   createdBy?: FieldPolicy<any> | FieldReadFunction<any>;
   createdDate?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
+  invitedToParent?: FieldPolicy<any> | FieldReadFunction<any>;
   lifecycle?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
   user?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1222,6 +1232,7 @@ export type InvitationExternalKeySpecifier = (
   | 'email'
   | 'firstName'
   | 'id'
+  | 'invitedToParent'
   | 'lastName'
   | 'profileCreated'
   | 'welcomeMessage'
@@ -1234,6 +1245,7 @@ export type InvitationExternalFieldPolicy = {
   email?: FieldPolicy<any> | FieldReadFunction<any>;
   firstName?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
+  invitedToParent?: FieldPolicy<any> | FieldReadFunction<any>;
   lastName?: FieldPolicy<any> | FieldReadFunction<any>;
   profileCreated?: FieldPolicy<any> | FieldReadFunction<any>;
   welcomeMessage?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1305,6 +1317,12 @@ export type LicenseFeatureFlagFieldPolicy = {
   enabled?: FieldPolicy<any> | FieldReadFunction<any>;
   name?: FieldPolicy<any> | FieldReadFunction<any>;
 };
+export type LicensePlanKeySpecifier = ('enabled' | 'id' | 'name' | LicensePlanKeySpecifier)[];
+export type LicensePlanFieldPolicy = {
+  enabled?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+};
 export type LicensePolicyKeySpecifier = ('authorization' | 'featureFlagRules' | 'id' | LicensePolicyKeySpecifier)[];
 export type LicensePolicyFieldPolicy = {
   authorization?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1321,6 +1339,13 @@ export type LicensePolicyRuleFeatureFlagFieldPolicy = {
   featureFlagName?: FieldPolicy<any> | FieldReadFunction<any>;
   grantedPrivileges?: FieldPolicy<any> | FieldReadFunction<any>;
   name?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type LicensingKeySpecifier = ('authorization' | 'id' | 'plans' | 'policy' | LicensingKeySpecifier)[];
+export type LicensingFieldPolicy = {
+  authorization?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  plans?: FieldPolicy<any> | FieldReadFunction<any>;
+  policy?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type LifecycleKeySpecifier = (
   | 'id'
@@ -1489,6 +1514,7 @@ export type MutationKeySpecifier = (
   | 'createInnovationFlowTemplate'
   | 'createInnovationHub'
   | 'createInnovationPackOnLibrary'
+  | 'createLicensePlan'
   | 'createOrganization'
   | 'createPostTemplate'
   | 'createReferenceOnProfile'
@@ -1513,6 +1539,7 @@ export type MutationKeySpecifier = (
   | 'deleteInnovationPack'
   | 'deleteInvitation'
   | 'deleteInvitationExternal'
+  | 'deleteLicensePlan'
   | 'deleteLink'
   | 'deleteOrganization'
   | 'deletePost'
@@ -1576,7 +1603,9 @@ export type MutationKeySpecifier = (
   | 'updateInnovationFlowStatesFromTemplate'
   | 'updateInnovationFlowTemplate'
   | 'updateInnovationHub'
+  | 'updateInnovationHubPlatformSettings'
   | 'updateInnovationPack'
+  | 'updateLicensePlan'
   | 'updateLink'
   | 'updateOrganization'
   | 'updatePost'
@@ -1644,6 +1673,7 @@ export type MutationFieldPolicy = {
   createInnovationFlowTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   createInnovationHub?: FieldPolicy<any> | FieldReadFunction<any>;
   createInnovationPackOnLibrary?: FieldPolicy<any> | FieldReadFunction<any>;
+  createLicensePlan?: FieldPolicy<any> | FieldReadFunction<any>;
   createOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   createPostTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   createReferenceOnProfile?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1668,6 +1698,7 @@ export type MutationFieldPolicy = {
   deleteInnovationPack?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteInvitation?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteInvitationExternal?: FieldPolicy<any> | FieldReadFunction<any>;
+  deleteLicensePlan?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteLink?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   deletePost?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1731,7 +1762,9 @@ export type MutationFieldPolicy = {
   updateInnovationFlowStatesFromTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   updateInnovationFlowTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   updateInnovationHub?: FieldPolicy<any> | FieldReadFunction<any>;
+  updateInnovationHubPlatformSettings?: FieldPolicy<any> | FieldReadFunction<any>;
   updateInnovationPack?: FieldPolicy<any> | FieldReadFunction<any>;
+  updateLicensePlan?: FieldPolicy<any> | FieldReadFunction<any>;
   updateLink?: FieldPolicy<any> | FieldReadFunction<any>;
   updateOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   updatePost?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1876,7 +1909,7 @@ export type PlatformKeySpecifier = (
   | 'innovationHubs'
   | 'latestReleaseDiscussion'
   | 'library'
-  | 'licensePolicy'
+  | 'licensing'
   | 'metadata'
   | 'storageAggregator'
   | PlatformKeySpecifier
@@ -1890,7 +1923,7 @@ export type PlatformFieldPolicy = {
   innovationHubs?: FieldPolicy<any> | FieldReadFunction<any>;
   latestReleaseDiscussion?: FieldPolicy<any> | FieldReadFunction<any>;
   library?: FieldPolicy<any> | FieldReadFunction<any>;
-  licensePolicy?: FieldPolicy<any> | FieldReadFunction<any>;
+  licensing?: FieldPolicy<any> | FieldReadFunction<any>;
   metadata?: FieldPolicy<any> | FieldReadFunction<any>;
   storageAggregator?: FieldPolicy<any> | FieldReadFunction<any>;
 };
@@ -3355,6 +3388,10 @@ export type StrictTypedTypePolicies = {
     keyFields?: false | LicenseFeatureFlagKeySpecifier | (() => undefined | LicenseFeatureFlagKeySpecifier);
     fields?: LicenseFeatureFlagFieldPolicy;
   };
+  LicensePlan?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | LicensePlanKeySpecifier | (() => undefined | LicensePlanKeySpecifier);
+    fields?: LicensePlanFieldPolicy;
+  };
   LicensePolicy?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | LicensePolicyKeySpecifier | (() => undefined | LicensePolicyKeySpecifier);
     fields?: LicensePolicyFieldPolicy;
@@ -3365,6 +3402,10 @@ export type StrictTypedTypePolicies = {
       | LicensePolicyRuleFeatureFlagKeySpecifier
       | (() => undefined | LicensePolicyRuleFeatureFlagKeySpecifier);
     fields?: LicensePolicyRuleFeatureFlagFieldPolicy;
+  };
+  Licensing?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | LicensingKeySpecifier | (() => undefined | LicensingKeySpecifier);
+    fields?: LicensingFieldPolicy;
   };
   Lifecycle?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | LifecycleKeySpecifier | (() => undefined | LifecycleKeySpecifier);

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -14243,6 +14243,50 @@ export function refetchAdminInnovationHubsListQuery(variables?: SchemaTypes.Admi
   return { query: AdminInnovationHubsListDocument, variables: variables };
 }
 
+export const AccountsDocument = gql`
+  query Accounts {
+    accounts {
+      id
+    }
+  }
+`;
+
+/**
+ * __useAccountsQuery__
+ *
+ * To run a query within a React component, call `useAccountsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAccountsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useAccountsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useAccountsQuery(
+  baseOptions?: Apollo.QueryHookOptions<SchemaTypes.AccountsQuery, SchemaTypes.AccountsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SchemaTypes.AccountsQuery, SchemaTypes.AccountsQueryVariables>(AccountsDocument, options);
+}
+
+export function useAccountsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<SchemaTypes.AccountsQuery, SchemaTypes.AccountsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SchemaTypes.AccountsQuery, SchemaTypes.AccountsQueryVariables>(AccountsDocument, options);
+}
+
+export type AccountsQueryHookResult = ReturnType<typeof useAccountsQuery>;
+export type AccountsLazyQueryHookResult = ReturnType<typeof useAccountsLazyQuery>;
+export type AccountsQueryResult = Apollo.QueryResult<SchemaTypes.AccountsQuery, SchemaTypes.AccountsQueryVariables>;
+export function refetchAccountsQuery(variables?: SchemaTypes.AccountsQueryVariables) {
+  return { query: AccountsDocument, variables: variables };
+}
+
 export const DeleteInnovationHubDocument = gql`
   mutation deleteInnovationHub($innovationHubId: UUID!) {
     deleteInnovationHub(deleteData: { ID: $innovationHubId }) {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -36,6 +36,8 @@ export type Apm = {
 
 export type Account = {
   __typename?: 'Account';
+  /** The Agent representing this Account. */
+  agent: Agent;
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
   /** The defaults in use by this Account */
@@ -738,6 +740,7 @@ export enum AuthorizationPrivilege {
   Read = 'READ',
   ReadUsers = 'READ_USERS',
   ReadUserPii = 'READ_USER_PII',
+  ReadUserSettings = 'READ_USER_SETTINGS',
   SaveAsTemplate = 'SAVE_AS_TEMPLATE',
   Update = 'UPDATE',
   UpdateCalloutPublisher = 'UPDATE_CALLOUT_PUBLISHER',
@@ -1180,6 +1183,8 @@ export type Community = Groupable & {
   myMembershipStatus?: Maybe<CommunityMembershipStatus>;
   /** The roles on this community for the currently logged in user. */
   myRoles: Array<CommunityRole>;
+  /** The implicit roles on this community for the currently logged in user. */
+  myRolesImplicit: Array<CommunityRoleImplicit>;
   /** All Organizations that have the specified Role in this Community. */
   organizationsInRole: Array<Organization>;
   /** The policy that defines the roles for this Community. */
@@ -1274,6 +1279,10 @@ export enum CommunityRole {
   Admin = 'ADMIN',
   Lead = 'LEAD',
   Member = 'MEMBER',
+}
+
+export enum CommunityRoleImplicit {
+  SubspaceAdmin = 'SUBSPACE_ADMIN',
 }
 
 export type CommunityRolePolicy = {
@@ -1487,6 +1496,8 @@ export type CreateInnovationFlowTemplateOnTemplatesSetInput = {
 };
 
 export type CreateInnovationHubInput = {
+  /** Account ID, associated with the Innovation Hub. */
+  accountID: Scalars['UUID'];
   /** A readable identifier, unique within the containing scope. */
   nameID?: InputMaybe<Scalars['NameID']>;
   profileData: CreateProfileInput;
@@ -1509,19 +1520,25 @@ export type CreateInnovationPackOnLibraryInput = {
   tags?: InputMaybe<Array<Scalars['String']>>;
 };
 
-export type CreateInvitationExistingUserOnCommunityInput = {
+export type CreateInvitationForUsersOnCommunityInput = {
   communityID: Scalars['UUID'];
-  /** The identifier for the user being invited. */
+  /** The identifiers for the users being invited. */
   invitedUsers: Array<Scalars['UUID']>;
   welcomeMessage?: InputMaybe<Scalars['String']>;
 };
 
-export type CreateInvitationExternalUserOnCommunityInput = {
+export type CreateInvitationUserByEmailOnCommunityInput = {
   communityID: Scalars['UUID'];
   email: Scalars['String'];
   firstName?: InputMaybe<Scalars['String']>;
   lastName?: InputMaybe<Scalars['String']>;
   welcomeMessage?: InputMaybe<Scalars['String']>;
+};
+
+export type CreateLicensePlanOnLicensingInput = {
+  licensingID: Scalars['UUID'];
+  /** The name of the License Plan */
+  name: Scalars['String'];
 };
 
 export type CreateLinkInput = {
@@ -1692,8 +1709,12 @@ export type CreateWhiteboardTemplateOnTemplatesSetInput = {
 
 export type Credential = {
   __typename?: 'Credential';
+  /** The timestamp for the expiry of this credential. */
+  expires?: Maybe<Scalars['Float']>;
   /** The ID of the entity */
   id: Scalars['UUID'];
+  /** The User issuing the credential */
+  issuer?: Maybe<Scalars['UUID']>;
   resourceID: Scalars['String'];
   type: AuthorizationCredential;
 };
@@ -1775,6 +1796,10 @@ export type DeleteInvitationExternalInput = {
 };
 
 export type DeleteInvitationInput = {
+  ID: Scalars['UUID'];
+};
+
+export type DeleteLicensePlanInput = {
   ID: Scalars['UUID'];
 };
 
@@ -2058,6 +2083,8 @@ export type InnovationFlowTemplate = {
 
 export type InnovationHub = {
   __typename?: 'InnovationHub';
+  /** The Innovation Hub account. */
+  account: Account;
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
   /** The ID of the entity */
@@ -2118,6 +2145,8 @@ export type Invitation = {
   createdDate: Scalars['DateTime'];
   /** The ID of the entity */
   id: Scalars['UUID'];
+  /** Whether to also add the invited user to the parent community. */
+  invitedToParent: Scalars['Boolean'];
   lifecycle: Lifecycle;
   updatedDate: Scalars['DateTime'];
   /** The User who is invited. */
@@ -2142,6 +2171,8 @@ export type InvitationExternal = {
   firstName: Scalars['String'];
   /** The ID of the entity */
   id: Scalars['UUID'];
+  /** Whether to also add the invited user to the parent community. */
+  invitedToParent: Scalars['Boolean'];
   lastName: Scalars['String'];
   /** Whether a new user profile has been created. */
   profileCreated: Scalars['Boolean'];
@@ -2232,6 +2263,16 @@ export enum LicenseFeatureFlagName {
   WhiteboardMultiUser = 'WHITEBOARD_MULTI_USER',
 }
 
+export type LicensePlan = {
+  __typename?: 'LicensePlan';
+  /** Is this plan enabled? */
+  enabled: Scalars['Boolean'];
+  /** The ID of the entity */
+  id: Scalars['UUID'];
+  /** The name of the License Plan */
+  name: Scalars['String'];
+};
+
 export type LicensePolicy = {
   __typename?: 'LicensePolicy';
   /** The authorization rules for the entity */
@@ -2254,6 +2295,18 @@ export enum LicensePrivilege {
   VirtualContributorAccess = 'VIRTUAL_CONTRIBUTOR_ACCESS',
   WhiteboardMultiUser = 'WHITEBOARD_MULTI_USER',
 }
+
+export type Licensing = {
+  __typename?: 'Licensing';
+  /** The authorization rules for the entity */
+  authorization?: Maybe<Authorization>;
+  /** The ID of the entity */
+  id: Scalars['UUID'];
+  /** The License Plans in use on the platform. */
+  plans: Array<LicensePlan>;
+  /** The LicensePolicy in use by the Licensing setup. */
+  policy: LicensePolicy;
+};
 
 export type Lifecycle = {
   __typename?: 'Lifecycle';
@@ -2452,6 +2505,7 @@ export type MeQueryResultsInvitationsArgs = {
 
 export type MeQueryResultsMySpacesArgs = {
   limit?: InputMaybe<Scalars['Float']>;
+  showOnlyMyCreatedSpaces?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type MeQueryResultsSpaceMembershipsArgs = {
@@ -2581,6 +2635,8 @@ export type Mutation = {
   createInnovationHub: InnovationHub;
   /** Create a new InnovatonPack on the Library. */
   createInnovationPackOnLibrary: InnovationPack;
+  /** Create a new LicensePlan on the Licensing. */
+  createLicensePlan: LicensePlan;
   /** Creates a new Organization on the platform. */
   createOrganization: Organization;
   /** Creates a new PostTemplate on the specified TemplatesSet. */
@@ -2629,6 +2685,8 @@ export type Mutation = {
   deleteInvitation: Invitation;
   /** Removes the specified User invitationExternal. */
   deleteInvitationExternal: InvitationExternal;
+  /** Deletes the specified LicensePlan. */
+  deleteLicensePlan: LicensePlan;
   /** Deletes the specified Link. */
   deleteLink: Link;
   /** Deletes the specified Organization. */
@@ -2755,8 +2813,12 @@ export type Mutation = {
   updateInnovationFlowTemplate: InnovationFlowTemplate;
   /** Update Innovation Hub. */
   updateInnovationHub: InnovationHub;
+  /** Update Innovation Hub Settings. */
+  updateInnovationHubPlatformSettings: InnovationHub;
   /** Updates the InnovationPack. */
   updateInnovationPack: InnovationPack;
+  /** Updates the LicensePlan. */
+  updateLicensePlan: LicensePlan;
   /** Updates the specified Link. */
   updateLink: Link;
   /** Updates the specified Organization. */
@@ -2947,6 +3009,10 @@ export type MutationCreateInnovationPackOnLibraryArgs = {
   packData: CreateInnovationPackOnLibraryInput;
 };
 
+export type MutationCreateLicensePlanArgs = {
+  planData: CreateLicensePlanOnLicensingInput;
+};
+
 export type MutationCreateOrganizationArgs = {
   organizationData: CreateOrganizationInput;
 };
@@ -3039,6 +3105,10 @@ export type MutationDeleteInvitationExternalArgs = {
   deleteData: DeleteInvitationExternalInput;
 };
 
+export type MutationDeleteLicensePlanArgs = {
+  deleteData: DeleteLicensePlanInput;
+};
+
 export type MutationDeleteLinkArgs = {
   deleteData: DeleteLinkInput;
 };
@@ -3120,11 +3190,11 @@ export type MutationGrantCredentialToUserArgs = {
 };
 
 export type MutationInviteExistingUserForCommunityMembershipArgs = {
-  invitationData: CreateInvitationExistingUserOnCommunityInput;
+  invitationData: CreateInvitationForUsersOnCommunityInput;
 };
 
 export type MutationInviteForCommunityMembershipByEmailArgs = {
-  invitationData: CreateInvitationExternalUserOnCommunityInput;
+  invitationData: CreateInvitationUserByEmailOnCommunityInput;
 };
 
 export type MutationJoinCommunityArgs = {
@@ -3279,8 +3349,16 @@ export type MutationUpdateInnovationHubArgs = {
   updateData: UpdateInnovationHubInput;
 };
 
+export type MutationUpdateInnovationHubPlatformSettingsArgs = {
+  updateData: UpdateInnovationHubPlatformSettingsInput;
+};
+
 export type MutationUpdateInnovationPackArgs = {
   innovationPackData: UpdateInnovationPackInput;
+};
+
+export type MutationUpdateLicensePlanArgs = {
+  updateData: UpdateLicensePlanInput;
 };
 
 export type MutationUpdateLinkArgs = {
@@ -3559,8 +3637,8 @@ export type Platform = {
   latestReleaseDiscussion?: Maybe<LatestReleaseDiscussion>;
   /** The Innovation Library for the platform */
   library: Library;
-  /** The LicensePolicy in use by the platform. */
-  licensePolicy: LicensePolicy;
+  /** The Licensing in use by the platform. */
+  licensing: Licensing;
   /** Alkemio Services Metadata. */
   metadata: Metadata;
   /** The StorageAggregator with documents in use by Users + Organizations on the Platform. */
@@ -5132,6 +5210,12 @@ export type UpdateInnovationHubInput = {
   spaceVisibilityFilter?: InputMaybe<SpaceVisibility>;
 };
 
+export type UpdateInnovationHubPlatformSettingsInput = {
+  ID: Scalars['UUID'];
+  /** An Account ID associated with the InnovationHub */
+  accountID: Scalars['UUID'];
+};
+
 export type UpdateInnovationPackInput = {
   /** The ID or NameID of the InnovationPack. */
   ID: Scalars['UUID_NAMEID'];
@@ -5148,6 +5232,10 @@ export type UpdateLicenseInput = {
   featureFlags?: InputMaybe<Array<UpdateFeatureFlagInput>>;
   /** Visibility of the Space. */
   visibility?: InputMaybe<SpaceVisibility>;
+};
+
+export type UpdateLicensePlanInput = {
+  ID: Scalars['UUID'];
 };
 
 export type UpdateLinkInput = {
@@ -16659,6 +16747,10 @@ export type AdminInnovationHubsListQuery = {
     }>;
   };
 };
+
+export type AccountsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type AccountsQuery = { __typename?: 'Query'; accounts: Array<{ __typename?: 'Account'; id: string }> };
 
 export type DeleteInnovationHubMutationVariables = Exact<{
   innovationHubId: Scalars['UUID'];

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1896,7 +1896,8 @@
       "innovationHubs": {
         "fields": {
           "host": "Host Organization",
-          "subdomain": "Subdomain"
+          "subdomain": "Subdomain",
+          "account": "Account"
         },
         "saveForMoreDetails": "Save the new $t(common.innovation-hub) to edit the rest of the details",
         "back": "All $t(common.innovation-hubs)",

--- a/src/domain/innovationHub/InnovationHubsAdmin/AdminNewInnovationHubPage.tsx
+++ b/src/domain/innovationHub/InnovationHubsAdmin/AdminNewInnovationHubPage.tsx
@@ -12,6 +12,7 @@ import {
   refetchAdminInnovationHubsListQuery,
   useCreateInnovationHubMutation,
   useOrganizationsListQuery,
+  useAccountsQuery,
 } from '../../../core/apollo/generated/apollo-hooks';
 import { InnovationHubType } from '../../../core/apollo/generated/graphql-schema';
 import PageContent from '../../../core/ui/content/PageContent';
@@ -22,6 +23,7 @@ const AdminNewInnovationHubPage = () => {
   const navigate = useNavigate();
 
   const { data: organizationsList, loading: loadingOrganizations } = useOrganizationsListQuery();
+  const { data: accountsList, loading: loadingAccounts } = useAccountsQuery();
 
   const organizations = useMemo(
     () =>
@@ -30,6 +32,14 @@ const AdminNewInnovationHubPage = () => {
         org => org.name
       ),
     [organizationsList]
+  );
+
+  const accounts = useMemo(
+    // We have two options here.
+    // 1. Make a second query, get the space.profile and use its display name.
+    // 2. Have Profile for Account.
+    () => sortBy(accountsList?.accounts.map(e => ({ id: e.id, name: e.id })) || [], account => account.name),
+    [accountsList]
   );
 
   const [createInnovationHub, { loading: creating }] = useCreateInnovationHubMutation();
@@ -48,6 +58,7 @@ const AdminNewInnovationHubPage = () => {
           },
           type: InnovationHubType.List,
           spaceListFilter: [],
+          accountID: formData.accountId,
         },
       },
       refetchQueries: [refetchAdminInnovationHubsListQuery()],
@@ -57,7 +68,7 @@ const AdminNewInnovationHubPage = () => {
     }
   };
 
-  const isLoading = loadingOrganizations || creating;
+  const isLoading = loadingOrganizations || loadingAccounts || creating;
 
   return (
     <AdminLayout currentTab={AdminSection.InnovationHubs}>
@@ -66,7 +77,13 @@ const AdminNewInnovationHubPage = () => {
           <Button component={RouterLink} to="../" startIcon={<ArrowBackIcon />}>
             {t('pages.admin.innovationHubs.back')}
           </Button>
-          <InnovationHubForm isNew organizations={organizations} onSubmit={handleSubmit} loading={isLoading} />
+          <InnovationHubForm
+            isNew
+            organizations={organizations}
+            accounts={accounts}
+            onSubmit={handleSubmit}
+            loading={isLoading}
+          />
         </PageContentColumn>
       </PageContent>
     </AdminLayout>

--- a/src/domain/innovationHub/InnovationHubsAdmin/InnovationHubForm.tsx
+++ b/src/domain/innovationHub/InnovationHubsAdmin/InnovationHubForm.tsx
@@ -27,6 +27,7 @@ export interface InnovationHubFormValues {
     tagsets: Pick<Tagset, 'id' | 'tags' | 'name' | 'allowedValues' | 'type'>[];
   };
   hostId: string;
+  accountId: string;
 }
 
 interface InnovationHubFormProps {
@@ -42,8 +43,10 @@ interface InnovationHubFormProps {
     visual?: Visual;
   };
   hostId?: string;
+  accountId?: string;
 
   organizations?: { id: string; name: string }[];
+  accounts?: { id: string; name: string }[];
 
   loading?: boolean;
   onSubmit: (formData: InnovationHubFormValues) => void;
@@ -56,6 +59,8 @@ const InnovationHubForm: FC<InnovationHubFormProps> = ({
   profile,
   hostId,
   organizations,
+  accounts,
+  accountId,
   loading,
   onSubmit,
 }) => {
@@ -74,6 +79,7 @@ const InnovationHubForm: FC<InnovationHubFormProps> = ({
       tagsets: [profile?.tagset ?? { id: '', name: 'Tags', tags: [], allowedValues: [], type: TagsetType.Freeform }],
     },
     hostId: hostId ?? '',
+    accountId: accountId ?? '',
   };
 
   const validationSchema = yup.object().shape({
@@ -108,6 +114,16 @@ const InnovationHubForm: FC<InnovationHubFormProps> = ({
                 /* required */
                 disabled
                 placeholder={t('pages.admin.innovationHubs.fields.host')}
+              />
+            </FormGroup>
+            <FormGroup>
+              <FormikAutocomplete
+                title={t('pages.admin.innovationHubs.fields.account')}
+                name="accountId"
+                values={accounts ?? []}
+                /* required */
+                disabled={!isNew}
+                placeholder={t('pages.admin.innovationHubs.fields.account')}
               />
             </FormGroup>
             <FormikInputField

--- a/src/domain/innovationHub/InnovationHubsAdmin/InnovationHubsAdmin.graphql
+++ b/src/domain/innovationHub/InnovationHubsAdmin/InnovationHubsAdmin.graphql
@@ -13,6 +13,12 @@ query AdminInnovationHubsList {
   }
 }
 
+query Accounts {
+  accounts {
+    id
+  }
+}
+
 mutation deleteInnovationHub($innovationHubId: UUID!) {
   deleteInnovationHub(deleteData: { ID: $innovationHubId }) {
     id


### PR DESCRIPTION
- We need a `displayName` for the `account`
- Not all `innovationHubs` have an `account`, so `innovationHubs` query with a property selection of `account` throws an exception
- if we omit the `account` from the query, we won't refetch the values correctly...