### PR TITLE
Keep selected collapsed/expanded state of the subspaces menu

### DIFF
--- a/src/domain/journey/subspace/layout/SubspacePageLayout.tsx
+++ b/src/domain/journey/subspace/layout/SubspacePageLayout.tsx
@@ -95,9 +95,10 @@ export const useConsumeAction = (action: SubspaceDialog | undefined | null | fal
   return actionDef;
 };
 
+const MENU_STATE_KEY = 'menuState';
 enum MenuState {
-  expanded = 'expanded',
-  collapsed = 'collapsed',
+  EXPANDED = 'expanded',
+  COLLAPSED = 'collapsed',
 }
 
 const SubspacePageLayout = ({
@@ -113,7 +114,7 @@ const SubspacePageLayout = ({
   children,
   infoColumnChildren,
 }: PropsWithChildren<SubspacePageLayoutProps>) => {
-  const [isCollapsed, setIsCollapsed] = useState(localStorage.getItem('menuState') === MenuState.collapsed || false);
+  const [isCollapsed, setIsCollapsed] = useState(localStorage.getItem(MENU_STATE_KEY) === MenuState.COLLAPSED || false);
 
   const { t } = useTranslation();
 
@@ -191,7 +192,7 @@ const SubspacePageLayout = ({
                         variant="contained"
                         onClick={() => {
                           setIsCollapsed(true);
-                          localStorage.setItem('menuState', MenuState.collapsed);
+                          localStorage.setItem(MENU_STATE_KEY, MenuState.COLLAPSED);
                         }}
                         sx={{ '.MuiSvgIcon-root': { transform: 'rotate(180deg)' } }}
                       >
@@ -207,7 +208,7 @@ const SubspacePageLayout = ({
                           iconButton
                           onClick={() => {
                             setIsCollapsed(false);
-                            localStorage.setItem('menuState', MenuState.expanded);
+                            localStorage.setItem(MENU_STATE_KEY, MenuState.EXPANDED);
                           }}
                         >
                           <KeyboardTab />

--- a/src/domain/journey/subspace/layout/SubspacePageLayout.tsx
+++ b/src/domain/journey/subspace/layout/SubspacePageLayout.tsx
@@ -95,6 +95,11 @@ export const useConsumeAction = (action: SubspaceDialog | undefined | null | fal
   return actionDef;
 };
 
+enum MenuState {
+  expanded = 'expanded',
+  collapsed = 'collapsed',
+}
+
 const SubspacePageLayout = ({
   journeyId,
   spaceReadAccess,
@@ -108,7 +113,7 @@ const SubspacePageLayout = ({
   children,
   infoColumnChildren,
 }: PropsWithChildren<SubspacePageLayoutProps>) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(localStorage.getItem('menuState') === MenuState.collapsed || false);
 
   const { t } = useTranslation();
 
@@ -178,26 +183,32 @@ const SubspacePageLayout = ({
                 }
               >
                 <PageContent>
-                  <InfoColumn collapsed={isExpanded}>
-                    {!isExpanded && <WelcomeBlock about={!isMobile}>{welcome}</WelcomeBlock>}
-                    {!isExpanded && (
+                  <InfoColumn collapsed={isCollapsed}>
+                    {!isCollapsed && <WelcomeBlock about={!isMobile}>{welcome}</WelcomeBlock>}
+                    {!isCollapsed && (
                       <FullWidthButton
                         startIcon={<KeyboardTab />}
                         variant="contained"
-                        onClick={() => setIsExpanded(true)}
+                        onClick={() => {
+                          setIsCollapsed(true);
+                          localStorage.setItem('menuState', MenuState.collapsed);
+                        }}
                         sx={{ '.MuiSvgIcon-root': { transform: 'rotate(180deg)' } }}
                       >
                         {t('buttons.collapse')}
                       </FullWidthButton>
                     )}
-                    <DialogActionButtons column={isExpanded}>
+                    <DialogActionButtons column={isCollapsed}>
                       {unconsumedActions}
-                      {isExpanded && (
+                      {isCollapsed && (
                         <ButtonWithTooltip
                           tooltip={t('buttons.expand')}
                           tooltipPlacement="right"
                           iconButton
-                          onClick={() => setIsExpanded(false)}
+                          onClick={() => {
+                            setIsCollapsed(false);
+                            localStorage.setItem('menuState', MenuState.expanded);
+                          }}
                         >
                           <KeyboardTab />
                         </ButtonWithTooltip>
@@ -206,7 +217,7 @@ const SubspacePageLayout = ({
                     {infoColumnChildren}
                   </InfoColumn>
                   <PageContentColumnBase
-                    columns={isExpanded ? 12 : 9}
+                    columns={isCollapsed ? 12 : 9}
                     flexBasis={0}
                     flexGrow={1}
                     flexShrink={1}


### PR DESCRIPTION
Keeping the selected state for all subspaces.
Renaming the prop isExpanded - having isExpanded(true) for collapsed and isExpanded(false) for expanded is very confusing.