### PR TITLE
VCs to be created only with subspace BoK

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2815,6 +2815,7 @@
     "name": "Name",
     "body-of-knowledge": "Body Of Knowledge",
     "info-text": "Select the Space or Subspace that you want to use as a body of knowledge for this Virtual Contributor",
+    "noSubspacesInfo": "Create a Subspace first, and populate it with the relevant information for your Virtual Contributor.",
     "confirm-deletion": {
       "description": "Are you certain you want to delete this {{entity}}? Keep in mind that this action is irreversible. All profile information will be removed and people will no longer be able to interact with the {{entity}}. "
     }

--- a/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
+++ b/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
@@ -34,12 +34,15 @@ import useNavigate from '../../../../../core/routing/useNavigate';
 import { PlanFeatures, PlanFooter, PlanName, PlanPrice } from '../../../../license/plans/ui/PlanCardsComponents';
 import { getPlanTranslations } from '../../../../license/plans/utils/getPlanTranslations';
 import RouterLink from '../../../../../core/ui/link/RouterLink';
+import useCommunityAdmin from '../../../../community/community/CommunityAdmin/useCommunityAdmin';
+import { useSpace } from '../../SpaceContext/useSpace';
 
 interface SpaceAccountPageProps {
   journeyId: string;
 }
 
 const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
+  const { communityId } = useSpace();
   const { t } = useTranslation();
   const planTranslations = getPlanTranslations(t);
   const notify = useNotification();
@@ -57,6 +60,8 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
   const openDeleteVCDialog = () => setIsOpenDeleteVCDialog(true);
   const closeDeleteVCDialog = () => setIsOpenDeleteVCDialog(false);
   const [selectedVirtualContributorId, setSelectedVirtualContributorId] = useState<string | null>(null);
+
+  const { permissions } = useCommunityAdmin({ communityId, spaceId: journeyId, journeyLevel: 0 });
 
   const { data, loading: loadingAccount } = useSpaceAccountQuery({
     variables: { spaceId: journeyId },
@@ -339,35 +344,37 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
                 )}
             </Gutters>
           </PageContentBlock>
-          <PageContentBlock columns={5} sx={{ gap: gutters(2) }}>
-            <Gutters disablePadding alignItems={'flex-start'}>
-              {virtualContributors.length > 0 &&
-                virtualContributors?.map(vc => (
+          {permissions.virtualContributorsEnabled && (
+            <PageContentBlock columns={5} sx={{ gap: gutters(2) }}>
+              <Gutters disablePadding alignItems={'flex-start'}>
+                {virtualContributors.length > 0 &&
+                  virtualContributors?.map(vc => (
+                    <>
+                      <BlockTitle>{t('pages.admin.space.settings.account.vc-section-title')}</BlockTitle>
+                      <ContributorOnAccountCard
+                        contributor={vc}
+                        space={bokSpaceData}
+                        hasDelete={canCreateVirtualContributor}
+                        onDeleteClick={() => initiateDeleteVC(vc.nameID)}
+                      />
+                    </>
+                  ))}
+                {canCreateVirtualContributor && (
                   <>
-                    <BlockTitle>{t('pages.admin.space.settings.account.vc-section-title')}</BlockTitle>
-                    <ContributorOnAccountCard
-                      contributor={vc}
-                      space={bokSpaceData}
-                      hasDelete={canCreateVirtualContributor}
-                      onDeleteClick={() => initiateDeleteVC(vc.nameID)}
-                    />
+                    <Button
+                      variant="outlined"
+                      startIcon={<ControlPointIcon />}
+                      onClick={openCreateVCDialog}
+                      disabled={disabledVirtualCreation}
+                    >
+                      {t('pages.admin.space.settings.account.vc-create-button')}
+                    </Button>
+                    {noSubspaces && <Caption>{t('virtualContributorSpaceSettings.noSubspacesInfo')}</Caption>}
                   </>
-                ))}
-              {canCreateVirtualContributor && (
-                <>
-                  <Button
-                    variant="outlined"
-                    startIcon={<ControlPointIcon />}
-                    onClick={openCreateVCDialog}
-                    disabled={disabledVirtualCreation}
-                  >
-                    {t('pages.admin.space.settings.account.vc-create-button')}
-                  </Button>
-                  {noSubspaces && <Caption>{t('virtualContributorSpaceSettings.noSubspacesInfo')}</Caption>}
-                </>
-              )}
-            </Gutters>
-          </PageContentBlock>
+                )}
+              </Gutters>
+            </PageContentBlock>
+          )}
           {canDelete && (
             <PageContentBlock sx={{ borderColor: errorColor }}>
               <PageContentBlockHeader sx={{ color: errorColor }} title={t('components.deleteSpace.title')} />

--- a/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
+++ b/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
@@ -163,20 +163,14 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
   const accountPrivileges = spaceData?.space?.account.authorization?.myPrivileges ?? [];
   const canCreateVirtualContributor = accountPrivileges?.includes(AuthorizationPrivilege.CreateVirtualContributor);
 
-  const subspaces = useMemo(() => {
-    const result =
+  const subspaces = useMemo(
+    () =>
       spaceData?.space?.subspaces.map(subspace => ({
         id: subspace.id,
         name: subspace?.profile.displayName,
-      })) ?? [];
-
-    result.push({
-      id: journeyId,
-      name: spaceData?.space?.profile.displayName || '',
-    });
-
-    return result;
-  }, [spaceData]);
+      })) ?? [],
+    [spaceData]
+  );
 
   const bokSpaceData = useMemo(
     () =>
@@ -218,7 +212,8 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
   };
 
   const loading = loadingAccount && deletingSpace;
