### PR TITLE
(Kratos) Placement and styling of the back button

### DIFF
--- a/src/core/auth/authentication/components/Button.tsx
+++ b/src/core/auth/authentication/components/Button.tsx
@@ -4,8 +4,8 @@ export interface AuthActionButtonProps extends ButtonProps {
   justifyContent?: 'start' | 'center';
 }
 
-const AuthActionButton = ({ justifyContent, ...props }: AuthActionButtonProps) => {
-  return <Button variant="contained" sx={{ width: '100%', justifyContent }} {...(props as ButtonProps)} />;
+const AuthActionButton = ({ justifyContent, variant = 'contained', ...props }: AuthActionButtonProps) => {
+  return <Button variant={variant} sx={{ width: '100%', justifyContent }} {...(props as ButtonProps)} />;
 };
 
 export default AuthActionButton;

--- a/src/core/auth/authentication/components/Kratos/KratosButton.tsx
+++ b/src/core/auth/authentication/components/Kratos/KratosButton.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@mui/material';
+import { ButtonProps, Grid } from '@mui/material';
 import { UiNodeInputAttributes } from '@ory/kratos-client';
 import React, { FC, useContext } from 'react';
 import { KratosUIContext } from '../KratosUI';
@@ -7,9 +7,11 @@ import { KratosProps } from './KratosProps';
 import AuthActionButton, { AuthActionButtonProps } from '../Button';
 import { useTranslation } from 'react-i18next';
 
-interface KratosButtonProps extends KratosProps {}
+interface KratosButtonProps extends KratosProps {
+  variant?: ButtonProps['variant'];
+}
 
-export const KratosButton: FC<KratosButtonProps> = ({ node }) => {
+export const KratosButton: FC<KratosButtonProps> = ({ node, variant = 'contained' }) => {
   const attributes = node.attributes as UiNodeInputAttributes;
   const { onBeforeSubmit } = useContext(KratosUIContext);
   const { t } = useTranslation();
@@ -22,6 +24,7 @@ export const KratosButton: FC<KratosButtonProps> = ({ node }) => {
         disabled={attributes.disabled}
         value={attributes.value}
         onClick={onBeforeSubmit}
+        variant={variant}
       >
         {getNodeTitle(node, t)}
       </AuthActionButton>

--- a/src/core/auth/authentication/components/Kratos/helpers.ts
+++ b/src/core/auth/authentication/components/Kratos/helpers.ts
@@ -76,6 +76,8 @@ export const guessVariant = ({ attributes }: UiNode) => {
       return null;
     case 'password':
       return 'password';
+    case 'profile':
+      return 'profile';
     default:
       return 'text';
   }

--- a/src/core/auth/authentication/components/KratosUI.tsx
+++ b/src/core/auth/authentication/components/KratosUI.tsx
@@ -106,6 +106,11 @@ export const KratosUI: FC<KratosUIProps> = ({
               return { ...acc, submit: [...acc.submit, node] };
             }
             return { ...acc, password: [...acc.password, node] };
+          case 'profile':
+            if (isSubmitButton(node)) {
+              return { ...acc, submit: [...acc.submit, node] };
+            }
+            return { ...acc, password: [...acc.password, node] };
           default:
             return { ...acc, rest: [...acc.rest, node] };
         }
@@ -158,6 +163,9 @@ export const KratosUI: FC<KratosUIProps> = ({
       case 'hidden':
         return <KratosHidden key={key} node={node} />;
       case 'submit':
+        if (node.attributes.value.includes(':back')) {
+          return <KratosButton key={key} node={node} variant="text" />;
+        }
         return <KratosButton key={key} node={node} />;
       case 'checkbox':
         return <KratosCheckbox key={key} node={node} />;


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6687

Handling of the back button:
- [x] position (after any submit buttons);
- [x] styling (less prominent than the submit) / overall support of different variants for the Kratos buttons;
- [x]  variant for 'profile' added;


When reviewing please note the check for ':back'. It's not ideal but I couldn't think of a better one. It works and it should work for other 'back' buttons.   


⚠️Note, in order to review the change locally you need to remove the following line from the .build\ory\kratos\kratos.yml in the server:
`enable_legacy_one_step: true`