### PR TITLE
VC creation flow fixes

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -16722,6 +16722,66 @@ export function refetchSpaceUrlQuery(variables: SchemaTypes.SpaceUrlQueryVariabl
   return { query: SpaceUrlDocument, variables: variables };
 }
 
+export const SpaceCommunityIdDocument = gql`
+  query SpaceCommunityId($spaceNameId: UUID_NAMEID!) {
+    space(ID: $spaceNameId) {
+      id
+      community {
+        id
+      }
+    }
+  }
+`;
+
+/**
+ * __useSpaceCommunityIdQuery__
+ *
+ * To run a query within a React component, call `useSpaceCommunityIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSpaceCommunityIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSpaceCommunityIdQuery({
+ *   variables: {
+ *      spaceNameId: // value for 'spaceNameId'
+ *   },
+ * });
+ */
+export function useSpaceCommunityIdQuery(
+  baseOptions: Apollo.QueryHookOptions<SchemaTypes.SpaceCommunityIdQuery, SchemaTypes.SpaceCommunityIdQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SchemaTypes.SpaceCommunityIdQuery, SchemaTypes.SpaceCommunityIdQueryVariables>(
+    SpaceCommunityIdDocument,
+    options
+  );
+}
+
+export function useSpaceCommunityIdLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.SpaceCommunityIdQuery,
+    SchemaTypes.SpaceCommunityIdQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SchemaTypes.SpaceCommunityIdQuery, SchemaTypes.SpaceCommunityIdQueryVariables>(
+    SpaceCommunityIdDocument,
+    options
+  );
+}
+
+export type SpaceCommunityIdQueryHookResult = ReturnType<typeof useSpaceCommunityIdQuery>;
+export type SpaceCommunityIdLazyQueryHookResult = ReturnType<typeof useSpaceCommunityIdLazyQuery>;
+export type SpaceCommunityIdQueryResult = Apollo.QueryResult<
+  SchemaTypes.SpaceCommunityIdQuery,
+  SchemaTypes.SpaceCommunityIdQueryVariables
+>;
+export function refetchSpaceCommunityIdQuery(variables: SchemaTypes.SpaceCommunityIdQueryVariables) {
+  return { query: SpaceCommunityIdDocument, variables: variables };
+}
+
 export const SpaceHostDocument = gql`
   query SpaceHost($spaceNameId: UUID_NAMEID!) {
     space(ID: $spaceNameId) {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -21359,6 +21359,15 @@ export type SpaceUrlQuery = {
   space: { __typename?: 'Space'; id: string; profile: { __typename?: 'Profile'; id: string; url: string } };
 };
 
+export type SpaceCommunityIdQueryVariables = Exact<{
+  spaceNameId: Scalars['UUID_NAMEID'];
+}>;
+
+export type SpaceCommunityIdQuery = {
+  __typename?: 'Query';
+  space: { __typename?: 'Space'; id: string; community: { __typename?: 'Community'; id: string } };
+};
+
 export type SpaceInfoFragment = {
   __typename?: 'Space';
   visibility: SpaceVisibility;

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2946,6 +2946,10 @@
       "description": "",
       "successMessage": "Virtual Contributor '{{name}}' created successfully"
     },
+    "autoCreated": {
+      "subSpaceVision": "-",
+      "subSpaceTagline": "A Knowledge Base of a Virtual Contributor"
+    },
     "initial": {
       "title": "Create a Virtual Contributor",
       "profileDescription": "Choose a name and enrich your Virtual Contributors profile below.",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2944,7 +2944,7 @@
     "noSpaces": "Couldn't find any Space hosted by you, please contact us for support.",
     "createdVirtualContributor": {
       "description": "",
-      "successMessage": "Virtual Contributor '{{virtualContributorName}}' created successfully"
+      "successMessage": "Virtual Contributor '{{name}}' created successfully"
     },
     "initial": {
       "title": "Create a Virtual Contributor",

--- a/src/domain/journey/space/SpaceContext/spaceProvider.graphql
+++ b/src/domain/journey/space/SpaceContext/spaceProvider.graphql
@@ -14,6 +14,15 @@ query SpaceUrl($spaceNameId: UUID_NAMEID!) {
   }
 }
 
+query SpaceCommunityId($spaceNameId: UUID_NAMEID!) {
+  space(ID: $spaceNameId) {
+    id
+    community {
+      id
+    }
+  }
+}
+
 fragment SpaceInfo on Space {
   ...SpaceDetails
   authorization {

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/ExistingSpace.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/ExistingSpace.tsx
@@ -15,6 +15,7 @@ export interface SelectableKnowledgeProps {
   accountId: string;
   url: string | undefined;
   communityId?: string;
+  parentCommunityId?: string;
 }
 
 interface ExistingSpaceProps {


### PR DESCRIPTION

- [x] Fixing https://github.com/alkem-io/client-web/issues/6793 by storing the parentCommunityId and adding the VC to it;
- [x] Translations - fix of the VC creation success msg; auto-generated vision & tagline for subspace are now in the translations;
- [x] `spaceId` & `mySpaceId` were ambiguous making the code hard to follow. Fixed.
- [x] ⚠️ UX change - on Existing knowledge and subspace creation, navigate the user to the Space (not the subspace as it was);
- cleanup;
 


Note, that it's not ideal but currently we're adding the VCs to the first space in the account (creating subspaces there):
`selectedExistingSpaceId: mySpaces?.[0]?.id,`
I don't know how we can improve that, atm.