### PR TITLE
VC - invite display & accept

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -2273,6 +2273,7 @@ export type QueryKeySpecifier = (
   | 'platform'
   | 'rolesOrganization'
   | 'rolesUser'
+  | 'rolesVirtualContributor'
   | 'search'
   | 'space'
   | 'spaces'
@@ -2308,6 +2309,7 @@ export type QueryFieldPolicy = {
   platform?: FieldPolicy<any> | FieldReadFunction<any>;
   rolesOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   rolesUser?: FieldPolicy<any> | FieldReadFunction<any>;
+  rolesVirtualContributor?: FieldPolicy<any> | FieldReadFunction<any>;
   search?: FieldPolicy<any> | FieldReadFunction<any>;
   space?: FieldPolicy<any> | FieldReadFunction<any>;
   spaces?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -14348,6 +14348,7 @@ export const UserProviderDocument = gql`
         invitation {
           id
           welcomeMessage
+          contributorType
           createdBy {
             id
           }

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -23150,6 +23150,7 @@ export const NewMembershipsDocument = gql`
         invitation {
           id
           welcomeMessage
+          contributorType
           createdBy {
             id
           }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -29559,6 +29559,7 @@ export type NewMembershipsQuery = {
         __typename?: 'Invitation';
         id: string;
         welcomeMessage?: string | undefined;
+        contributorType: CommunityContributorType;
         createdDate: Date;
         createdBy: { __typename?: 'User'; id: string };
         lifecycle: { __typename?: 'Lifecycle'; id: string; state?: string | undefined };

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -4321,6 +4321,8 @@ export type Query = {
   rolesOrganization: ContributorRoles;
   /** The roles that that the specified User has. */
   rolesUser: ContributorRoles;
+  /** The roles that the specified VirtualContributor has. */
+  rolesVirtualContributor: ContributorRoles;
   /** Search the platform for terms supplied */
   search: ISearchResults;
   /** Look up a top level Space (i.e. a Space that does not have a parent Space) by the UUID or NameID. */
@@ -4405,6 +4407,10 @@ export type QueryRolesOrganizationArgs = {
 
 export type QueryRolesUserArgs = {
   rolesData: RolesUserInput;
+};
+
+export type QueryRolesVirtualContributorArgs = {
+  rolesData: RolesVirtualContributorInput;
 };
 
 export type QuerySearchArgs = {
@@ -4719,6 +4725,11 @@ export type RolesUserInput = {
   filter?: InputMaybe<SpaceFilterInput>;
   /** The ID of the user to retrieve the roles of. */
   userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
+export type RolesVirtualContributorInput = {
+  /** The ID or nameID of the VC to retrieve the roles of. */
+  virtualContributorID: Scalars['UUID_NAMEID'];
 };
 
 export type Room = {
@@ -18219,6 +18230,7 @@ export type UserProviderQuery = {
         __typename?: 'Invitation';
         id: string;
         welcomeMessage?: string | undefined;
+        contributorType: CommunityContributorType;
         createdDate: Date;
         createdBy: { __typename?: 'User'; id: string };
         lifecycle: { __typename?: 'Lifecycle'; id: string; state?: string | undefined };

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -635,10 +635,14 @@
       "applicationsSectionTitle": "Open applications",
       "invitationDialog": {
         "title": "Pending Membership: {{journey}}",
+        "vc": {
+          "title": "Pending Virtual Contributor membership: {{journey}}"
+        },
         "actions": {
           "hide": "Hide this invitation",
           "reject": "Decline",
-          "accept": "Join"
+          "join": "Join",
+          "accept": "Accept"
         }
       },
       "invitationTitle": "{{time}} {{user}} invited {{invitedEntity}} to <journeyicon /> {{journey}}",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -631,6 +631,7 @@
       "pendingMemberships": "Pending Memberships",
       "pendingMembershipsWithCount": "Pending Memberships ({{count}})",
       "invitationsSectionTitle": "Invitations",
+      "virtualInvitationsSectionTitle": "Invitations for my Virtual Contributor",
       "applicationsSectionTitle": "Open applications",
       "invitationDialog": {
         "title": "Pending Membership: {{journey}}",
@@ -640,7 +641,9 @@
           "accept": "Join"
         }
       },
-      "invitationTitle": "{{time}} {{user}} invited you to <journeyicon /> {{journey}}"
+      "invitationTitle": "{{time}} {{user}} invited {{invitedEntity}} to <journeyicon /> {{journey}}",
+      "you": "you",
+      "vc": "your Virtual Contributor"
     },
     "memberSettings": {
       "title": "Member Settings",

--- a/src/domain/community/invitations/InvitationCardHorizontal/InvitationCardHorizontal.tsx
+++ b/src/domain/community/invitations/InvitationCardHorizontal/InvitationCardHorizontal.tsx
@@ -33,6 +33,7 @@ const InvitationCardHorizontal = ({ invitation, onClick }: InvitationCardHorizon
           journeyTypeName={getChildJourneyTypeName(invitation.space)}
           createdDate={invitation.invitation.createdDate}
           author={{ displayName: invitation.userDisplayName }}
+          type={invitation.invitation.contributorType}
         />
       </BlockSectionTitle>
       <CardText

--- a/src/domain/community/invitations/InvitationDialog.tsx
+++ b/src/domain/community/invitations/InvitationDialog.tsx
@@ -1,5 +1,9 @@
 import React, { ReactNode } from 'react';
-import { getChildJourneyTypeName, InvitationHydrator } from '../pendingMembership/PendingMemberships';
+import {
+  getChildJourneyTypeName,
+  InvitationHydrator,
+  InvitationWithMeta,
+} from '../pendingMembership/PendingMemberships';
 import DialogHeader from '../../../core/ui/dialog/DialogHeader';
 import Gutters from '../../../core/ui/grid/Gutters';
 import { CheckOutlined, HdrStrongOutlined } from '@mui/icons-material';
@@ -13,7 +17,7 @@ import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
 import DialogWithGrid from '../../../core/ui/dialog/DialogWithGrid';
 import { InvitationItem } from '../user/providers/UserProvider/InvitationItem';
 import { useTranslation } from 'react-i18next';
-import { VisualType } from '../../../core/apollo/generated/graphql-schema';
+import { CommunityContributorType, VisualType } from '../../../core/apollo/generated/graphql-schema';
 import { Box, DialogActions, DialogContent } from '@mui/material';
 import WrapperMarkdown from '../../../core/ui/markdown/WrapperMarkdown';
 import References from '../../shared/components/References/References';
@@ -45,6 +49,26 @@ const InvitationDialog = ({
 }: InvitationDialogProps) => {
   const { t } = useTranslation();
 
+  const getTitle = (invitation: InvitationWithMeta) => {
+    if (invitation.invitation.contributorType === CommunityContributorType.Virtual) {
+      return t('community.pendingMembership.invitationDialog.vc.title', {
+        journey: invitation?.space.profile.displayName,
+      });
+    }
+
+    return t('community.pendingMembership.invitationDialog.title', {
+      journey: invitation?.space.profile.displayName,
+    });
+  };
+
+  const getAcceptLabel = (invitation: InvitationWithMeta) => {
+    if (invitation.invitation.contributorType === CommunityContributorType.Virtual) {
+      return t('community.pendingMembership.invitationDialog.actions.accept');
+    }
+
+    return t('community.pendingMembership.invitationDialog.actions.join');
+  };
+
   return (
     <DialogWithGrid columns={12} open={open} onClose={onClose}>
       {invitation && (
@@ -61,9 +85,7 @@ const InvitationDialog = ({
                   title={
                     <Gutters row disablePadding>
                       <HdrStrongOutlined fontSize="small" />
-                      {t('community.pendingMembership.invitationDialog.title', {
-                        journey: invitation?.space.profile.displayName,
-                      })}
+                      {getTitle(invitation)}
                     </Gutters>
                   }
                   onClose={onClose}
@@ -88,6 +110,7 @@ const InvitationDialog = ({
                           journeyTypeName={getChildJourneyTypeName(invitation.space)}
                           createdDate={invitation.invitation.createdDate}
                           author={{ displayName: invitation.userDisplayName }}
+                          type={invitation.invitation.contributorType}
                         />
                       </Caption>
                       {invitation.invitation.welcomeMessage && <Text>{invitation.invitation.welcomeMessage}</Text>}
@@ -128,7 +151,7 @@ const InvitationDialog = ({
                     loading={accepting}
                     disabled={updating && !accepting}
                   >
-                    {t('community.pendingMembership.invitationDialog.actions.accept')}
+                    {getAcceptLabel(invitation)}
                   </LoadingButton>
                 </DialogActions>
               </>

--- a/src/domain/community/invitations/InvitationDialog.tsx
+++ b/src/domain/community/invitations/InvitationDialog.tsx
@@ -137,7 +137,7 @@ const InvitationDialog = ({
                   <FlexSpacer />
                   <LoadingButton
                     startIcon={<CloseOutlinedIcon />}
-                    onClick={() => rejectInvitation(invitation.id)}
+                    onClick={() => rejectInvitation(invitation.invitation.id)}
                     variant="outlined"
                     loading={rejecting}
                     disabled={updating && !rejecting}
@@ -146,7 +146,7 @@ const InvitationDialog = ({
                   </LoadingButton>
                   <LoadingButton
                     startIcon={<CheckOutlined />}
-                    onClick={() => acceptInvitation(invitation.id)}
+                    onClick={() => acceptInvitation(invitation.invitation.id)}
                     variant="contained"
                     loading={accepting}
                     disabled={updating && !accepting}

--- a/src/domain/community/pendingMembership/PendingMembershipsUserMenuItem.tsx
+++ b/src/domain/community/pendingMembership/PendingMembershipsUserMenuItem.tsx
@@ -9,6 +9,7 @@ import {
   ApplicationHydrator,
   getChildJourneyTypeName,
   InvitationHydrator,
+  InvitationWithMeta,
   usePendingMemberships,
 } from './PendingMemberships';
 import InvitationCardHorizontal from '../invitations/InvitationCardHorizontal/InvitationCardHorizontal';
@@ -22,7 +23,6 @@ import { CommunityContributorType, VisualType } from '../../../core/apollo/gener
 import BackButton from '../../../core/ui/actions/BackButton';
 import useNavigate from '../../../core/routing/useNavigate';
 import { useNewMembershipsQuery } from '../../../core/apollo/generated/apollo-hooks';
-import { Identifiable } from '../../../core/utils/Identifiable';
 
 interface ButtonImplementationParams {
   header: ReactNode;
@@ -64,11 +64,11 @@ const PendingMembershipsUserMenuItem = ({ children }: PendingMembershipsUserMenu
 
   const closeDialog = () => setOpenDialog(undefined);
 
-  const handleInvitationCardClick = ({ id, space }: Identifiable & { space: { profile: { url: string } } }) => {
+  const handleInvitationCardClick = ({ id, space, invitation }: InvitationWithMeta) => {
     setOpenDialog({
       type: DialogType.InvitationView,
       invitationId: id,
-      journeyUri: space.profile.url,
+      journeyUri: invitation.contributorType === CommunityContributorType.Virtual ? undefined : space.profile.url,
     });
   };
 

--- a/src/domain/community/pendingMembership/PendingMembershipsUserMenuItem.tsx
+++ b/src/domain/community/pendingMembership/PendingMembershipsUserMenuItem.tsx
@@ -18,7 +18,7 @@ import ScrollableCardsLayoutContainer from '../../../core/ui/card/cardsLayout/Sc
 import JourneyCardTagline from '../../journey/common/JourneyCard/JourneyCardTagline';
 import InvitationDialog from '../invitations/InvitationDialog';
 import InvitationActionsContainer from '../invitations/InvitationActionsContainer';
-import { VisualType } from '../../../core/apollo/generated/graphql-schema';
+import { CommunityContributorType, VisualType } from '../../../core/apollo/generated/graphql-schema';
 import BackButton from '../../../core/ui/actions/BackButton';
 import useNavigate from '../../../core/routing/useNavigate';
 import { useNewMembershipsQuery } from '../../../core/apollo/generated/apollo-hooks';
@@ -79,6 +79,14 @@ const PendingMembershipsUserMenuItem = ({ children }: PendingMembershipsUserMenu
       ? invitations?.find(invitation => invitation.id === openDialog.invitationId)
       : undefined;
 
+  const virtualContributorIviitations = invitations?.filter(
+    invitation => invitation.invitation.contributorType === CommunityContributorType.Virtual
+  );
+
+  const nonVirtualContributorInvitations = invitations?.filter(
+    invitation => invitation.invitation.contributorType !== CommunityContributorType.Virtual
+  );
+
   const pendingMembershipsCount = invitations && applications ? invitations.length + applications.length : undefined;
 
   const onInvitationAccept = () => {
@@ -113,10 +121,25 @@ const PendingMembershipsUserMenuItem = ({ children }: PendingMembershipsUserMenu
           onClose={closeDialog}
         />
         <Gutters paddingTop={0}>
-          {invitations && invitations.length > 0 && (
+          {nonVirtualContributorInvitations && nonVirtualContributorInvitations.length > 0 && (
             <>
               <BlockSectionTitle>{t('community.pendingMembership.invitationsSectionTitle')}</BlockSectionTitle>
-              {invitations?.map(invitation => (
+              {nonVirtualContributorInvitations?.map(invitation => (
+                <InvitationHydrator key={invitation.id} invitation={invitation}>
+                  {({ invitation }) => (
+                    <InvitationCardHorizontal
+                      invitation={invitation}
+                      onClick={() => invitation && handleInvitationCardClick(invitation)}
+                    />
+                  )}
+                </InvitationHydrator>
+              ))}
+            </>
+          )}
+          {virtualContributorIviitations && virtualContributorIviitations.length > 0 && (
+            <>
+              <BlockSectionTitle>{t('community.pendingMembership.virtualInvitationsSectionTitle')}</BlockSectionTitle>
+              {virtualContributorIviitations?.map(invitation => (
                 <InvitationHydrator key={invitation.id} invitation={invitation}>
                   {({ invitation }) => (
                     <InvitationCardHorizontal

--- a/src/domain/community/user/providers/UserProvider/InvitationItem.ts
+++ b/src/domain/community/user/providers/UserProvider/InvitationItem.ts
@@ -12,6 +12,7 @@ export interface InvitationItem extends Identifiable {
     };
   };
   invitation: {
+    id: string;
     createdBy: Identifiable;
     welcomeMessage?: string;
     createdDate: Date | string;

--- a/src/domain/community/user/providers/UserProvider/InvitationItem.ts
+++ b/src/domain/community/user/providers/UserProvider/InvitationItem.ts
@@ -1,3 +1,4 @@
+import { CommunityContributorType } from '../../../../../core/apollo/generated/graphql-schema';
 import { Identifiable } from '../../../../../core/utils/Identifiable';
 import { JourneyLevel } from '../../../../../main/routing/resolvers/RouteResolver';
 
@@ -15,5 +16,6 @@ export interface InvitationItem extends Identifiable {
     welcomeMessage?: string;
     createdDate: Date | string;
     lifecycle: { state?: string };
+    contributorType?: CommunityContributorType.Virtual;
   };
 }

--- a/src/domain/community/user/providers/UserProvider/UserProvider.graphql
+++ b/src/domain/community/user/providers/UserProvider/UserProvider.graphql
@@ -40,6 +40,7 @@ query UserProvider {
       invitation {
         id
         welcomeMessage
+        contributorType
         createdBy {
           id
         }

--- a/src/domain/shared/components/ActivityDescription/DetailedActivityDescription.tsx
+++ b/src/domain/shared/components/ActivityDescription/DetailedActivityDescription.tsx
@@ -5,6 +5,7 @@ import { JourneyTypeName } from '../../../journey/JourneyTypeName';
 import { formatTimeElapsed } from '../../utils/formatTimeElapsed';
 import journeyIcon from '../JourneyIcon/JourneyIcon';
 import RouterLink from '../../../../core/ui/link/RouterLink';
+import { CommunityContributorType } from '../../../../core/apollo/generated/graphql-schema';
 
 export interface ActivityDescriptionProps {
   i18nKey: TranslationKey;
@@ -19,6 +20,7 @@ export interface ActivityDescriptionProps {
     url?: string;
   };
   withLinkToParent?: boolean;
+  type?: CommunityContributorType;
 }
 
 const PARENT_NAME_MAX_LENGTH = 20;
@@ -33,6 +35,7 @@ const DetailedActivityDescription = ({
   values = {},
   components = {},
   withLinkToParent,
+  type,
 }: ActivityDescriptionProps) => {
   const { t } = useTranslation();
 
@@ -55,6 +58,11 @@ const DetailedActivityDescription = ({
     }
 
     mergedValues['journey'] = journeyDisplayName;
+
+    mergedValues['invitedEntity'] =
+      type === CommunityContributorType.Virtual
+        ? t('community.pendingMembership.vc')
+        : t('community.pendingMembership.you');
 
     const truncatedParentName =
       journeyDisplayName && journeyDisplayName.length > PARENT_NAME_MAX_LENGTH

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
@@ -22,6 +22,7 @@ query NewMemberships {
       invitation {
         id
         welcomeMessage
+        contributorType
         createdBy {
           id
         }

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
@@ -7,6 +7,7 @@ import {
   ApplicationHydrator,
   getChildJourneyTypeName,
   InvitationHydrator,
+  InvitationWithMeta,
 } from '../../../../domain/community/pendingMembership/PendingMemberships';
 import InvitationCardHorizontal from '../../../../domain/community/invitations/InvitationCardHorizontal/InvitationCardHorizontal';
 import React, { useMemo, useState } from 'react';
@@ -24,13 +25,12 @@ import InvitationActionsContainer from '../../../../domain/community/invitations
 import InvitationDialog from '../../../../domain/community/invitations/InvitationDialog';
 import NewMembershipCard from './NewMembershipCard';
 import SeeMore from '../../../../core/ui/content/SeeMore';
-import { VisualType } from '../../../../core/apollo/generated/graphql-schema';
+import { CommunityContributorType, VisualType } from '../../../../core/apollo/generated/graphql-schema';
 import BadgeCounter from '../../../../core/ui/icon/BadgeCounter';
 import HorizontalCardsGroup from '../../../../core/ui/content/HorizontalCardsGroup';
 import useNavigate from '../../../../core/routing/useNavigate';
 import { PendingApplication } from '../../../../domain/community/user';
 import { InvitationItem } from '../../../../domain/community/user/providers/UserProvider/InvitationItem';
-import { Identifiable } from '../../../../core/utils/Identifiable';
 
 enum PendingMembershipItemType {
   Invitation,
@@ -153,14 +153,14 @@ const NewMembershipsBlock = ({
   const closeDialog = () => setOpenDialog(undefined);
 
   const handleInvitationCardClick = (
-    { id, space }: Identifiable & { space: { profile: { url: string } } },
+    { id, space, invitation }: InvitationWithMeta,
     from: InvitationViewDialogDetails['from']
   ) => {
     setOpenDialog({
       type: DialogType.InvitationView,
       invitationId: id,
       from,
-      journeyUri: space.profile.url,
+      journeyUri: invitation.contributorType === CommunityContributorType.Virtual ? undefined : space.profile.url,
     });
   };
 


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6417

- [x] display VC block in pending invites list (User Menu);
- [x] display VC specific copy in invite Dialog;
- [x] don't navigate to the space on Accept of VC invite;
- [ ] VC block in Spaces widget on My Profile - agreed to be extracted in separate task;
- [x] Make the Accept of VC invite work - fixed with this PR - https://github.com/alkem-io/server/pull/4142

You can use the following mutation to send invite, just add existing communityId and VC contributor ID:

```
mutation inviteContributorsToCommunity($contributorIds: [UUID!]!, $communityId: UUID!, $message: String) {
  inviteContributorsForCommunityMembership(invitationData: {
    invitedContributors: $contributorIds
    communityID: $communityId
    welcomeMessage: $message
  }) {
    id
  }
}

{
  "communityId": "",
  "contributorIds": [""],
  "message": "Custom message."
}