### PR TITLE
Change StorageContext when VCs are used

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -2273,6 +2273,7 @@ export type QueryKeySpecifier = (
   | 'platform'
   | 'rolesOrganization'
   | 'rolesUser'
+  | 'rolesVirtualContributor'
   | 'search'
   | 'space'
   | 'spaces'
@@ -2308,6 +2309,7 @@ export type QueryFieldPolicy = {
   platform?: FieldPolicy<any> | FieldReadFunction<any>;
   rolesOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   rolesUser?: FieldPolicy<any> | FieldReadFunction<any>;
+  rolesVirtualContributor?: FieldPolicy<any> | FieldReadFunction<any>;
   search?: FieldPolicy<any> | FieldReadFunction<any>;
   space?: FieldPolicy<any> | FieldReadFunction<any>;
   spaces?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -21191,6 +21191,74 @@ export function refetchUserStorageConfigQuery(variables: SchemaTypes.UserStorage
   return { query: UserStorageConfigDocument, variables: variables };
 }
 
+export const VirtualContributorStorageConfigDocument = gql`
+  query VirtualContributorStorageConfig($virtualContributorId: UUID_NAMEID!) {
+    virtualContributor(ID: $virtualContributorId) {
+      id
+      profile {
+        ...ProfileStorageConfig
+      }
+    }
+  }
+  ${ProfileStorageConfigFragmentDoc}
+`;
+
+/**
+ * __useVirtualContributorStorageConfigQuery__
+ *
+ * To run a query within a React component, call `useVirtualContributorStorageConfigQuery` and pass it any options that fit your needs.
+ * When your component renders, `useVirtualContributorStorageConfigQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useVirtualContributorStorageConfigQuery({
+ *   variables: {
+ *      virtualContributorId: // value for 'virtualContributorId'
+ *   },
+ * });
+ */
+export function useVirtualContributorStorageConfigQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    SchemaTypes.VirtualContributorStorageConfigQuery,
+    SchemaTypes.VirtualContributorStorageConfigQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    SchemaTypes.VirtualContributorStorageConfigQuery,
+    SchemaTypes.VirtualContributorStorageConfigQueryVariables
+  >(VirtualContributorStorageConfigDocument, options);
+}
+
+export function useVirtualContributorStorageConfigLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.VirtualContributorStorageConfigQuery,
+    SchemaTypes.VirtualContributorStorageConfigQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SchemaTypes.VirtualContributorStorageConfigQuery,
+    SchemaTypes.VirtualContributorStorageConfigQueryVariables
+  >(VirtualContributorStorageConfigDocument, options);
+}
+
+export type VirtualContributorStorageConfigQueryHookResult = ReturnType<typeof useVirtualContributorStorageConfigQuery>;
+export type VirtualContributorStorageConfigLazyQueryHookResult = ReturnType<
+  typeof useVirtualContributorStorageConfigLazyQuery
+>;
+export type VirtualContributorStorageConfigQueryResult = Apollo.QueryResult<
+  SchemaTypes.VirtualContributorStorageConfigQuery,
+  SchemaTypes.VirtualContributorStorageConfigQueryVariables
+>;
+export function refetchVirtualContributorStorageConfigQuery(
+  variables: SchemaTypes.VirtualContributorStorageConfigQueryVariables
+) {
+  return { query: VirtualContributorStorageConfigDocument, variables: variables };
+}
+
 export const OrganizationStorageConfigDocument = gql`
   query OrganizationStorageConfig($organizationId: UUID_NAMEID!) {
     organization(ID: $organizationId) {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -4321,6 +4321,8 @@ export type Query = {
   rolesOrganization: ContributorRoles;
   /** The roles that that the specified User has. */
   rolesUser: ContributorRoles;
+  /** The roles that the specified VirtualContributor has. */
+  rolesVirtualContributor: ContributorRoles;
   /** Search the platform for terms supplied */
   search: ISearchResults;
   /** Look up a top level Space (i.e. a Space that does not have a parent Space) by the UUID or NameID. */
@@ -4405,6 +4407,10 @@ export type QueryRolesOrganizationArgs = {
 
 export type QueryRolesUserArgs = {
   rolesData: RolesUserInput;
+};
+
+export type QueryRolesVirtualContributorArgs = {
+  rolesData: RolesVirtualContributorInput;
 };
 
 export type QuerySearchArgs = {
@@ -4719,6 +4725,11 @@ export type RolesUserInput = {
   filter?: InputMaybe<SpaceFilterInput>;
   /** The ID of the user to retrieve the roles of. */
   userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
+export type RolesVirtualContributorInput = {
+  /** The ID or nameID of the VC to retrieve the roles of. */
+  virtualContributorID: Scalars['UUID_NAMEID'];
 };
 
 export type Room = {
@@ -25611,6 +25622,31 @@ export type UserStorageConfigQuery = {
   __typename?: 'Query';
   user: {
     __typename?: 'User';
+    id: string;
+    profile: {
+      __typename?: 'Profile';
+      id: string;
+      storageBucket: {
+        __typename?: 'StorageBucket';
+        id: string;
+        allowedMimeTypes: Array<string>;
+        maxFileSize: number;
+        authorization?:
+          | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+          | undefined;
+      };
+    };
+  };
+};
+
+export type VirtualContributorStorageConfigQueryVariables = Exact<{
+  virtualContributorId: Scalars['UUID_NAMEID'];
+}>;
+
+export type VirtualContributorStorageConfigQuery = {
+  __typename?: 'Query';
+  virtualContributor: {
+    __typename?: 'VirtualContributor';
     id: string;
     profile: {
       __typename?: 'Profile';

--- a/src/domain/community/virtualContributor/VCAccessibilitySettings/VCAccessibilitySettingsPage.tsx
+++ b/src/domain/community/virtualContributor/VCAccessibilitySettings/VCAccessibilitySettingsPage.tsx
@@ -59,56 +59,61 @@ export const VCAccessibilitySettingsPage = () => {
   };
 
   return (
-    <StorageConfigContextProvider locationType="platform">
-      <VCSettingsPageLayout currentTab={SettingsSection.Settings}>
-        <PageContent background="background.paper">
-          <PageContentColumn columns={12}>
-            <PageContentBlock>
-              <RadioSettingsGroup
-                value={data?.virtualContributor?.searchVisibility ?? SearchVisibility.Account}
-                options={{
-                  [SearchVisibility.Public]: {
-                    label: (
-                      <Trans
-                        i18nKey="pages.virtualContributorProfile.settings.access.visibility.public"
-                        components={{ b: <strong /> }}
-                      />
-                    ),
-                  },
-                  [SearchVisibility.Account]: {
-                    label: (
-                      <Trans
-                        i18nKey="pages.virtualContributorProfile.settings.access.visibility.private"
-                        components={{ b: <strong /> }}
-                      />
-                    ),
-                  },
-                  [SearchVisibility.Hidden]: {
-                    label: (
-                      <Trans
-                        i18nKey="pages.virtualContributorProfile.settings.access.visibility.hidden"
-                        components={{ b: <strong /> }}
-                      />
-                    ),
-                  },
-                }}
-                onChange={newValue => updateVisibility(newValue)}
-              />
-              <SwitchSettingsGroup
-                options={{
-                  listedInStore: {
-                    checked: data?.virtualContributor?.listedInStore ?? false,
-                    disabled: data?.virtualContributor?.searchVisibility !== SearchVisibility.Public,
-                    label: t('pages.virtualContributorProfile.settings.access.listedInStore'),
-                  },
-                }}
-                onChange={(key, newValue) => updateListedInStore(newValue)}
-              />
-            </PageContentBlock>
-          </PageContentColumn>
-        </PageContent>
-      </VCSettingsPageLayout>
-    </StorageConfigContextProvider>
+    data?.virtualContributor && (
+      <StorageConfigContextProvider
+        locationType="virtualContributor"
+        virtualContributorId={data?.virtualContributor?.id}
+      >
+        <VCSettingsPageLayout currentTab={SettingsSection.Settings}>
+          <PageContent background="background.paper">
+            <PageContentColumn columns={12}>
+              <PageContentBlock>
+                <RadioSettingsGroup
+                  value={data?.virtualContributor?.searchVisibility ?? SearchVisibility.Account}
+                  options={{
+                    [SearchVisibility.Public]: {
+                      label: (
+                        <Trans
+                          i18nKey="pages.virtualContributorProfile.settings.access.visibility.public"
+                          components={{ b: <strong /> }}
+                        />
+                      ),
+                    },
+                    [SearchVisibility.Account]: {
+                      label: (
+                        <Trans
+                          i18nKey="pages.virtualContributorProfile.settings.access.visibility.private"
+                          components={{ b: <strong /> }}
+                        />
+                      ),
+                    },
+                    [SearchVisibility.Hidden]: {
+                      label: (
+                        <Trans
+                          i18nKey="pages.virtualContributorProfile.settings.access.visibility.hidden"
+                          components={{ b: <strong /> }}
+                        />
+                      ),
+                    },
+                  }}
+                  onChange={newValue => updateVisibility(newValue)}
+                />
+                <SwitchSettingsGroup
+                  options={{
+                    listedInStore: {
+                      checked: data?.virtualContributor?.listedInStore ?? false,
+                      disabled: data?.virtualContributor?.searchVisibility !== SearchVisibility.Public,
+                      label: t('pages.virtualContributorProfile.settings.access.listedInStore'),
+                    },
+                  }}
+                  onChange={(key, newValue) => updateListedInStore(newValue)}
+                />
+              </PageContentBlock>
+            </PageContentColumn>
+          </PageContent>
+        </VCSettingsPageLayout>
+      </StorageConfigContextProvider>
+    )
   );
 };
 

--- a/src/domain/community/virtualContributor/VCAccessibilitySettings/VCAccessibilitySettingsPage.tsx
+++ b/src/domain/community/virtualContributor/VCAccessibilitySettings/VCAccessibilitySettingsPage.tsx
@@ -58,62 +58,61 @@ export const VCAccessibilitySettingsPage = () => {
     handleUpdate({ searchVisibility: newValue });
   };
 
+  if (!data?.virtualContributor) {
+    return null;
+  }
+
   return (
-    data?.virtualContributor && (
-      <StorageConfigContextProvider
-        locationType="virtualContributor"
-        virtualContributorId={data?.virtualContributor?.id}
-      >
-        <VCSettingsPageLayout currentTab={SettingsSection.Settings}>
-          <PageContent background="background.paper">
-            <PageContentColumn columns={12}>
-              <PageContentBlock>
-                <RadioSettingsGroup
-                  value={data?.virtualContributor?.searchVisibility ?? SearchVisibility.Account}
-                  options={{
-                    [SearchVisibility.Public]: {
-                      label: (
-                        <Trans
-                          i18nKey="pages.virtualContributorProfile.settings.access.visibility.public"
-                          components={{ b: <strong /> }}
-                        />
-                      ),
-                    },
-                    [SearchVisibility.Account]: {
-                      label: (
-                        <Trans
-                          i18nKey="pages.virtualContributorProfile.settings.access.visibility.private"
-                          components={{ b: <strong /> }}
-                        />
-                      ),
-                    },
-                    [SearchVisibility.Hidden]: {
-                      label: (
-                        <Trans
-                          i18nKey="pages.virtualContributorProfile.settings.access.visibility.hidden"
-                          components={{ b: <strong /> }}
-                        />
-                      ),
-                    },
-                  }}
-                  onChange={newValue => updateVisibility(newValue)}
-                />
-                <SwitchSettingsGroup
-                  options={{
-                    listedInStore: {
-                      checked: data?.virtualContributor?.listedInStore ?? false,
-                      disabled: data?.virtualContributor?.searchVisibility !== SearchVisibility.Public,
-                      label: t('pages.virtualContributorProfile.settings.access.listedInStore'),
-                    },
-                  }}
-                  onChange={(key, newValue) => updateListedInStore(newValue)}
-                />
-              </PageContentBlock>
-            </PageContentColumn>
-          </PageContent>
-        </VCSettingsPageLayout>
-      </StorageConfigContextProvider>
-    )
+    <StorageConfigContextProvider locationType="virtualContributor" virtualContributorId={data.virtualContributor.id}>
+      <VCSettingsPageLayout currentTab={SettingsSection.Settings}>
+        <PageContent background="background.paper">
+          <PageContentColumn columns={12}>
+            <PageContentBlock>
+              <RadioSettingsGroup
+                value={data?.virtualContributor?.searchVisibility ?? SearchVisibility.Account}
+                options={{
+                  [SearchVisibility.Public]: {
+                    label: (
+                      <Trans
+                        i18nKey="pages.virtualContributorProfile.settings.access.visibility.public"
+                        components={{ b: <strong /> }}
+                      />
+                    ),
+                  },
+                  [SearchVisibility.Account]: {
+                    label: (
+                      <Trans
+                        i18nKey="pages.virtualContributorProfile.settings.access.visibility.private"
+                        components={{ b: <strong /> }}
+                      />
+                    ),
+                  },
+                  [SearchVisibility.Hidden]: {
+                    label: (
+                      <Trans
+                        i18nKey="pages.virtualContributorProfile.settings.access.visibility.hidden"
+                        components={{ b: <strong /> }}
+                      />
+                    ),
+                  },
+                }}
+                onChange={newValue => updateVisibility(newValue)}
+              />
+              <SwitchSettingsGroup
+                options={{
+                  listedInStore: {
+                    checked: data?.virtualContributor?.listedInStore ?? false,
+                    disabled: data?.virtualContributor?.searchVisibility !== SearchVisibility.Public,
+                    label: t('pages.virtualContributorProfile.settings.access.listedInStore'),
+                  },
+                }}
+                onChange={(key, newValue) => updateListedInStore(newValue)}
+              />
+            </PageContentBlock>
+          </PageContentColumn>
+        </PageContent>
+      </VCSettingsPageLayout>
+    </StorageConfigContextProvider>
   );
 };
 

--- a/src/domain/community/virtualContributor/vcSettingsPage/VCEditProfilePage.tsx
+++ b/src/domain/community/virtualContributor/vcSettingsPage/VCEditProfilePage.tsx
@@ -18,7 +18,7 @@ import VCSettingsPageLayout from '../layout/VCSettingsPageLayout';
 export const VCSettingsPage = () => {
   const { t } = useTranslation();
 
-  const { vcNameId = '' } = useUrlParams();
+  const { vcNameId = '' } = useUrlParams() ?? { vcNameId: '' };
 
   const notify = useNotification();
 
@@ -52,23 +52,26 @@ export const VCSettingsPage = () => {
     );
 
   return (
-    <StorageConfigContextProvider locationType="platform">
-      <VCSettingsPageLayout currentTab={SettingsSection.MyProfile}>
-        <PageContent background="background.paper">
-          <PageContentColumn columns={12}>
-            <PageContentBlock>
-              {data?.virtualContributor && (
+    data?.virtualContributor && (
+      <StorageConfigContextProvider
+        locationType="virtualContributor"
+        virtualContributorId={data?.virtualContributor.id}
+      >
+        <VCSettingsPageLayout currentTab={SettingsSection.MyProfile}>
+          <PageContent background="background.paper">
+            <PageContentColumn columns={12}>
+              <PageContentBlock>
                 <VirtualContributorForm
                   virtualContributor={data?.virtualContributor}
                   avatar={data?.virtualContributor.profile.avatar}
                   onSave={handleUpdate}
                 />
-              )}
-            </PageContentBlock>
-          </PageContentColumn>
-        </PageContent>
-      </VCSettingsPageLayout>
-    </StorageConfigContextProvider>
+              </PageContentBlock>
+            </PageContentColumn>
+          </PageContent>
+        </VCSettingsPageLayout>
+      </StorageConfigContextProvider>
+    )
   );
 };
 

--- a/src/domain/community/virtualContributor/vcSettingsPage/VCEditProfilePage.tsx
+++ b/src/domain/community/virtualContributor/vcSettingsPage/VCEditProfilePage.tsx
@@ -18,7 +18,7 @@ import VCSettingsPageLayout from '../layout/VCSettingsPageLayout';
 export const VCSettingsPage = () => {
   const { t } = useTranslation();
 
-  const { vcNameId = '' } = useUrlParams() ?? { vcNameId: '' };
+  const { vcNameId = '' } = useUrlParams();
 
   const notify = useNotification();
 
@@ -50,28 +50,25 @@ export const VCSettingsPage = () => {
         text={t('components.loading.message', { blockName: t('pages.virtualContributorProfile.settings.title') })}
       />
     );
-
+  if (!data?.virtualContributor) {
+    return null;
+  }
   return (
-    data?.virtualContributor && (
-      <StorageConfigContextProvider
-        locationType="virtualContributor"
-        virtualContributorId={data?.virtualContributor.id}
-      >
-        <VCSettingsPageLayout currentTab={SettingsSection.MyProfile}>
-          <PageContent background="background.paper">
-            <PageContentColumn columns={12}>
-              <PageContentBlock>
-                <VirtualContributorForm
-                  virtualContributor={data?.virtualContributor}
-                  avatar={data?.virtualContributor.profile.avatar}
-                  onSave={handleUpdate}
-                />
-              </PageContentBlock>
-            </PageContentColumn>
-          </PageContent>
-        </VCSettingsPageLayout>
-      </StorageConfigContextProvider>
-    )
+    <StorageConfigContextProvider locationType="virtualContributor" virtualContributorId={data.virtualContributor.id}>
+      <VCSettingsPageLayout currentTab={SettingsSection.MyProfile}>
+        <PageContent background="background.paper">
+          <PageContentColumn columns={12}>
+            <PageContentBlock>
+              <VirtualContributorForm
+                virtualContributor={data?.virtualContributor}
+                avatar={data?.virtualContributor.profile.avatar}
+                onSave={handleUpdate}
+              />
+            </PageContentBlock>
+          </PageContentColumn>
+        </PageContent>
+      </VCSettingsPageLayout>
+    </StorageConfigContextProvider>
   );
 };
 

--- a/src/domain/platform/admin/virtual-contributors/VirtualContributorsPage.tsx
+++ b/src/domain/platform/admin/virtual-contributors/VirtualContributorsPage.tsx
@@ -7,7 +7,6 @@ import { BlockTitle } from '../../../../core/ui/typography';
 import { useTranslation } from 'react-i18next';
 import BadgeCardView from '../../../../core/ui/list/BadgeCardView';
 import PageContentBlockSeamless from '../../../../core/ui/content/PageContentBlockSeamless';
-import { StorageConfigContextProvider } from '../../../storage/StorageBucket/StorageConfigContext';
 import RouterLink from '../../../../core/ui/link/RouterLink';
 import Loading from '../../../../core/ui/loading/Loading';
 
@@ -18,26 +17,24 @@ const VirtualContributorsPage: FC = () => {
   return (
     <AdminLayout currentTab={AdminSection.VirtualContributors}>
       <PageContentBlockSeamless disablePadding>
-        <StorageConfigContextProvider locationType="platform">
-          <BlockTitle>{t('pages.admin.virtualContributors.title')}</BlockTitle>
-          {loadingVCs && <Loading />}
-          {data?.virtualContributors.map(virtualContributor => (
-            <BadgeCardView
-              key={virtualContributor.id}
-              outlined
-              visual={
-                <Avatar
-                  src={virtualContributor.profile.avatar?.uri}
-                  alt={t('common.avatar-of', { user: virtualContributor.profile.displayName })}
-                />
-              }
-              component={RouterLink}
-              to={virtualContributor.profile.url}
-            >
-              <BlockTitle>{virtualContributor.profile.displayName}</BlockTitle>
-            </BadgeCardView>
-          ))}
-        </StorageConfigContextProvider>
+        <BlockTitle>{t('pages.admin.virtualContributors.title')}</BlockTitle>
+        {loadingVCs && <Loading />}
+        {data?.virtualContributors.map(virtualContributor => (
+          <BadgeCardView
+            key={virtualContributor.id}
+            outlined
+            visual={
+              <Avatar
+                src={virtualContributor.profile.avatar?.uri}
+                alt={t('common.avatar-of', { user: virtualContributor.profile.displayName })}
+              />
+            }
+            component={RouterLink}
+            to={virtualContributor.profile.url}
+          >
+            <BlockTitle>{virtualContributor.profile.displayName}</BlockTitle>
+          </BadgeCardView>
+        ))}
       </PageContentBlockSeamless>
     </AdminLayout>
   );

--- a/src/domain/storage/StorageBucket/StorageConfig.graphql
+++ b/src/domain/storage/StorageBucket/StorageConfig.graphql
@@ -47,6 +47,14 @@ query UserStorageConfig($userId: UUID_NAMEID_EMAIL!) {
     }
   }
 }
+query VirtualContributorStorageConfig($virtualContributorId: UUID_NAMEID!) {
+  virtualContributor(ID: $virtualContributorId) {
+    id
+    profile {
+      ...ProfileStorageConfig
+    }
+  }
+}
 
 query OrganizationStorageConfig($organizationId: UUID_NAMEID!) {
   organization(ID: $organizationId) {

--- a/src/domain/storage/StorageBucket/useStorageConfig.tsx
+++ b/src/domain/storage/StorageBucket/useStorageConfig.tsx
@@ -8,6 +8,7 @@ import {
   usePlatformStorageConfigQuery,
   useSpaceGuidelinesTemplateStorageConfigQuery,
   useUserStorageConfigQuery,
+  useVirtualContributorStorageConfigQuery,
 } from '../../../core/apollo/generated/apollo-hooks';
 import { useMemo } from 'react';
 import { AuthorizationPrivilege } from '../../../core/apollo/generated/graphql-schema';
@@ -22,6 +23,7 @@ export interface StorageConfig {
 type StorageConfigLocation =
   | 'journey'
   | 'user'
+  | 'virtualContributor'
   | 'organization'
   | 'callout'
   | 'post'
@@ -61,6 +63,11 @@ interface UseStorageConfigOptionsUser extends UseStorageConfigOptionsBase {
   locationType: 'user';
 }
 
+interface UseStorageConfigOptionsVirtualContributor extends UseStorageConfigOptionsBase {
+  virtualContributorId: string;
+  locationType: 'virtualContributor';
+}
+
 interface UseStorageConfigOptionsOrganization extends UseStorageConfigOptionsBase {
   organizationId: string | undefined;
   locationType: 'organization';
@@ -83,6 +90,7 @@ interface UseStorageConfigOptionsPlatform extends UseStorageConfigOptionsBase {
 export type StorageConfigOptions =
   | UseStorageConfigOptionsSpace
   | UseStorageConfigOptionsUser
+  | UseStorageConfigOptionsVirtualContributor
   | UseStorageConfigOptionsOrganization
   | UseStorageConfigOptionsCallout
   | UseStorageConfigOptionsPost
@@ -135,6 +143,12 @@ const useStorageConfig = ({ locationType, skip, ...options }: StorageConfigOptio
     skip: skip || locationType !== 'user',
   });
 
+  const virtualContributorOptions = options as UseStorageConfigOptionsVirtualContributor;
+  const { data: virtualContributorStorageConfigData } = useVirtualContributorStorageConfigQuery({
+    variables: virtualContributorOptions,
+    skip: skip || locationType !== 'virtualContributor',
+  });
+
   const organizationOptions = options as UseStorageConfigOptionsOrganization;
   const { data: organizationStorageConfigData } = useOrganizationStorageConfigQuery({
     variables: {
@@ -175,6 +189,7 @@ const useStorageConfig = ({ locationType, skip, ...options }: StorageConfigOptio
     contribution?.post ??
     guidelinesTemplateStorageConfigData?.lookup.communityGuidelinesTemplate ??
     userStorageConfigData?.user ??
+    virtualContributorStorageConfigData?.virtualContributor ??
     organizationStorageConfigData?.organization ??
     innovationPackStorageConfigData?.platform.library.innovationPack ??
     innovationHubStorageConfigData?.platform.innovationHub ??


### PR DESCRIPTION
Extend storage config context to support VCs
- wrongly, the Platform context was used
- swapped Platform with VCs

Should be picking up the right context now (please double check). The [bug](https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/gh/alkem-io/client-web/6461) is fixed, but the places where this is used need double-checking.