### PR TITLE
Change Post icon and restore Call for posts icon

### DIFF
--- a/src/domain/collaboration/callout/utils/calloutIcons.ts
+++ b/src/domain/collaboration/callout/utils/calloutIcons.ts
@@ -1,13 +1,18 @@
 import { ComponentType } from 'react';
 import { SvgIconProps } from '@mui/material';
 import { CalloutType } from '../../../../core/apollo/generated/graphql-schema';
-import { FormatListBulletedOutlined, ForumOutlined, NotesOutlined, PhotoLibraryOutlined } from '@mui/icons-material';
+import {
+  FormatListBulletedOutlined,
+  ForumOutlined,
+  LibraryBooksOutlined,
+  PhotoLibraryOutlined,
+} from '@mui/icons-material';
 import { WhiteboardIcon } from '../../whiteboard/icon/WhiteboardIcon';
 
 const calloutIcons: Record<CalloutType, ComponentType<SvgIconProps>> = {
-  [CalloutType.PostCollection]: ForumOutlined,
+  [CalloutType.PostCollection]: LibraryBooksOutlined,
   [CalloutType.WhiteboardCollection]: PhotoLibraryOutlined,
-  [CalloutType.Post]: NotesOutlined,
+  [CalloutType.Post]: ForumOutlined,
   [CalloutType.LinkCollection]: FormatListBulletedOutlined,
   [CalloutType.Whiteboard]: WhiteboardIcon,
 } as const;


### PR DESCRIPTION
Restoring changed in previous PR call for posts icon and changing the correct one - for posts. 