### PR TITLE
[Tech] merge assignCommunityRoleToVirtual into one mutation

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -1844,6 +1844,7 @@ export type MutationKeySpecifier = (
   | 'assignCommunityRoleToOrganization'
   | 'assignCommunityRoleToUser'
   | 'assignCommunityRoleToVirtual'
+  | 'assignLicensePlanToAccount'
   | 'assignLicensePlanToSpace'
   | 'assignOrganizationRoleToUser'
   | 'assignPlatformRoleToUser'
@@ -1936,6 +1937,7 @@ export type MutationKeySpecifier = (
   | 'resetChatGuidance'
   | 'revokeCredentialFromOrganization'
   | 'revokeCredentialFromUser'
+  | 'revokeLicensePlanFromAccount'
   | 'revokeLicensePlanFromSpace'
   | 'sendMessageReplyToRoom'
   | 'sendMessageToCommunityLeads'
@@ -2013,6 +2015,7 @@ export type MutationFieldPolicy = {
   assignCommunityRoleToOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   assignCommunityRoleToUser?: FieldPolicy<any> | FieldReadFunction<any>;
   assignCommunityRoleToVirtual?: FieldPolicy<any> | FieldReadFunction<any>;
+  assignLicensePlanToAccount?: FieldPolicy<any> | FieldReadFunction<any>;
   assignLicensePlanToSpace?: FieldPolicy<any> | FieldReadFunction<any>;
   assignOrganizationRoleToUser?: FieldPolicy<any> | FieldReadFunction<any>;
   assignPlatformRoleToUser?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2105,6 +2108,7 @@ export type MutationFieldPolicy = {
   resetChatGuidance?: FieldPolicy<any> | FieldReadFunction<any>;
   revokeCredentialFromOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   revokeCredentialFromUser?: FieldPolicy<any> | FieldReadFunction<any>;
+  revokeLicensePlanFromAccount?: FieldPolicy<any> | FieldReadFunction<any>;
   revokeLicensePlanFromSpace?: FieldPolicy<any> | FieldReadFunction<any>;
   sendMessageReplyToRoom?: FieldPolicy<any> | FieldReadFunction<any>;
   sendMessageToCommunityLeads?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -11123,60 +11123,6 @@ export function refetchAvailableVirtualContributorsInLibraryQuery(
   return { query: AvailableVirtualContributorsInLibraryDocument, variables: variables };
 }
 
-export const AddVirtualContributorToCommunityDocument = gql`
-  mutation AddVirtualContributorToCommunity($communityId: UUID!, $virtualContributorId: UUID_NAMEID!) {
-    assignCommunityRoleToVirtual(
-      roleData: { communityID: $communityId, role: MEMBER, virtualContributorID: $virtualContributorId }
-    ) {
-      id
-    }
-  }
-`;
-export type AddVirtualContributorToCommunityMutationFn = Apollo.MutationFunction<
-  SchemaTypes.AddVirtualContributorToCommunityMutation,
-  SchemaTypes.AddVirtualContributorToCommunityMutationVariables
->;
-
-/**
- * __useAddVirtualContributorToCommunityMutation__
- *
- * To run a mutation, you first call `useAddVirtualContributorToCommunityMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useAddVirtualContributorToCommunityMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [addVirtualContributorToCommunityMutation, { data, loading, error }] = useAddVirtualContributorToCommunityMutation({
- *   variables: {
- *      communityId: // value for 'communityId'
- *      virtualContributorId: // value for 'virtualContributorId'
- *   },
- * });
- */
-export function useAddVirtualContributorToCommunityMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    SchemaTypes.AddVirtualContributorToCommunityMutation,
-    SchemaTypes.AddVirtualContributorToCommunityMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    SchemaTypes.AddVirtualContributorToCommunityMutation,
-    SchemaTypes.AddVirtualContributorToCommunityMutationVariables
-  >(AddVirtualContributorToCommunityDocument, options);
-}
-
-export type AddVirtualContributorToCommunityMutationHookResult = ReturnType<
-  typeof useAddVirtualContributorToCommunityMutation
->;
-export type AddVirtualContributorToCommunityMutationResult =
-  Apollo.MutationResult<SchemaTypes.AddVirtualContributorToCommunityMutation>;
-export type AddVirtualContributorToCommunityMutationOptions = Apollo.BaseMutationOptions<
-  SchemaTypes.AddVirtualContributorToCommunityMutation,
-  SchemaTypes.AddVirtualContributorToCommunityMutationVariables
->;
 export const RemoveVirtualContributorFromCommunityDocument = gql`
   mutation RemoveVirtualContributorFromCommunity($communityId: UUID!, $virtualContributorId: UUID_NAMEID!) {
     removeCommunityRoleFromVirtual(
@@ -11235,7 +11181,7 @@ export const AssignCommunityRoleToVirtualContributorDocument = gql`
   mutation AssignCommunityRoleToVirtualContributor(
     $communityId: UUID!
     $virtualContributorId: UUID_NAMEID!
-    $role: CommunityRole!
+    $role: CommunityRole! = MEMBER
   ) {
     assignCommunityRoleToVirtual(
       roleData: { communityID: $communityId, role: $role, virtualContributorID: $virtualContributorId }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -733,6 +733,15 @@ export type AssignCommunityRoleToVirtualInput = {
   virtualContributorID: Scalars['UUID_NAMEID'];
 };
 
+export type AssignLicensePlanToAccount = {
+  /** The ID of the Account to assign the LicensePlan to. */
+  accountID: Scalars['UUID'];
+  /** The ID of the LicensePlan to assign. */
+  licensePlanID: Scalars['UUID'];
+  /** The ID of the Licensing to use. */
+  licensingID?: InputMaybe<Scalars['UUID']>;
+};
+
 export type AssignLicensePlanToSpace = {
   /** The ID of the LicensePlan to assign. */
   licensePlanID: Scalars['UUID'];
@@ -3136,6 +3145,8 @@ export type Mutation = {
   assignCommunityRoleToUser: User;
   /** Assigns a Virtual Contributor to a role in the specified Community. */
   assignCommunityRoleToVirtual: VirtualContributor;
+  /** Assign the specified LicensePlan to an Account. */
+  assignLicensePlanToAccount: Account;
   /** Assign the specified LicensePlan to a Space. */
   assignLicensePlanToSpace: Space;
   /** Assigns an Organization Role to user. */
@@ -3320,6 +3331,8 @@ export type Mutation = {
   revokeCredentialFromOrganization: Organization;
   /** Removes an authorization credential from a User. */
   revokeCredentialFromUser: User;
+  /** Revokes the specified LicensePlan on an Account. */
+  revokeLicensePlanFromAccount: Account;
   /** Revokes the specified LicensePlan on a Space. */
   revokeLicensePlanFromSpace: Space;
   /** Sends a reply to a message from the specified Room. */
@@ -3490,6 +3503,10 @@ export type MutationAssignCommunityRoleToUserArgs = {
 
 export type MutationAssignCommunityRoleToVirtualArgs = {
   roleData: AssignCommunityRoleToVirtualInput;
+};
+
+export type MutationAssignLicensePlanToAccountArgs = {
+  planData: AssignLicensePlanToAccount;
 };
 
 export type MutationAssignLicensePlanToSpaceArgs = {
@@ -3830,6 +3847,10 @@ export type MutationRevokeCredentialFromOrganizationArgs = {
 
 export type MutationRevokeCredentialFromUserArgs = {
   revokeCredentialData: RevokeAuthorizationCredentialInput;
+};
+
+export type MutationRevokeLicensePlanFromAccountArgs = {
+  planData: RevokeLicensePlanFromAccount;
 };
 
 export type MutationRevokeLicensePlanFromSpaceArgs = {
@@ -4944,6 +4965,15 @@ export type RevokeAuthorizationCredentialInput = {
   type: AuthorizationCredential;
   /** The user from whom the credential is being removed. */
   userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
+export type RevokeLicensePlanFromAccount = {
+  /** The ID of the Account to assign the LicensePlan to. */
+  accountID: Scalars['UUID'];
+  /** The ID of the LicensePlan to assign. */
+  licensePlanID: Scalars['UUID'];
+  /** The ID of the Licensing to use. */
+  licensingID?: InputMaybe<Scalars['UUID']>;
 };
 
 export type RevokeLicensePlanFromSpace = {
@@ -16811,16 +16841,6 @@ export type VirtualContributorNameFragment = {
   profile: { __typename?: 'Profile'; id: string; displayName: string };
 };
 
-export type AddVirtualContributorToCommunityMutationVariables = Exact<{
-  communityId: Scalars['UUID'];
-  virtualContributorId: Scalars['UUID_NAMEID'];
-}>;
-
-export type AddVirtualContributorToCommunityMutation = {
-  __typename?: 'Mutation';
-  assignCommunityRoleToVirtual: { __typename?: 'VirtualContributor'; id: string };
-};
-
 export type RemoveVirtualContributorFromCommunityMutationVariables = Exact<{
   communityId: Scalars['UUID'];
   virtualContributorId: Scalars['UUID_NAMEID'];
@@ -16834,7 +16854,7 @@ export type RemoveVirtualContributorFromCommunityMutation = {
 export type AssignCommunityRoleToVirtualContributorMutationVariables = Exact<{
   communityId: Scalars['UUID'];
   virtualContributorId: Scalars['UUID_NAMEID'];
-  role: CommunityRole;
+  role?: CommunityRole;
 }>;
 
 export type AssignCommunityRoleToVirtualContributorMutation = {

--- a/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
+++ b/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
@@ -20,9 +20,9 @@ import {
   useAssignCommunityRoleToUserMutation,
   useRemoveCommunityRoleFromUserMutation,
   useAvailableVirtualContributorsLazyQuery,
-  useAddVirtualContributorToCommunityMutation,
   useRemoveVirtualContributorFromCommunityMutation,
   useAvailableVirtualContributorsInLibraryLazyQuery,
+  useAssignCommunityRoleToVirtualContributorMutation,
 } from '../../../../core/apollo/generated/apollo-hooks';
 import {
   AuthorizationCredential,
@@ -427,7 +427,7 @@ const useCommunityAdmin = ({
     return refetchCommunityMembers();
   };
 
-  const [addVirtualContributor] = useAddVirtualContributorToCommunityMutation();
+  const [addVirtualContributor] = useAssignCommunityRoleToVirtualContributorMutation();
   const handleAddVirtualContributor = async (virtualContributorId: string) => {
     if (!communityId) {
       return;

--- a/src/domain/community/community/useCommunityAssignment/VirtualContributors.graphql
+++ b/src/domain/community/community/useCommunityAssignment/VirtualContributors.graphql
@@ -46,14 +46,6 @@ fragment VirtualContributorName on VirtualContributor {
   }
 }
 
-mutation AddVirtualContributorToCommunity($communityId: UUID!, $virtualContributorId: UUID_NAMEID!) {
-  assignCommunityRoleToVirtual(
-    roleData: { communityID: $communityId, role: MEMBER, virtualContributorID: $virtualContributorId }
-  ) {
-    id
-  }
-}
-
 mutation RemoveVirtualContributorFromCommunity($communityId: UUID!, $virtualContributorId: UUID_NAMEID!) {
   removeCommunityRoleFromVirtual(
     roleData: { communityID: $communityId, role: MEMBER, virtualContributorID: $virtualContributorId }
@@ -65,7 +57,7 @@ mutation RemoveVirtualContributorFromCommunity($communityId: UUID!, $virtualCont
 mutation AssignCommunityRoleToVirtualContributor(
   $communityId: UUID!
   $virtualContributorId: UUID_NAMEID!
-  $role: CommunityRole!
+  $role: CommunityRole! = MEMBER
 ) {
   assignCommunityRoleToVirtual(
     roleData: { communityID: $communityId, role: $role, virtualContributorID: $virtualContributorId }

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -1,7 +1,6 @@
 import { ComponentType, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   refetchSubspacesInSpaceQuery,
-  useAddVirtualContributorToCommunityMutation,
   useCreateSpaceMutation,
   useCreatePostFromContributeTabMutation,
   useCreateSubspaceMutation,
@@ -12,6 +11,7 @@ import {
   useSpaceUrlLazyQuery,
   useSubspaceProfileInfoQuery,
   useSubspaceCommunityIdLazyQuery,
+  useAssignCommunityRoleToVirtualContributorMutation,
 } from '../../../../core/apollo/generated/apollo-hooks';
 import {
   CalloutGroupName,
@@ -412,7 +412,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
     }
   };
 
-  const [addVirtualContributorToCommunity] = useAddVirtualContributorToCommunityMutation();
+  const [addVirtualContributorToCommunity] = useAssignCommunityRoleToVirtualContributorMutation();
   const [createVirtualContributor] = useCreateVirtualContributorOnAccountMutation({
     refetchQueries: ['MyAccount'],
   });


### PR DESCRIPTION
It's a simple technical one (no ticket).
We had two definitions using the same `assignCommunityRoleToVirtual` mutation. 
Now they are merged into one with a default value of the 'role'.