### PR TITLE
Sentry log improvements

### DIFF
--- a/src/core/apollo/graphqlLinks/useErrorLoggerLink.ts
+++ b/src/core/apollo/graphqlLinks/useErrorLoggerLink.ts
@@ -2,6 +2,12 @@ import { onError } from '@apollo/client/link/error';
 import { error as sentryError, TagCategoryValues } from '../../logging/sentry/log';
 import { useApm } from '../../analytics/apm/context';
 
+const getErrorCode = error => {
+  if (error && typeof error !== 'string') {
+    return error?.extensions?.code ?? undefined;
+  }
+};
+
 /**
  * This function is called after the GraphQL operation completes and execution is moving back up your link chain. i.e. a response is received
  * The function should not return a value unless you want to retry the operation.
@@ -25,7 +31,7 @@ export const useErrorLoggerLink = (errorLogging = false) => {
     }
 
     errors.forEach(e => {
-      sentryError(e, { category: TagCategoryValues.SERVER });
+      sentryError(e, { category: TagCategoryValues.SERVER, code: getErrorCode(e) });
       apm?.captureError(e);
     });
   });


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6538

- [x] Sentry logging was extended to pass 'code' as a tag.
- [x] CODE is now parsed on the Graphql onError handler.
- [x] The GraphQL web socket connection logic was altered to send Sentry errors on every  `onNonLazyError`. It was tested that on closing of a connection, an error is sent to Sentry.
- [x] On a development environment, a console log - [Sentry Log] - was added. It reveals the handled Sentry errors.