### PR TITLE
External VCs button in Community Admin

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -1553,6 +1553,7 @@ export type MutationKeySpecifier = (
   | 'assignCommunityRoleToOrganization'
   | 'assignCommunityRoleToUser'
   | 'assignCommunityRoleToVirtual'
+  | 'assignLicensePlanToAccount'
   | 'assignOrganizationRoleToUser'
   | 'assignPlatformRoleToUser'
   | 'assignUserToGroup'
@@ -1646,6 +1647,7 @@ export type MutationKeySpecifier = (
   | 'resetChatGuidance'
   | 'revokeCredentialFromOrganization'
   | 'revokeCredentialFromUser'
+  | 'revokeLicensePlanFromAccount'
   | 'sendMessageReplyToRoom'
   | 'sendMessageToCommunityLeads'
   | 'sendMessageToOrganization'
@@ -1714,6 +1716,7 @@ export type MutationFieldPolicy = {
   assignCommunityRoleToOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   assignCommunityRoleToUser?: FieldPolicy<any> | FieldReadFunction<any>;
   assignCommunityRoleToVirtual?: FieldPolicy<any> | FieldReadFunction<any>;
+  assignLicensePlanToAccount?: FieldPolicy<any> | FieldReadFunction<any>;
   assignOrganizationRoleToUser?: FieldPolicy<any> | FieldReadFunction<any>;
   assignPlatformRoleToUser?: FieldPolicy<any> | FieldReadFunction<any>;
   assignUserToGroup?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1807,6 +1810,7 @@ export type MutationFieldPolicy = {
   resetChatGuidance?: FieldPolicy<any> | FieldReadFunction<any>;
   revokeCredentialFromOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   revokeCredentialFromUser?: FieldPolicy<any> | FieldReadFunction<any>;
+  revokeLicensePlanFromAccount?: FieldPolicy<any> | FieldReadFunction<any>;
   sendMessageReplyToRoom?: FieldPolicy<any> | FieldReadFunction<any>;
   sendMessageToCommunityLeads?: FieldPolicy<any> | FieldReadFunction<any>;
   sendMessageToOrganization?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -10561,6 +10561,12 @@ export const AvailableVirtualContributorsDocument = gql`
             ...VirtualContributorName
           }
         }
+        account {
+          id
+          virtualContributors {
+            ...VirtualContributorName
+          }
+        }
       }
     }
     virtualContributors @skip(if: $filterSpace) {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -732,6 +732,7 @@ export enum AuthorizationPrivilege {
   AccessVirtualContributor = 'ACCESS_VIRTUAL_CONTRIBUTOR',
   AuthorizationReset = 'AUTHORIZATION_RESET',
   CommunityAddMember = 'COMMUNITY_ADD_MEMBER',
+  CommunityAddMemberVcFromAccount = 'COMMUNITY_ADD_MEMBER_VC_FROM_ACCOUNT',
   CommunityApply = 'COMMUNITY_APPLY',
   CommunityInvite = 'COMMUNITY_INVITE',
   CommunityInviteAccept = 'COMMUNITY_INVITE_ACCEPT',

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -621,6 +621,15 @@ export type AssignCommunityRoleToVirtualInput = {
   virtualContributorID: Scalars['UUID_NAMEID'];
 };
 
+export type AssignLicensePlanToAccount = {
+  /** The ID of the Account to assign the LicensePlan to. */
+  accountID: Scalars['UUID'];
+  /** The ID of the LicensePlan to assign. */
+  licensePlanID: Scalars['UUID'];
+  /** The ID of the Licensing to use. */
+  licensingID?: InputMaybe<Scalars['UUID']>;
+};
+
 export type AssignOrganizationRoleToUserInput = {
   organizationID: Scalars['UUID_NAMEID'];
   role: OrganizationRole;
@@ -2711,6 +2720,8 @@ export type Mutation = {
   assignCommunityRoleToUser: User;
   /** Assigns a Virtual Contributor to a role in the specified Community. */
   assignCommunityRoleToVirtual: VirtualContributor;
+  /** Assign the specified LicensePlan to an Account. */
+  assignLicensePlanToAccount: Account;
   /** Assigns an Organization Role to user. */
   assignOrganizationRoleToUser: User;
   /** Assigns a platform role to a User. */
@@ -2897,6 +2908,8 @@ export type Mutation = {
   revokeCredentialFromOrganization: Organization;
   /** Removes an authorization credential from a User. */
   revokeCredentialFromUser: User;
+  /** Revokes the specified LicensePlan on an Account. */
+  revokeLicensePlanFromAccount: Account;
   /** Sends a reply to a message from the specified Room. */
   sendMessageReplyToRoom: Message;
   /** Send message to Community Leads. */
@@ -3041,6 +3054,10 @@ export type MutationAssignCommunityRoleToUserArgs = {
 
 export type MutationAssignCommunityRoleToVirtualArgs = {
   roleData: AssignCommunityRoleToVirtualInput;
+};
+
+export type MutationAssignLicensePlanToAccountArgs = {
+  planData: AssignLicensePlanToAccount;
 };
 
 export type MutationAssignOrganizationRoleToUserArgs = {
@@ -3389,6 +3406,10 @@ export type MutationRevokeCredentialFromOrganizationArgs = {
 
 export type MutationRevokeCredentialFromUserArgs = {
   revokeCredentialData: RevokeAuthorizationCredentialInput;
+};
+
+export type MutationRevokeLicensePlanFromAccountArgs = {
+  planData: RevokeLicensePlanFromAccount;
 };
 
 export type MutationSendMessageReplyToRoomArgs = {
@@ -4408,6 +4429,15 @@ export type RevokeAuthorizationCredentialInput = {
   userID: Scalars['UUID_NAMEID_EMAIL'];
 };
 
+export type RevokeLicensePlanFromAccount = {
+  /** The ID of the Account to assign the LicensePlan to. */
+  accountID: Scalars['UUID'];
+  /** The ID of the LicensePlan to assign. */
+  licensePlanID: Scalars['UUID'];
+  /** The ID of the Licensing to use. */
+  licensingID?: InputMaybe<Scalars['UUID']>;
+};
+
 export type RevokeOrganizationAuthorizationCredentialInput = {
   /** The Organization from whom the credential is being removed. */
   organizationID: Scalars['UUID'];
@@ -5159,6 +5189,7 @@ export type UpdateCalloutFramingInput = {
   /** The Profile of the Template. */
   profile?: InputMaybe<UpdateProfileInput>;
   whiteboard?: InputMaybe<UpdateWhiteboardInput>;
+  whiteboardContent?: InputMaybe<UpdateWhiteboardContentInput>;
 };
 
 export type UpdateCalloutInput = {
@@ -15000,6 +15031,16 @@ export type AvailableVirtualContributorsQuery = {
             __typename?: 'Community';
             id: string;
             virtualContributorsInRole: Array<{
+              __typename?: 'VirtualContributor';
+              id: string;
+              nameID: string;
+              profile: { __typename?: 'Profile'; id: string; displayName: string };
+            }>;
+          };
+          account: {
+            __typename?: 'Account';
+            id: string;
+            virtualContributors: Array<{
               __typename?: 'VirtualContributor';
               id: string;
               nameID: string;

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -574,7 +574,7 @@
         "title": "Remove Virtual Contributor",
         "confirm": "Are you sure?"
       },
-      "externalVCButton": "Add External VC",
+      "addExternalVC": "Add External VC",
       "externalVCsInfo": "At the moment, only Alkemio Support can add an external Virtual Contributor to your Space. Please contact Support <click>here</click> if you wish to do so, we are happy to help!"
     },
     "application-form": {

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -573,7 +573,9 @@
       "removeDialog": {
         "title": "Remove Virtual Contributor",
         "confirm": "Are you sure?"
-      }
+      },
+      "externalVCButton": "Add External VC",
+      "externalVCsInfo": "At the moment, only Alkemio Support can add an external Virtual Contributor to your Space. Please contact Support <click>here</click> if you wish to do so, we are happy to help!"
     },
     "application-form": {
       "title": "Application Form",

--- a/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
+++ b/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
@@ -115,14 +115,14 @@ const CommunityVirtualContributors: FC<CommunityVirtualContributorsProps> = ({
   const [deletingMemberId, setDeletingMemberId] = useState<string>();
   const [isAddingNewMember, setAddingNewMember] = useState(false);
   const [allVirtualContributors, setAllVirtualContributors] = useState(false);
-  const [supportMessegeOpen, setSupportMessegeOpen] = useState(false);
-  const closeSupportDialog = () => setSupportMessegeOpen(false);
+  const [supportMessageOpen, setSupportMessageOpen] = useState(false);
+  const closeSupportDialog = () => setSupportMessageOpen(false);
 
   const openAvailableContributorsDialog = (external: boolean = false) => {
     setAllVirtualContributors(external);
 
     if (external && !isPlatformAdmin) {
-      setSupportMessegeOpen(true);
+      setSupportMessageOpen(true);
     } else {
       setAddingNewMember(true);
     }
@@ -143,7 +143,7 @@ const CommunityVirtualContributors: FC<CommunityVirtualContributorsProps> = ({
               {t('common.add')}
             </Button>
             <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog(true)}>
-              {t('community.virtualContributors.externalVCButton')}
+              {t('community.virtualContributors.addExternalVC')}
             </Button>
           </Actions>
         )}
@@ -208,7 +208,7 @@ const CommunityVirtualContributors: FC<CommunityVirtualContributorsProps> = ({
           onClose={() => setAddingNewMember(false)}
         />
       )}
-      <DialogWithGrid open={supportMessegeOpen} columns={6} onClose={closeSupportDialog}>
+      <DialogWithGrid open={supportMessageOpen} columns={6} onClose={closeSupportDialog}>
         <DialogHeader onClose={closeSupportDialog}>{t('community.addMember')}</DialogHeader>
         <Gutters>
           <GridItem>

--- a/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
+++ b/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
@@ -208,7 +208,7 @@ const CommunityVirtualContributors: FC<CommunityVirtualContributorsProps> = ({
           onClose={() => setAddingNewMember(false)}
         />
       )}
-      <DialogWithGrid open={!supportMessegeOpen} columns={6} onClose={closeSupportDialog}>
+      <DialogWithGrid open={supportMessegeOpen} columns={6} onClose={closeSupportDialog}>
         <DialogHeader onClose={closeSupportDialog}>{t('community.addMember')}</DialogHeader>
         <Gutters>
           <GridItem>

--- a/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
+++ b/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
@@ -14,10 +14,18 @@ import { CommunityMemberVirtualContributorFragment } from '../../../../core/apol
 import { gutters } from '../../../../core/ui/grid/utils';
 import DataGridSkeleton from '../../../../core/ui/table/DataGridSkeleton';
 import DataGridTable from '../../../../core/ui/table/DataGridTable';
-import { BlockTitle } from '../../../../core/ui/typography';
-import CommunityAddMembersDialog, { CommunityAddMembersDialogProps } from './CommunityAddMembersDialog';
+import { BlockTitle, Caption } from '../../../../core/ui/typography';
+import CommunityAddMembersDialog from './CommunityAddMembersDialog';
 import { Remove } from '@mui/icons-material';
 import ConfirmationDialog from '../../../../core/ui/dialogs/ConfirmationDialog';
+import { Actions } from '../../../../core/ui/actions/Actions';
+import DialogWithGrid from '../../../../core/ui/dialog/DialogWithGrid';
+import DialogHeader from '../../../../core/ui/dialog/DialogHeader';
+import Gutters from '../../../../core/ui/grid/Gutters';
+import GridItem from '../../../../core/ui/grid/GridItem';
+import { Identifiable } from '../../../../core/utils/Identifiable';
+import { TranslateWithElements } from '../../../../domain/shared/i18n/TranslateWithElements';
+import { useConfig } from '../../../platform/config/useConfig';
 
 type RenderParams = GridRenderCellParams<string, CommunityMemberVirtualContributorFragment>;
 type GetterParams = GridValueGetterParams<string, CommunityMemberVirtualContributorFragment>;
@@ -39,12 +47,20 @@ const initialState: GridInitialState = {
   },
 };
 
+interface Entity extends Identifiable {
+  email?: string;
+  profile: {
+    displayName: string;
+  };
+}
+
 interface CommunityVirtualContributorsProps {
   virtualContributors: CommunityMemberVirtualContributorFragment[] | undefined;
   onRemoveMember: (memberId: string) => Promise<unknown> | void;
   canAddVirtualContributors: boolean;
   onAddMember: (memberId: string) => Promise<unknown> | undefined;
-  fetchAvailableVirtualContributors: CommunityAddMembersDialogProps['fetchAvailableEntities'];
+  fetchAvailableVirtualContributors: (filter?: string, all?: boolean) => Promise<Entity[] | undefined>;
+  isPlatformAdmin?: boolean;
   loading?: boolean;
 }
 
@@ -54,9 +70,11 @@ const CommunityVirtualContributors: FC<CommunityVirtualContributorsProps> = ({
   canAddVirtualContributors,
   onAddMember,
   fetchAvailableVirtualContributors,
+  isPlatformAdmin,
   loading,
 }) => {
   const { t } = useTranslation();
+  const { locations } = useConfig();
 
   const usersColumns: GridColDef[] = [
     {
@@ -96,15 +114,38 @@ const CommunityVirtualContributors: FC<CommunityVirtualContributorsProps> = ({
 
   const [deletingMemberId, setDeletingMemberId] = useState<string>();
   const [isAddingNewMember, setAddingNewMember] = useState(false);
+  const [allVirtualContributors, setAllVirtualContributors] = useState(false);
+  const [supportMessegeOpen, setSupportMessegeOpen] = useState(false);
+  const closeSupportDialog = () => setSupportMessegeOpen(false);
+
+  const openAvailableContributorsDialog = (external: boolean = false) => {
+    setAllVirtualContributors(external);
+
+    if (external && !isPlatformAdmin) {
+      setSupportMessegeOpen(true);
+    } else {
+      setAddingNewMember(true);
+    }
+  };
+
+  const getFilteredVirtualContributors = async (filter?: string) =>
+    fetchAvailableVirtualContributors(filter, allVirtualContributors);
+
+  const tTerms = TranslateWithElements(<Link target="_blank" />);
 
   return (
     <>
       <Box display="flex" justifyContent="space-between">
         <BlockTitle>{t('community.virtualContributors.blockTitle', { count: virtualContributors.length })}</BlockTitle>
         {canAddVirtualContributors && (
-          <Button variant="contained" startIcon={<AddIcon />} onClick={() => setAddingNewMember(true)}>
-            {t('common.add')}
-          </Button>
+          <Actions>
+            <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog()}>
+              {t('common.add')}
+            </Button>
+            <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog(true)}>
+              {t('community.virtualContributors.externalVCButton')}
+            </Button>
+          </Actions>
         )}
       </Box>
       <TextField
@@ -163,10 +204,24 @@ const CommunityVirtualContributors: FC<CommunityVirtualContributorsProps> = ({
       {isAddingNewMember && (
         <CommunityAddMembersDialog
           onAdd={onAddMember}
-          fetchAvailableEntities={fetchAvailableVirtualContributors}
+          fetchAvailableEntities={getFilteredVirtualContributors}
           onClose={() => setAddingNewMember(false)}
         />
       )}
+      <DialogWithGrid open={!supportMessegeOpen} columns={6} onClose={closeSupportDialog}>
+        <DialogHeader onClose={closeSupportDialog}>{t('community.addMember')}</DialogHeader>
+        <Gutters>
+          <GridItem>
+            <Caption>
+              {tTerms('community.virtualContributors.externalVCsInfo', {
+                click: {
+                  href: locations?.support,
+                },
+              })}
+            </Caption>
+          </GridItem>
+        </Gutters>
+      </DialogWithGrid>
     </>
   );
 };

--- a/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
+++ b/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
@@ -230,10 +230,10 @@ const useCommunityAdmin = ({
   };
 
   const [fetchAllVirtualContributors] = useAvailableVirtualContributorsLazyQuery();
-  const getAvailableVirtualContributors = async (filter: string | undefined) => {
+  const getAvailableVirtualContributors = async (filter: string | undefined, all: boolean = false) => {
     const { data } = await fetchAllVirtualContributors({
       variables: {
-        filterSpace: journeyLevel > 0,
+        filterSpace: journeyLevel > 0 && !all,
         filterSpaceId: spaceId,
       },
     });

--- a/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
+++ b/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
@@ -102,8 +102,10 @@ const useCommunityAdmin = ({
     canAddMembers: (data?.lookup.community?.authorization?.myPrivileges ?? []).some(
       priv => priv === AuthorizationPrivilege.CommunityAddMember
     ),
-    canAddVirtualContributors: (data?.lookup.community?.authorization?.myPrivileges ?? []).some(
-      priv => priv === AuthorizationPrivilege.CommunityAddMember // TODO: Change to CommunityAddVirtualContributor
+    // the following privilege allows Admins of a space without CommunityAddMember privilege, to
+    // be able to add VC from the account; CommunityAddMember overrides this privilege as it's not granted to PAs
+    canAddVirtualContributorsFromAccount: (data?.lookup.community?.authorization?.myPrivileges ?? []).some(
+      priv => priv === AuthorizationPrivilege.CommunityAddMemberVcFromAccount
     ),
   };
 

--- a/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
+++ b/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
@@ -60,8 +60,7 @@ interface useCommunityAdminParams {
   journeyLevel: JourneyLevel | -1;
 }
 
-interface VirtaulContributorNameProps extends Identifiable {
-  nameID: string;
+interface VirtualContributorNameProps extends Identifiable {
   profile: {
     id: string;
     displayName: string;
@@ -238,7 +237,7 @@ const useCommunityAdmin = ({
     );
   };
 
-  const filterByName = (vc: VirtaulContributorNameProps, filter?: string) =>
+  const filterByName = (vc: VirtualContributorNameProps, filter?: string) =>
     vc.profile.displayName.toLowerCase().includes(filter?.toLowerCase() ?? '');
 
   const [fetchAllVirtualContributors] = useAvailableVirtualContributorsLazyQuery();

--- a/src/domain/community/community/useCommunityAssignment/VirtualContributors.graphql
+++ b/src/domain/community/community/useCommunityAssignment/VirtualContributors.graphql
@@ -11,6 +11,12 @@ query AvailableVirtualContributors(
           ...VirtualContributorName
         }
       }
+      account {
+        id
+        virtualContributors {
+          ...VirtualContributorName
+        }
+      }
     }
   }
   virtualContributors @skip(if: $filterSpace) {

--- a/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
+++ b/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
@@ -11,9 +11,12 @@ import { useOpportunity } from '../hooks/useOpportunity';
 import SubspaceSettingsLayout from '../../../platform/admin/subspace/SubspaceSettingsLayout';
 import CommunityVirtualContributors from '../../../community/community/CommunityAdmin/CommunityVirtualContributors';
 import { useSpace } from '../../space/SpaceContext/useSpace';
+import { AuthorizationPrivilege } from '../../../../core/apollo/generated/graphql-schema';
+import { useUserContext } from '../../../community/user';
 
 const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' }) => {
   const { loading: isLoadingChallenge, communityId, opportunityId } = useOpportunity();
+  const { user: { hasPlatformPrivilege } = {} } = useUserContext();
 
   const { spaceId } = useSpace();
 
@@ -82,6 +85,7 @@ const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '.
                 canAddVirtualContributors={permissions.canAddVirtualContributors}
                 onAddMember={onAddVirtualContributor}
                 onRemoveMember={onRemoveVirtualContributor}
+                isPlatformAdmin={hasPlatformPrivilege?.(AuthorizationPrivilege.PlatformAdmin)}
                 fetchAvailableVirtualContributors={getAvailableVirtualContributors}
                 loading={loading}
               />

--- a/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
+++ b/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
@@ -82,7 +82,9 @@ const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '.
             <PageContentBlock>
               <CommunityVirtualContributors
                 virtualContributors={virtualContributors}
-                canAddVirtualContributors={permissions.canAddVirtualContributors}
+                canAddVirtualContributors={
+                  permissions.canAddVirtualContributorsFromAccount || permissions.canAddMembers
+                }
                 onAddMember={onAddVirtualContributor}
                 onRemoveMember={onRemoveVirtualContributor}
                 isPlatformAdmin={hasPlatformPrivilege?.(AuthorizationPrivilege.PlatformAdmin)}

--- a/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
+++ b/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
@@ -19,10 +19,13 @@ import { Trans, useTranslation } from 'react-i18next';
 import { gutters } from '../../../../core/ui/grid/utils';
 import CommunityGuidelines from '../../../community/community/CommunityGuidelines/CommunityGuidelines';
 import CommunityVirtualContributors from '../../../community/community/CommunityAdmin/CommunityVirtualContributors';
+import { useUserContext } from '../../../community/user';
+import { AuthorizationPrivilege } from '../../../../core/apollo/generated/graphql-schema';
 
 const AdminSpaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' }) => {
   const { t } = useTranslation();
   const { spaceId, loading: isLoadingSpace, communityId, profile: spaceProfile } = useSpace();
+  const { user: { hasPlatformPrivilege } = {} } = useUserContext();
 
   const {
     users,
@@ -151,6 +154,7 @@ const AdminSpaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' })
                 canAddVirtualContributors={permissions.canAddVirtualContributors}
                 onAddMember={onAddVirtualContributor}
                 onRemoveMember={onRemoveVirtualContributor}
+                isPlatformAdmin={hasPlatformPrivilege?.(AuthorizationPrivilege.PlatformAdmin)}
                 fetchAvailableVirtualContributors={getAvailableVirtualContributors}
                 loading={loading}
               />

--- a/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
+++ b/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
@@ -151,7 +151,9 @@ const AdminSpaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' })
             <PageContentBlock>
               <CommunityVirtualContributors
                 virtualContributors={virtualContributors}
-                canAddVirtualContributors={permissions.canAddVirtualContributors}
+                canAddVirtualContributors={
+                  permissions.canAddVirtualContributorsFromAccount || permissions.canAddMembers
+                }
                 onAddMember={onAddVirtualContributor}
                 onRemoveMember={onRemoveVirtualContributor}
                 isPlatformAdmin={hasPlatformPrivilege?.(AuthorizationPrivilege.PlatformAdmin)}

--- a/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
+++ b/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
@@ -150,7 +150,9 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
             <PageContentBlock>
               <CommunityVirtualContributors
                 virtualContributors={virtualContributors}
-                canAddVirtualContributors={permissions.canAddVirtualContributors}
+                canAddVirtualContributors={
+                  permissions.canAddVirtualContributorsFromAccount || permissions.canAddMembers
+                }
                 onAddMember={onAddVirtualContributor}
                 onRemoveMember={onRemoveVirtualContributor}
                 isPlatformAdmin={hasPlatformPrivilege?.(AuthorizationPrivilege.PlatformAdmin)}

--- a/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
+++ b/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
@@ -19,11 +19,14 @@ import PageContentBlockCollapsible from '../../../../core/ui/content/PageContent
 import { BlockTitle } from '../../../../core/ui/typography';
 import CommunityGuidelines from '../../../community/community/CommunityGuidelines/CommunityGuidelines';
 import { useSpace } from '../../space/SpaceContext/useSpace';
+import { AuthorizationPrivilege } from '../../../../core/apollo/generated/graphql-schema';
+import { useUserContext } from '../../../community/user';
 
 const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' }) => {
   const { t } = useTranslation();
   const { loading: isLoadingChallenge, communityId, subspaceId: challengeId, subspaceNameId } = useSubSpace();
   const { isPrivate, loading: isLoadingSpace } = useSpace();
+  const { user: { hasPlatformPrivilege } = {} } = useUserContext();
 
   const { spaceId, journeyLevel } = useRouteResolver();
 
@@ -150,6 +153,7 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
                 canAddVirtualContributors={permissions.canAddVirtualContributors}
                 onAddMember={onAddVirtualContributor}
                 onRemoveMember={onRemoveVirtualContributor}
+                isPlatformAdmin={hasPlatformPrivilege?.(AuthorizationPrivilege.PlatformAdmin)}
                 fetchAvailableVirtualContributors={getAvailableVirtualContributors}
                 loading={loading}
               />


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6307
https://github.com/alkem-io/client-web/issues/6311

- [x] Add External VCs button;
   - [x] Show all VCs for PLATFORM_ADMINS;
   - [x] Show text to contact support for non-PAs;  
- [x] Filter VCs on click on the existing Add button:


https://github.com/alkem-io/server/pull/4068
With this sever PR the following change was introduced in the client:
- [x] show **Add** VCs buttons if COMMUNITY_ADD_MEMBER_VC_FROM_ACCOUNT privilege is available;