### PR TITLE
Fix server 4251: Read My created spaces from its own field

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -1538,6 +1538,7 @@ export type MeQueryResultsKeySpecifier = (
   | 'communityApplications'
   | 'communityInvitations'
   | 'id'
+  | 'myCreatedSpaces'
   | 'mySpaces'
   | 'spaceMemberships'
   | 'user'
@@ -1548,6 +1549,7 @@ export type MeQueryResultsFieldPolicy = {
   communityApplications?: FieldPolicy<any> | FieldReadFunction<any>;
   communityInvitations?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
+  myCreatedSpaces?: FieldPolicy<any> | FieldReadFunction<any>;
   mySpaces?: FieldPolicy<any> | FieldReadFunction<any>;
   spaceMemberships?: FieldPolicy<any> | FieldReadFunction<any>;
   user?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -23681,33 +23681,31 @@ export function refetchMembershipSuggestionSpaceQuery(variables: SchemaTypes.Mem
 export const MyAccountDocument = gql`
   query MyAccount {
     me {
-      mySpaces(showOnlyMyCreatedSpaces: true) {
-        space {
+      myCreatedSpaces {
+        id
+        profile {
           id
-          profile {
-            id
-            displayName
-            tagline
-            url
-            avatar: visual(type: AVATAR) {
-              ...VisualUri
-            }
-            cardBanner: visual(type: CARD) {
-              ...VisualUri
-            }
+          displayName
+          tagline
+          url
+          avatar: visual(type: AVATAR) {
+            ...VisualUri
           }
-          level
-          account {
+          cardBanner: visual(type: CARD) {
+            ...VisualUri
+          }
+        }
+        level
+        account {
+          id
+          host {
             id
-            host {
+            nameID
+            profile {
               id
-              nameID
-              profile {
-                id
-                displayName
-                tagline
-                url
-              }
+              displayName
+              tagline
+              url
             }
           }
         }
@@ -24036,30 +24034,28 @@ export const NewVirtualContributorMySpacesDocument = gql`
   query NewVirtualContributorMySpaces {
     me {
       id
-      mySpaces(showOnlyMyCreatedSpaces: true) {
-        space {
+      myCreatedSpaces {
+        id
+        account {
           id
-          account {
+          host {
             id
-            host {
-              id
-            }
           }
+        }
+        profile {
+          id
+          displayName
+        }
+        subspaces {
+          id
+          type
           profile {
             id
             displayName
+            url
           }
-          subspaces {
+          community {
             id
-            type
-            profile {
-              id
-              displayName
-              url
-            }
-            community {
-              id
-            }
           }
         }
       }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -2754,6 +2754,8 @@ export type MeQueryResults = {
   communityInvitations: Array<CommunityInvitationResult>;
   /** The query id */
   id: Scalars['String'];
+  /** The Spaces I have created */
+  myCreatedSpaces: Array<Space>;
   /** The Spaces I am contributing to */
   mySpaces: Array<MySpaceResults>;
   /** The applications of the current authenticated user */
@@ -2770,9 +2772,12 @@ export type MeQueryResultsCommunityInvitationsArgs = {
   states?: InputMaybe<Array<Scalars['String']>>;
 };
 
+export type MeQueryResultsMyCreatedSpacesArgs = {
+  limit?: InputMaybe<Scalars['Float']>;
+};
+
 export type MeQueryResultsMySpacesArgs = {
   limit?: InputMaybe<Scalars['Float']>;
-  showOnlyMyCreatedSpaces?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type MeQueryResultsSpaceMembershipsArgs = {
@@ -30106,45 +30111,42 @@ export type MyAccountQuery = {
   __typename?: 'Query';
   me: {
     __typename?: 'MeQueryResults';
-    mySpaces: Array<{
-      __typename?: 'MySpaceResults';
-      space: {
-        __typename?: 'Space';
+    myCreatedSpaces: Array<{
+      __typename?: 'Space';
+      id: string;
+      level: number;
+      profile: {
+        __typename?: 'Profile';
         id: string;
-        level: number;
-        profile: {
-          __typename?: 'Profile';
-          id: string;
-          displayName: string;
-          tagline: string;
-          url: string;
-          avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-          cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-        };
-        account: {
-          __typename?: 'Account';
-          id: string;
-          host?:
-            | {
-                __typename?: 'Organization';
-                id: string;
-                nameID: string;
-                profile: { __typename?: 'Profile'; id: string; displayName: string; tagline: string; url: string };
-              }
-            | {
-                __typename?: 'User';
-                id: string;
-                nameID: string;
-                profile: { __typename?: 'Profile'; id: string; displayName: string; tagline: string; url: string };
-              }
-            | {
-                __typename?: 'VirtualContributor';
-                id: string;
-                nameID: string;
-                profile: { __typename?: 'Profile'; id: string; displayName: string; tagline: string; url: string };
-              }
-            | undefined;
-        };
+        displayName: string;
+        tagline: string;
+        url: string;
+        avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+        cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+      };
+      account: {
+        __typename?: 'Account';
+        id: string;
+        host?:
+          | {
+              __typename?: 'Organization';
+              id: string;
+              nameID: string;
+              profile: { __typename?: 'Profile'; id: string; displayName: string; tagline: string; url: string };
+            }
+          | {
+              __typename?: 'User';
+              id: string;
+              nameID: string;
+              profile: { __typename?: 'Profile'; id: string; displayName: string; tagline: string; url: string };
+            }
+          | {
+              __typename?: 'VirtualContributor';
+              id: string;
+              nameID: string;
+              profile: { __typename?: 'Profile'; id: string; displayName: string; tagline: string; url: string };
+            }
+          | undefined;
       };
     }>;
     user?:
@@ -30332,29 +30334,26 @@ export type NewVirtualContributorMySpacesQuery = {
   me: {
     __typename?: 'MeQueryResults';
     id: string;
-    mySpaces: Array<{
-      __typename?: 'MySpaceResults';
-      space: {
+    myCreatedSpaces: Array<{
+      __typename?: 'Space';
+      id: string;
+      account: {
+        __typename?: 'Account';
+        id: string;
+        host?:
+          | { __typename?: 'Organization'; id: string }
+          | { __typename?: 'User'; id: string }
+          | { __typename?: 'VirtualContributor'; id: string }
+          | undefined;
+      };
+      profile: { __typename?: 'Profile'; id: string; displayName: string };
+      subspaces: Array<{
         __typename?: 'Space';
         id: string;
-        account: {
-          __typename?: 'Account';
-          id: string;
-          host?:
-            | { __typename?: 'Organization'; id: string }
-            | { __typename?: 'User'; id: string }
-            | { __typename?: 'VirtualContributor'; id: string }
-            | undefined;
-        };
-        profile: { __typename?: 'Profile'; id: string; displayName: string };
-        subspaces: Array<{
-          __typename?: 'Space';
-          id: string;
-          type: SpaceType;
-          profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
-          community: { __typename?: 'Community'; id: string };
-        }>;
-      };
+        type: SpaceType;
+        profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
+        community: { __typename?: 'Community'; id: string };
+      }>;
     }>;
   };
 };

--- a/src/main/topLevelPages/myDashboard/myAccount/MyAccount.graphql
+++ b/src/main/topLevelPages/myDashboard/myAccount/MyAccount.graphql
@@ -1,32 +1,30 @@
 query MyAccount {
   me {
-    mySpaces (showOnlyMyCreatedSpaces: true) {
-      space {
+    myCreatedSpaces {
+      id
+      profile {
         id
-        profile {
-          id
-          displayName
-          tagline
-          url
-          avatar: visual(type: AVATAR) {
-            ...VisualUri
-          }
-          cardBanner: visual(type: CARD) {
-            ...VisualUri
-          }
+        displayName
+        tagline
+        url
+        avatar: visual(type: AVATAR) {
+          ...VisualUri
         }
-        level
-        account {
+        cardBanner: visual(type: CARD) {
+          ...VisualUri
+        }
+      }
+      level
+      account {
+        id
+        host {
           id
-          host {
+          nameID
+          profile {
             id
-            nameID
-            profile {
-              id
-              displayName
-              tagline
-              url
-            }
+            displayName
+            tagline
+            url
           }
         }
       }

--- a/src/main/topLevelPages/myDashboard/myAccount/MyAccountBlock.tsx
+++ b/src/main/topLevelPages/myDashboard/myAccount/MyAccountBlock.tsx
@@ -25,10 +25,9 @@ const MyAccountBlock = () => {
   const { startWizard, NewVirtualContributorWizard } = useNewVirtualContributorWizard();
 
   // Curently displaying only the first hosted space and the first VC in it.
-  const hostedSpace = data?.me.mySpaces.filter(
-    spaceData =>
-      spaceData.space.account && spaceData.space.account.host?.id === data?.me.user?.id && spaceData.space.level === 0
-  )[0]?.space;
+  const hostedSpace = data?.me.myCreatedSpaces.filter(
+    spaceData => spaceData.account && spaceData.account.host?.id === data?.me.user?.id && spaceData.level === 0
+  )[0];
 
   const virtualContributors = data?.me.user?.accounts
     .filter(account => account.id === hostedSpace?.account.id)

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/newVirtualContributorQueries.graphql
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/newVirtualContributorQueries.graphql
@@ -1,30 +1,28 @@
 query NewVirtualContributorMySpaces {
   me {
     id
-    mySpaces(showOnlyMyCreatedSpaces: true) {
-      space {
+    myCreatedSpaces {
+      id
+      account {
         id
-        account {
+        host {
           id
-          host {
-            id
-          }
         }
+      }
+      profile {
+        id
+        displayName
+      }
+      subspaces {
+        id
+        type
         profile {
           id
           displayName
+          url
         }
-        subspaces {
+        community {
           id
-          type
-          profile {
-            id
-            displayName
-            url
-          }
-          community {
-            id
-          }
         }
       }
     }

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -61,12 +61,12 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
 
   const findMySpace = (
     userId: string | undefined,
-    mySpaces: NewVirtualContributorMySpacesQuery['me']['mySpaces'] | undefined
+    mySpaces: NewVirtualContributorMySpacesQuery['me']['myCreatedSpaces'] | undefined
   ) => {
     if (!userId || !mySpaces) {
       return undefined;
     }
-    const spacesHostedByUser = mySpaces.filter(space => space.space.account.host?.id === userId);
+    const spacesHostedByUser = mySpaces.filter(space => space.account.host?.id === userId);
     if (spacesHostedByUser.length > 0) {
       return spacesHostedByUser[0];
     } else {
@@ -76,15 +76,15 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
   };
 
   const { mySpaceId, myAccountId, mySpaceName, mySubspaces, selectableSubspaces } = useMemo(() => {
-    const mySpace = findMySpace(user?.user.id, data?.me.mySpaces);
+    const mySpace = findMySpace(user?.user.id, data?.me.myCreatedSpaces);
 
-    const mySubspaces = mySpace?.space.subspaces ?? [];
+    const mySubspaces = mySpace?.subspaces ?? [];
     const selectableSubspaces = mySubspaces.map(subspace => ({ id: subspace.id, name: subspace.profile.displayName }));
 
     return {
-      mySpaceId: mySpace?.space.id,
-      myAccountId: mySpace?.space.account.id,
-      mySpaceName: mySpace?.space.profile.displayName,
+      mySpaceId: mySpace?.id,
+      myAccountId: mySpace?.account.id,
+      mySpaceName: mySpace?.profile.displayName,
       mySubspaces,
       selectableSubspaces,
     };


### PR DESCRIPTION
Goes together with server PR: https://github.com/alkem-io/server/pull/4273

I've just removed the param `showOnlyMyCreatedSpaces` and have added a field to the `me` query that returns directly my created spaces instead of passing through activities.

