### PR TITLE
Fix subspace invites and applications in MyMemberships dashboard widget

### DIFF
--- a/src/domain/community/pendingMembership/PendingMemberships.tsx
+++ b/src/domain/community/pendingMembership/PendingMemberships.tsx
@@ -65,12 +65,12 @@ type InvitationHydratorProps = {
 );
 
 const getChildJourneyTypeName = (
-  membership: Pick<ContributionItem, 'subspaceId' | 'subsubspaceId'>
+  membership: Pick<ContributionItem, 'subspaceID' | 'subsubspaceID'>
 ): JourneyTypeName => {
-  if (membership.subsubspaceId) {
+  if (membership.subsubspaceID) {
     return 'subsubspace';
   }
-  if (membership.subspaceId) {
+  if (membership.subspaceID) {
     return 'subspace';
   }
   return 'space';
@@ -92,27 +92,27 @@ export const InvitationHydrator = ({
       fetchCommunityGuidelines: withCommunityGuidelines,
       visualType: visualType === VisualType.Avatar ? VisualType.Card : visualType, // Spaces don't have avatars
     },
-    skip: Boolean(invitation.subspaceId || invitation.subsubspaceId),
+    skip: Boolean(invitation.subspaceID || invitation.subsubspaceID),
   });
 
   const { data: challengeData } = usePendingMembershipsSpaceQuery({
     variables: {
-      spaceId: invitation.subspaceId!,
+      spaceId: invitation.subspaceID!,
       fetchDetails: withJourneyDetails,
       fetchCommunityGuidelines: withCommunityGuidelines,
       visualType,
     },
-    skip: !invitation.subspaceId,
+    skip: !invitation.subspaceID,
   });
 
   const { data: opportunityData } = usePendingMembershipsSpaceQuery({
     variables: {
-      spaceId: invitation.subsubspaceId!,
+      spaceId: invitation.subsubspaceID!,
       fetchDetails: withJourneyDetails,
       fetchCommunityGuidelines: withCommunityGuidelines,
       visualType,
     },
-    skip: !invitation.subsubspaceId,
+    skip: !invitation.subsubspaceID,
   });
 
   const journey = opportunityData?.lookup.space ?? challengeData?.lookup.space ?? spaceData?.lookup.space;
@@ -129,6 +129,7 @@ export const InvitationHydrator = ({
     if (!invitation || !journey) {
       return undefined;
     }
+
     return {
       id: invitation.id,
       welcomeMessage: invitation.welcomeMessage,
@@ -165,25 +166,25 @@ export const ApplicationHydrator = ({ application, visualType, children }: Appli
       fetchDetails: true,
       visualType: visualType === VisualType.Avatar ? VisualType.Card : visualType, // Spaces don't have avatars
     },
-    skip: Boolean(application.subspaceId || application.subsubspaceId),
+    skip: Boolean(application.subspaceID || application.subsubspaceID),
   });
 
   const { data: challengeData } = usePendingMembershipsSpaceQuery({
     variables: {
-      spaceId: application.subspaceId!,
+      spaceId: application.subspaceID!,
       fetchDetails: true,
       visualType,
     },
-    skip: !application.subspaceId,
+    skip: !application.subspaceID,
   });
 
   const { data: opportunityData } = usePendingMembershipsSpaceQuery({
     variables: {
-      spaceId: application.subsubspaceId!,
+      spaceId: application.subsubspaceID!,
       fetchDetails: true,
       visualType,
     },
-    skip: !application.subsubspaceId,
+    skip: !application.subsubspaceID,
   });
 
   const journey = opportunityData?.lookup.space ?? challengeData?.lookup.space ?? spaceData?.lookup.space;

--- a/src/domain/community/user/contribution.ts
+++ b/src/domain/community/user/contribution.ts
@@ -4,6 +4,8 @@ export interface ContributionItem extends Identifiable {
   spaceId: string;
   subspaceId?: string;
   subsubspaceId?: string;
+  subspaceID?: string;
+  subsubspaceID?: string;
 }
 
 export interface LegacyContributionItem extends Identifiable {


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6219

As a quick fix for the issue where Invites are broken for subspace levels, 
the `ContributionItem` was extended to support the `subspaceID` as the server responds with this format and the client was expecting `subspaceId`.

I was about to create mapping similar to `getPendingInvitations` in userMetadataWrapper, but there were way to many changes complicating the existing logic. 

Now applications and invitations are working on all levels.

