### PR TITLE
Contributor card in Search results not clickable

### DIFF
--- a/src/domain/community/user/ContributingUserCard/ContributingUserCard.tsx
+++ b/src/domain/community/user/ContributingUserCard/ContributingUserCard.tsx
@@ -50,6 +50,7 @@ const ContributingUserCard = ({ id, isContactable, ...contributorCardProps }: Co
         avatarAltText={t('common.avatar-of', { user: contributorCardProps.displayName })}
         isContactable={isContactable}
         onContact={openMessageUserDialog}
+        url={contributorCardProps.userUri}
         {...contributorCardProps}
       />
       <DirectMessageDialog


### PR DESCRIPTION
Go to Search and search for user. Scroll down to "Contributors" category - the card should be clickable and should redirect to the user's profile.