### PR TITLE
Space's nameId creation handled on the server

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -17,6 +17,7 @@ export type AccountKeySpecifier = (
   | 'library'
   | 'licensePrivileges'
   | 'spaceID'
+  | 'storageAggregator'
   | 'subscriptions'
   | 'updatedDate'
   | 'virtualContributors'
@@ -35,6 +36,7 @@ export type AccountFieldPolicy = {
   library?: FieldPolicy<any> | FieldReadFunction<any>;
   licensePrivileges?: FieldPolicy<any> | FieldReadFunction<any>;
   spaceID?: FieldPolicy<any> | FieldReadFunction<any>;
+  storageAggregator?: FieldPolicy<any> | FieldReadFunction<any>;
   subscriptions?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
   virtualContributors?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -23752,54 +23752,6 @@ export function refetchNewVirtualContributorMySpacesQuery(
   return { query: NewVirtualContributorMySpacesDocument, variables: variables };
 }
 
-export const AllSpacesDocument = gql`
-  query AllSpaces {
-    spaces {
-      id
-      nameID
-    }
-  }
-`;
-
-/**
- * __useAllSpacesQuery__
- *
- * To run a query within a React component, call `useAllSpacesQuery` and pass it any options that fit your needs.
- * When your component renders, `useAllSpacesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useAllSpacesQuery({
- *   variables: {
- *   },
- * });
- */
-export function useAllSpacesQuery(
-  baseOptions?: Apollo.QueryHookOptions<SchemaTypes.AllSpacesQuery, SchemaTypes.AllSpacesQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<SchemaTypes.AllSpacesQuery, SchemaTypes.AllSpacesQueryVariables>(AllSpacesDocument, options);
-}
-
-export function useAllSpacesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<SchemaTypes.AllSpacesQuery, SchemaTypes.AllSpacesQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<SchemaTypes.AllSpacesQuery, SchemaTypes.AllSpacesQueryVariables>(
-    AllSpacesDocument,
-    options
-  );
-}
-
-export type AllSpacesQueryHookResult = ReturnType<typeof useAllSpacesQuery>;
-export type AllSpacesLazyQueryHookResult = ReturnType<typeof useAllSpacesLazyQuery>;
-export type AllSpacesQueryResult = Apollo.QueryResult<SchemaTypes.AllSpacesQuery, SchemaTypes.AllSpacesQueryVariables>;
-export function refetchAllSpacesQuery(variables?: SchemaTypes.AllSpacesQueryVariables) {
-  return { query: AllSpacesDocument, variables: variables };
-}
-
 export const RecentForumMessagesDocument = gql`
   query recentForumMessages($limit: Float = 5) {
     platform {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -60,6 +60,8 @@ export type Account = {
   licensePrivileges?: Maybe<Array<LicensePrivilege>>;
   /** The ID for the root space for the Account . */
   spaceID: Scalars['String'];
+  /** The StorageAggregator in use by this Account */
+  storageAggregator: StorageAggregator;
   /** The subscriptions active for this Account. */
   subscriptions: Array<AccountSubscription>;
   /** The date at which the entity was last updated. */
@@ -30455,13 +30457,6 @@ export type NewVirtualContributorMySpacesQuery = {
       }>;
     }>;
   };
-};
-
-export type AllSpacesQueryVariables = Exact<{ [key: string]: never }>;
-
-export type AllSpacesQuery = {
-  __typename?: 'Query';
-  spaces: Array<{ __typename?: 'Space'; id: string; nameID: string }>;
 };
 
 export type RecentForumMessagesQueryVariables = Exact<{

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/newVirtualContributorQueries.graphql
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/newVirtualContributorQueries.graphql
@@ -35,10 +35,3 @@ query NewVirtualContributorMySpaces {
     }
   }
 }
-
-query AllSpaces {
-  spaces {
-    id
-    nameID
-  }
-}

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -1,7 +1,6 @@
 import { ComponentType, useCallback, useMemo, useState } from 'react';
 import {
   refetchMyAccountQuery,
-  useAllSpacesQuery,
   useCreateNewSpaceMutation,
   useCreateVirtualContributorOnAccountMutation,
   useDeleteSpaceMutation,
@@ -123,20 +122,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
     setDialogOpen(true);
   };
 
-  const { data: allSpaces } = useAllSpacesQuery();
-  const allSpacesNameIds = allSpaces?.spaces.map(space => space.nameID) || [];
-  const makeUniqueName = (name: string): string => {
-    let uniqueName = name;
-    let counter = 1;
-    while (allSpacesNameIds.includes(uniqueName)) {
-      uniqueName = `${name}${counter}`;
-      counter++;
-    }
-    return uniqueName;
-  };
-
   const generateSpaceName = (name: string) => `${name}'s Space`;
-  const generateNameId = (name: string) => `${name}s Space`.toLowerCase().replaceAll(' ', '');
 
   const [CreateNewSpace] = useCreateNewSpaceMutation();
   const handleCreateSpace = async () => {
@@ -153,7 +139,6 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
       variables: {
         hostId: user?.user.id,
         spaceData: {
-          nameID: makeUniqueName(generateNameId(user?.user.profile.displayName!)),
           profileData: {
             displayName: generateSpaceName(user?.user.profile.displayName!),
           },


### PR DESCRIPTION
No need to handle the nameId generation on the client during space creation in the VC flow.