### PR TITLE
Fix user getting error messages in the dashboard on the first login

### DIFF
--- a/src/core/auth/authentication/pages/LoginSuccessPage.tsx
+++ b/src/core/auth/authentication/pages/LoginSuccessPage.tsx
@@ -1,19 +1,29 @@
 import { FC, useEffect } from 'react';
 import { STORAGE_KEY_RETURN_URL } from '../constants/authentication.constants';
 import { useReturnUrl } from '../utils/SignUpReturnUrl';
+import { useUserContext } from '../../../../domain/community/user';
 
 interface LoginSuccessPageProps {}
 
 export const LoginSuccessPage: FC<LoginSuccessPageProps> = () => {
   const returnUrl = useReturnUrl();
+  // We don't really need to use user info here on every login,
+  // but user profile creation is triggered the first time the user logs in,
+  // and this way we ensure the profile is created before the user is redirected to the returnUrl.
+  // Probably this won't be needed once we refactor UserProvider
+  // We could maybe do a lighter query here to check if the user has profile or not, and trigger the creation if needed.
+  const { user, loading } = useUserContext();
+
   useEffect(() => {
-    if (returnUrl) {
-      window.location.replace(returnUrl);
-      return () => {
-        sessionStorage.removeItem(STORAGE_KEY_RETURN_URL);
-      };
+    if (!loading) {
+      if (returnUrl) {
+        window.location.replace(returnUrl);
+        return () => {
+          sessionStorage.removeItem(STORAGE_KEY_RETURN_URL);
+        };
+      }
     }
-  }, [returnUrl]);
+  }, [returnUrl, user, loading]);
 
   return null;
 };

--- a/src/domain/community/application/containers/ApplicationButtonContainer.tsx
+++ b/src/domain/community/application/containers/ApplicationButtonContainer.tsx
@@ -49,7 +49,9 @@ export const ApplicationButtonContainer: FC<ApplicationButtonContainerProps> = (
   const notify = useNotification();
   const { isAuthenticated } = useAuthenticationContext();
   const { user, loadingMe: membershipLoading } = useUserContext();
-  const { data: pendingMembershipsData } = useUserPendingMembershipsQuery();
+  const { data: pendingMembershipsData } = useUserPendingMembershipsQuery({
+    skip: !isAuthenticated,
+  });
   const { communityApplications: pendingApplications, communityInvitations: pendingInvitations } =
     pendingMembershipsData?.me ?? {};
 

--- a/src/domain/community/pendingMembership/PendingMemberships.tsx
+++ b/src/domain/community/pendingMembership/PendingMemberships.tsx
@@ -11,6 +11,7 @@ import { InvitationItem } from '../user/providers/UserProvider/InvitationItem';
 import { CommunityGuidelinesSummaryFragment, VisualType } from '../../../core/apollo/generated/graphql-schema';
 import { JourneyLevel } from '../../../main/routing/resolvers/RouteResolver';
 import { Identifiable } from '../../../core/utils/Identifiable';
+import { useAuthenticationContext } from '../../../core/auth/authentication/hooks/useAuthenticationContext';
 
 export interface JourneyDetails {
   profile: {
@@ -40,7 +41,10 @@ interface UsePendingMembershipsProvided {
 }
 
 export const usePendingMemberships = (): UsePendingMembershipsProvided => {
-  const { data } = useUserPendingMembershipsQuery();
+  const { isAuthenticated } = useAuthenticationContext();
+  const { data } = useUserPendingMembershipsQuery({
+    skip: !isAuthenticated,
+  });
 
   return {
     invitations: data?.me.communityInvitations,

--- a/src/domain/community/user/pages/UserMembershipPage.tsx
+++ b/src/domain/community/user/pages/UserMembershipPage.tsx
@@ -62,6 +62,7 @@ const UserMembershipPage: FC<UserMembershipPageProps> = () => {
     }, [] as SpaceHostedItem[]);
   }, [data]);
 
+  // TODO: I think this is wrong, we are seeing the memberships of certain user, not ours.
   const { data: pendingMembershipsData } = useUserPendingMembershipsQuery();
   const applications = useMemo<SpaceHostedItem[] | undefined>(() => {
     if (!pendingMembershipsData || !userMetadata) {


### PR DESCRIPTION
Fix bug #6476 
Users were redirected to the dashboard after login, and on the first login they don't have yet their profile created.
That was causing a lot of errors in other queries.
UserProvider (useUserContext), creates the profile the first time it's called if it doesn't exist yet. I think we need to refactor that in the future.
For now I have added a call to useUserContext to the loginSuccessPage.
That will make the login slower but at least we make sure the profile is fully created when the user is redirected.

We could also trigger a smaller request to from the login page and create the user there. I'll check on monday because I think we had a task about refactoring that profile creation, but I haven't seen it, probably @techsmyth remembers


also added two skips to `usePendingMemberships`, which I think were causing issues too