### PR TITLE
Log errors' messages to Sentry as LABEL for ease of filtering

### DIFF
--- a/src/core/apollo/graphqlLinks/useErrorLoggerLink.ts
+++ b/src/core/apollo/graphqlLinks/useErrorLoggerLink.ts
@@ -2,10 +2,12 @@ import { onError } from '@apollo/client/link/error';
 import { error as sentryError, TagCategoryValues } from '../../logging/sentry/log';
 import { useApm } from '../../analytics/apm/context';
 
-const getErrorCode = error => {
-  if (error && typeof error !== 'string') {
-    return error?.extensions?.code ?? undefined;
-  }
+const getErrorCode = (error: Error & { extensions?: { code?: string } }) => {
+  return error?.extensions?.code ?? undefined;
+};
+
+const getErrorMessage = (error: Error) => {
+  return error?.message ?? undefined;
 };
 
 /**
@@ -31,7 +33,7 @@ export const useErrorLoggerLink = (errorLogging = false) => {
     }
 
     errors.forEach(e => {
-      sentryError(e, { category: TagCategoryValues.SERVER, code: getErrorCode(e) });
+      sentryError(e, { category: TagCategoryValues.SERVER, code: getErrorCode(e), label: getErrorMessage(e) });
       apm?.captureError(e);
     });
   });


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6566

Currently, we're logging the errors of missing spaces:
![image](https://github.com/user-attachments/assets/dbb7b972-17ae-473d-aaa4-38d6c9468fa8)

https://alkemio.sentry.io/issues/5591643394/events/57ff0d39aaa0431e93f6eae293cfb476/?project=5862875

However, Sentry doesn't allow filtering of the error data. We can filter by our custom tags - CATEGORY, CODE & LABEL.
We can filter by CODE:"ENTITY_NOT_FOUND" but that includes all the entities not only spaces.


The fix is passing the error message to the LABEL tag. That way we can then filter by LABEL:"Unable to find Space with ID*".