### PR TITLE
Add VC to sub community on creation

### DIFF
--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/ExistingSpace.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/ExistingSpace.tsx
@@ -14,6 +14,7 @@ export interface SelectableKnowledgeProps {
   name: string;
   accountId: string;
   url: string | undefined;
+  communityId?: string;
 }
 
 interface ExistingSpaceProps {


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6604

Fixing - a newly created VC with a subspace as BoK is not part of the BoK community. 

The implementation depends on community.id passed only for subspaces. 