### PR TITLE
Allow searching for external VCs by URL

### DIFF
--- a/src/core/utils/links.ts
+++ b/src/core/utils/links.ts
@@ -44,3 +44,11 @@ export const isFileAttachmentUrl = (link: string) => {
   }
   return path.startsWith(PRIVATE_STORAGE_ROOT_PATH);
 };
+
+export const getURLPath = (link: string) => {
+  try {
+    return new URL(link).pathname;
+  } catch (e) {
+    return null;
+  }
+};

--- a/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
+++ b/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
@@ -215,6 +215,7 @@ const CommunityVirtualContributors: FC<CommunityVirtualContributorsProps> = ({
         <CommunityAddMembersDialog
           onAdd={onAddClick}
           fetchAvailableEntities={getFilteredVirtualContributors}
+          allowSearchByURL
           onClose={() => setAddingNewMember(false)}
         />
       )}


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6480

The same Search was reused instead of duplicating both the search and result/s table (the story will be updated).

The `CommunityAddMembersDialog` now supports search of entities by URL, just by passing a flag, it could be easily enabled for users/orgs.