### PR TITLE
Create a subspace as BoK for every VC but the first one

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2948,12 +2948,12 @@
       "externalAI": "External AI"
     },
     "loadingInfo": {
-      "spaceCreation": "A Space for adding the knowledge for your Virtual Contributor is being built. This process may take a few moments to complete.",
+      "spaceCreation": "A {{entity}} for adding the knowledge for your Virtual Contributor is being built. This process may take a few moments to complete.",
       "vcCreation": "Your Virtual Contributor is being created. This process may take a few moments to complete."
     },
     "cancel": {
       "title": "Discard Virtual Contributor",
-      "description": "Are you sure you want to stop creating your Virtual Contributor? Your work will not be saved. A space might already be created for you. Please, reload the page if you confirm the cancellation.",
+      "description": "Are you sure you want to stop creating your Virtual Contributor? Your work will not be saved. A space/subspace might already be created for you. Please, reload the page if you confirm the cancellation.",
       "deleted": "Virtual Contributor deleted successfuly!"
     },
     "addContent": {

--- a/src/domain/collaboration/callout/creationDialog/useCalloutCreation/useCalloutCreation.ts
+++ b/src/domain/collaboration/callout/creationDialog/useCalloutCreation/useCalloutCreation.ts
@@ -38,6 +38,7 @@ export interface CalloutCreationType {
 
 export interface CalloutCreationParams {
   journeyId: string | undefined;
+  collabId?: string;
   initialOpened?: boolean;
 }
 
@@ -54,6 +55,7 @@ export interface CalloutCreationUtils {
 
 export const useCalloutCreation = ({
   journeyId,
+  collabId,
   initialOpened = false,
 }: CalloutCreationParams): CalloutCreationUtils => {
   const [isCalloutCreationDialogOpen, setIsCalloutCreationDialogOpen] = useState(initialOpened);
@@ -62,15 +64,14 @@ export const useCalloutCreation = ({
 
   const [createCallout] = useCreateCalloutMutation({
     update: (cache, { data }) => {
-      if (!data || !collaborationId) {
+      if (!data || !(collabId || collaborationId)) {
         return;
       }
-
       const { createCalloutOnCollaboration } = data;
 
       const collabRefId = cache.identify({
         __typename: 'Collaboration',
-        id: collaborationId,
+        id: collabId ?? collaborationId,
       });
 
       if (!collabRefId) {
@@ -100,7 +101,7 @@ export const useCalloutCreation = ({
 
   const handleCreateCallout = useCallback(
     async (callout: CalloutCreationType) => {
-      if (!collaborationId) {
+      if (!collaborationId && !collabId) {
         return;
       }
 
@@ -110,7 +111,7 @@ export const useCalloutCreation = ({
         const result = await createCallout({
           variables: {
             calloutData: {
-              collaborationID: collaborationId,
+              collaborationID: collabId ?? collaborationId ?? '',
               ...callout,
             },
           },
@@ -123,7 +124,7 @@ export const useCalloutCreation = ({
         setIsCreating(false);
       }
     },
-    [collaborationId, createCallout]
+    [collabId, collaborationId, createCallout]
   );
 
   return {

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/LoadingState.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/LoadingState.tsx
@@ -9,9 +9,10 @@ import CancelDialog from './CancelDialog';
 
 type LoadingStateProps = {
   onClose: () => void;
+  entity?: string;
 };
 
-const LoadingState = ({ onClose }: LoadingStateProps) => {
+const LoadingState = ({ onClose, entity = 'space' }: LoadingStateProps) => {
   const { t } = useTranslation();
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -19,12 +20,24 @@ const LoadingState = ({ onClose }: LoadingStateProps) => {
     setDialogOpen(true);
   };
 
+  const getEntityValue = (entity: string) => {
+    switch (entity) {
+      case 'subspace':
+        return t('common.subspace');
+      case 'space':
+      default:
+        return t('common.space');
+    }
+  };
+
   return (
     <>
       <DialogHeader onClose={onCancel} />
       <Loading text="" />
       <Gutters padding={gutters(2)} textAlign="center">
-        <Caption>{t('createVirtualContributorWizard.loadingInfo.spaceCreation')}</Caption>
+        <Caption>
+          {t('createVirtualContributorWizard.loadingInfo.spaceCreation', { entity: getEntityValue(entity) })}
+        </Caption>
       </Gutters>
       <CancelDialog open={dialogOpen} onClose={() => setDialogOpen(false)} onConfirm={onClose} />
     </>

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/TryVirtualContributorDialog.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/TryVirtualContributorDialog.tsx
@@ -137,6 +137,8 @@ const TryVirtualContributorDialog: React.FC<TryVirtualContributorDialogProps> = 
   }, [spaceId, open, canCreateCallout]);
 
   if (calloutError || hasError) {
+    setDemoCalloutCreationLoading(false);
+    removeVCCreationCache();
     return null;
   }
 


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6727

- [x] If you create your first VC and then you continue to create VCs (without full page reload), all postCallouts are created in the main space (instead of its corresponding subspace);