### PR TITLE
Organization Account tab fixes

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1841,6 +1841,7 @@
             "hostedSpaces": "Hosted Spaces",
             "virtualContributors": "Virtual Contributors",
             "innovationPacks": "$t(common.innovation-packs)",
+            "noTemplates": "This Innovation Pack doesn't have any template yet",
             "customHomepages": "Your Custom Homepages",
             "hostTitle": "Host",
             "contactsLink": "If you want to change any of these settings, please contact the Alkemio team here.",

--- a/src/core/ui/card/ContributorCardHorizontal.tsx
+++ b/src/core/ui/card/ContributorCardHorizontal.tsx
@@ -20,9 +20,9 @@ export interface ContributorCardHorizontalProps {
         tagline?: string;
         location?: Location;
         tagsets?: { tags: string[] }[];
+        url?: string;
       }
     | undefined;
-  url?: string;
   onContact?: () => void;
   seamless?: boolean;
   actions?: ReactNode;
@@ -30,7 +30,6 @@ export interface ContributorCardHorizontalProps {
 }
 
 const ContributorCardHorizontal = ({
-  url,
   profile,
   onContact,
   seamless = false,
@@ -47,7 +46,7 @@ const ContributorCardHorizontal = ({
   if (!seamless) {
     return (
       <SwapColors>
-        <ContributorCardHorizontal profile={profile} url={url} onContact={onContact} seamless />
+        <ContributorCardHorizontal profile={profile} onContact={onContact} seamless />
       </SwapColors>
     );
   }
@@ -75,7 +74,7 @@ const ContributorCardHorizontal = ({
               </Avatar>
             }
             component={RouterLink}
-            to={url ?? ''}
+            to={profile?.url ?? ''}
           >
             <Box display="flex" flexDirection="row" justifyContent="space-between">
               <Box display="flex" flexDirection="column">

--- a/src/domain/collaboration/InnovationPack/InnovationPackCardHorizontal/InnovationPackCardHorizontal.tsx
+++ b/src/domain/collaboration/InnovationPack/InnovationPackCardHorizontal/InnovationPackCardHorizontal.tsx
@@ -20,11 +20,13 @@ export interface InnovationPackCardHorizontalProps {
     description?: string;
     url: string;
   };
-  calloutTemplatesCount?: number;
-  communityGuidelinesTemplatesCount?: number;
-  innovationFlowTemplatesCount?: number;
-  postTemplatesCount?: number;
-  whiteboardTemplatesCount?: number;
+  templates?: {
+    calloutTemplatesCount?: number;
+    communityGuidelinesTemplatesCount?: number;
+    innovationFlowTemplatesCount?: number;
+    postTemplatesCount?: number;
+    whiteboardTemplatesCount?: number;
+  };
 }
 
 export const InnovationPackCardHorizontalSkeleton = () => {
@@ -39,13 +41,24 @@ export const InnovationPackCardHorizontalSkeleton = () => {
 
 const InnovationPackCardHorizontal = ({
   profile: { displayName, description, url },
-  calloutTemplatesCount,
-  communityGuidelinesTemplatesCount,
-  innovationFlowTemplatesCount,
-  postTemplatesCount,
-  whiteboardTemplatesCount,
+  templates,
 }: InnovationPackCardHorizontalProps) => {
   const { t } = useTranslation();
+  const {
+    calloutTemplatesCount,
+    communityGuidelinesTemplatesCount,
+    innovationFlowTemplatesCount,
+    postTemplatesCount,
+    whiteboardTemplatesCount,
+  } = templates ?? {};
+
+  const totalTemplatesCount =
+    (calloutTemplatesCount ?? 0) +
+    (communityGuidelinesTemplatesCount ?? 0) +
+    (innovationFlowTemplatesCount ?? 0) +
+    (postTemplatesCount ?? 0) +
+    (whiteboardTemplatesCount ?? 0);
+
   return (
     <BadgeCardView
       visual={<RoundedIcon size="medium" component={InnovationPackIcon} />}
@@ -110,6 +123,7 @@ const InnovationPackCardHorizontal = ({
             <Caption>{innovationFlowTemplatesCount}</Caption>
           </CardFooterCountWithBadge>
         )}
+        {totalTemplatesCount === 0 && <Caption>{t('pages.admin.generic.sections.account.noTemplates')}</Caption>}
       </Box>
     </BadgeCardView>
   );

--- a/src/domain/collaboration/InnovationPack/InnovationPackProfilePage/InnovationPackBanner.tsx
+++ b/src/domain/collaboration/InnovationPack/InnovationPackProfilePage/InnovationPackBanner.tsx
@@ -66,8 +66,8 @@ const InnovationPackBanner = ({
             avatar: {
               uri: providerVisualUri,
             },
+            url: providerUri,
           }}
-          url={providerUri}
         />
       </PageContent>
     </Root>

--- a/src/domain/collaboration/whiteboard/share/WhiteboardShareSettings.tsx
+++ b/src/domain/collaboration/whiteboard/share/WhiteboardShareSettings.tsx
@@ -64,9 +64,7 @@ const WhiteboardShareSettings = ({
         <GridItem columns={4}>
           <Gutters disablePadding>
             <BlockSectionTitle>{t('components.shareSettings.ownedBy.title')}</BlockSectionTitle>
-            {createdBy && (
-              <ContributorCardHorizontal profile={createdBy.profile} url={createdBy.profile.url} seamless />
-            )}
+            {createdBy && <ContributorCardHorizontal profile={createdBy.profile} seamless />}
           </Gutters>
         </GridItem>
         <GridItem columns={4}>

--- a/src/domain/community/community/CommunityContributors/ContributingOrganizations.tsx
+++ b/src/domain/community/community/CommunityContributors/ContributingOrganizations.tsx
@@ -70,8 +70,8 @@ const ContributingOrganizations: FC<ContributingOrganizationsProps> = ({
           city: org.city,
           country: org.country,
         },
+        url: org.url,
       } || undefined,
-    url: org.url,
     titleEndAmendment: renderAssociatesCount(org),
     onContact: () => {
       sendMessage('organization', {

--- a/src/domain/community/user/pages/UserAccountPage.tsx
+++ b/src/domain/community/user/pages/UserAccountPage.tsx
@@ -88,10 +88,7 @@ export const UserAccountPage: FC<UserAccountPageProps> = () => {
           <BlockTitle>{t('pages.admin.generic.sections.account.virtualContributors')}</BlockTitle>
           <Gutters disablePadding>
             {loading && <JourneyCardHorizontalSkeleton />}
-            {!loading &&
-              virtualContributors?.map(vc => (
-                <ContributorCardHorizontal profile={vc.profile} url={vc.profile.url} seamless />
-              ))}
+            {!loading && virtualContributors?.map(vc => <ContributorCardHorizontal profile={vc.profile} seamless />)}
           </Gutters>
         </PageContentBlock>
         <PageContentBlock halfWidth>

--- a/src/domain/community/user/pages/UserAccountPage.tsx
+++ b/src/domain/community/user/pages/UserAccountPage.tsx
@@ -97,8 +97,7 @@ export const UserAccountPage: FC<UserAccountPageProps> = () => {
         <PageContentBlock halfWidth>
           <BlockTitle>{t('pages.admin.generic.sections.account.innovationPacks')}</BlockTitle>
           {loading && <InnovationPackCardHorizontalSkeleton />}
-          {!loading &&
-            innovationPacks?.map(pack => <InnovationPackCardHorizontal profile={pack.profile} {...pack.templates} />)}
+          {!loading && innovationPacks?.map(pack => <InnovationPackCardHorizontal {...pack} />)}
           <Actions>{isMyProfile && accountId && <CreateInnovationPackDialog accountId={accountId} />}</Actions>
         </PageContentBlock>
         {innovationHubs.length > 0 && (

--- a/src/domain/innovationHub/InnovationHubCardHorizontal/InnovationHubCardHorizontal.tsx
+++ b/src/domain/innovationHub/InnovationHubCardHorizontal/InnovationHubCardHorizontal.tsx
@@ -4,9 +4,10 @@ import Avatar from '../../../core/ui/avatar/Avatar';
 import RouterLink from '../../../core/ui/link/RouterLink';
 import { Caption, CardTitle } from '../../../core/ui/typography';
 import OneLineMarkdown from '../../../core/ui/markdown/OneLineMarkdown';
-import { SpaceVisibility } from '../../../core/apollo/generated/graphql-schema';
+import { AuthorizationPrivilege, SpaceVisibility } from '../../../core/apollo/generated/graphql-schema';
 import { gutters } from '../../../core/ui/grid/utils';
 import { useTranslation } from 'react-i18next';
+import { useUserContext } from '../../community/user';
 
 export const InnovationHubCardHorizontalSkeleton = () => (
   <BadgeCardView
@@ -62,8 +63,13 @@ const InnovationHubCardHorizontal = ({
   profile: { displayName, description, url, banner },
   ...spaces
 }: InnovationHubCardHorizontalProps) => {
+  const { user: { hasPlatformPrivilege } = {} } = useUserContext();
+  const isPlatformAdmin = hasPlatformPrivilege?.(AuthorizationPrivilege.PlatformAdmin);
+
+  const SelectComponent = () => (url && isPlatformAdmin ? { component: RouterLink, to: url } : { component: Box });
+
   return (
-    <BadgeCardView visual={<Avatar src={banner?.uri} size="medium" />} component={RouterLink} to={url ?? ''}>
+    <BadgeCardView visual={<Avatar src={banner?.uri} size="medium" />} {...SelectComponent()}>
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Box display="flex" flexDirection="column">
           <CardTitle>{displayName}</CardTitle>

--- a/src/domain/innovationHub/InnovationHubCardHorizontal/InnovationHubCardHorizontal.tsx
+++ b/src/domain/innovationHub/InnovationHubCardHorizontal/InnovationHubCardHorizontal.tsx
@@ -66,10 +66,16 @@ const InnovationHubCardHorizontal = ({
   const { user: { hasPlatformPrivilege } = {} } = useUserContext();
   const isPlatformAdmin = hasPlatformPrivilege?.(AuthorizationPrivilege.PlatformAdmin);
 
-  const SelectComponent = () => (url && isPlatformAdmin ? { component: RouterLink, to: url } : { component: Box });
+  const componentProps =
+    url && isPlatformAdmin
+      ? {
+          component: RouterLink,
+          to: url,
+        }
+      : undefined;
 
   return (
-    <BadgeCardView visual={<Avatar src={banner?.uri} size="medium" />} {...SelectComponent()}>
+    <BadgeCardView visual={<Avatar src={banner?.uri} size="medium" />} {...componentProps}>
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Box display="flex" flexDirection="column">
           <CardTitle>{displayName}</CardTitle>

--- a/src/domain/journey/common/journeyDashboardWelcomeBlock/JourneyDashboardWelcomeBlock.tsx
+++ b/src/domain/journey/common/journeyDashboardWelcomeBlock/JourneyDashboardWelcomeBlock.tsx
@@ -54,8 +54,7 @@ const JourneyDashboardWelcomeBlock = ({
           {leadUsers.slice(0, 2).map(user => (
             <ContributorCardHorizontal
               key={user.id}
-              profile={user.profile}
-              url={buildUserProfileUrl(user.nameID)}
+              profile={{ ...user.profile, url: buildUserProfileUrl(user.nameID) }}
               onContact={() => {
                 onContactLeadUser({
                   id: user.id,
@@ -75,8 +74,7 @@ const JourneyDashboardWelcomeBlock = ({
           {leadOrganizationsUnique.slice(0, 2).map(org => (
             <ContributorCardHorizontal
               key={org.id}
-              profile={org.profile}
-              url={buildOrganizationUrl(org.nameID)}
+              profile={{ ...org.profile, url: buildOrganizationUrl(org.nameID) }}
               onContact={() => {
                 onContactLeadOrganization({
                   id: org.id,
@@ -94,7 +92,7 @@ const JourneyDashboardWelcomeBlock = ({
       {leadVirtualContributors && leadVirtualContributors.length > 0 && (
         <Gutters flexWrap="wrap" row disablePadding>
           {leadVirtualContributors.slice(0, 2).map(vc => (
-            <ContributorCardHorizontal key={vc.id} profile={vc.profile} url={vc.profile.url} seamless />
+            <ContributorCardHorizontal key={vc.id} profile={vc.profile} seamless />
           ))}
         </Gutters>
       )}

--- a/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
+++ b/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
@@ -268,8 +268,8 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
                   avatar: hostOrganization.profile.avatar,
                   location: hostOrganization.profile.location,
                   tagsets: undefined,
+                  url: hostOrganization.profile.url,
                 }}
-                url={hostOrganization.profile.url}
                 seamless
               />
             </Gutters>

--- a/src/domain/platform/admin/organization/OrganizationAccountPage.tsx
+++ b/src/domain/platform/admin/organization/OrganizationAccountPage.tsx
@@ -20,10 +20,7 @@ const OrganizationAccountPage: FC<SettingsPageProps> = () => {
   const { spaceIds, virtualContributors, innovationPacks, innovationHubs } = useMemo(
     () => ({
       spaceIds: compact(accounts.flatMap(account => account.spaceID)),
-      virtualContributors: (accounts.flatMap(account => account.virtualContributors) ?? []).map(vc => ({
-        ...vc,
-        url: vc.profile.url,
-      })), // ContributorsCards have their url in the root of the properties
+      virtualContributors: accounts.flatMap(account => account.virtualContributors) ?? [],
       innovationPacks: accounts.flatMap(account => account.innovationPacks) ?? [],
       innovationHubs: accounts.flatMap(account => account.innovationHubs) ?? [],
     }),

--- a/src/domain/platform/admin/organization/OrganizationAccountPage.tsx
+++ b/src/domain/platform/admin/organization/OrganizationAccountPage.tsx
@@ -20,7 +20,10 @@ const OrganizationAccountPage: FC<SettingsPageProps> = () => {
   const { spaceIds, virtualContributors, innovationPacks, innovationHubs } = useMemo(
     () => ({
       spaceIds: compact(accounts.flatMap(account => account.spaceID)),
-      virtualContributors: accounts.flatMap(account => account.virtualContributors) ?? [],
+      virtualContributors: (accounts.flatMap(account => account.virtualContributors) ?? []).map(vc => ({
+        ...vc,
+        url: vc.profile.url,
+      })), // ContributorsCards have their url in the root of the properties
       innovationPacks: accounts.flatMap(account => account.innovationPacks) ?? [],
       innovationHubs: accounts.flatMap(account => account.innovationHubs) ?? [],
     }),

--- a/src/domain/platform/admin/organization/views/OrganizationAccountView.tsx
+++ b/src/domain/platform/admin/organization/views/OrganizationAccountView.tsx
@@ -13,7 +13,6 @@ import ContributorCardHorizontal, {
 } from '../../../../../core/ui/card/ContributorCardHorizontal';
 import InnovationPackCardHorizontal, {
   InnovationPackCardHorizontalProps,
-  InnovationPackCardHorizontalSkeleton,
 } from '../../../../collaboration/InnovationPack/InnovationPackCardHorizontal/InnovationPackCardHorizontal';
 import InnovationHubCardHorizontal, {
   InnovationHubCardHorizontalProps,
@@ -64,11 +63,12 @@ export const OrganizationAccountView = ({
           {!loading && virtualContributors?.map(vc => <ContributorCardHorizontal {...vc} seamless />)}
         </Gutters>
       </PageContentBlock>
-      <PageContentBlock halfWidth>
-        <BlockTitle>{t('pages.admin.generic.sections.account.innovationPacks')}</BlockTitle>
-        {loading && <InnovationPackCardHorizontalSkeleton />}
-        {!loading && innovationPacks?.map(pack => <InnovationPackCardHorizontal {...pack} />)}
-      </PageContentBlock>
+      {(innovationPacks?.length ?? 0) > 0 && (
+        <PageContentBlock halfWidth>
+          <BlockTitle>{t('pages.admin.generic.sections.account.innovationPacks')}</BlockTitle>
+          {!loading && innovationPacks.map(pack => <InnovationPackCardHorizontal {...pack} />)}
+        </PageContentBlock>
+      )}
       {innovationHubs.length > 0 && (
         <PageContentBlock halfWidth>
           <BlockTitle>{t('pages.admin.generic.sections.account.customHomepages')}</BlockTitle>


### PR DESCRIPTION
- Fixed Clicking on VC profile (refactor ContributorCardHorizontal and all its usages, now url is in the profile).
- Hide innnovationPacks if there are none
- Fix missing icons from the InnovationPacks cards
- Only link to the InnovationHub settings if you're an admin
