### PR TITLE
Add Community Guidelines to subspaces

### DIFF
--- a/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
+++ b/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
@@ -51,6 +51,7 @@ export interface JourneyAboutDialogProps extends EntityDashboardLeads {
   background: string | undefined;
   who: string | undefined;
   impact: string | undefined;
+  guidelines?: ReactNode;
   loading?: boolean;
   leftColumnChildrenTop?: ReactNode;
   leftColumnChildrenBottom?: ReactNode;
@@ -96,6 +97,7 @@ const JourneyAboutDialog = ({
   background,
   who,
   impact,
+  guidelines,
   loading = false,
   startButton,
   endButton,
@@ -209,6 +211,7 @@ const JourneyAboutDialog = ({
                 <WrapperMarkdown>{who}</WrapperMarkdown>
               </PageContentBlock>
             )}
+            {guidelines}
           </PageContentColumn>
           <PageContentColumn columns={4}>
             <PageContentBlockSeamless disablePadding order={1}>

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
@@ -86,6 +86,12 @@ const SpaceDashboardPage: FC<SpaceDashboardPageProps> = ({ dialog }) => {
               background={entities.space?.profile.description}
               who={entities.space?.context?.who}
               impact={entities.space?.context?.impact}
+              guidelines={
+                <CommunityGuidelinesBlock
+                  communityId={entities.space?.community?.id}
+                  journeyUrl={entities.space?.profile.url}
+                />
+              }
               loading={state.loading}
               leadUsers={entities.space?.community?.leadUsers}
               host={entities.host}
@@ -96,12 +102,6 @@ const SpaceDashboardPage: FC<SpaceDashboardPageProps> = ({ dialog }) => {
                 </IconButton>
               }
               shareUrl={buildAboutUrl(entities.space?.profile.url)}
-              leftColumnChildrenTop={
-                <CommunityGuidelinesBlock
-                  communityId={entities.space?.community?.id}
-                  journeyUrl={entities.space?.profile.url}
-                />
-              }
             />
           </>
         )}

--- a/src/domain/journey/subspace/pages/SubspaceAboutPage.tsx
+++ b/src/domain/journey/subspace/pages/SubspaceAboutPage.tsx
@@ -13,6 +13,7 @@ import SeeMore from '../../../../core/ui/content/SeeMore';
 import { useTranslation } from 'react-i18next';
 import { buildAboutUrl } from '../../../../main/routing/urlBuilders';
 import { useRouteResolver } from '../../../../main/routing/resolvers/RouteResolver';
+import CommunityGuidelinesBlock from '../../../community/community/CommunityGuidelines/CommunityGuidelinesBlock';
 
 const SubspaceAboutPage: FC = () => {
   const { communityId, profile } = useSubSpace();
@@ -57,6 +58,7 @@ const SubspaceAboutPage: FC = () => {
             background={profile?.description}
             who={context?.who}
             impact={context?.impact}
+            guidelines={<CommunityGuidelinesBlock communityId={communityId} journeyUrl={profile.url} />}
             loading={state.loading}
             leadUsers={leadUsers}
             host={host}


### PR DESCRIPTION
-  Show community guidelines in subspace about dialog on the right side, below all other blocks
-  Do the same for the space about dialog (move to the right, currently on the left)