### PR TITLE
Remove check for unique name

### DIFF
--- a/src/domain/collaboration/KnowledgeBase/KnowedgeBasePage.tsx
+++ b/src/domain/collaboration/KnowledgeBase/KnowedgeBasePage.tsx
@@ -81,7 +81,6 @@ const KnowledgeBasePage = () => {
               onClose={handleCreateCalloutClosed}
               onCreateCallout={handleCreateCallout}
               loading={loadingCalloutCreation}
-              calloutNames={calloutNames}
               groupName={CalloutGroupName.Knowledge}
               journeyTypeName="space"
             />

--- a/src/domain/collaboration/callout/CalloutForm.tsx
+++ b/src/domain/collaboration/callout/CalloutForm.tsx
@@ -88,14 +88,12 @@ export interface CalloutFormProps {
   onChange?: (callout: CalloutFormOutput) => void;
   onStatusChanged?: (isValid: boolean) => void;
   children?: FormikConfig<FormValueType>['children'];
-  calloutNames: string[];
   journeyTypeName: JourneyTypeName;
 }
 
 const CalloutForm: FC<CalloutFormProps> = ({
   calloutType,
   callout,
-  calloutNames,
   editMode = false,
   canChangeCalloutLocation,
   onChange,
@@ -145,19 +143,8 @@ const CalloutForm: FC<CalloutFormProps> = ({
     [callout?.id, tagsets]
   );
 
-  const uniqueNameValidator = yup
-    .string()
-    .required(t('common.field-required'))
-    .test('is-valid-name', t('components.callout-creation.info-step.unique-title-validation-text'), value => {
-      if (editMode) {
-        return Boolean(value && (!calloutNames.includes(value) || value === callout?.displayName));
-      } else {
-        return Boolean(value && !calloutNames.includes(value));
-      }
-    });
-
   const validationSchema = yup.object().shape({
-    displayName: displayNameValidator.concat(uniqueNameValidator),
+    displayName: displayNameValidator,
     description: MarkdownValidator(MARKDOWN_TEXT_LENGTH),
     type: yup.string().required(t('common.field-required')),
     opened: yup.boolean().required(),

--- a/src/domain/collaboration/callout/CalloutsInContext/CalloutsGroupView.tsx
+++ b/src/domain/collaboration/callout/CalloutsInContext/CalloutsGroupView.tsx
@@ -57,7 +57,6 @@ const CalloutsGroupView = ({
         onClose={handleCreateCalloutClosed}
         onCreateCallout={handleCreateCallout}
         loading={loading}
-        calloutNames={calloutNames}
         groupName={groupName}
         flowState={flowState}
         journeyTypeName={journeyTypeName}

--- a/src/domain/collaboration/callout/calloutBlock/CalloutSettingsContainer.tsx
+++ b/src/domain/collaboration/callout/calloutBlock/CalloutSettingsContainer.tsx
@@ -94,7 +94,6 @@ export interface CalloutSettingsContainerProps
     authorAvatarUri?: string;
     publishedAt?: string;
   };
-  calloutNames: string[];
   expanded?: boolean;
   journeyTypeName: JourneyTypeName;
 }
@@ -104,7 +103,6 @@ const CalloutSettingsContainer = ({
   onVisibilityChange,
   onCalloutEdit,
   onCalloutDelete,
-  calloutNames,
   topCallout,
   bottomCallout,
   onMoveUp,
@@ -290,7 +288,6 @@ const CalloutSettingsContainer = ({
           onCalloutEdit={handleCalloutEdit}
           onDelete={() => setDeleteDialogOpen(true)}
           canChangeCalloutLocation
-          calloutNames={calloutNames}
           journeyTypeName={journeyTypeName}
         />
       )}

--- a/src/domain/collaboration/callout/comments/CommentsCallout.tsx
+++ b/src/domain/collaboration/callout/comments/CommentsCallout.tsx
@@ -26,7 +26,6 @@ interface CommentsCalloutProps extends BaseCalloutViewProps {
   callout: CalloutLayoutProps['callout'] & {
     comments: CommentsCalloutData | undefined;
   };
-  calloutNames: string[];
   calloutActions?: boolean;
 }
 

--- a/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
+++ b/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
@@ -51,7 +51,6 @@ export interface CalloutCreationDialogProps {
   onClose: () => void;
   onCreateCallout: (callout: CalloutCreationTypeWithPreviewImages) => Promise<Identifiable | undefined>;
   loading: boolean;
-  calloutNames: string[];
   groupName: CalloutGroupName;
   flowState?: string;
   journeyTypeName: JourneyTypeName;
@@ -62,7 +61,6 @@ const CalloutCreationDialog: FC<CalloutCreationDialogProps> = ({
   onClose,
   onCreateCallout,
   loading,
-  calloutNames,
   groupName,
   flowState,
   journeyTypeName,
@@ -245,7 +243,6 @@ const CalloutCreationDialog: FC<CalloutCreationDialogProps> = ({
             <CalloutForm
               calloutType={selectedCalloutType}
               callout={callout}
-              calloutNames={calloutNames}
               onChange={handleValueChange}
               onStatusChanged={handleStatusChange}
               journeyTypeName={journeyTypeName}

--- a/src/domain/collaboration/callout/edit/editDialog/CalloutEditDialog.tsx
+++ b/src/domain/collaboration/callout/edit/editDialog/CalloutEditDialog.tsx
@@ -23,7 +23,6 @@ export interface CalloutEditDialogProps {
   onDelete: (callout: CalloutDeleteType) => void;
   onCalloutEdit: (callout: CalloutEditType) => Promise<void>;
   canChangeCalloutLocation?: boolean;
-  calloutNames: string[];
   journeyTypeName: JourneyTypeName;
 }
 
@@ -35,7 +34,6 @@ const CalloutEditDialog: FC<CalloutEditDialogProps> = ({
   onDelete,
   onCalloutEdit,
   canChangeCalloutLocation,
-  calloutNames,
   journeyTypeName,
 }) => {
   const { t } = useTranslation();
@@ -109,7 +107,6 @@ const CalloutEditDialog: FC<CalloutEditDialogProps> = ({
             <CalloutForm
               calloutType={calloutType}
               callout={initialValues}
-              calloutNames={calloutNames}
               editMode
               onStatusChanged={handleStatusChanged}
               onChange={handleChange}

--- a/src/domain/collaboration/callout/links/LinkCollectionCallout.tsx
+++ b/src/domain/collaboration/callout/links/LinkCollectionCallout.tsx
@@ -39,7 +39,6 @@ export interface LinkDetails {
 
 interface LinkCollectionCalloutProps extends BaseCalloutViewProps {
   callout: CalloutLayoutProps['callout'];
-  calloutNames: string[];
 }
 
 const LinkCollectionCallout = ({
@@ -50,7 +49,6 @@ const LinkCollectionCallout = ({
   onExpand,
   onCollapse,
   onCalloutUpdate,
-  calloutNames,
   journeyTypeName,
   ...calloutLayoutProps
 }: LinkCollectionCalloutProps) => {
@@ -198,7 +196,6 @@ const LinkCollectionCallout = ({
     >
       <CalloutSettingsContainer
         callout={callout}
-        calloutNames={calloutNames}
         journeyTypeName={journeyTypeName}
         expanded={expanded}
         {...calloutLayoutProps}

--- a/src/domain/collaboration/post/PostForm/PostForm.tsx
+++ b/src/domain/collaboration/post/PostForm/PostForm.tsx
@@ -96,19 +96,8 @@ const PostForm: FC<PostFormProps> = ({
     [post?.id]
   );
 
-  const uniqueNameValidator = yup
-    .string()
-    .required(t('common.field-required'))
-    .test('is-valid-name', t('components.post-creation.info-step.unique-name-validation-text'), value => {
-      if (edit) {
-        return Boolean(value && (!postNames?.includes(value) || value === post?.profileData?.displayName));
-      } else {
-        return Boolean(value && !postNames?.includes(value));
-      }
-    });
-
   const validationSchema = yup.object().shape({
-    name: displayNameValidator.concat(uniqueNameValidator),
+    name: displayNameValidator,
     description: MarkdownValidator(LONG_MARKDOWN_TEXT_LENGTH).required(),
     tagsets: tagsetSegmentSchema,
     references: referenceSegmentSchema,

--- a/src/domain/journey/subspace/subspaceHome/SubspaceHomeView.tsx
+++ b/src/domain/journey/subspace/subspaceHome/SubspaceHomeView.tsx
@@ -137,7 +137,6 @@ const SubspaceHomeView = ({
         onClose={handleCreateCalloutClosed}
         onCreateCallout={handleCreateCallout}
         loading={loading}
-        calloutNames={calloutNames}
         groupName={CalloutGroupName.Home}
         journeyTypeName={journeyTypeName}
         flowState={selectedInnovationFlowState}


### PR DESCRIPTION
Allow callouts with the same displayName to be created within a collaboration