-  const disabledVirtualCreation = virtualContributors.length > 0 || spaceDataLoading;
+  const noSubspaces = subspaces?.length < 1;
+  const disabledVirtualCreation = virtualContributors.length > 0 || spaceDataLoading || noSubspaces;
 
   return (
     <PageContent background="transparent">
@@ -346,25 +341,30 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
           </PageContentBlock>
           <PageContentBlock columns={5} sx={{ gap: gutters(2) }}>
             <Gutters disablePadding alignItems={'flex-start'}>
-              <BlockTitle>{t('pages.admin.space.settings.account.vc-section-title')}</BlockTitle>
               {virtualContributors.length > 0 &&
                 virtualContributors?.map(vc => (
-                  <ContributorOnAccountCard
-                    contributor={vc}
-                    space={bokSpaceData}
-                    hasDelete={canCreateVirtualContributor}
-                    onDeleteClick={() => initiateDeleteVC(vc.nameID)}
-                  />
+                  <>
+                    <BlockTitle>{t('pages.admin.space.settings.account.vc-section-title')}</BlockTitle>
+                    <ContributorOnAccountCard
+                      contributor={vc}
+                      space={bokSpaceData}
+                      hasDelete={canCreateVirtualContributor}
+                      onDeleteClick={() => initiateDeleteVC(vc.nameID)}
+                    />
+                  </>
                 ))}
               {canCreateVirtualContributor && (
-                <Button
-                  variant="outlined"
-                  startIcon={<ControlPointIcon />}
-                  onClick={openCreateVCDialog}
-                  disabled={disabledVirtualCreation}
-                >
-                  {t('pages.admin.space.settings.account.vc-create-button')}
-                </Button>
+                <>
+                  <Button
+                    variant="outlined"
+                    startIcon={<ControlPointIcon />}
+                    onClick={openCreateVCDialog}
+                    disabled={disabledVirtualCreation}
+                  >
+                    {t('pages.admin.space.settings.account.vc-create-button')}
+                  </Button>
+                  {noSubspaces && <Caption>{t('virtualContributorSpaceSettings.noSubspacesInfo')}</Caption>}
+                </>
               )}
             </Gutters>
           </PageContentBlock>


### PR DESCRIPTION
https://github.com/alkem-io/client-web/pull/6318
Besides the ACs from the story, the following changes were made.

- [x] The title of the list of VCs was conditionally shown if there is a list of VCs.
- [x] The VC create button is disabled if you don't have subspaces in the space. 
- [x] Feature flag check added - if Virtual Contributor on a Space is not enabled, the VC block in Account is hidden. 