### PR TITLE
Validation for mentions

### DIFF
--- a/src/domain/communication/room/Comments/CommentInputField.tsx
+++ b/src/domain/communication/room/Comments/CommentInputField.tsx
@@ -13,7 +13,11 @@ import Gutters from '../../../../core/ui/grid/Gutters';
 
 export const POPPER_Z_INDEX = 1400; // Dialogs are 1300
 const MAX_USERS_LISTED = 30;
+
 export const MENTION_SYMBOL = '@';
+const MENTION_INVALID_CHARS_REGEXP = /[.?%_\\]/; // skip mentions if any of these are used after MENTION_SYMBOL
+const MAX_SPACES_IN_MENTION = 2;
+const MAX_MENTION_LENGTH = 30;
 
 interface EnrichedSuggestionDataItem extends SuggestionDataItem {
   // `id` and `display` are from SuggestionDataItem and used by react-mentions
@@ -124,6 +128,8 @@ const StyledCommentInput = styled(Box)(({ theme }) => ({
   },
 }));
 
+const hasExcessiveSpaces = (searchTerm: string) => searchTerm.trim().split(' ').length > MAX_SPACES_IN_MENTION + 1;
+
 export const CommentInputField: FC<InputBaseComponentProps> = forwardRef<
   HTMLDivElement | null,
   InputBaseComponentProps
@@ -160,7 +166,13 @@ export const CommentInputField: FC<InputBaseComponentProps> = forwardRef<
   const hasVcInteraction = vcInteractions.some(interaction => interaction?.threadID === threadId);
 
   const getMentionableUsers = async (search: string): Promise<EnrichedSuggestionDataItem[]> => {
-    if (!search || emptyQueries.some(query => search.startsWith(query))) {
+    if (
+      !search ||
+      emptyQueries.some(query => search.startsWith(query)) ||
+      hasExcessiveSpaces(search) ||
+      MENTION_INVALID_CHARS_REGEXP.test(search) ||
+      search.length > MAX_MENTION_LENGTH
+    ) {
       return [];
     }
 

--- a/src/domain/communication/room/Comments/CommentInputField.tsx
+++ b/src/domain/communication/room/Comments/CommentInputField.tsx
@@ -15,7 +15,7 @@ export const POPPER_Z_INDEX = 1400; // Dialogs are 1300
 const MAX_USERS_LISTED = 30;
 
 export const MENTION_SYMBOL = '@';
-const MENTION_INVALID_CHARS_REGEXP = /[.?%_\\]/; // skip mentions if any of these are used after MENTION_SYMBOL
+const MENTION_INVALID_CHARS_REGEXP = /[?]/; // skip mentions if any of these are used after MENTION_SYMBOL
 const MAX_SPACES_IN_MENTION = 2;
 const MAX_MENTION_LENGTH = 30;
 


### PR DESCRIPTION
The following error: https://github.com/alkem-io/client-web/issues/6622
is caused after pasting a text in a comment textarea, where there's '@' (user mention). Everything behind the '@' is sent to the usersPaginated query. So it could be something like "@bobbykolev 1 what's the weather?" and the entire string is sent for search, throwing an SQL error. The '?' symbol causes the actual error.

In order to handle this situation (not only*), the following validation was added. In the case of:
- Invalid chars ~~(.?%_\)~~ '?';
- too many empty spaces (> 2);
- too long mention string (> 30);
skip the `usersPaginated` request and do not suggest mentions. 

*You can easily reproduce the issue without pasting content. Just put a question mark after the '@'.