### PR TITLE
Disable host selection on space admin dialog

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -2748,13 +2748,6 @@ export const AdminSpaceFragmentDoc = gql`
           enabled
         }
       }
-      host {
-        id
-        profile {
-          id
-          displayName
-        }
-      }
     }
     profile {
       id

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -21617,19 +21617,6 @@ export type AdminSpacesListQuery = {
         visibility: SpaceVisibility;
         featureFlags: Array<{ __typename?: 'LicenseFeatureFlag'; name: LicenseFeatureFlagName; enabled: boolean }>;
       };
-      host?:
-        | {
-            __typename?: 'Organization';
-            id: string;
-            profile: { __typename?: 'Profile'; id: string; displayName: string };
-          }
-        | { __typename?: 'User'; id: string; profile: { __typename?: 'Profile'; id: string; displayName: string } }
-        | {
-            __typename?: 'VirtualContributor';
-            id: string;
-            profile: { __typename?: 'Profile'; id: string; displayName: string };
-          }
-        | undefined;
     };
     profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
     authorization?:
@@ -21651,19 +21638,6 @@ export type AdminSpaceFragment = {
       visibility: SpaceVisibility;
       featureFlags: Array<{ __typename?: 'LicenseFeatureFlag'; name: LicenseFeatureFlagName; enabled: boolean }>;
     };
-    host?:
-      | {
-          __typename?: 'Organization';
-          id: string;
-          profile: { __typename?: 'Profile'; id: string; displayName: string };
-        }
-      | { __typename?: 'User'; id: string; profile: { __typename?: 'Profile'; id: string; displayName: string } }
-      | {
-          __typename?: 'VirtualContributor';
-          id: string;
-          profile: { __typename?: 'Profile'; id: string; displayName: string };
-        }
-      | undefined;
   };
   profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
   authorization?:

--- a/src/domain/platform/admin/space/AdminSpaceListPage/SpaceList.tsx
+++ b/src/domain/platform/admin/space/AdminSpaceListPage/SpaceList.tsx
@@ -65,7 +65,8 @@ export const SpaceList: FC = () => {
           nameId: space.nameID,
           account: {
             visibility: space.account.license.visibility,
-            hostId: space.account.host?.id,
+            // TODO: Temporarily removed host field because of it gives an error trying to access it
+            hostId: undefined, // space.account.host?.id,
             features: Object.values(LicenseFeatureFlagName).reduce((acc, licenseFeature) => {
               acc[licenseFeature] = licenseHasFeature(licenseFeature, space.account.license);
               return acc;

--- a/src/domain/platform/admin/space/AdminSpaceListPage/SpaceListItem.tsx
+++ b/src/domain/platform/admin/space/AdminSpaceListPage/SpaceListItem.tsx
@@ -178,7 +178,7 @@ const SpaceListItem = ({
                   name="hostId"
                   values={organizations}
                   required
-                  disabled={loading}
+                  disabled
                   placeholder={t('components.editSpaceForm.host.title')}
                 />
                 <FormikAutocomplete

--- a/src/domain/platform/admin/space/AdminSpaceListPage/adminSpacesList.graphql
+++ b/src/domain/platform/admin/space/AdminSpaceListPage/adminSpacesList.graphql
@@ -17,13 +17,6 @@ fragment AdminSpace on Space {
         enabled
       }
     }
-    host {
-      id
-      profile {
-        id
-        displayName
-      }
-    }
   }
   profile {
     id


### PR DESCRIPTION
The issue is the introduction of `User` association to the `Account`. Now `User` can be `ACCOUNT_HOST` and this method on the server:

```typescript
  async getHost(account: IAccount): Promise<IContributor | null> {
    const contributors =
      await this.contributorService.contributorsWithCredentials({
        type: AuthorizationCredential.ACCOUNT_HOST,
        resourceID: account.id,
      });
    if (contributors.length === 1) {
      return contributors[0];
    } else if (contributors.length > 1) {
      this.logger.error(
        `Account with ID: ${account.id} has multiple hosts. This should not happen.`,
        LogContext.ACCOUNT
      );
    }

    return null;
  }

```

Returns 2/3 `Contributors` per `ACCOUNT_HOST` - 1/2 `Users` and 1 `Organization`. That is in line with `Community_Policy` but we need a structural solution how `Account` is managed, and what can be selected in the `Space` settings, by whom (which privileges?). 

For the time being, in order to be able to edit the settings, I have disabled the `Host` field on the `Space` in this dialog.