### PR TITLE
updated to work with community invitations for multiple types managed by the user

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -502,27 +502,6 @@ export type ApplicationFieldPolicy = {
   questions?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ApplicationForRoleResultKeySpecifier = (
-  | 'communityID'
-  | 'createdDate'
-  | 'displayName'
-  | 'id'
-  | 'spaceID'
-  | 'spaceLevel'
-  | 'state'
-  | 'updatedDate'
-  | ApplicationForRoleResultKeySpecifier
-)[];
-export type ApplicationForRoleResultFieldPolicy = {
-  communityID?: FieldPolicy<any> | FieldReadFunction<any>;
-  createdDate?: FieldPolicy<any> | FieldReadFunction<any>;
-  displayName?: FieldPolicy<any> | FieldReadFunction<any>;
-  id?: FieldPolicy<any> | FieldReadFunction<any>;
-  spaceID?: FieldPolicy<any> | FieldReadFunction<any>;
-  spaceLevel?: FieldPolicy<any> | FieldReadFunction<any>;
-  state?: FieldPolicy<any> | FieldReadFunction<any>;
-  updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
-};
 export type AuthenticationConfigKeySpecifier = ('providers' | AuthenticationConfigKeySpecifier)[];
 export type AuthenticationConfigFieldPolicy = {
   providers?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -900,6 +879,27 @@ export type CommunityFieldPolicy = {
   usersInRole?: FieldPolicy<any> | FieldReadFunction<any>;
   virtualContributorsInRole?: FieldPolicy<any> | FieldReadFunction<any>;
 };
+export type CommunityApplicationForRoleResultKeySpecifier = (
+  | 'communityID'
+  | 'createdDate'
+  | 'displayName'
+  | 'id'
+  | 'spaceID'
+  | 'spaceLevel'
+  | 'state'
+  | 'updatedDate'
+  | CommunityApplicationForRoleResultKeySpecifier
+)[];
+export type CommunityApplicationForRoleResultFieldPolicy = {
+  communityID?: FieldPolicy<any> | FieldReadFunction<any>;
+  createdDate?: FieldPolicy<any> | FieldReadFunction<any>;
+  displayName?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  spaceID?: FieldPolicy<any> | FieldReadFunction<any>;
+  spaceLevel?: FieldPolicy<any> | FieldReadFunction<any>;
+  state?: FieldPolicy<any> | FieldReadFunction<any>;
+  updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
+};
 export type CommunityGuidelinesKeySpecifier = ('authorization' | 'id' | 'profile' | CommunityGuidelinesKeySpecifier)[];
 export type CommunityGuidelinesFieldPolicy = {
   authorization?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -918,6 +918,35 @@ export type CommunityGuidelinesTemplateFieldPolicy = {
   guidelines?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   profile?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type CommunityInvitationForRoleResultKeySpecifier = (
+  | 'communityID'
+  | 'contributorID'
+  | 'contributorType'
+  | 'createdBy'
+  | 'createdDate'
+  | 'displayName'
+  | 'id'
+  | 'spaceID'
+  | 'spaceLevel'
+  | 'state'
+  | 'updatedDate'
+  | 'welcomeMessage'
+  | CommunityInvitationForRoleResultKeySpecifier
+)[];
+export type CommunityInvitationForRoleResultFieldPolicy = {
+  communityID?: FieldPolicy<any> | FieldReadFunction<any>;
+  contributorID?: FieldPolicy<any> | FieldReadFunction<any>;
+  contributorType?: FieldPolicy<any> | FieldReadFunction<any>;
+  createdBy?: FieldPolicy<any> | FieldReadFunction<any>;
+  createdDate?: FieldPolicy<any> | FieldReadFunction<any>;
+  displayName?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  spaceID?: FieldPolicy<any> | FieldReadFunction<any>;
+  spaceLevel?: FieldPolicy<any> | FieldReadFunction<any>;
+  state?: FieldPolicy<any> | FieldReadFunction<any>;
+  updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
+  welcomeMessage?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CommunityPolicyKeySpecifier = ('admin' | 'id' | 'lead' | 'member' | CommunityPolicyKeySpecifier)[];
 export type CommunityPolicyFieldPolicy = {
@@ -1276,31 +1305,6 @@ export type InvitationExternalFieldPolicy = {
   profileCreated?: FieldPolicy<any> | FieldReadFunction<any>;
   welcomeMessage?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type InvitationForRoleResultKeySpecifier = (
-  | 'communityID'
-  | 'createdBy'
-  | 'createdDate'
-  | 'displayName'
-  | 'id'
-  | 'spaceID'
-  | 'spaceLevel'
-  | 'state'
-  | 'updatedDate'
-  | 'welcomeMessage'
-  | InvitationForRoleResultKeySpecifier
-)[];
-export type InvitationForRoleResultFieldPolicy = {
-  communityID?: FieldPolicy<any> | FieldReadFunction<any>;
-  createdBy?: FieldPolicy<any> | FieldReadFunction<any>;
-  createdDate?: FieldPolicy<any> | FieldReadFunction<any>;
-  displayName?: FieldPolicy<any> | FieldReadFunction<any>;
-  id?: FieldPolicy<any> | FieldReadFunction<any>;
-  spaceID?: FieldPolicy<any> | FieldReadFunction<any>;
-  spaceLevel?: FieldPolicy<any> | FieldReadFunction<any>;
-  state?: FieldPolicy<any> | FieldReadFunction<any>;
-  updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
-  welcomeMessage?: FieldPolicy<any> | FieldReadFunction<any>;
-};
 export type LatestReleaseDiscussionKeySpecifier = ('id' | 'nameID' | LatestReleaseDiscussionKeySpecifier)[];
 export type LatestReleaseDiscussionFieldPolicy = {
   id?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1493,20 +1497,20 @@ export type LookupQueryResultsFieldPolicy = {
   whiteboardTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type MeQueryResultsKeySpecifier = (
-  | 'applications'
   | 'canCreateFreeSpace'
+  | 'communityApplications'
+  | 'communityInvitations'
   | 'id'
-  | 'invitations'
   | 'mySpaces'
   | 'spaceMemberships'
   | 'user'
   | MeQueryResultsKeySpecifier
 )[];
 export type MeQueryResultsFieldPolicy = {
-  applications?: FieldPolicy<any> | FieldReadFunction<any>;
   canCreateFreeSpace?: FieldPolicy<any> | FieldReadFunction<any>;
+  communityApplications?: FieldPolicy<any> | FieldReadFunction<any>;
+  communityInvitations?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
-  invitations?: FieldPolicy<any> | FieldReadFunction<any>;
   mySpaces?: FieldPolicy<any> | FieldReadFunction<any>;
   spaceMemberships?: FieldPolicy<any> | FieldReadFunction<any>;
   user?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -3157,10 +3161,6 @@ export type StrictTypedTypePolicies = {
     keyFields?: false | ApplicationKeySpecifier | (() => undefined | ApplicationKeySpecifier);
     fields?: ApplicationFieldPolicy;
   };
-  ApplicationForRoleResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
-    keyFields?: false | ApplicationForRoleResultKeySpecifier | (() => undefined | ApplicationForRoleResultKeySpecifier);
-    fields?: ApplicationForRoleResultFieldPolicy;
-  };
   AuthenticationConfig?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | AuthenticationConfigKeySpecifier | (() => undefined | AuthenticationConfigKeySpecifier);
     fields?: AuthenticationConfigFieldPolicy;
@@ -3291,6 +3291,13 @@ export type StrictTypedTypePolicies = {
     keyFields?: false | CommunityKeySpecifier | (() => undefined | CommunityKeySpecifier);
     fields?: CommunityFieldPolicy;
   };
+  CommunityApplicationForRoleResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CommunityApplicationForRoleResultKeySpecifier
+      | (() => undefined | CommunityApplicationForRoleResultKeySpecifier);
+    fields?: CommunityApplicationForRoleResultFieldPolicy;
+  };
   CommunityGuidelines?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | CommunityGuidelinesKeySpecifier | (() => undefined | CommunityGuidelinesKeySpecifier);
     fields?: CommunityGuidelinesFieldPolicy;
@@ -3301,6 +3308,13 @@ export type StrictTypedTypePolicies = {
       | CommunityGuidelinesTemplateKeySpecifier
       | (() => undefined | CommunityGuidelinesTemplateKeySpecifier);
     fields?: CommunityGuidelinesTemplateFieldPolicy;
+  };
+  CommunityInvitationForRoleResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CommunityInvitationForRoleResultKeySpecifier
+      | (() => undefined | CommunityInvitationForRoleResultKeySpecifier);
+    fields?: CommunityInvitationForRoleResultFieldPolicy;
   };
   CommunityPolicy?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | CommunityPolicyKeySpecifier | (() => undefined | CommunityPolicyKeySpecifier);
@@ -3405,10 +3419,6 @@ export type StrictTypedTypePolicies = {
   InvitationExternal?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | InvitationExternalKeySpecifier | (() => undefined | InvitationExternalKeySpecifier);
     fields?: InvitationExternalFieldPolicy;
-  };
-  InvitationForRoleResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
-    keyFields?: false | InvitationForRoleResultKeySpecifier | (() => undefined | InvitationForRoleResultKeySpecifier);
-    fields?: InvitationForRoleResultFieldPolicy;
   };
   LatestReleaseDiscussion?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | LatestReleaseDiscussionKeySpecifier | (() => undefined | LatestReleaseDiscussionKeySpecifier);

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -14263,7 +14263,7 @@ export const UserProviderDocument = gql`
         ...UserDetails
         ...UserAgent
       }
-      applications(states: ["new"]) {
+      communityApplications(states: ["new"]) {
         id
         communityID
         displayName
@@ -14271,7 +14271,7 @@ export const UserProviderDocument = gql`
         spaceID
         spaceLevel
       }
-      invitations(states: ["invited"]) {
+      communityInvitations(states: ["invited"]) {
         id
         spaceID
         spaceLevel
@@ -23058,7 +23058,7 @@ export function refetchMyMembershipsSubspaceQuery(variables: SchemaTypes.MyMembe
 export const NewMembershipsDocument = gql`
   query NewMemberships {
     me {
-      applications(states: ["new", "approved"]) {
+      communityApplications(states: ["new", "approved"]) {
         id
         communityID
         displayName
@@ -23067,9 +23067,11 @@ export const NewMembershipsDocument = gql`
         spaceLevel
         createdDate
       }
-      invitations(states: ["invited", "accepted"]) {
+      communityInvitations(states: ["invited", "accepted"]) {
         id
         spaceID
+        contributorID
+        contributorType
         spaceLevel
         state
         welcomeMessage

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -577,26 +577,6 @@ export type ApplicationEventInput = {
   eventName: Scalars['String'];
 };
 
-export type ApplicationForRoleResult = {
-  __typename?: 'ApplicationForRoleResult';
-  /** ID for the community */
-  communityID: Scalars['UUID'];
-  /** Date of creation */
-  createdDate: Scalars['DateTime'];
-  /** Display name of the community */
-  displayName: Scalars['String'];
-  /** ID for the application */
-  id: Scalars['UUID'];
-  /** ID for the ultimate containing Space */
-  spaceID: Scalars['UUID'];
-  /** Nesting level of the Space */
-  spaceLevel: Scalars['Float'];
-  /** The current state of the application. */
-  state: Scalars['String'];
-  /** Date of last update */
-  updatedDate: Scalars['DateTime'];
-};
-
 export type AssignCommunityRoleToOrganizationInput = {
   communityID: Scalars['UUID'];
   organizationID: Scalars['UUID_NAMEID'];
@@ -1252,6 +1232,26 @@ export type CommunityVirtualContributorsInRoleArgs = {
   role: CommunityRole;
 };
 
+export type CommunityApplicationForRoleResult = {
+  __typename?: 'CommunityApplicationForRoleResult';
+  /** ID for the community */
+  communityID: Scalars['UUID'];
+  /** Date of creation */
+  createdDate: Scalars['DateTime'];
+  /** Display name of the community */
+  displayName: Scalars['String'];
+  /** ID for the application */
+  id: Scalars['UUID'];
+  /** ID for the ultimate containing Space */
+  spaceID: Scalars['UUID'];
+  /** Nesting level of the Space */
+  spaceLevel: Scalars['Float'];
+  /** The current state of the application. */
+  state: Scalars['String'];
+  /** Date of last update */
+  updatedDate: Scalars['DateTime'];
+};
+
 export type CommunityApplyInput = {
   communityID: Scalars['UUID'];
   questions: Array<CreateNvpInput>;
@@ -1283,6 +1283,34 @@ export type CommunityGuidelinesTemplate = {
   id: Scalars['UUID'];
   /** The Profile for this template. */
   profile: Profile;
+};
+
+export type CommunityInvitationForRoleResult = {
+  __typename?: 'CommunityInvitationForRoleResult';
+  /** ID for the community */
+  communityID: Scalars['UUID'];
+  /** ID for Contrbutor that is being invited to a community */
+  contributorID: Scalars['UUID'];
+  /** The Type of the Contrbutor that is being invited to a community */
+  contributorType: CommunityContributorType;
+  /** ID for the user that created the invitation. */
+  createdBy: Scalars['UUID'];
+  /** Date of creation */
+  createdDate: Scalars['DateTime'];
+  /** Display name of the community */
+  displayName: Scalars['String'];
+  /** ID for the Invitation */
+  id: Scalars['UUID'];
+  /** ID for the ultimate containing Space */
+  spaceID: Scalars['UUID'];
+  /** Nesting level of the Space */
+  spaceLevel: Scalars['Float'];
+  /** The current state of the invitation. */
+  state: Scalars['String'];
+  /** Date of last update */
+  updatedDate: Scalars['DateTime'];
+  /** The welcome message of the invitation */
+  welcomeMessage?: Maybe<Scalars['UUID']>;
 };
 
 export type CommunityJoinInput = {
@@ -1401,10 +1429,10 @@ export type ContributorFilterInput = {
 export type ContributorRoles = {
   __typename?: 'ContributorRoles';
   /** The applications for the specified user; only accessible for platform admins */
-  applications: Array<ApplicationForRoleResult>;
+  applications: Array<CommunityApplicationForRoleResult>;
   id: Scalars['UUID'];
   /** The invitations for the specified user; only accessible for platform admins */
-  invitations: Array<InvitationForRoleResult>;
+  invitations: Array<CommunityInvitationForRoleResult>;
   /** Details of the roles the contributor has in Organizations */
   organizations: Array<RolesResultOrganization>;
   /** Details of Spaces the User or Organization is a member of, with child memberships - if Space is accessible for the current user. */
@@ -2278,30 +2306,6 @@ export type InvitationExternal = {
   welcomeMessage?: Maybe<Scalars['String']>;
 };
 
-export type InvitationForRoleResult = {
-  __typename?: 'InvitationForRoleResult';
-  /** ID for the community */
-  communityID: Scalars['UUID'];
-  /** ID for the user that created the invitation. */
-  createdBy: Scalars['UUID'];
-  /** Date of creation */
-  createdDate: Scalars['DateTime'];
-  /** Display name of the community */
-  displayName: Scalars['String'];
-  /** ID for the application */
-  id: Scalars['UUID'];
-  /** ID for the ultimate containing Space */
-  spaceID: Scalars['UUID'];
-  /** Nesting level of the Space */
-  spaceLevel: Scalars['Float'];
-  /** The current state of the invitation. */
-  state: Scalars['String'];
-  /** Date of last update */
-  updatedDate: Scalars['DateTime'];
-  /** The welcome message of the invitation */
-  welcomeMessage?: Maybe<Scalars['UUID']>;
-};
-
 export type LatestReleaseDiscussion = {
   __typename?: 'LatestReleaseDiscussion';
   /** Id of the latest release discussion. */
@@ -2613,14 +2617,14 @@ export type LookupQueryResultsWhiteboardTemplateArgs = {
 
 export type MeQueryResults = {
   __typename?: 'MeQueryResults';
-  /** The applications of the current authenticated user */
-  applications: Array<ApplicationForRoleResult>;
   /** Can I create a free space? */
   canCreateFreeSpace: Scalars['Boolean'];
+  /** The community applicationscurrent authenticated user can act on. */
+  communityApplications: Array<CommunityApplicationForRoleResult>;
+  /** The invitations the current authenticated user can act on. */
+  communityInvitations: Array<CommunityInvitationForRoleResult>;
   /** The query id */
   id: Scalars['String'];
-  /** The invitations of the current authenticated user */
-  invitations: Array<InvitationForRoleResult>;
   /** The Spaces I am contributing to */
   mySpaces: Array<MySpaceResults>;
   /** The applications of the current authenticated user */
@@ -2629,11 +2633,11 @@ export type MeQueryResults = {
   user?: Maybe<User>;
 };
 
-export type MeQueryResultsApplicationsArgs = {
+export type MeQueryResultsCommunityApplicationsArgs = {
   states?: InputMaybe<Array<Scalars['String']>>;
 };
 
-export type MeQueryResultsInvitationsArgs = {
+export type MeQueryResultsCommunityInvitationsArgs = {
   states?: InputMaybe<Array<Scalars['String']>>;
 };
 
@@ -17983,8 +17987,8 @@ export type UserProviderQuery = {
           };
         }
       | undefined;
-    applications: Array<{
-      __typename?: 'ApplicationForRoleResult';
+    communityApplications: Array<{
+      __typename?: 'CommunityApplicationForRoleResult';
       id: string;
       communityID: string;
       displayName: string;
@@ -17992,8 +17996,8 @@ export type UserProviderQuery = {
       spaceID: string;
       spaceLevel: number;
     }>;
-    invitations: Array<{
-      __typename?: 'InvitationForRoleResult';
+    communityInvitations: Array<{
+      __typename?: 'CommunityInvitationForRoleResult';
       id: string;
       spaceID: string;
       spaceLevel: number;
@@ -29286,8 +29290,8 @@ export type NewMembershipsQuery = {
   __typename?: 'Query';
   me: {
     __typename?: 'MeQueryResults';
-    applications: Array<{
-      __typename?: 'ApplicationForRoleResult';
+    communityApplications: Array<{
+      __typename?: 'CommunityApplicationForRoleResult';
       id: string;
       communityID: string;
       displayName: string;
@@ -29296,10 +29300,12 @@ export type NewMembershipsQuery = {
       spaceLevel: number;
       createdDate: Date;
     }>;
-    invitations: Array<{
-      __typename?: 'InvitationForRoleResult';
+    communityInvitations: Array<{
+      __typename?: 'CommunityInvitationForRoleResult';
       id: string;
       spaceID: string;
+      contributorID: string;
+      contributorType: CommunityContributorType;
       spaceLevel: number;
       state: string;
       welcomeMessage?: string | undefined;

--- a/src/domain/community/pendingMembership/PendingMemberships.graphql
+++ b/src/domain/community/pendingMembership/PendingMemberships.graphql
@@ -65,6 +65,7 @@ fragment PendingMembershipInvitation on Invitation {
     profile {
       id
       displayName
+
     }
   }
 }

--- a/src/domain/community/pendingMembership/PendingMemberships.graphql
+++ b/src/domain/community/pendingMembership/PendingMemberships.graphql
@@ -65,7 +65,6 @@ fragment PendingMembershipInvitation on Invitation {
     profile {
       id
       displayName
-
     }
   }
 }

--- a/src/domain/community/user/hooks/useUserMetadataWrapper.ts
+++ b/src/domain/community/user/hooks/useUserMetadataWrapper.ts
@@ -1,8 +1,8 @@
 import { KEYWORDS_TAGSET, SKILLS_TAGSET } from '../../../common/tags/tagset.constants';
 import {
-  ApplicationForRoleResult,
+  CommunityApplicationForRoleResult,
   AuthorizationPrivilege,
-  InvitationForRoleResult,
+  CommunityInvitationForRoleResult,
   MyPrivilegesFragment,
   UserDetailsFragment,
 } from '../../../../core/apollo/generated/graphql-schema';
@@ -22,7 +22,7 @@ export interface UserMetadata {
   pendingInvitations: InvitationItem[];
 }
 
-export const getPendingApplications = (applicationsData: ApplicationForRoleResult[]) => {
+export const getPendingApplications = (applicationsData: CommunityApplicationForRoleResult[]) => {
   return (
     applicationsData.map<PendingApplication>(application => ({
       ...application,
@@ -31,7 +31,7 @@ export const getPendingApplications = (applicationsData: ApplicationForRoleResul
   );
 };
 
-const getPendingInvitations = (invitationsData: InvitationForRoleResult[]) => {
+const getPendingInvitations = (invitationsData: CommunityInvitationForRoleResult[]) => {
   return (
     invitationsData.map<InvitationItem>(invitation => ({
       ...invitation,
@@ -42,8 +42,8 @@ const getPendingInvitations = (invitationsData: InvitationForRoleResult[]) => {
 
 export const toUserMetadata = (
   user: UserDetailsFragment | undefined,
-  applications: ApplicationForRoleResult[],
-  invitations: InvitationForRoleResult[],
+  applications: CommunityApplicationForRoleResult[],
+  invitations: CommunityInvitationForRoleResult[],
   platformLevelAuthorization: MyPrivilegesFragment | undefined
 ): UserMetadata | undefined => {
   if (!user) {

--- a/src/domain/community/user/providers/UserProvider/UserProvider.graphql
+++ b/src/domain/community/user/providers/UserProvider/UserProvider.graphql
@@ -4,7 +4,7 @@ query UserProvider {
       ...UserDetails
       ...UserAgent
     }
-    applications(states: ["new"]) {
+    communityApplications(states: ["new"]) {
       id
       communityID
       displayName
@@ -12,7 +12,7 @@ query UserProvider {
       spaceID
       spaceLevel
     }
-    invitations(states: ["invited"]) {
+    communityInvitations(states: ["invited"]) {
       id
       spaceID
       spaceLevel

--- a/src/domain/community/user/providers/UserProvider/UserProvider.tsx
+++ b/src/domain/community/user/providers/UserProvider/UserProvider.tsx
@@ -7,8 +7,8 @@ import {
 } from '../../../../../core/apollo/generated/apollo-hooks';
 import { ErrorPage } from '../../../../../core/pages/Errors/ErrorPage';
 import {
-  ApplicationForRoleResult,
-  InvitationForRoleResult,
+  CommunityApplicationForRoleResult,
+  CommunityInvitationForRoleResult,
   User,
 } from '../../../../../core/apollo/generated/graphql-schema';
 import { useAuthenticationContext } from '../../../../../core/auth/authentication/hooks/useAuthenticationContext';
@@ -67,8 +67,8 @@ const UserProvider: FC<{}> = ({ children }) => {
       meData?.me
         ? toUserMetadata(
             meData.me.user as User,
-            meData.me.applications as ApplicationForRoleResult[],
-            meData.me.invitations as InvitationForRoleResult[],
+            meData.me.communityApplications as CommunityApplicationForRoleResult[],
+            meData.me.communityInvitations as CommunityInvitationForRoleResult[],
             platformLevelAuthorization
           )
         : undefined,

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
@@ -1,6 +1,6 @@
 query NewMemberships {
   me {
-    applications(states: ["new", "approved"]) {
+    communityApplications(states: ["new", "approved"]) {
       id
       communityID
       displayName
@@ -9,9 +9,11 @@ query NewMemberships {
       spaceLevel
       createdDate
     }
-    invitations(states: ["invited", "accepted"]) {
+    communityInvitations(states: ["invited", "accepted"]) {
       id
       spaceID
+      contributorID
+      contributorType
       spaceLevel
       state
       welcomeMessage

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
@@ -76,9 +76,9 @@ const NewMembershipsBlock = ({
 
   const { data, refetch: refetchNewMembershipsQuery } = useNewMembershipsQuery();
 
-  const invitations = useMemo(
+  const communityInvitations = useMemo(
     () =>
-      data?.me.invitations.map(
+      data?.me.communityInvitations.map(
         invitation =>
           ({
             type: PendingMembershipItemType.Invitation,
@@ -86,21 +86,21 @@ const NewMembershipsBlock = ({
             spaceLevel: invitation.spaceLevel as JourneyLevel,
           } as const)
       ) ?? [],
-    [data?.me.invitations]
+    [data?.me.communityInvitations]
   );
 
-  const pendingInvitations = useMemo(
+  const pendingCommunityInvitations = useMemo(
     () =>
       sortBy(
-        invitations.filter(invitation => !RECENT_MEMBERSHIP_STATES.includes(invitation.state)),
+        communityInvitations.filter(invitation => !RECENT_MEMBERSHIP_STATES.includes(invitation.state)),
         ({ createdDate }) => createdDate
       ).reverse(),
-    [invitations]
+    [communityInvitations]
   );
 
-  const applications = useMemo(
+  const communityApplications = useMemo(
     () =>
-      data?.me.applications.map(
+      data?.me.communityApplications.map(
         application =>
           ({
             type: PendingMembershipItemType.Application,
@@ -108,30 +108,34 @@ const NewMembershipsBlock = ({
             spaceLevel: application.spaceLevel as JourneyLevel,
           } as const)
       ) ?? [],
-    [data?.me.applications]
+    [data?.me.communityApplications]
   );
 
-  const pendingApplications = applications.filter(invitation => !RECENT_MEMBERSHIP_STATES.includes(invitation.state));
+  const pendingCommunityApplications = communityApplications.filter(
+    invitation => !RECENT_MEMBERSHIP_STATES.includes(invitation.state)
+  );
 
   const recentPendingApplications = useMemo(
     () =>
-      sortBy(pendingApplications, ({ createdDate }) => createdDate)
+      sortBy(pendingCommunityApplications, ({ createdDate }) => createdDate)
         .reverse()
-        .slice(0, Math.max(0, PENDING_MEMBERSHIPS_MAX_ITEMS - pendingInvitations.length)),
-    [applications]
+        .slice(0, Math.max(0, PENDING_MEMBERSHIPS_MAX_ITEMS - pendingCommunityInvitations.length)),
+    [communityApplications]
   );
 
-  const pendingMembershipsCount = pendingInvitations.length + recentPendingApplications.length;
+  const pendingMembershipsCount = pendingCommunityInvitations.length + recentPendingApplications.length;
 
   const recentMemberships = useMemo(
     () =>
       sortBy(
-        [...invitations, ...applications].filter(({ state }) => RECENT_MEMBERSHIP_STATES.includes(state)),
+        [...communityInvitations, ...communityApplications].filter(({ state }) =>
+          RECENT_MEMBERSHIP_STATES.includes(state)
+        ),
         ({ createdDate }) => createdDate
       )
         .reverse()
         .slice(0, Math.max(0, PENDING_MEMBERSHIPS_MAX_ITEMS - pendingMembershipsCount - 1)),
-    [invitations, applications]
+    [communityInvitations, communityApplications]
   );
 
   const mySpaces = data?.me.mySpaces ?? [];
@@ -151,7 +155,7 @@ const NewMembershipsBlock = ({
 
   const currentInvitation =
     openDialog?.type === DialogType.InvitationView
-      ? invitations?.find(invitation => invitation.id === openDialog.invitationId)
+      ? communityInvitations?.find(invitation => invitation.id === openDialog.invitationId)
       : undefined;
 
   const handleInvitationDialogClose = () => {
@@ -186,7 +190,7 @@ const NewMembershipsBlock = ({
       <PageContentBlock halfWidth={halfWidth} disableGap flex>
         <PageContentBlockHeader title={t('pages.home.sections.newMemberships.title')} />
 
-        {pendingInvitations.length === 0 && recentPendingApplications.length === 0 && (
+        {pendingCommunityInvitations.length === 0 && recentPendingApplications.length === 0 && (
           <CaptionSmall color={theme => theme.palette.neutral.light} marginBottom={gutters(0.5)}>
             {t('pages.home.sections.newMemberships.noOpenInvitations')}
           </CaptionSmall>
@@ -196,11 +200,11 @@ const NewMembershipsBlock = ({
           title={
             <>
               {t('pages.home.sections.newMemberships.openInvitations')}
-              <BadgeCounter count={pendingInvitations.length} size="small" />
+              <BadgeCounter count={pendingCommunityInvitations.length} size="small" />
             </>
           }
         >
-          {pendingInvitations.slice(0, PENDING_MEMBERSHIPS_MAX_ITEMS).map(pendingInvitation => (
+          {pendingCommunityInvitations.slice(0, PENDING_MEMBERSHIPS_MAX_ITEMS).map(pendingInvitation => (
             <InvitationHydrator
               key={pendingInvitation.id}
               invitation={pendingInvitation}
@@ -322,13 +326,13 @@ const NewMembershipsBlock = ({
           onClose={closeDialog}
         />
         <Gutters paddingTop={0}>
-          {pendingInvitations && pendingInvitations.length > 0 && (
+          {pendingCommunityInvitations && pendingCommunityInvitations.length > 0 && (
             <>
               <BlockSectionTitle>
                 {t('community.pendingMembership.invitationsSectionTitle')}
-                <BadgeCounter count={pendingInvitations.length} size="small" />
+                <BadgeCounter count={pendingCommunityInvitations.length} size="small" />
               </BlockSectionTitle>
-              {pendingInvitations?.map(invitation => (
+              {pendingCommunityInvitations?.map(invitation => (
                 <InvitationHydrator key={invitation.id} invitation={invitation}>
                   {({ invitation }) => (
                     <InvitationCardHorizontal
@@ -340,11 +344,11 @@ const NewMembershipsBlock = ({
               ))}
             </>
           )}
-          {pendingApplications && pendingApplications.length > 0 && (
+          {pendingCommunityApplications && pendingCommunityApplications.length > 0 && (
             <>
               <BlockSectionTitle>{t('community.pendingMembership.applicationsSectionTitle')}</BlockSectionTitle>
               <ScrollableCardsLayoutContainer>
-                {pendingApplications?.map(application => (
+                {pendingCommunityApplications?.map(application => (
                   <ApplicationHydrator key={application.id} application={application} visualType={VisualType.Card}>
                     {({ application: hydratedApplication }) =>
                       hydratedApplication && (


### PR DESCRIPTION
Depends on the following Server PR: https://github.com/alkem-io/server/pull/4123

The me query fields have been renamed

In addition, both users and organizations now have an Accounts field to retrieve the set of Accounts that they are hosting. 