### PR TITLE
Update the default inno tab on template change

### DIFF
--- a/src/domain/journey/subspace/subspaceHome/SubspaceHomeView.tsx
+++ b/src/domain/journey/subspace/subspaceHome/SubspaceHomeView.tsx
@@ -7,7 +7,7 @@ import InnovationFlowStates from '../../../collaboration/InnovationFlow/Innovati
 import CalloutsGroupView from '../../../collaboration/callout/CalloutsInContext/CalloutsGroupView';
 import { OrderUpdate, TypedCallout } from '../../../collaboration/callout/useCallouts/useCallouts';
 import { InnovationFlowState } from '../../../collaboration/InnovationFlow/InnovationFlow';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { SubspaceInnovationFlow, useConsumeAction } from '../layout/SubspacePageLayout';
 import { useCalloutCreationWithPreviewImages } from '../../../collaboration/callout/creationDialog/useCalloutCreation/useCalloutCreationWithPreviewImages';
 import CalloutCreationDialog from '../../../collaboration/callout/creationDialog/CalloutCreationDialog';
@@ -67,9 +67,15 @@ const SubspaceHomeView = ({
     </Button>
   );
 
+  // on innovation flow tab change
   const [selectedInnovationFlowState, setSelectedInnovationFlowState] = useResettableState(currentInnovationFlowState, [
     innovationFlowId,
   ]);
+
+  // on innovation flow template change #6319
+  useEffect(() => {
+    setSelectedInnovationFlowState(currentInnovationFlowState);
+  }, [currentInnovationFlowState]);
 
   const selectedFlowStateCallouts = useMemo(() => {
     const filterCallouts = (callouts: TypedCallout[] | undefined) => {


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6319

@me-andre, please double-check the fix.

I know we had issues loading the default state in the past, and newly created callouts getting under different state... etc.

I've checked the main cases but please double-check we're not breaking existing logic.

___
I have to say I'm not a fan of _useResettableState_. Having the useEffect logic in the component would make it easier to understand, track issues, and even apply fixes.

