### PR TITLE
Only show invite members block for public space with settings

### DIFF
--- a/src/domain/community/invitations/InvitationOptionsBlock.tsx
+++ b/src/domain/community/invitations/InvitationOptionsBlock.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, CircularProgress } from '@mui/material';
+import AssignmentIndOutlinedIcon from '@mui/icons-material/AssignmentIndOutlined';
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import PageContentBlock from '../../../core/ui/content/PageContentBlock';
 import PageContentBlockHeader from '../../../core/ui/content/PageContentBlockHeader';
 import Gutters from '../../../core/ui/grid/Gutters';
 import RadioButton from '../../shared/components/RadioButtons/RadioButton';
-import AssignmentIndOutlinedIcon from '@mui/icons-material/AssignmentIndOutlined';
-import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import { Caption } from '../../../core/ui/typography';
+import { useSpaceSettingsQuery } from '../../../core/apollo/generated/apollo-hooks';
 import InviteExistingUserDialog from './InviteExistingUserDialog';
 import { InviteExistingUserData, InviteExternalUserData } from './useInviteUsers';
 import InviteExternalUserDialog from './InviteExternalUserDialog';
-import { useTranslation } from 'react-i18next';
 
 interface InvitationOptionsBlockProps {
   spaceDisplayName: string | undefined;
@@ -18,6 +20,8 @@ interface InvitationOptionsBlockProps {
   currentApplicationsUserIds: string[];
   currentInvitationsUserIds: string[];
   currentMembersIds: string[];
+  spaceId: string;
+  isPrivate: boolean | undefined;
 }
 
 enum UserInvite {
@@ -32,6 +36,8 @@ const InvitationOptionsBlock = ({
   currentApplicationsUserIds,
   currentInvitationsUserIds,
   currentMembersIds,
+  spaceId,
+  isPrivate,
 }: InvitationOptionsBlockProps) => {
   const [currentInvitation, setCurrentInvitation] = useState<UserInvite>();
 
@@ -39,29 +45,43 @@ const InvitationOptionsBlock = ({
 
   const { t } = useTranslation();
 
-  return (
+  const { data, loading } = useSpaceSettingsQuery({
+    variables: {
+      spaceId,
+    },
+  });
+
+  const allowSubspaceAdminsToInviteMembers = data?.lookup.space?.settings.membership.allowSubspaceAdminsToInviteMembers;
+
+  return loading ? (
+    <Box marginX="auto">
+      <CircularProgress />
+    </Box>
+  ) : (
     <>
-      <PageContentBlock>
-        <PageContentBlockHeader title={t('components.invitations.inviteOthers')} />
-        <Gutters row disablePadding flexWrap="wrap">
-          <RadioButton
-            value=""
-            iconComponent={AssignmentIndOutlinedIcon}
-            size="small"
-            onClick={() => setCurrentInvitation(UserInvite.Existing)}
-          >
-            {t('components.invitations.inviteExistingUser')}
-          </RadioButton>
-          <RadioButton
-            value=""
-            iconComponent={MailOutlineIcon}
-            size="small"
-            onClick={() => setCurrentInvitation(UserInvite.External)}
-          >
-            {t('components.invitations.inviteExternalUser')}
-          </RadioButton>
-        </Gutters>
-      </PageContentBlock>
+      {!isPrivate && allowSubspaceAdminsToInviteMembers && (
+        <PageContentBlock>
+          <PageContentBlockHeader title={t('components.invitations.inviteOthers')} />
+          <Gutters row disablePadding flexWrap="wrap">
+            <RadioButton
+              value=""
+              iconComponent={AssignmentIndOutlinedIcon}
+              size="small"
+              onClick={() => setCurrentInvitation(UserInvite.Existing)}
+            >
+              {t('components.invitations.inviteExistingUser')}
+            </RadioButton>
+            <RadioButton
+              value=""
+              iconComponent={MailOutlineIcon}
+              size="small"
+              onClick={() => setCurrentInvitation(UserInvite.External)}
+            >
+              {t('components.invitations.inviteExternalUser')}
+            </RadioButton>
+          </Gutters>
+        </PageContentBlock>
+      )}
       <PageContentBlock>
         <Caption textTransform="uppercase" color="muted.main" textAlign="center">
           {t('components.invitations.inviteOrganizations')}

--- a/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
+++ b/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
@@ -22,7 +22,7 @@ import CommunityVirtualContributors from '../../../community/community/Community
 
 const AdminSpaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' }) => {
   const { t } = useTranslation();
-  const { spaceId, loading: isLoadingSpace, communityId, profile: spaceProfile } = useSpace();
+  const { spaceId, loading: isLoadingSpace, communityId, profile: spaceProfile, isPrivate } = useSpace();
 
   const {
     users,
@@ -101,6 +101,8 @@ const AdminSpaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' })
               currentApplicationsUserIds={currentApplicationsUserIds}
               currentInvitationsUserIds={currentInvitationsUserIds}
               currentMembersIds={currentMembersIds}
+              spaceId={spaceId}
+              isPrivate={isPrivate}
             />
           </PageContentBlockSeamless>
         </PageContentColumn>


### PR DESCRIPTION
 Only show "invite others" block to challenges of public spaces, that have the flag for allowSubspaceAdminsToInviteMembers:true