### PR TITLE
Add Invite block in subspaces if parent is public and feature is allowed

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -2700,6 +2700,7 @@ export const SubspaceInfoFragmentDoc = gql`
     authorization {
       id
       myPrivileges
+      anonymousReadAccess
     }
     context {
       id

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -20282,7 +20282,12 @@ export type SubspaceInfoQuery = {
               | undefined;
           };
           authorization?:
-            | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | {
+                __typename?: 'Authorization';
+                id: string;
+                myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+                anonymousReadAccess: boolean;
+              }
             | undefined;
           context: {
             __typename?: 'Context';
@@ -20353,7 +20358,12 @@ export type SubspaceInfoFragment = {
       | undefined;
   };
   authorization?:
-    | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+    | {
+        __typename?: 'Authorization';
+        id: string;
+        myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+        anonymousReadAccess: boolean;
+      }
     | undefined;
   context: {
     __typename?: 'Context';

--- a/src/domain/community/invitations/InvitationOptionsBlock.tsx
+++ b/src/domain/community/invitations/InvitationOptionsBlock.tsx
@@ -20,7 +20,7 @@ interface InvitationOptionsBlockProps {
   currentApplicationsUserIds: string[];
   currentInvitationsUserIds: string[];
   currentMembersIds: string[];
-  spaceId?: string | undefined;
+  spaceId: string | undefined;
   isParentPrivate?: boolean | undefined;
   isSubspace?: boolean;
 }

--- a/src/domain/community/invitations/InvitationOptionsBlock.tsx
+++ b/src/domain/community/invitations/InvitationOptionsBlock.tsx
@@ -20,7 +20,7 @@ interface InvitationOptionsBlockProps {
   currentApplicationsUserIds: string[];
   currentInvitationsUserIds: string[];
   currentMembersIds: string[];
-  spaceId?: string;
+  spaceId?: string | undefined;
   isParentPrivate?: boolean | undefined;
   isSubspace?: boolean;
 }
@@ -37,7 +37,7 @@ const InvitationOptionsBlock = ({
   currentApplicationsUserIds,
   currentInvitationsUserIds,
   currentMembersIds,
-  spaceId = '',
+  spaceId,
   isParentPrivate,
   isSubspace = false,
 }: InvitationOptionsBlockProps) => {
@@ -49,7 +49,7 @@ const InvitationOptionsBlock = ({
 
   const { data, loading } = useSpaceSettingsQuery({
     variables: {
-      spaceId,
+      spaceId: spaceId!,
     },
     skip: !spaceId,
   });

--- a/src/domain/community/invitations/InvitationOptionsBlock.tsx
+++ b/src/domain/community/invitations/InvitationOptionsBlock.tsx
@@ -20,8 +20,9 @@ interface InvitationOptionsBlockProps {
   currentApplicationsUserIds: string[];
   currentInvitationsUserIds: string[];
   currentMembersIds: string[];
-  spaceId: string;
-  isPrivate: boolean | undefined;
+  spaceId?: string;
+  isParentPrivate?: boolean | undefined;
+  isSubspace?: boolean;
 }
 
 enum UserInvite {
@@ -36,8 +37,9 @@ const InvitationOptionsBlock = ({
   currentApplicationsUserIds,
   currentInvitationsUserIds,
   currentMembersIds,
-  spaceId,
-  isPrivate,
+  spaceId = '',
+  isParentPrivate,
+  isSubspace = false,
 }: InvitationOptionsBlockProps) => {
   const [currentInvitation, setCurrentInvitation] = useState<UserInvite>();
 
@@ -49,9 +51,11 @@ const InvitationOptionsBlock = ({
     variables: {
       spaceId,
     },
+    skip: !spaceId,
   });
 
   const allowSubspaceAdminsToInviteMembers = data?.lookup.space?.settings.membership.allowSubspaceAdminsToInviteMembers;
+  const showInviteBlock = isSubspace ? !isParentPrivate && allowSubspaceAdminsToInviteMembers : true; // for Spaces the block is always visible
 
   return loading ? (
     <Box marginX="auto">
@@ -59,7 +63,7 @@ const InvitationOptionsBlock = ({
     </Box>
   ) : (
     <>
-      {!isPrivate && allowSubspaceAdminsToInviteMembers && (
+      {showInviteBlock && (
         <PageContentBlock>
           <PageContentBlockHeader title={t('components.invitations.inviteOthers')} />
           <Gutters row disablePadding flexWrap="wrap">

--- a/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
+++ b/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
@@ -22,7 +22,7 @@ import CommunityVirtualContributors from '../../../community/community/Community
 
 const AdminSpaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' }) => {
   const { t } = useTranslation();
-  const { spaceId, loading: isLoadingSpace, communityId, profile: spaceProfile, isPrivate } = useSpace();
+  const { spaceId, loading: isLoadingSpace, communityId, profile: spaceProfile } = useSpace();
 
   const {
     users,
@@ -102,7 +102,6 @@ const AdminSpaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' })
               currentInvitationsUserIds={currentInvitationsUserIds}
               currentMembersIds={currentMembersIds}
               spaceId={spaceId}
-              isPrivate={isPrivate}
             />
           </PageContentBlockSeamless>
         </PageContentColumn>

--- a/src/domain/journey/subspace/context/SubspaceProvider.tsx
+++ b/src/domain/journey/subspace/context/SubspaceProvider.tsx
@@ -100,9 +100,9 @@ const SubspaceProvider: FC<SubspaceProviderProps> = ({ children }) => {
   return (
     <SubspaceContext.Provider
       value={{
-        subspace: subspace,
+        subspace,
         subspaceId: journeyId ?? '',
-        subspaceNameId: subspaceNameId,
+        subspaceNameId,
         communityId,
         permissions,
         profile,

--- a/src/domain/journey/subspace/context/SubspaceProvider.tsx
+++ b/src/domain/journey/subspace/context/SubspaceProvider.tsx
@@ -18,6 +18,7 @@ interface SubspacePermissions {
 interface SubspaceContextProps {
   subspace?: SubspaceInfoFragment;
   subspaceId: string;
+  subspaceNameId: string;
   communityId: string;
   loading: boolean;
   permissions: SubspacePermissions;
@@ -28,6 +29,7 @@ interface SubspaceContextProps {
 export const SubspaceContext = React.createContext<SubspaceContextProps>({
   loading: true,
   subspaceId: '',
+  subspaceNameId: '',
   communityId: '',
   permissions: {
     canUpdate: false,
@@ -59,6 +61,7 @@ const SubspaceProvider: FC<SubspaceProviderProps> = ({ children }) => {
 
   const subspace = data?.lookup.space;
   const communityId = subspace?.community?.id ?? '';
+  const subspaceNameId = data?.lookup.space?.profile.displayName ?? '';
 
   const myPrivileges = useMemo(
     () => subspace?.authorization?.myPrivileges ?? [],
@@ -99,6 +102,7 @@ const SubspaceProvider: FC<SubspaceProviderProps> = ({ children }) => {
       value={{
         subspace: subspace,
         subspaceId: journeyId ?? '',
+        subspaceNameId: subspaceNameId,
         communityId,
         permissions,
         profile,

--- a/src/domain/journey/subspace/context/subspaceInfoFragment.graphql
+++ b/src/domain/journey/subspace/context/subspaceInfoFragment.graphql
@@ -33,6 +33,7 @@ fragment SubspaceInfo on Space {
   authorization {
     id
     myPrivileges
+    anonymousReadAccess
   }
   context {
     id

--- a/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
+++ b/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
@@ -1,4 +1,5 @@
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import PageContent from '../../../../core/ui/content/PageContent';
 import PageContentBlock from '../../../../core/ui/content/PageContentBlock';
 import PageContentColumn from '../../../../core/ui/content/PageContentColumn';
@@ -12,9 +13,17 @@ import { useSubSpace } from '../hooks/useChallenge';
 import SubspaceSettingsLayout from '../../../platform/admin/subspace/SubspaceSettingsLayout';
 import { useRouteResolver } from '../../../../main/routing/resolvers/RouteResolver';
 import CommunityVirtualContributors from '../../../community/community/CommunityAdmin/CommunityVirtualContributors';
+import PageContentBlockSeamless from '../../../../core/ui/content/PageContentBlockSeamless';
+import InvitationOptionsBlock from '../../../community/invitations/InvitationOptionsBlock';
+import PageContentBlockCollapsible from '../../../../core/ui/content/PageContentBlockCollapsible';
+import { BlockTitle } from '../../../../core/ui/typography';
+import CommunityGuidelines from '../../../community/community/CommunityGuidelines/CommunityGuidelines';
+import { useSpace } from '../../space/SpaceContext/useSpace';
 
 const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' }) => {
-  const { loading: isLoadingChallenge, communityId, subspaceId: challengeId } = useSubSpace();
+  const { t } = useTranslation();
+  const { loading: isLoadingChallenge, communityId, subspaceId: challengeId, subspaceNameId } = useSubSpace();
+  const { isPrivate, loading: isLoadingSpace } = useSpace();
 
   const { spaceId, journeyLevel } = useRouteResolver();
 
@@ -23,6 +32,7 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
     organizations,
     virtualContributors,
     applications,
+    invitations,
     communityPolicy,
     permissions,
     onApplicationStateChange,
@@ -39,9 +49,29 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
     getAvailableOrganizations,
     getAvailableVirtualContributors,
     loading,
+    inviteExternalUser,
+    inviteExistingUser,
   } = useCommunityAdmin({ communityId, spaceId, challengeId, journeyLevel });
 
-  if (!spaceId || isLoadingChallenge) {
+  const currentApplicationsUserIds = useMemo(
+    () =>
+      applications
+        ?.filter(application => application.lifecycle.state === 'new')
+        .map(application => application.user.id) ?? [],
+    [applications]
+  );
+
+  const currentInvitationsUserIds = useMemo(
+    () =>
+      invitations
+        ?.filter(invitation => invitation.lifecycle.state === 'invited')
+        .map(invitation => invitation.user.id) ?? [],
+    [invitations]
+  );
+
+  const currentMembersIds = useMemo(() => users.map(user => user.id), [users]);
+
+  if (!spaceId || isLoadingChallenge || isLoadingSpace) {
     return null;
   }
 
@@ -49,14 +79,30 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
     <SubspaceSettingsLayout currentTab={SettingsSection.Community} tabRoutePrefix={routePrefix}>
       <PageContent background="transparent">
         <PageContentColumn columns={12}>
-          <PageContentBlock columns={12}>
+          <PageContentBlock columns={8}>
             <CommunityApplications
               applications={applications}
               onApplicationStateChange={onApplicationStateChange}
               loading={loading}
             />
           </PageContentBlock>
+          <PageContentBlockSeamless columns={4} disablePadding>
+            <InvitationOptionsBlock
+              spaceDisplayName={subspaceNameId}
+              inviteExistingUser={inviteExistingUser}
+              inviteExternalUser={inviteExternalUser}
+              currentApplicationsUserIds={currentApplicationsUserIds}
+              currentInvitationsUserIds={currentInvitationsUserIds}
+              currentMembersIds={currentMembersIds}
+              spaceId={spaceId}
+              isParentPrivate={isPrivate}
+              isSubspace
+            />
+          </PageContentBlockSeamless>
         </PageContentColumn>
+        <PageContentBlockCollapsible header={<BlockTitle>{t('community.communityGuidelines.title')}</BlockTitle>}>
+          <CommunityGuidelines communityId={communityId} />
+        </PageContentBlockCollapsible>
         <PageContentColumn columns={6}>
           <PageContentBlock>
             <CommunityUsers


### PR DESCRIPTION
- Show Invitation block on Subspace settings > Community only to challenges of public spaces, that have the flag for allowSubspaceAdminsToInviteMembers:true
- Show Community guidelines block on Subspace settings > Community