### PR TITLE
Create VC on Account

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -5,6 +5,7 @@ export type APMFieldPolicy = {
   rumEnabled?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type AccountKeySpecifier = (
+  | 'activeSubscription'
   | 'agent'
   | 'authorization'
   | 'defaults'
@@ -14,9 +15,11 @@ export type AccountKeySpecifier = (
   | 'license'
   | 'spaceID'
   | 'subscriptions'
+  | 'virtualContributors'
   | AccountKeySpecifier
 )[];
 export type AccountFieldPolicy = {
+  activeSubscription?: FieldPolicy<any> | FieldReadFunction<any>;
   agent?: FieldPolicy<any> | FieldReadFunction<any>;
   authorization?: FieldPolicy<any> | FieldReadFunction<any>;
   defaults?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -26,6 +29,7 @@ export type AccountFieldPolicy = {
   license?: FieldPolicy<any> | FieldReadFunction<any>;
   spaceID?: FieldPolicy<any> | FieldReadFunction<any>;
   subscriptions?: FieldPolicy<any> | FieldReadFunction<any>;
+  virtualContributors?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type AccountSubscriptionKeySpecifier = ('expires' | 'name' | AccountSubscriptionKeySpecifier)[];
 export type AccountSubscriptionFieldPolicy = {

--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -1599,6 +1599,7 @@ export type MutationKeySpecifier = (
   | 'deleteCallout'
   | 'deleteCalloutTemplate'
   | 'deleteCollaboration'
+  | 'deleteCommunityGuidelinesTemplate'
   | 'deleteDiscussion'
   | 'deleteDocument'
   | 'deleteInnovationFlowTemplate'
@@ -1660,6 +1661,7 @@ export type MutationKeySpecifier = (
   | 'updateCalloutsSortOrder'
   | 'updateCommunityApplicationForm'
   | 'updateCommunityGuidelines'
+  | 'updateCommunityGuidelinesTemplate'
   | 'updateDiscussion'
   | 'updateDocument'
   | 'updateEcosystemModel'
@@ -1757,6 +1759,7 @@ export type MutationFieldPolicy = {
   deleteCallout?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteCalloutTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteCollaboration?: FieldPolicy<any> | FieldReadFunction<any>;
+  deleteCommunityGuidelinesTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteDiscussion?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteDocument?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteInnovationFlowTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1818,6 +1821,7 @@ export type MutationFieldPolicy = {
   updateCalloutsSortOrder?: FieldPolicy<any> | FieldReadFunction<any>;
   updateCommunityApplicationForm?: FieldPolicy<any> | FieldReadFunction<any>;
   updateCommunityGuidelines?: FieldPolicy<any> | FieldReadFunction<any>;
+  updateCommunityGuidelinesTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   updateDiscussion?: FieldPolicy<any> | FieldReadFunction<any>;
   updateDocument?: FieldPolicy<any> | FieldReadFunction<any>;
   updateEcosystemModel?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2020,6 +2024,7 @@ export type PlatformLocationsKeySpecifier = (
   | 'releases'
   | 'security'
   | 'support'
+  | 'switchplan'
   | 'terms'
   | 'tips'
   | PlatformLocationsKeySpecifier
@@ -2046,6 +2051,7 @@ export type PlatformLocationsFieldPolicy = {
   releases?: FieldPolicy<any> | FieldReadFunction<any>;
   security?: FieldPolicy<any> | FieldReadFunction<any>;
   support?: FieldPolicy<any> | FieldReadFunction<any>;
+  switchplan?: FieldPolicy<any> | FieldReadFunction<any>;
   terms?: FieldPolicy<any> | FieldReadFunction<any>;
   tips?: FieldPolicy<any> | FieldReadFunction<any>;
 };

--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -1689,6 +1689,7 @@ export type MutationKeySpecifier = (
   | 'updateUserGroup'
   | 'updateUserPlatformSettings'
   | 'updateVirtualContributor'
+  | 'updateVirtualContributorPlatformSettings'
   | 'updateVirtualPersona'
   | 'updateVisual'
   | 'updateWhiteboard'
@@ -1846,6 +1847,7 @@ export type MutationFieldPolicy = {
   updateUserGroup?: FieldPolicy<any> | FieldReadFunction<any>;
   updateUserPlatformSettings?: FieldPolicy<any> | FieldReadFunction<any>;
   updateVirtualContributor?: FieldPolicy<any> | FieldReadFunction<any>;
+  updateVirtualContributorPlatformSettings?: FieldPolicy<any> | FieldReadFunction<any>;
   updateVirtualPersona?: FieldPolicy<any> | FieldReadFunction<any>;
   updateVisual?: FieldPolicy<any> | FieldReadFunction<any>;
   updateWhiteboard?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -17314,6 +17314,9 @@ export const SpaceSubspacesDocument = gql`
       }
       account {
         id
+        authorization {
+          myPrivileges
+        }
         virtualContributors {
           id
           nameID

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -17316,6 +17316,7 @@ export const SpaceSubspacesDocument = gql`
         id
         virtualContributors {
           id
+          nameID
           bodyOfKnowledgeID
           profile {
             displayName

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -17198,6 +17198,125 @@ export type UpdateSpaceSettingsMutationOptions = Apollo.BaseMutationOptions<
   SchemaTypes.UpdateSpaceSettingsMutation,
   SchemaTypes.UpdateSpaceSettingsMutationVariables
 >;
+export const CreateVirtualContributorOnAccountDocument = gql`
+  mutation createVirtualContributorOnAccount($virtualContributorData: CreateVirtualContributorOnAccountInput!) {
+    createVirtualContributor(virtualContributorData: $virtualContributorData) {
+      id
+    }
+  }
+`;
+export type CreateVirtualContributorOnAccountMutationFn = Apollo.MutationFunction<
+  SchemaTypes.CreateVirtualContributorOnAccountMutation,
+  SchemaTypes.CreateVirtualContributorOnAccountMutationVariables
+>;
+
+/**
+ * __useCreateVirtualContributorOnAccountMutation__
+ *
+ * To run a mutation, you first call `useCreateVirtualContributorOnAccountMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateVirtualContributorOnAccountMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createVirtualContributorOnAccountMutation, { data, loading, error }] = useCreateVirtualContributorOnAccountMutation({
+ *   variables: {
+ *      virtualContributorData: // value for 'virtualContributorData'
+ *   },
+ * });
+ */
+export function useCreateVirtualContributorOnAccountMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    SchemaTypes.CreateVirtualContributorOnAccountMutation,
+    SchemaTypes.CreateVirtualContributorOnAccountMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    SchemaTypes.CreateVirtualContributorOnAccountMutation,
+    SchemaTypes.CreateVirtualContributorOnAccountMutationVariables
+  >(CreateVirtualContributorOnAccountDocument, options);
+}
+
+export type CreateVirtualContributorOnAccountMutationHookResult = ReturnType<
+  typeof useCreateVirtualContributorOnAccountMutation
+>;
+export type CreateVirtualContributorOnAccountMutationResult =
+  Apollo.MutationResult<SchemaTypes.CreateVirtualContributorOnAccountMutation>;
+export type CreateVirtualContributorOnAccountMutationOptions = Apollo.BaseMutationOptions<
+  SchemaTypes.CreateVirtualContributorOnAccountMutation,
+  SchemaTypes.CreateVirtualContributorOnAccountMutationVariables
+>;
+export const SpaceSubspacesDocument = gql`
+  query spaceSubspaces($spaceId: UUID_NAMEID!) {
+    space(ID: $spaceId) {
+      id
+      profile {
+        id
+        displayName
+      }
+      account {
+        id
+      }
+      subspaces {
+        id
+        profile {
+          id
+          displayName
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useSpaceSubspacesQuery__
+ *
+ * To run a query within a React component, call `useSpaceSubspacesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSpaceSubspacesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSpaceSubspacesQuery({
+ *   variables: {
+ *      spaceId: // value for 'spaceId'
+ *   },
+ * });
+ */
+export function useSpaceSubspacesQuery(
+  baseOptions: Apollo.QueryHookOptions<SchemaTypes.SpaceSubspacesQuery, SchemaTypes.SpaceSubspacesQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SchemaTypes.SpaceSubspacesQuery, SchemaTypes.SpaceSubspacesQueryVariables>(
+    SpaceSubspacesDocument,
+    options
+  );
+}
+
+export function useSpaceSubspacesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<SchemaTypes.SpaceSubspacesQuery, SchemaTypes.SpaceSubspacesQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SchemaTypes.SpaceSubspacesQuery, SchemaTypes.SpaceSubspacesQueryVariables>(
+    SpaceSubspacesDocument,
+    options
+  );
+}
+
+export type SpaceSubspacesQueryHookResult = ReturnType<typeof useSpaceSubspacesQuery>;
+export type SpaceSubspacesLazyQueryHookResult = ReturnType<typeof useSpaceSubspacesLazyQuery>;
+export type SpaceSubspacesQueryResult = Apollo.QueryResult<
+  SchemaTypes.SpaceSubspacesQuery,
+  SchemaTypes.SpaceSubspacesQueryVariables
+>;
+export function refetchSpaceSubspacesQuery(variables: SchemaTypes.SpaceSubspacesQueryVariables) {
+  return { query: SpaceSubspacesDocument, variables: variables };
+}
+
 export const SpaceDashboardNavigationChallengesDocument = gql`
   query SpaceDashboardNavigationChallenges($spaceId: UUID!) {
     lookup {

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -17199,9 +17199,13 @@ export type UpdateSpaceSettingsMutationOptions = Apollo.BaseMutationOptions<
   SchemaTypes.UpdateSpaceSettingsMutationVariables
 >;
 export const CreateVirtualContributorOnAccountDocument = gql`
-  mutation createVirtualContributorOnAccount($virtualContributorData: CreateVirtualContributorOnAccountInput!) {
+  mutation CreateVirtualContributorOnAccount($virtualContributorData: CreateVirtualContributorOnAccountInput!) {
     createVirtualContributor(virtualContributorData: $virtualContributorData) {
       id
+      profile {
+        id
+        url
+      }
     }
   }
 `;
@@ -17249,8 +17253,59 @@ export type CreateVirtualContributorOnAccountMutationOptions = Apollo.BaseMutati
   SchemaTypes.CreateVirtualContributorOnAccountMutation,
   SchemaTypes.CreateVirtualContributorOnAccountMutationVariables
 >;
+export const DeleteVirtualContributorOnAccountDocument = gql`
+  mutation DeleteVirtualContributorOnAccount($virtualContributorData: DeleteVirtualContributorInput!) {
+    deleteVirtualContributor(deleteData: $virtualContributorData) {
+      id
+    }
+  }
+`;
+export type DeleteVirtualContributorOnAccountMutationFn = Apollo.MutationFunction<
+  SchemaTypes.DeleteVirtualContributorOnAccountMutation,
+  SchemaTypes.DeleteVirtualContributorOnAccountMutationVariables
+>;
+
+/**
+ * __useDeleteVirtualContributorOnAccountMutation__
+ *
+ * To run a mutation, you first call `useDeleteVirtualContributorOnAccountMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteVirtualContributorOnAccountMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteVirtualContributorOnAccountMutation, { data, loading, error }] = useDeleteVirtualContributorOnAccountMutation({
+ *   variables: {
+ *      virtualContributorData: // value for 'virtualContributorData'
+ *   },
+ * });
+ */
+export function useDeleteVirtualContributorOnAccountMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    SchemaTypes.DeleteVirtualContributorOnAccountMutation,
+    SchemaTypes.DeleteVirtualContributorOnAccountMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    SchemaTypes.DeleteVirtualContributorOnAccountMutation,
+    SchemaTypes.DeleteVirtualContributorOnAccountMutationVariables
+  >(DeleteVirtualContributorOnAccountDocument, options);
+}
+
+export type DeleteVirtualContributorOnAccountMutationHookResult = ReturnType<
+  typeof useDeleteVirtualContributorOnAccountMutation
+>;
+export type DeleteVirtualContributorOnAccountMutationResult =
+  Apollo.MutationResult<SchemaTypes.DeleteVirtualContributorOnAccountMutation>;
+export type DeleteVirtualContributorOnAccountMutationOptions = Apollo.BaseMutationOptions<
+  SchemaTypes.DeleteVirtualContributorOnAccountMutation,
+  SchemaTypes.DeleteVirtualContributorOnAccountMutationVariables
+>;
 export const SpaceSubspacesDocument = gql`
-  query spaceSubspaces($spaceId: UUID_NAMEID!) {
+  query SpaceSubspaces($spaceId: UUID_NAMEID!) {
     space(ID: $spaceId) {
       id
       profile {
@@ -17259,12 +17314,26 @@ export const SpaceSubspacesDocument = gql`
       }
       account {
         id
+        virtualContributors {
+          id
+          bodyOfKnowledgeID
+          profile {
+            displayName
+            url
+            avatar: visual(type: AVATAR) {
+              uri
+            }
+          }
+        }
       }
       subspaces {
         id
         profile {
           id
           displayName
+          avatar: visual(type: AVATAR) {
+            uri
+          }
         }
       }
     }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -1748,7 +1748,7 @@ export type CreateVirtualPersonaInput = {
   /** A readable identifier, unique within the containing scope. */
   nameID: Scalars['NameID'];
   profileData: CreateProfileInput;
-  prompt: Scalars['JSON'];
+  prompt?: InputMaybe<Scalars['JSON']>;
 };
 
 export type CreateWhiteboardInput = {
@@ -5524,7 +5524,7 @@ export type UpdateVirtualPersonaInput = {
   nameID?: InputMaybe<Scalars['NameID']>;
   /** The Profile of this entity. */
   profileData?: InputMaybe<UpdateProfileInput>;
-  prompt: Scalars['JSON'];
+  prompt?: InputMaybe<Scalars['JSON']>;
 };
 
 export type UpdateVisualInput = {
@@ -21316,6 +21316,34 @@ export type UpdateSpaceSettingsMutation = {
         inheritMembershipRights: boolean;
       };
     };
+  };
+};
+
+export type CreateVirtualContributorOnAccountMutationVariables = Exact<{
+  virtualContributorData: CreateVirtualContributorOnAccountInput;
+}>;
+
+export type CreateVirtualContributorOnAccountMutation = {
+  __typename?: 'Mutation';
+  createVirtualContributor: { __typename?: 'VirtualContributor'; id: string };
+};
+
+export type SpaceSubspacesQueryVariables = Exact<{
+  spaceId: Scalars['UUID_NAMEID'];
+}>;
+
+export type SpaceSubspacesQuery = {
+  __typename?: 'Query';
+  space: {
+    __typename?: 'Space';
+    id: string;
+    profile: { __typename?: 'Profile'; id: string; displayName: string };
+    account: { __typename?: 'Account'; id: string };
+    subspaces: Array<{
+      __typename?: 'Space';
+      id: string;
+      profile: { __typename?: 'Profile'; id: string; displayName: string };
+    }>;
   };
 };
 

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -2974,6 +2974,8 @@ export type Mutation = {
   updateUserPlatformSettings: User;
   /** Updates the specified VirtualContributor. */
   updateVirtualContributor: VirtualContributor;
+  /** Update VirtualContributor Platform Settings. */
+  updateVirtualContributorPlatformSettings: VirtualContributor;
   /** Updates the specified VirtualPersona. */
   updateVirtualPersona: VirtualPersona;
   /** Updates the image URI for the specified Visual. */
@@ -3544,6 +3546,10 @@ export type MutationUpdateUserPlatformSettingsArgs = {
 
 export type MutationUpdateVirtualContributorArgs = {
   virtualContributorData: UpdateVirtualContributorInput;
+};
+
+export type MutationUpdateVirtualContributorPlatformSettingsArgs = {
+  updateData: UpdateVirtualContributorPlatformSettingsInput;
 };
 
 export type MutationUpdateVirtualPersonaArgs = {
@@ -5520,6 +5526,12 @@ export type UpdateVirtualContributorInput = {
   nameID?: InputMaybe<Scalars['NameID']>;
   /** The Profile of this entity. */
   profileData?: InputMaybe<UpdateProfileInput>;
+};
+
+export type UpdateVirtualContributorPlatformSettingsInput = {
+  ID: Scalars['UUID'];
+  /** An Account ID associated with the VirtualContributor */
+  accountID: Scalars['UUID'];
 };
 
 export type UpdateVirtualPersonaInput = {
@@ -21362,6 +21374,7 @@ export type SpaceSubspacesQuery = {
       virtualContributors: Array<{
         __typename?: 'VirtualContributor';
         id: string;
+        nameID: string;
         bodyOfKnowledgeID?: string | undefined;
         profile: {
           __typename?: 'Profile';

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -1863,6 +1863,10 @@ export type DeleteCollaborationInput = {
   ID: Scalars['UUID'];
 };
 
+export type DeleteCommunityGuidelinesTemplateInput = {
+  ID: Scalars['UUID'];
+};
+
 export type DeleteDiscussionInput = {
   ID: Scalars['UUID'];
 };
@@ -2794,6 +2798,8 @@ export type Mutation = {
   deleteCalloutTemplate: CalloutTemplate;
   /** Delete Collaboration. */
   deleteCollaboration: Collaboration;
+  /** Deletes the specified CommunityGuidelines Template. */
+  deleteCommunityGuidelinesTemplate: CommunityGuidelinesTemplate;
   /** Deletes the specified Discussion. */
   deleteDiscussion: Discussion;
   /** Deletes the specified Document. */
@@ -2916,6 +2922,8 @@ export type Mutation = {
   updateCommunityApplicationForm: Community;
   /** Updates the CommunityGuidelines. */
   updateCommunityGuidelines: CommunityGuidelines;
+  /** Updates the specified CommunityGuidelinesTemplate. */
+  updateCommunityGuidelinesTemplate: CommunityGuidelinesTemplate;
   /** Updates the specified Discussion. */
   updateDiscussion: Discussion;
   /** Updates the specified Document. */
@@ -3196,6 +3204,10 @@ export type MutationDeleteCollaborationArgs = {
   deleteData: DeleteCollaborationInput;
 };
 
+export type MutationDeleteCommunityGuidelinesTemplateArgs = {
+  deleteData: DeleteCommunityGuidelinesTemplateInput;
+};
+
 export type MutationDeleteDiscussionArgs = {
   deleteData: DeleteDiscussionInput;
 };
@@ -3430,6 +3442,10 @@ export type MutationUpdateCommunityApplicationFormArgs = {
 
 export type MutationUpdateCommunityGuidelinesArgs = {
   communityGuidelinesData: UpdateCommunityGuidelinesInput;
+};
+
+export type MutationUpdateCommunityGuidelinesTemplateArgs = {
+  communityGuidelinesTemplateInput: UpdateCommunityGuidelinesTemplateInput;
 };
 
 export type MutationUpdateDiscussionArgs = {
@@ -3837,6 +3853,8 @@ export type PlatformLocations = {
   security: Scalars['String'];
   /** URL where users can get support for the platform */
   support: Scalars['String'];
+  /** URL for the link Contact in the HomePage to switch between plans */
+  switchplan: Scalars['String'];
   /** URL to the terms of usage for the platform */
   terms: Scalars['String'];
   /** URL where users can get tips and tricks */
@@ -5188,6 +5206,19 @@ export type UpdateCommunityGuidelinesInput = {
   communityGuidelinesID: Scalars['UUID'];
   /** The Profile for this community guidelines. */
   profile: UpdateProfileInput;
+};
+
+export type UpdateCommunityGuidelinesOfTemplateInput = {
+  /** The Profile for this community guidelines. */
+  profile: UpdateProfileInput;
+};
+
+export type UpdateCommunityGuidelinesTemplateInput = {
+  ID: Scalars['UUID'];
+  /** The Community guidelines to associate with this template. */
+  communityGuidelines?: InputMaybe<UpdateCommunityGuidelinesOfTemplateInput>;
+  /** The Profile of the Template. */
+  profile?: InputMaybe<UpdateProfileInput>;
 };
 
 export type UpdateContextInput = {
@@ -21371,6 +21402,9 @@ export type SpaceSubspacesQuery = {
     account: {
       __typename?: 'Account';
       id: string;
+      authorization?:
+        | { __typename?: 'Authorization'; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+        | undefined;
       virtualContributors: Array<{
         __typename?: 'VirtualContributor';
         id: string;

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -36,6 +36,8 @@ export type Apm = {
 
 export type Account = {
   __typename?: 'Account';
+  /** The "highest" subscription active for this Account. */
+  activeSubscription?: Maybe<AccountSubscription>;
   /** The Agent representing this Account. */
   agent: Agent;
   /** The authorization rules for the entity */
@@ -54,6 +56,8 @@ export type Account = {
   spaceID: Scalars['String'];
   /** The subscriptions active for this Account. */
   subscriptions: Array<AccountSubscription>;
+  /** The virtual contributors for this Account. */
+  virtualContributors: Array<VirtualContributor>;
 };
 
 export type AccountAuthorizationResetInput = {
@@ -66,7 +70,7 @@ export type AccountSubscription = {
   /** The expiry date of this subscription, null if it does never expire. */
   expires?: Maybe<Scalars['DateTime']>;
   /** The name of the Subscription. */
-  name: Scalars['String'];
+  name: LicenseCredential;
 };
 
 export type ActivityCreatedSubscriptionInput = {
@@ -758,6 +762,7 @@ export enum AuthorizationPrivilege {
 }
 
 export enum BodyOfKnowledgeType {
+  Other = 'OTHER',
   Space = 'SPACE',
 }
 
@@ -1735,8 +1740,8 @@ export type CreateUserInput = {
 
 export type CreateVirtualContributorOnAccountInput = {
   accountID: Scalars['UUID'];
-  bodyOfKnowledgeID: Scalars['UUID'];
-  bodyOfKnowledgeType: BodyOfKnowledgeType;
+  bodyOfKnowledgeID?: InputMaybe<Scalars['UUID']>;
+  bodyOfKnowledgeType?: InputMaybe<BodyOfKnowledgeType>;
   /** A readable identifier, unique within the containing scope. */
   nameID: Scalars['NameID'];
   profileData: CreateProfileInput;
@@ -5704,9 +5709,9 @@ export type VirtualContributor = Contributor & {
   /** The authorization rules for the Contributor */
   authorization?: Maybe<Authorization>;
   /** The body of knowledge ID used for the Virtual Contributor */
-  bodyOfKnowledgeID: Scalars['UUID'];
+  bodyOfKnowledgeID?: Maybe<Scalars['UUID']>;
   /** The body of knowledge type used for the Virtual Contributor */
-  bodyOfKnowledgeType: BodyOfKnowledgeType;
+  bodyOfKnowledgeType?: Maybe<BodyOfKnowledgeType>;
   /** The ID of the Contributor */
   id: Scalars['UUID'];
   /** A name identifier of the Contributor, unique within a given scope. */
@@ -17329,7 +17334,7 @@ export type VirtualContributorQuery = {
     __typename?: 'VirtualContributor';
     id: string;
     nameID: string;
-    bodyOfKnowledgeID: string;
+    bodyOfKnowledgeID?: string | undefined;
     authorization?:
       | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
       | undefined;
@@ -21325,7 +21330,20 @@ export type CreateVirtualContributorOnAccountMutationVariables = Exact<{
 
 export type CreateVirtualContributorOnAccountMutation = {
   __typename?: 'Mutation';
-  createVirtualContributor: { __typename?: 'VirtualContributor'; id: string };
+  createVirtualContributor: {
+    __typename?: 'VirtualContributor';
+    id: string;
+    profile: { __typename?: 'Profile'; id: string; url: string };
+  };
+};
+
+export type DeleteVirtualContributorOnAccountMutationVariables = Exact<{
+  virtualContributorData: DeleteVirtualContributorInput;
+}>;
+
+export type DeleteVirtualContributorOnAccountMutation = {
+  __typename?: 'Mutation';
+  deleteVirtualContributor: { __typename?: 'VirtualContributor'; id: string };
 };
 
 export type SpaceSubspacesQueryVariables = Exact<{
@@ -21338,11 +21356,30 @@ export type SpaceSubspacesQuery = {
     __typename?: 'Space';
     id: string;
     profile: { __typename?: 'Profile'; id: string; displayName: string };
-    account: { __typename?: 'Account'; id: string };
+    account: {
+      __typename?: 'Account';
+      id: string;
+      virtualContributors: Array<{
+        __typename?: 'VirtualContributor';
+        id: string;
+        bodyOfKnowledgeID?: string | undefined;
+        profile: {
+          __typename?: 'Profile';
+          displayName: string;
+          url: string;
+          avatar?: { __typename?: 'Visual'; uri: string } | undefined;
+        };
+      }>;
+    };
     subspaces: Array<{
       __typename?: 'Space';
       id: string;
-      profile: { __typename?: 'Profile'; id: string; displayName: string };
+      profile: {
+        __typename?: 'Profile';
+        id: string;
+        displayName: string;
+        avatar?: { __typename?: 'Visual'; uri: string } | undefined;
+      };
     }>;
   };
 };

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1898,6 +1898,10 @@
             "createSubspaces": "<b>Create Subspaces</b>: allow members to create Subspaces in this Space. If you deactivate this, you can still create Subspaces yourself and add other people as an admin inside the Subspace.",
             "inheritRights": "Allow Space members to contribute.",
             "supportAsAdmin": "<b>Alkemio Support</b>: Allow the Alkemio Support team to act as an admin in this Space."
+          },
+          "account": {
+            "vc-section-title": "Virtual Contributors created from this Space",
+            "vc-create-button": "Create Virtual Contributor"
           }
         }
       },
@@ -2795,6 +2799,15 @@
           "continue": "Continue"
         }
       }
+    }
+  },
+  "virtualContributorDialog": {
+    "title": "Create a Virtual Contributor",
+    "name": "Name",
+    "info-text": "Select the Space or Subspace that you want to use as a body of knowledge for this Virtual Contributor",
+    "confirm-deletion": {
+      "title": "Confirm Virtual Contributor Deletion",
+      "description": "Are you certain you want to delete this Virtual Contributor? Keep in mind that this action is irreversible. All profile information will be removed and people will no longer be able to interact with the Virtual Contributor. "
     }
   }
 }

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -343,6 +343,7 @@
     "url": "URL",
     "sources": "Sources",
     "virtual-contributors": "VC",
+    "virtual-contributor": "Virtual Contributor",
     "collaborationTool": "Collaboration tool",
     "genders": {
       "notSpecified": "not specified",
@@ -2460,7 +2461,7 @@
       "sections": {
         "knowledge": {
           "title": "Knowledge",
-          "description": "Answers {{name}} gives are based on the body of knowledge that is specified in the following Space:"
+          "description": "Answers {{name}} gives are based on the body of knowledge coming from:"
         },
 
         "personality": {
@@ -2801,13 +2802,13 @@
       }
     }
   },
-  "virtualContributorDialog": {
+  "virtualContributorSpaceSettings": {
     "title": "Create a Virtual Contributor",
     "name": "Name",
+    "body-of-knowledge": "Body Of Knowledge",
     "info-text": "Select the Space or Subspace that you want to use as a body of knowledge for this Virtual Contributor",
     "confirm-deletion": {
-      "title": "Confirm Virtual Contributor Deletion",
-      "description": "Are you certain you want to delete this Virtual Contributor? Keep in mind that this action is irreversible. All profile information will be removed and people will no longer be able to interact with the Virtual Contributor. "
+      "description": "Are you certain you want to delete this {{entity}}? Keep in mind that this action is irreversible. All profile information will be removed and people will no longer be able to interact with the {{entity}}. "
     }
   }
 }

--- a/src/domain/community/virtualContributor/components/BasicSpaceCard.tsx
+++ b/src/domain/community/virtualContributor/components/BasicSpaceCard.tsx
@@ -3,7 +3,6 @@ import BadgeCardView from '../../../../core/ui/list/BadgeCardView';
 import Avatar from '../../../../core/ui/avatar/Avatar';
 import { BlockSectionTitle } from '../../../../core/ui/typography';
 import { useTranslation } from 'react-i18next';
-import { theme } from '../../../../core/ui/themes/default/Theme';
 import RouterLink from '../../../../core/ui/link/RouterLink';
 import defaultJourneyCardBanner from '../../../../domain/journey/defaultVisuals/Card.jpg';
 
@@ -42,7 +41,6 @@ const BasicSpaceCard: FC<Props> = ({ space, showDefaults }) => {
 
   return (
     <BadgeCardView
-      marginTop={theme.spacing(2)}
       visual={
         <Avatar
           src={spaceData.avatar?.uri || defaultJourneyCardBanner}

--- a/src/domain/community/virtualContributor/layout/VCPageBanner.tsx
+++ b/src/domain/community/virtualContributor/layout/VCPageBanner.tsx
@@ -3,6 +3,7 @@ import { useVirtualContributorQuery } from '../../../../core/apollo/generated/ap
 import { useUrlParams } from '../../../../core/routing/useUrlParams';
 import ProfilePageBanner from '../../../common/profile/ProfilePageBanner';
 import { AuthorizationPrivilege } from '../../../../core/apollo/generated/graphql-schema';
+import { buildSettingsUrl } from '../../../../main/routing/urlBuilders';
 
 const VCPageBanner = () => {
   const { vcNameId = '' } = useUrlParams();
@@ -26,7 +27,7 @@ const VCPageBanner = () => {
       isVirtualContributor
       entityId={vcId}
       profile={profile}
-      settingsUri={hasSettingsAccess ? `${data?.virtualContributor.profile.url}/settings/profile` : undefined}
+      settingsUri={hasSettingsAccess ? buildSettingsUrl(data?.virtualContributor.profile.url ?? '') : undefined}
       loading={loading}
     />
   );

--- a/src/domain/community/virtualContributor/vcProfilePage/VCProfilePageView.tsx
+++ b/src/domain/community/virtualContributor/vcProfilePage/VCProfilePageView.tsx
@@ -13,6 +13,7 @@ import useTheme from '@mui/material/styles/useTheme';
 import { Trans, useTranslation } from 'react-i18next';
 import ProfileDetail from '../../profile/ProfileDetail/ProfileDetail';
 import BasicSpaceCard, { BasicSpaceProps } from '../components/BasicSpaceCard';
+import Spacer from '../../../../core/ui/content/Spacer';
 
 interface Props {
   virtualContributor: VirtualContributorQuery['virtualContributor'] | undefined;
@@ -59,6 +60,7 @@ export const VCProfilePageView: FC<PropsWithChildren<Props>> = ({
           </SectionTitle>
           <SectionContent withBottomOffset>
             <Trans i18nKey="pages.virtual-contributor-profile.sections.knowledge.description" values={{ name }} />
+            <Spacer />
             <BasicSpaceCard space={bokProfile} showDefaults={showDefaults} />
           </SectionContent>
           <SectionTitle>

--- a/src/domain/community/virtualContributor/vcSettingsPage/VirtualContributorForm.tsx
+++ b/src/domain/community/virtualContributor/vcSettingsPage/VirtualContributorForm.tsx
@@ -138,7 +138,13 @@ export const VirtualContributorForm: FC<Props> = ({
   const HostFields = () => (
     <>
       <FormikInputField name="hostDisplayName" title="Host" required readOnly disabled />
-      <FormikInputField name="subSpaceName" title="Body Of Knowledge Subspace" required readOnly disabled />
+      <FormikInputField
+        name="subSpaceName"
+        title={t('virtualContributorSpaceSettings.body-of-knowledge')}
+        required
+        readOnly
+        disabled
+      />
     </>
   );
 

--- a/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
+++ b/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
@@ -117,6 +117,9 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
     skip: !spaceNameId,
   });
 
+  const accountPrivileges = spaceData?.space?.account.authorization?.myPrivileges ?? [];
+  const canCreateVirtualContributor = accountPrivileges?.includes(AuthorizationPrivilege.CreateVirtualContributor);
+
   const subspaces = useMemo(() => {
     const result =
       spaceData?.space?.subspaces.map(subspace => ({
@@ -230,17 +233,20 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
                 <ContributorOnAccountCard
                   contributor={currentVirtualContributor}
                   space={bokSpaceData}
+                  hasDelete={canCreateVirtualContributor}
                   onDeleteClick={openDeleteVCDialog}
                 />
               )}
-              <Button
-                variant="outlined"
-                startIcon={<ControlPointIcon />}
-                onClick={openCreateVCDialog}
-                disabled={!!currentVirtualContributor || spaceDataLoading}
-              >
-                {t('pages.admin.space.settings.account.vc-create-button')}
-              </Button>
+              {canCreateVirtualContributor && (
+                <Button
+                  variant="outlined"
+                  startIcon={<ControlPointIcon />}
+                  onClick={openCreateVCDialog}
+                  disabled={!!currentVirtualContributor || spaceDataLoading}
+                >
+                  {t('pages.admin.space.settings.account.vc-create-button')}
+                </Button>
+              )}
             </Gutters>
           </PageContentBlock>
           {canDelete && (

--- a/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
+++ b/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
@@ -198,6 +198,7 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
     const vsResponse = await createVirtualContributorOnAccount({
       variables: {
         virtualContributorData: {
+          // todo: guarantee uniqueness but use createNameId(displayName)
           nameID: `v-c-${uuidv4()}`.slice(0, 25).toLocaleLowerCase(),
           profileData: {
             displayName,

--- a/src/domain/journey/space/pages/SpaceSettings/ContributorOnAccountCard.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/ContributorOnAccountCard.tsx
@@ -22,10 +22,16 @@ interface ContributorOnAccountCardProps {
       };
     };
   };
+  hasDelete?: boolean;
   onDeleteClick: () => void;
 }
 
-const ContributorOnAccountCard: FC<ContributorOnAccountCardProps> = ({ contributor, space, onDeleteClick }) => {
+const ContributorOnAccountCard: FC<ContributorOnAccountCardProps> = ({
+  contributor,
+  space,
+  hasDelete = false,
+  onDeleteClick,
+}) => {
   const spaceData = {
     displayName: contributor?.profile.displayName ?? '',
     url: contributor?.profile.url ? contributor?.profile.url : '',
@@ -41,9 +47,11 @@ const ContributorOnAccountCard: FC<ContributorOnAccountCardProps> = ({ contribut
       sx={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}
     >
       <BasicSpaceCard space={spaceData} />
-      <IconButton onClick={onDeleteClick}>
-        <DeleteIcon />
-      </IconButton>
+      {hasDelete && (
+        <IconButton onClick={onDeleteClick}>
+          <DeleteIcon />
+        </IconButton>
+      )}
     </Gutters>
   );
 };

--- a/src/domain/journey/space/pages/SpaceSettings/ContributorOnAccountCard.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/ContributorOnAccountCard.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
+import IconButton from '@mui/material/IconButton';
 import BasicSpaceCard from '../../../../community/virtualContributor/components/BasicSpaceCard';
 import { DeleteIcon } from '../SpaceSettings/icon/DeleteIcon';
 import Gutters from '../../../../../core/ui/grid/Gutters';
-import { Button } from '@mui/material';
+import { buildSettingsUrl } from '../../../../../main/routing/urlBuilders';
 
 interface ContributorOnAccountCardProps {
   contributor?: {
@@ -22,12 +23,13 @@ interface ContributorOnAccountCardProps {
       };
     };
   };
+  onDeleteClick: () => void;
 }
 
-const ContributorOnAccountCard: FC<ContributorOnAccountCardProps> = ({ contributor, space }) => {
+const ContributorOnAccountCard: FC<ContributorOnAccountCardProps> = ({ contributor, space, onDeleteClick }) => {
   const spaceData = {
     displayName: contributor?.profile.displayName ?? '',
-    url: contributor?.profile.url ? contributor?.profile.url + '/settings/profile' : '',
+    url: contributor?.profile.url ? buildSettingsUrl(contributor?.profile.url) : '',
     avatar: {
       uri: contributor?.profile.avatar?.uri ?? '',
     },
@@ -35,12 +37,15 @@ const ContributorOnAccountCard: FC<ContributorOnAccountCardProps> = ({ contribut
   };
 
   return (
-    <>
-      <Gutters display={'flex'} sx={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
-        <BasicSpaceCard space={spaceData} />
-        <Button variant="text" startIcon={<DeleteIcon />} />
-      </Gutters>
-    </>
+    <Gutters
+      display={'flex'}
+      sx={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}
+    >
+      <BasicSpaceCard space={spaceData} />
+      <IconButton onClick={onDeleteClick}>
+        <DeleteIcon />
+      </IconButton>
+    </Gutters>
   );
 };
 

--- a/src/domain/journey/space/pages/SpaceSettings/ContributorOnAccountCard.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/ContributorOnAccountCard.tsx
@@ -3,7 +3,6 @@ import IconButton from '@mui/material/IconButton';
 import BasicSpaceCard from '../../../../community/virtualContributor/components/BasicSpaceCard';
 import { DeleteIcon } from '../SpaceSettings/icon/DeleteIcon';
 import Gutters from '../../../../../core/ui/grid/Gutters';
-import { buildSettingsUrl } from '../../../../../main/routing/urlBuilders';
 
 interface ContributorOnAccountCardProps {
   contributor?: {
@@ -29,7 +28,7 @@ interface ContributorOnAccountCardProps {
 const ContributorOnAccountCard: FC<ContributorOnAccountCardProps> = ({ contributor, space, onDeleteClick }) => {
   const spaceData = {
     displayName: contributor?.profile.displayName ?? '',
-    url: contributor?.profile.url ? buildSettingsUrl(contributor?.profile.url) : '',
+    url: contributor?.profile.url ? contributor?.profile.url : '',
     avatar: {
       uri: contributor?.profile.avatar?.uri ?? '',
     },

--- a/src/domain/journey/space/pages/SpaceSettings/ContributorOnAccountCard.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/ContributorOnAccountCard.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react';
+import BasicSpaceCard from '../../../../community/virtualContributor/components/BasicSpaceCard';
+import { DeleteIcon } from '../SpaceSettings/icon/DeleteIcon';
+import Gutters from '../../../../../core/ui/grid/Gutters';
+import { Button } from '@mui/material';
+
+interface ContributorOnAccountCardProps {
+  contributor?: {
+    profile: {
+      displayName: string;
+      url: string;
+      avatar?: {
+        uri: string;
+      };
+    };
+  };
+  space?: {
+    profile: {
+      displayName: string;
+      avatar?: {
+        uri: string;
+      };
+    };
+  };
+}
+
+const ContributorOnAccountCard: FC<ContributorOnAccountCardProps> = ({ contributor, space }) => {
+  const spaceData = {
+    displayName: contributor?.profile.displayName ?? '',
+    url: contributor?.profile.url ? contributor?.profile.url + '/settings/profile' : '',
+    avatar: {
+      uri: contributor?.profile.avatar?.uri ?? '',
+    },
+    tagline: space?.profile.displayName ?? '',
+  };
+
+  return (
+    <>
+      <Gutters display={'flex'} sx={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+        <BasicSpaceCard space={spaceData} />
+        <Button variant="text" startIcon={<DeleteIcon />} />
+      </Gutters>
+    </>
+  );
+};
+
+export default ContributorOnAccountCard;

--- a/src/domain/journey/space/pages/SpaceSettings/CreateVirtualContributorDialog.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/CreateVirtualContributorDialog.tsx
@@ -50,8 +50,8 @@ const CreateVirtualContributorDialog: FC<CreateVirtualContributorDialogProps> = 
       <DialogHeader onClose={onClose} title={t('virtualContributorDialog.title')} />
       <DialogContent>
         <Formik initialValues={initialValues} onSubmit={handleCreate}>
-          <Gutters disablePadding>
-            <Form noValidate>
+          <Form noValidate>
+            <Gutters>
               <FormikInputField title={t('virtualContributorDialog.name')} name="displayName" />
               <FormikSelect title="Body Of Knowledge" name="bodyOfKnowledgeID" values={spaces ?? []} />
               <Actions justifyContent="flex-end" paddingTop={gutters()}>
@@ -66,8 +66,8 @@ const CreateVirtualContributorDialog: FC<CreateVirtualContributorDialogProps> = 
                   {t('buttons.create')}
                 </LoadingButton>
               </Actions>
-            </Form>
-          </Gutters>
+            </Gutters>
+          </Form>
         </Formik>
       </DialogContent>
     </Dialog>

--- a/src/domain/journey/space/pages/SpaceSettings/CreateVirtualContributorDialog.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/CreateVirtualContributorDialog.tsx
@@ -1,0 +1,77 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, Dialog, DialogContent } from '@mui/material';
+import LoadingButton from '@mui/lab/LoadingButton';
+import DialogHeader from '../../../../../core/ui/dialog/DialogHeader';
+import Gutters from '../../../../../core/ui/grid/Gutters';
+import { Actions } from '../../../../../core/ui/actions/Actions';
+import { gutters } from '../../../../../core/ui/grid/utils';
+import { Form, Formik } from 'formik';
+import FormikInputField from '../../../../../core/ui/forms/FormikInputField/FormikInputField';
+import FormikSelect from '../../../../../core/ui/forms/FormikSelect';
+import useLoadingState from '../../../../shared/utils/useLoadingState';
+
+export interface VirtualContributorFormValues {
+  displayName: string;
+  bodyOfKnowledgeID: string;
+}
+
+interface CreateVirtualContributorDialogProps {
+  spaces: { name: string; id: string }[];
+  open: boolean;
+  onClose: () => void;
+  onCreate: ({ bodyOfKnowledgeID, displayName }) => void;
+  submitting: boolean;
+}
+
+const CreateVirtualContributorDialog: FC<CreateVirtualContributorDialogProps> = ({
+  spaces,
+  open,
+  onClose,
+  onCreate,
+  submitting,
+}) => {
+  const { t } = useTranslation();
+
+  const initialValues = {
+    displayName: '',
+    spaces: [],
+    bodyOfKnowledgeID: '',
+  };
+
+  const [handleCreate, loading] = useLoadingState(async (values: VirtualContributorFormValues) => {
+    await onCreate?.({
+      ...values,
+    });
+  });
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogHeader onClose={onClose} title={t('virtualContributorDialog.title')} />
+      <DialogContent>
+        <Formik initialValues={initialValues} onSubmit={handleCreate}>
+          <Gutters disablePadding>
+            <Form noValidate>
+              <FormikInputField title={t('virtualContributorDialog.name')} name="displayName" />
+              <FormikSelect title="Body Of Knowledge" name="bodyOfKnowledgeID" values={spaces ?? []} />
+              <Actions justifyContent="flex-end" paddingTop={gutters()}>
+                <Button onClick={onClose}>{t('buttons.cancel')}</Button>
+                <LoadingButton
+                  variant="contained"
+                  disabled={loading}
+                  loading={submitting}
+                  loadingIndicator="..."
+                  type="submit"
+                >
+                  {t('buttons.create')}
+                </LoadingButton>
+              </Actions>
+            </Form>
+          </Gutters>
+        </Formik>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreateVirtualContributorDialog;

--- a/src/domain/journey/space/pages/SpaceSettings/CreateVirtualContributorDialog.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/CreateVirtualContributorDialog.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Dialog, DialogContent } from '@mui/material';
 import LoadingButton from '@mui/lab/LoadingButton';
+import * as yup from 'yup';
 import DialogHeader from '../../../../../core/ui/dialog/DialogHeader';
 import Gutters from '../../../../../core/ui/grid/Gutters';
 import { Actions } from '../../../../../core/ui/actions/Actions';
@@ -11,6 +12,7 @@ import FormikInputField from '../../../../../core/ui/forms/FormikInputField/Form
 import FormikSelect from '../../../../../core/ui/forms/FormikSelect';
 import useLoadingState from '../../../../shared/utils/useLoadingState';
 import { Caption } from '../../../../../core/ui/typography';
+import { nameSegmentSchema } from '../../../../platform/admin/components/Common/NameSegment';
 
 export interface VirtualContributorFormValues {
   displayName: string;
@@ -40,6 +42,11 @@ const CreateVirtualContributorDialog: FC<CreateVirtualContributorDialogProps> = 
     bodyOfKnowledgeID: '',
   };
 
+  const validationSchema = yup.object().shape({
+    displayName: nameSegmentSchema.fields?.name ?? yup.string(),
+    bodyOfKnowledgeID: yup.string().required(t('forms.validations.required')),
+  });
+
   const [handleCreate, loading] = useLoadingState(async (values: VirtualContributorFormValues) => {
     await onCreate?.({
       ...values,
@@ -50,14 +57,15 @@ const CreateVirtualContributorDialog: FC<CreateVirtualContributorDialogProps> = 
     <Dialog open={open} onClose={onClose}>
       <DialogHeader onClose={onClose} title={t('virtualContributorSpaceSettings.title')} />
       <DialogContent>
-        <Formik initialValues={initialValues} onSubmit={handleCreate}>
+        <Formik initialValues={initialValues} validationSchema={validationSchema} onSubmit={handleCreate}>
           <Form noValidate>
             <Gutters>
-              <FormikInputField title={t('virtualContributorSpaceSettings.name')} name="displayName" />
+              <FormikInputField title={t('virtualContributorSpaceSettings.name')} name="displayName" required />
               <FormikSelect
                 title={t('virtualContributorSpaceSettings.body-of-knowledge')}
                 name="bodyOfKnowledgeID"
                 values={spaces ?? []}
+                required
               />
               <Caption>{t('virtualContributorSpaceSettings.info-text')}</Caption>
               <Actions justifyContent="flex-end" paddingTop={gutters()}>

--- a/src/domain/journey/space/pages/SpaceSettings/CreateVirtualContributorDialog.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/CreateVirtualContributorDialog.tsx
@@ -10,6 +10,7 @@ import { Form, Formik } from 'formik';
 import FormikInputField from '../../../../../core/ui/forms/FormikInputField/FormikInputField';
 import FormikSelect from '../../../../../core/ui/forms/FormikSelect';
 import useLoadingState from '../../../../shared/utils/useLoadingState';
+import { Caption } from '../../../../../core/ui/typography';
 
 export interface VirtualContributorFormValues {
   displayName: string;
@@ -47,13 +48,18 @@ const CreateVirtualContributorDialog: FC<CreateVirtualContributorDialogProps> = 
 
   return (
     <Dialog open={open} onClose={onClose}>
-      <DialogHeader onClose={onClose} title={t('virtualContributorDialog.title')} />
+      <DialogHeader onClose={onClose} title={t('virtualContributorSpaceSettings.title')} />
       <DialogContent>
         <Formik initialValues={initialValues} onSubmit={handleCreate}>
           <Form noValidate>
             <Gutters>
-              <FormikInputField title={t('virtualContributorDialog.name')} name="displayName" />
-              <FormikSelect title="Body Of Knowledge" name="bodyOfKnowledgeID" values={spaces ?? []} />
+              <FormikInputField title={t('virtualContributorSpaceSettings.name')} name="displayName" />
+              <FormikSelect
+                title={t('virtualContributorSpaceSettings.body-of-knowledge')}
+                name="bodyOfKnowledgeID"
+                values={spaces ?? []}
+              />
+              <Caption>{t('virtualContributorSpaceSettings.info-text')}</Caption>
               <Actions justifyContent="flex-end" paddingTop={gutters()}>
                 <Button onClick={onClose}>{t('buttons.cancel')}</Button>
                 <LoadingButton

--- a/src/domain/journey/space/pages/SpaceSettings/SpaceProfileDeleteDialog.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/SpaceProfileDeleteDialog.tsx
@@ -7,9 +7,11 @@ import Gutters from '../../../../../core/ui/grid/Gutters';
 import { Actions } from '../../../../../core/ui/actions/Actions';
 import { Caption } from '../../../../../core/ui/typography';
 import { gutters } from '../../../../../core/ui/grid/utils';
+import TranslationKey from '../../../../../core/i18n/utils/TranslationKey';
 
 interface SpaceProfileDeleteDialogProps {
   entity: string;
+  description?: TranslationKey;
   open: boolean;
   onClose: () => void;
   onDelete: () => void;
@@ -18,6 +20,7 @@ interface SpaceProfileDeleteDialogProps {
 
 const SpaceProfileDeleteDialog: FC<SpaceProfileDeleteDialogProps> = ({
   entity,
+  description,
   open,
   onClose,
   onDelete,
@@ -32,7 +35,9 @@ const SpaceProfileDeleteDialog: FC<SpaceProfileDeleteDialogProps> = ({
       <DialogContent>
         <Gutters disablePadding>
           <Box sx={{ wordWrap: 'break-word' }}>
-            <Caption>{t('components.deleteSpace.confirmDialog.description', { entity: entity })} </Caption>
+            <Caption>
+              {t(description ?? 'components.deleteSpace.confirmDialog.description', { entity: entity })}{' '}
+            </Caption>
             <FormControlLabel
               control={<Checkbox checked={checked} onChange={() => setChecked(!checked)} />}
               label={<Caption>{t('components.deleteSpace.confirmDialog.checkbox', { entity: entity })}</Caption>}

--- a/src/domain/journey/space/pages/SpaceSettings/VirtualContributor.graphql
+++ b/src/domain/journey/space/pages/SpaceSettings/VirtualContributor.graphql
@@ -1,0 +1,25 @@
+mutation createVirtualContributorOnAccount($virtualContributorData: CreateVirtualContributorOnAccountInput!) {
+  createVirtualContributor(virtualContributorData: $virtualContributorData) {
+    id
+  }
+}
+
+query spaceSubspaces($spaceId: UUID_NAMEID!) {
+  space (ID: $spaceId) {
+    id
+    profile {
+      id
+      displayName
+    }
+    account {
+      id
+    }
+    subspaces {
+      id
+      profile {
+        id
+        displayName
+      }
+    }
+  }
+}

--- a/src/domain/journey/space/pages/SpaceSettings/VirtualContributor.graphql
+++ b/src/domain/journey/space/pages/SpaceSettings/VirtualContributor.graphql
@@ -23,6 +23,9 @@ query SpaceSubspaces($spaceId: UUID_NAMEID!) {
     }
     account {
       id
+      authorization {
+        myPrivileges
+      }
       virtualContributors {
         id
         nameID

--- a/src/domain/journey/space/pages/SpaceSettings/VirtualContributor.graphql
+++ b/src/domain/journey/space/pages/SpaceSettings/VirtualContributor.graphql
@@ -1,10 +1,20 @@
-mutation createVirtualContributorOnAccount($virtualContributorData: CreateVirtualContributorOnAccountInput!) {
+mutation CreateVirtualContributorOnAccount($virtualContributorData: CreateVirtualContributorOnAccountInput!) {
   createVirtualContributor(virtualContributorData: $virtualContributorData) {
     id
+    profile {
+      id
+      url
+    }
   }
 }
 
-query spaceSubspaces($spaceId: UUID_NAMEID!) {
+mutation DeleteVirtualContributorOnAccount($virtualContributorData: DeleteVirtualContributorInput!) {
+  deleteVirtualContributor(deleteData: $virtualContributorData) {
+    id
+	}
+}
+
+query SpaceSubspaces($spaceId: UUID_NAMEID!) {
   space (ID: $spaceId) {
     id
     profile {
@@ -13,12 +23,26 @@ query spaceSubspaces($spaceId: UUID_NAMEID!) {
     }
     account {
       id
+      virtualContributors {
+        id
+        bodyOfKnowledgeID
+        profile {
+          displayName
+          url
+          avatar: visual(type: AVATAR) {
+            uri
+          }
+        }
+      }
     }
     subspaces {
       id
       profile {
         id
         displayName
+        avatar: visual(type: AVATAR) {
+          uri
+        }
       }
     }
   }

--- a/src/domain/journey/space/pages/SpaceSettings/VirtualContributor.graphql
+++ b/src/domain/journey/space/pages/SpaceSettings/VirtualContributor.graphql
@@ -25,6 +25,7 @@ query SpaceSubspaces($spaceId: UUID_NAMEID!) {
       id
       virtualContributors {
         id
+        nameID
         bodyOfKnowledgeID
         profile {
           displayName


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6254

Create, Display & Delete VCs in Settings/Account. 


- [x] 1 VC per space, after that create button is muted;
  - [ ] has tooltip as per design;
- [x] Create VC button leads to Create dialog where user chooses name + the space or some of it's subspaces;
- [x] After Creation the user is redirected to VCs settings;
  - [ ] preferably - dialog instead of redirect;
- [x] Clicking on existing VC leads to VC profile page;
- [x] Available only for users with account privilege for VC creation; 

#### VC card in block shows 
- [x] Avatar
- [x] Name
- [x] Space/Subspace (name) that the VC is based on
- [x] Bin to delete VC
- [x] Bin opens confirmation dialog (see design)
- [x] Clicking on the rest of the card opens VC profile page
