### PR TITLE
Deletion of entities on Account Tab

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1416,12 +1416,13 @@
       "visibility": "This Space is currently in <strong>{{visibility}}</strong> mode",
       "readOnly": "If you want to change any of this information, please contact the Alkemio team here."
     },
-    "deleteSpace": {
+    "deleteEntity": {
       "title": "Danger Zone",
       "description": "Click here to delete this {{entity}}. Be careful, this action cannot be undone.",
       "confirmDialog": {
         "title": "Confirm {{entity}} Deletion",
         "description": "Are you certain you want to delete this {{entity}}? Keep in mind that this action is irreversible. You can only delete a {{entity}} if there are no underlying Subspaces associated with it. If there are any Subspaces within this page, please delete them first (you can do so from the {{entity}} settings > Subspaces page).",
+        "descriptionShort": "Are you certain you want to delete this {{entity}}? Keep in mind that this action is irreversible.",
         "checkbox": "Please check this box if you are certain about deleting this {{entity}}",
         "confirm": "Yes, delete"
       }

--- a/src/core/ui/card/ActionsMenu.tsx
+++ b/src/core/ui/card/ActionsMenu.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { IconButton, Menu } from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import { useTranslation } from 'react-i18next';
+
+interface ActionsMenuProps {
+  children: React.ReactNode;
+}
+
+const ActionsMenu: React.FC<ActionsMenuProps> = ({ children }) => {
+  const { t } = useTranslation();
+  const [settingsAnchorEl, setSettingsAnchorEl] = useState<null | HTMLElement>(null);
+  const settingsOpened = Boolean(settingsAnchorEl);
+
+  const onMenuClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setSettingsAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setSettingsAnchorEl(null);
+  };
+
+  return (
+    <div onClick={e => e.stopPropagation()}>
+      <IconButton
+        aria-label={t('common.settings')}
+        aria-haspopup="true"
+        aria-controls={settingsOpened ? 'settings-menu' : undefined}
+        aria-expanded={settingsOpened ? 'true' : undefined}
+        onClick={onMenuClick}
+      >
+        <MoreVertIcon color="primary" />
+      </IconButton>
+      <Menu
+        aria-labelledby="settings-button"
+        anchorEl={settingsAnchorEl}
+        open={settingsOpened}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+      >
+        {children}
+      </Menu>
+    </div>
+  );
+};
+
+export default ActionsMenu;

--- a/src/core/ui/card/ContributorCardHorizontal.tsx
+++ b/src/core/ui/card/ContributorCardHorizontal.tsx
@@ -9,6 +9,7 @@ import SwapColors from '../palette/SwapColors';
 import RouterLink from '../link/RouterLink';
 import { BlockSectionTitle, Caption } from '../typography';
 import ContributorTooltip from './ContributorTooltip';
+import ActionsMenu from './ActionsMenu';
 
 export interface ContributorCardHorizontalProps {
   profile:
@@ -27,6 +28,7 @@ export interface ContributorCardHorizontalProps {
   seamless?: boolean;
   actions?: ReactNode;
   titleEndAmendment?: ReactNode;
+  menuActions?: ReactNode;
 }
 
 const ContributorCardHorizontal = ({
@@ -34,6 +36,7 @@ const ContributorCardHorizontal = ({
   onContact,
   seamless = false,
   actions,
+  menuActions,
   titleEndAmendment,
 }: ContributorCardHorizontalProps) => {
   const { t } = useTranslation();
@@ -75,6 +78,7 @@ const ContributorCardHorizontal = ({
             }
             component={RouterLink}
             to={profile?.url ?? ''}
+            actions={menuActions && <ActionsMenu>{menuActions}</ActionsMenu>}
           >
             <Box display="flex" flexDirection="row" justifyContent="space-between">
               <Box display="flex" flexDirection="column">

--- a/src/core/ui/list/BadgeCardView.tsx
+++ b/src/core/ui/list/BadgeCardView.tsx
@@ -5,6 +5,7 @@ import { gutters } from '../grid/utils';
 
 interface BadgeCardViewProps {
   visual?: ReactElement<{ sx: { flexShrink: number } }>;
+  actions?: ReactElement<{ sx: { flexShrink: number } }>;
   visualRight?: ReactElement<{ sx: { flexShrink: number } }>;
   contentProps?: BoxProps;
   outlined?: boolean;
@@ -37,6 +38,7 @@ const BadgeCardView = forwardRef(
       outlined = false,
       square = false,
       padding = outlined,
+      actions = undefined,
       ...containerProps
     }: PropsWithChildren<BadgeCardViewProps> & Omit<BoxProps<D, P>, 'padding'>,
     ref
@@ -59,6 +61,7 @@ const BadgeCardView = forwardRef(
           </Box>
         )}
         {cloneVisual(visualRight)}
+        {actions && cloneVisual(actions)}
       </Box>
     );
   }

--- a/src/domain/collaboration/InnovationPack/InnovationPackCardHorizontal/InnovationPackCardHorizontal.tsx
+++ b/src/domain/collaboration/InnovationPack/InnovationPackCardHorizontal/InnovationPackCardHorizontal.tsx
@@ -70,67 +70,65 @@ const InnovationPackCardHorizontal = ({
       to={url ?? ''}
       actions={actions && <ActionsMenu>{actions}</ActionsMenu>}
     >
-      <Box>
-        <Box display="flex" flexDirection="row" justifyContent="space-between">
-          <Box display="flex" flexDirection="column">
-            <CardTitle>{displayName}</CardTitle>
-            <OneLineMarkdown>{description ?? ''}</OneLineMarkdown>
-          </Box>
+      <Box display="flex" flexDirection="row" justifyContent="space-between">
+        <Box display="flex" flexDirection="column">
+          <CardTitle>{displayName}</CardTitle>
+          <OneLineMarkdown>{description ?? ''}</OneLineMarkdown>
         </Box>
-        <Box display="flex" gap={gutters(0.5)} height={gutters(2)} alignItems="center" justifyContent="start">
-          {!!calloutTemplatesCount && (
-            <CardFooterCountWithBadge
-              iconComponent={DesignServicesIcon}
-              tooltip={t('common.enums.templateTypes.CollaborationToolTemplate_plural')}
-            >
-              <Caption>{calloutTemplatesCount}</Caption>
-            </CardFooterCountWithBadge>
-          )}
-          {!!whiteboardTemplatesCount && (
-            <CardFooterCountWithBadge
-              iconComponent={WhiteboardIcon}
-              tooltip={t('common.enums.templateTypes.WhiteboardTemplate_plural')}
-            >
-              <Caption>{whiteboardTemplatesCount}</Caption>
-            </CardFooterCountWithBadge>
-          )}
-          {!!communityGuidelinesTemplatesCount && (
-            <CardFooterCountWithBadge
-              iconComponent={CommunityGuidelinesIcon}
-              tooltip={t('common.enums.templateTypes.CommunityGuidelinesTemplate_plural')}
-            >
-              <Caption>{communityGuidelinesTemplatesCount}</Caption>
-            </CardFooterCountWithBadge>
-          )}
-          {!!postTemplatesCount && (
-            <CardFooterCountWithBadge
-              iconComponent={PostIcon}
-              tooltip={t('common.enums.templateTypes.PostTemplate_plural')}
-            >
-              <Caption>{postTemplatesCount}</Caption>
-            </CardFooterCountWithBadge>
-          )}
-          {!!innovationFlowTemplatesCount && (
-            <CardFooterCountWithBadge
-              tooltip={t('common.enums.templateTypes.InnovationFlowTemplate_plural')}
-              icon={
-                // TODO Try to redraw InnovationFlowIcon in the same way as MUI icons are done
-                <Box
-                  width={theme => theme.spacing(1.5)}
-                  sx={{ svg: { width: '100%' } }}
-                  display="flex"
-                  justifyContent="center"
-                  alignItems="center"
-                >
-                  <InnovationFlowIcon />
-                </Box>
-              }
-            >
-              <Caption>{innovationFlowTemplatesCount}</Caption>
-            </CardFooterCountWithBadge>
-          )}
-          {totalTemplatesCount === 0 && <Caption>{t('pages.admin.generic.sections.account.noTemplates')}</Caption>}
-        </Box>
+      </Box>
+      <Box display="flex" gap={gutters(0.5)} height={gutters(2)} alignItems="center" justifyContent="start">
+        {!!calloutTemplatesCount && (
+          <CardFooterCountWithBadge
+            iconComponent={DesignServicesIcon}
+            tooltip={t('common.enums.templateTypes.CollaborationToolTemplate_plural')}
+          >
+            <Caption>{calloutTemplatesCount}</Caption>
+          </CardFooterCountWithBadge>
+        )}
+        {!!whiteboardTemplatesCount && (
+          <CardFooterCountWithBadge
+            iconComponent={WhiteboardIcon}
+            tooltip={t('common.enums.templateTypes.WhiteboardTemplate_plural')}
+          >
+            <Caption>{whiteboardTemplatesCount}</Caption>
+          </CardFooterCountWithBadge>
+        )}
+        {!!communityGuidelinesTemplatesCount && (
+          <CardFooterCountWithBadge
+            iconComponent={CommunityGuidelinesIcon}
+            tooltip={t('common.enums.templateTypes.CommunityGuidelinesTemplate_plural')}
+          >
+            <Caption>{communityGuidelinesTemplatesCount}</Caption>
+          </CardFooterCountWithBadge>
+        )}
+        {!!postTemplatesCount && (
+          <CardFooterCountWithBadge
+            iconComponent={PostIcon}
+            tooltip={t('common.enums.templateTypes.PostTemplate_plural')}
+          >
+            <Caption>{postTemplatesCount}</Caption>
+          </CardFooterCountWithBadge>
+        )}
+        {!!innovationFlowTemplatesCount && (
+          <CardFooterCountWithBadge
+            tooltip={t('common.enums.templateTypes.InnovationFlowTemplate_plural')}
+            icon={
+              // TODO Try to redraw InnovationFlowIcon in the same way as MUI icons are done
+              <Box
+                width={theme => theme.spacing(1.5)}
+                sx={{ svg: { width: '100%' } }}
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+              >
+                <InnovationFlowIcon />
+              </Box>
+            }
+          >
+            <Caption>{innovationFlowTemplatesCount}</Caption>
+          </CardFooterCountWithBadge>
+        )}
+        {totalTemplatesCount === 0 && <Caption>{t('pages.admin.generic.sections.account.noTemplates')}</Caption>}
       </Box>
     </BadgeCardView>
   );

--- a/src/domain/collaboration/InnovationPack/InnovationPackCardHorizontal/InnovationPackCardHorizontal.tsx
+++ b/src/domain/collaboration/InnovationPack/InnovationPackCardHorizontal/InnovationPackCardHorizontal.tsx
@@ -1,6 +1,5 @@
 import DesignServicesIcon from '@mui/icons-material/DesignServices';
-import { Box, IconButton, Menu, Skeleton, useTheme } from '@mui/material';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import { Box, Skeleton, useTheme } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import CardFooterCountWithBadge from '../../../../core/ui/card/CardFooterCountWithBadge';
 import { gutters } from '../../../../core/ui/grid/utils';
@@ -14,7 +13,7 @@ import { WhiteboardIcon } from '../../whiteboard/icon/WhiteboardIcon';
 import InnovationPackIcon from '../InnovationPackIcon';
 import OneLineMarkdown from '../../../../core/ui/markdown/OneLineMarkdown';
 import RoundedIcon from '../../../../core/ui/icon/RoundedIcon';
-import { useState } from 'react';
+import ActionsMenu from '../../../../core/ui/card/ActionsMenu';
 
 export interface InnovationPackCardHorizontalProps {
   profile: {
@@ -49,11 +48,6 @@ const InnovationPackCardHorizontal = ({
 }: InnovationPackCardHorizontalProps) => {
   const { t } = useTranslation();
 
-  const [settingsAnchorEl, setSettingsAnchorEl] = useState<null | HTMLElement>(null);
-  const settingsOpened = Boolean(settingsAnchorEl);
-  const handleSettingsOpened = (event: React.MouseEvent<HTMLElement>) => setSettingsAnchorEl(event.currentTarget);
-  const handleSettingsClose = () => setSettingsAnchorEl(null);
-
   const {
     calloutTemplatesCount,
     communityGuidelinesTemplatesCount,
@@ -72,35 +66,11 @@ const InnovationPackCardHorizontal = ({
   return (
     <BadgeCardView
       visual={<RoundedIcon size="medium" component={InnovationPackIcon} />}
-      actions={
-        actions && (
-          <>
-            <IconButton
-              aria-label={t('common.settings')}
-              aria-haspopup="true"
-              aria-controls={settingsOpened ? 'settings-menu' : undefined}
-              aria-expanded={settingsOpened ? 'true' : undefined}
-              onClick={handleSettingsOpened}
-            >
-              <MoreVertIcon color="primary" />
-            </IconButton>
-            <Menu
-              aria-labelledby="settings-button"
-              anchorEl={settingsAnchorEl}
-              open={settingsOpened}
-              onClose={handleSettingsClose}
-              anchorOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-            >
-              {actions}
-            </Menu>
-          </>
-        )
-      }
+      component={RouterLink}
+      to={url ?? ''}
+      actions={actions && <ActionsMenu>{actions}</ActionsMenu>}
     >
-      <Box component={RouterLink} to={url ?? ''}>
+      <Box>
         <Box display="flex" flexDirection="row" justifyContent="space-between">
           <Box display="flex" flexDirection="column">
             <CardTitle>{displayName}</CardTitle>

--- a/src/domain/collaboration/InnovationPack/InnovationPackCardHorizontal/InnovationPackCardHorizontal.tsx
+++ b/src/domain/collaboration/InnovationPack/InnovationPackCardHorizontal/InnovationPackCardHorizontal.tsx
@@ -1,5 +1,6 @@
 import DesignServicesIcon from '@mui/icons-material/DesignServices';
-import { Box, Skeleton, useTheme } from '@mui/material';
+import { Box, IconButton, Menu, Skeleton, useTheme } from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { useTranslation } from 'react-i18next';
 import CardFooterCountWithBadge from '../../../../core/ui/card/CardFooterCountWithBadge';
 import { gutters } from '../../../../core/ui/grid/utils';
@@ -13,6 +14,7 @@ import { WhiteboardIcon } from '../../whiteboard/icon/WhiteboardIcon';
 import InnovationPackIcon from '../InnovationPackIcon';
 import OneLineMarkdown from '../../../../core/ui/markdown/OneLineMarkdown';
 import RoundedIcon from '../../../../core/ui/icon/RoundedIcon';
+import { useState } from 'react';
 
 export interface InnovationPackCardHorizontalProps {
   profile: {
@@ -27,6 +29,7 @@ export interface InnovationPackCardHorizontalProps {
     postTemplatesCount?: number;
     whiteboardTemplatesCount?: number;
   };
+  actions?: React.ReactNode;
 }
 
 export const InnovationPackCardHorizontalSkeleton = () => {
@@ -42,8 +45,15 @@ export const InnovationPackCardHorizontalSkeleton = () => {
 const InnovationPackCardHorizontal = ({
   profile: { displayName, description, url },
   templates,
+  actions = undefined,
 }: InnovationPackCardHorizontalProps) => {
   const { t } = useTranslation();
+
+  const [settingsAnchorEl, setSettingsAnchorEl] = useState<null | HTMLElement>(null);
+  const settingsOpened = Boolean(settingsAnchorEl);
+  const handleSettingsOpened = (event: React.MouseEvent<HTMLElement>) => setSettingsAnchorEl(event.currentTarget);
+  const handleSettingsClose = () => setSettingsAnchorEl(null);
+
   const {
     calloutTemplatesCount,
     communityGuidelinesTemplatesCount,
@@ -62,68 +72,95 @@ const InnovationPackCardHorizontal = ({
   return (
     <BadgeCardView
       visual={<RoundedIcon size="medium" component={InnovationPackIcon} />}
-      component={RouterLink}
-      to={url ?? ''}
+      actions={
+        actions && (
+          <>
+            <IconButton
+              aria-label={t('common.settings')}
+              aria-haspopup="true"
+              aria-controls={settingsOpened ? 'settings-menu' : undefined}
+              aria-expanded={settingsOpened ? 'true' : undefined}
+              onClick={handleSettingsOpened}
+            >
+              <MoreVertIcon color="primary" />
+            </IconButton>
+            <Menu
+              aria-labelledby="settings-button"
+              anchorEl={settingsAnchorEl}
+              open={settingsOpened}
+              onClose={handleSettingsClose}
+              anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+            >
+              {actions}
+            </Menu>
+          </>
+        )
+      }
     >
-      <Box display="flex" flexDirection="row" justifyContent="space-between">
-        <Box display="flex" flexDirection="column">
-          <CardTitle>{displayName}</CardTitle>
-          <OneLineMarkdown>{description ?? ''}</OneLineMarkdown>
+      <Box component={RouterLink} to={url ?? ''}>
+        <Box display="flex" flexDirection="row" justifyContent="space-between">
+          <Box display="flex" flexDirection="column">
+            <CardTitle>{displayName}</CardTitle>
+            <OneLineMarkdown>{description ?? ''}</OneLineMarkdown>
+          </Box>
         </Box>
-      </Box>
-      <Box display="flex" gap={gutters(0.5)} height={gutters(2)} alignItems="center" justifyContent="start">
-        {!!calloutTemplatesCount && (
-          <CardFooterCountWithBadge
-            iconComponent={DesignServicesIcon}
-            tooltip={t('common.enums.templateTypes.CollaborationToolTemplate_plural')}
-          >
-            <Caption>{calloutTemplatesCount}</Caption>
-          </CardFooterCountWithBadge>
-        )}
-        {!!whiteboardTemplatesCount && (
-          <CardFooterCountWithBadge
-            iconComponent={WhiteboardIcon}
-            tooltip={t('common.enums.templateTypes.WhiteboardTemplate_plural')}
-          >
-            <Caption>{whiteboardTemplatesCount}</Caption>
-          </CardFooterCountWithBadge>
-        )}
-        {!!communityGuidelinesTemplatesCount && (
-          <CardFooterCountWithBadge
-            iconComponent={CommunityGuidelinesIcon}
-            tooltip={t('common.enums.templateTypes.CommunityGuidelinesTemplate_plural')}
-          >
-            <Caption>{communityGuidelinesTemplatesCount}</Caption>
-          </CardFooterCountWithBadge>
-        )}
-        {!!postTemplatesCount && (
-          <CardFooterCountWithBadge
-            iconComponent={PostIcon}
-            tooltip={t('common.enums.templateTypes.PostTemplate_plural')}
-          >
-            <Caption>{postTemplatesCount}</Caption>
-          </CardFooterCountWithBadge>
-        )}
-        {!!innovationFlowTemplatesCount && (
-          <CardFooterCountWithBadge
-            tooltip={t('common.enums.templateTypes.InnovationFlowTemplate_plural')}
-            icon={
-              // TODO Try to redraw InnovationFlowIcon in the same way as MUI icons are done
-              <Box
-                width={theme => theme.spacing(1.5)}
-                sx={{ svg: { width: '100%' } }}
-                display="flex"
-                justifyContent="center"
-                alignItems="center"
-              >
-                <InnovationFlowIcon />
-              </Box>
-            }
-          >
-            <Caption>{innovationFlowTemplatesCount}</Caption>
-          </CardFooterCountWithBadge>
-        )}
-        {totalTemplatesCount === 0 && <Caption>{t('pages.admin.generic.sections.account.noTemplates')}</Caption>}
+        <Box display="flex" gap={gutters(0.5)} height={gutters(2)} alignItems="center" justifyContent="start">
+          {!!calloutTemplatesCount && (
+            <CardFooterCountWithBadge
+              iconComponent={DesignServicesIcon}
+              tooltip={t('common.enums.templateTypes.CollaborationToolTemplate_plural')}
+            >
+              <Caption>{calloutTemplatesCount}</Caption>
+            </CardFooterCountWithBadge>
+          )}
+          {!!whiteboardTemplatesCount && (
+            <CardFooterCountWithBadge
+              iconComponent={WhiteboardIcon}
+              tooltip={t('common.enums.templateTypes.WhiteboardTemplate_plural')}
+            >
+              <Caption>{whiteboardTemplatesCount}</Caption>
+            </CardFooterCountWithBadge>
+          )}
+          {!!communityGuidelinesTemplatesCount && (
+            <CardFooterCountWithBadge
+              iconComponent={CommunityGuidelinesIcon}
+              tooltip={t('common.enums.templateTypes.CommunityGuidelinesTemplate_plural')}
+            >
+              <Caption>{communityGuidelinesTemplatesCount}</Caption>
+            </CardFooterCountWithBadge>
+          )}
+          {!!postTemplatesCount && (
+            <CardFooterCountWithBadge
+              iconComponent={PostIcon}
+              tooltip={t('common.enums.templateTypes.PostTemplate_plural')}
+            >
+              <Caption>{postTemplatesCount}</Caption>
+            </CardFooterCountWithBadge>
+          )}
+          {!!innovationFlowTemplatesCount && (
+            <CardFooterCountWithBadge
+              tooltip={t('common.enums.templateTypes.InnovationFlowTemplate_plural')}
+              icon={
+                // TODO Try to redraw InnovationFlowIcon in the same way as MUI icons are done
+                <Box
+                  width={theme => theme.spacing(1.5)}
+                  sx={{ svg: { width: '100%' } }}
+                  display="flex"
+                  justifyContent="center"
+                  alignItems="center"
+                >
+                  <InnovationFlowIcon />
+                </Box>
+              }
+            >
+              <Caption>{innovationFlowTemplatesCount}</Caption>
+            </CardFooterCountWithBadge>
+          )}
+          {totalTemplatesCount === 0 && <Caption>{t('pages.admin.generic.sections.account.noTemplates')}</Caption>}
+        </Box>
       </Box>
     </BadgeCardView>
   );

--- a/src/domain/community/contributor/AccountTab/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/AccountTab/ContributorAccountView.tsx
@@ -28,6 +28,7 @@ import { VIRTUAL_CONTRIBUTORS_LIMIT } from '../../../../main/topLevelPages/myDas
 import MenuItemWithIcon from '../../../../core/ui/menu/MenuItemWithIcon';
 import { DeleteOutline } from '@mui/icons-material';
 import {
+  useDeleteInnovationHubMutation,
   useDeleteInnovationPackMutation,
   useDeleteSpaceMutation,
   useDeleteVirtualContributorOnAccountMutation,
@@ -95,6 +96,7 @@ export interface ContributorAccountViewProps {
       };
     }[];
     innovationHubs: {
+      id: string;
       profile: AccountProfile & {
         banner?: { uri: string };
       };
@@ -187,33 +189,6 @@ export const ContributorAccountView: FC<ContributorAccountViewProps> = ({ accoun
     setDeleteDialogOpen(true);
   };
 
-  // Pack Deletion
-  const [deletePackMutation, { loading: deletePackLoading }] = useDeleteInnovationPackMutation({
-    onCompleted: () => {
-      clearDeleteState();
-      notify('Innovation Pack deleted successfully!', 'success');
-    },
-    refetchQueries: ['AccountInformation'],
-  });
-
-  const deletePack = () => {
-    if (!selectedId) {
-      return;
-    }
-
-    deletePackMutation({
-      variables: {
-        innovationPackId: selectedId,
-      },
-    });
-  };
-
-  const onDeletePackClick = (id: string) => {
-    setSelectedEntity(Entities.InnovationPack);
-    setSelectedId(id);
-    setDeleteDialogOpen(true);
-  };
-
   // VC Deletion
   const [deleteVCMutation, { loading: deleteVCLoading }] = useDeleteVirtualContributorOnAccountMutation({
     onCompleted: () => {
@@ -243,6 +218,60 @@ export const ContributorAccountView: FC<ContributorAccountViewProps> = ({ accoun
     setDeleteDialogOpen(true);
   };
 
+  // Pack Deletion
+  const [deletePackMutation, { loading: deletePackLoading }] = useDeleteInnovationPackMutation({
+    onCompleted: () => {
+      clearDeleteState();
+      notify('Innovation Pack deleted successfully!', 'success');
+    },
+    refetchQueries: ['AccountInformation'],
+  });
+
+  const deletePack = () => {
+    if (!selectedId) {
+      return;
+    }
+
+    deletePackMutation({
+      variables: {
+        innovationPackId: selectedId,
+      },
+    });
+  };
+
+  const onDeletePackClick = (id: string) => {
+    setSelectedEntity(Entities.InnovationPack);
+    setSelectedId(id);
+    setDeleteDialogOpen(true);
+  };
+
+  // Hub Deletion
+  const [deleteHubMutation, { loading: deleteHubLoading }] = useDeleteInnovationHubMutation({
+    onCompleted: () => {
+      clearDeleteState();
+      notify('Innovation Hub deleted successfully!', 'success');
+    },
+    refetchQueries: ['AccountInformation'],
+  });
+
+  const deleteHub = () => {
+    if (!selectedId) {
+      return;
+    }
+
+    deleteHubMutation({
+      variables: {
+        innovationHubId: selectedId,
+      },
+    });
+  };
+
+  const onDeleteHubClick = (id: string) => {
+    setSelectedEntity(Entities.InnovationHub);
+    setSelectedId(id);
+    setDeleteDialogOpen(true);
+  };
+
   const deleteEntity = () => {
     switch (entity) {
       case Entities.Space:
@@ -255,7 +284,7 @@ export const ContributorAccountView: FC<ContributorAccountViewProps> = ({ accoun
         deletePack();
         break;
       case Entities.InnovationHub:
-        // deleteInnovationHub();
+        deleteHub();
         break;
     }
   };
@@ -286,6 +315,18 @@ export const ContributorAccountView: FC<ContributorAccountViewProps> = ({ accoun
       </MenuItemWithIcon>
     );
 
+  const getVCActions = (id: string) =>
+    canDeleteEntities && (
+      <MenuItemWithIcon
+        key="delete"
+        disabled={deleteVCLoading}
+        iconComponent={DeleteOutline}
+        onClick={() => onDeleteVCClick(id)}
+      >
+        {t('buttons.delete')}
+      </MenuItemWithIcon>
+    );
+
   const getPackActions = (id: string) =>
     canDeleteEntities && (
       <MenuItemWithIcon
@@ -298,13 +339,13 @@ export const ContributorAccountView: FC<ContributorAccountViewProps> = ({ accoun
       </MenuItemWithIcon>
     );
 
-  const getVCActions = (id: string) =>
+  const getHubActions = (id: string) =>
     canDeleteEntities && (
       <MenuItemWithIcon
         key="delete"
-        disabled={deleteVCLoading}
+        disabled={deleteHubLoading}
         iconComponent={DeleteOutline}
-        onClick={() => onDeleteVCClick(id)}
+        onClick={() => onDeleteHubClick(id)}
       >
         {t('buttons.delete')}
       </MenuItemWithIcon>
@@ -400,7 +441,10 @@ export const ContributorAccountView: FC<ContributorAccountViewProps> = ({ accoun
         <BlockTitle>{t('pages.admin.generic.sections.account.customHomepages')}</BlockTitle>
         <Gutters disablePadding className={styles.gutters}>
           {loading && <InnovationHubCardHorizontalSkeleton />}
-          {!loading && innovationHubs?.map(hub => <InnovationHubCardHorizontal {...hub} />)}
+          {!loading &&
+            innovationHubs?.map(hub => (
+              <InnovationHubCardHorizontal key={hub.id} {...hub} actions={getHubActions(hub.id)} />
+            ))}
           <Actions>
             {canCreateInnovationHub && account?.id && (
               <CreateInnovationHubDialog accountId={account?.id} accountHostName={accountHostName} />

--- a/src/domain/community/user/pages/UserAccountPage.tsx
+++ b/src/domain/community/user/pages/UserAccountPage.tsx
@@ -3,7 +3,7 @@ import { useAccountInformationQuery, useUserAccountQuery } from '../../../../cor
 import UserSettingsLayout from '../../../platform/admin/user/layout/UserSettingsLayout';
 import { SettingsSection } from '../../../platform/admin/layout/EntitySettingsLayout/constants';
 import { useUrlParams } from '../../../../core/routing/useUrlParams';
-import ContributorAccountView from '../../../platform/admin/components/Common/ContributorAccountView';
+import ContributorAccountView from '../../contributor/AccountTab/ContributorAccountView';
 
 interface UserAccountPageProps {}
 

--- a/src/domain/innovationHub/InnovationHubCardHorizontal/InnovationHubCardHorizontal.tsx
+++ b/src/domain/innovationHub/InnovationHubCardHorizontal/InnovationHubCardHorizontal.tsx
@@ -8,6 +8,7 @@ import { SpaceVisibility } from '../../../core/apollo/generated/graphql-schema';
 import { gutters } from '../../../core/ui/grid/utils';
 import { useTranslation } from 'react-i18next';
 import { buildInnovationHubUrl } from '../../../main/routing/urlBuilders';
+import ActionsMenu from '../../../core/ui/card/ActionsMenu';
 
 export const InnovationHubCardHorizontalSkeleton = () => (
   <BadgeCardView
@@ -42,6 +43,7 @@ interface InnovationHubSpacesProps {
       displayName: string;
     };
   }[];
+  actions?: React.ReactNode;
 }
 
 const InnovationHubSpaces = ({ spaceVisibilityFilter, spaceListFilter }: InnovationHubSpacesProps) => {
@@ -63,6 +65,7 @@ const InnovationHubSpaces = ({ spaceVisibilityFilter, spaceListFilter }: Innovat
 const InnovationHubCardHorizontal = ({
   profile: { displayName, description, banner },
   subdomain,
+  actions = undefined,
   ...spaces
 }: InnovationHubCardHorizontalProps) => {
   return (
@@ -72,6 +75,7 @@ const InnovationHubCardHorizontal = ({
       to={buildInnovationHubUrl(subdomain)}
       target="_blank"
       strict
+      actions={actions && <ActionsMenu>{actions}</ActionsMenu>}
     >
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Box display="flex" flexDirection="column">

--- a/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
+++ b/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
@@ -14,7 +14,6 @@ import { useTranslation } from 'react-i18next';
 import { intersection } from 'lodash';
 import FlexSpacer from '../../../../core/ui/utils/FlexSpacer';
 import JourneyAvatar from '../JourneyAvatar/JourneyAvatar';
-import Gutters from '../../../../core/ui/grid/Gutters';
 import ActionsMenu from '../../../../core/ui/card/ActionsMenu';
 
 export const JourneyCardHorizontalSkeleton = () => (
@@ -85,23 +84,21 @@ const JourneyCardHorizontal = ({
         to={journey.profile.url}
         actions={actions && <ActionsMenu>{actions}</ActionsMenu>}
       >
-        <Gutters disableGap disablePadding>
-          <BlockTitleWithIcon title={journey.profile.displayName} icon={<Icon />} sx={{ height: gutters(1.5) }}>
-            <FlexSpacer />
-            {communityRole && (
-              <Chip
-                variant="filled"
-                color="primary"
-                label={
-                  <Typography variant="button">{t(`common.enums.communityRole.${communityRole}` as const)}</Typography>
-                }
-              />
-            )}
-          </BlockTitleWithIcon>
-          <Caption noWrap component="div" lineHeight={gutters(1.5)}>
-            {journey.profile.tagline}
-          </Caption>
-        </Gutters>
+        <BlockTitleWithIcon title={journey.profile.displayName} icon={<Icon />} sx={{ height: gutters(1.5) }}>
+          <FlexSpacer />
+          {communityRole && (
+            <Chip
+              variant="filled"
+              color="primary"
+              label={
+                <Typography variant="button">{t(`common.enums.communityRole.${communityRole}` as const)}</Typography>
+              }
+            />
+          )}
+        </BlockTitleWithIcon>
+        <Caption noWrap component="div" lineHeight={gutters(1.5)}>
+          {journey.profile.tagline}
+        </Caption>
       </BadgeCardView>
     </ElevatedPaper>
   );

--- a/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
+++ b/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
@@ -1,8 +1,7 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode } from 'react';
 import { gutters } from '../../../../core/ui/grid/utils';
 import BadgeCardView from '../../../../core/ui/list/BadgeCardView';
-import { Chip, IconButton, Menu, Paper, PaperProps, Skeleton, Typography } from '@mui/material';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import { Chip, Paper, PaperProps, Skeleton, Typography } from '@mui/material';
 import { Caption } from '../../../../core/ui/typography';
 import { Visual } from '../../../common/visual/Visual';
 import withElevationOnHover from '../../../shared/components/withElevationOnHover';
@@ -16,6 +15,7 @@ import { intersection } from 'lodash';
 import FlexSpacer from '../../../../core/ui/utils/FlexSpacer';
 import JourneyAvatar from '../JourneyAvatar/JourneyAvatar';
 import Gutters from '../../../../core/ui/grid/Gutters';
+import ActionsMenu from '../../../../core/ui/card/ActionsMenu';
 
 export const JourneyCardHorizontalSkeleton = () => (
   <ElevatedPaper sx={{ padding: gutters() }}>
@@ -72,11 +72,6 @@ const JourneyCardHorizontal = ({
     ...sx,
   };
 
-  const [settingsAnchorEl, setSettingsAnchorEl] = useState<null | HTMLElement>(null);
-  const settingsOpened = Boolean(settingsAnchorEl);
-  const handleSettingsOpened = (event: React.MouseEvent<HTMLElement>) => setSettingsAnchorEl(event.currentTarget);
-  const handleSettingsClose = () => setSettingsAnchorEl(null);
-
   return (
     <ElevatedPaper sx={mergedSx} elevation={seamless ? 0 : undefined}>
       <BadgeCardView
@@ -86,35 +81,11 @@ const JourneyCardHorizontal = ({
             sx={{ width: gutters(3), height: gutters(3) }}
           />
         }
-        actions={
-          actions && (
-            <>
-              <IconButton
-                aria-label={t('common.settings')}
-                aria-haspopup="true"
-                aria-controls={settingsOpened ? 'settings-menu' : undefined}
-                aria-expanded={settingsOpened ? 'true' : undefined}
-                onClick={handleSettingsOpened}
-              >
-                <MoreVertIcon color="primary" />
-              </IconButton>
-              <Menu
-                aria-labelledby="settings-button"
-                anchorEl={settingsAnchorEl}
-                open={settingsOpened}
-                onClose={handleSettingsClose}
-                anchorOrigin={{
-                  vertical: 'top',
-                  horizontal: 'right',
-                }}
-              >
-                {actions}
-              </Menu>
-            </>
-          )
-        }
+        component={RouterLink}
+        to={journey.profile.url}
+        actions={actions && <ActionsMenu>{actions}</ActionsMenu>}
       >
-        <Gutters disableGap disablePadding component={RouterLink} to={journey.profile.url}>
+        <Gutters disableGap disablePadding>
           <BlockTitleWithIcon title={journey.profile.displayName} icon={<Icon />} sx={{ height: gutters(1.5) }}>
             <FlexSpacer />
             {communityRole && (

--- a/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
+++ b/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
@@ -104,7 +104,7 @@ const JourneyCardHorizontal = ({
                 open={settingsOpened}
                 onClose={handleSettingsClose}
                 anchorOrigin={{
-                  vertical: 'bottom',
+                  vertical: 'top',
                   horizontal: 'right',
                 }}
               >

--- a/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
+++ b/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { ReactNode, useState } from 'react';
 import { gutters } from '../../../../core/ui/grid/utils';
 import BadgeCardView from '../../../../core/ui/list/BadgeCardView';
-import { Chip, Paper, PaperProps, Skeleton, Typography } from '@mui/material';
+import { Chip, IconButton, Menu, Paper, PaperProps, Skeleton, Typography } from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { Caption } from '../../../../core/ui/typography';
 import { Visual } from '../../../common/visual/Visual';
 import withElevationOnHover from '../../../shared/components/withElevationOnHover';
@@ -14,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { intersection } from 'lodash';
 import FlexSpacer from '../../../../core/ui/utils/FlexSpacer';
 import JourneyAvatar from '../JourneyAvatar/JourneyAvatar';
+import Gutters from '../../../../core/ui/grid/Gutters';
 
 export const JourneyCardHorizontalSkeleton = () => (
   <ElevatedPaper sx={{ padding: gutters() }}>
@@ -43,6 +45,7 @@ export interface JourneyCardHorizontalProps {
   seamless?: boolean;
   journeyTypeName: JourneyTypeName;
   sx?: PaperProps['sx'];
+  actions?: ReactNode;
 }
 
 const ElevatedPaper = withElevationOnHover(Paper) as typeof Paper;
@@ -55,6 +58,7 @@ const JourneyCardHorizontal = ({
   deepness = journeyTypeName === 'subspace' ? 0 : 1,
   seamless,
   sx,
+  actions,
 }: JourneyCardHorizontalProps) => {
   const Icon = JourneyIcon[journeyTypeName];
 
@@ -68,8 +72,13 @@ const JourneyCardHorizontal = ({
     ...sx,
   };
 
+  const [settingsAnchorEl, setSettingsAnchorEl] = useState<null | HTMLElement>(null);
+  const settingsOpened = Boolean(settingsAnchorEl);
+  const handleSettingsOpened = (event: React.MouseEvent<HTMLElement>) => setSettingsAnchorEl(event.currentTarget);
+  const handleSettingsClose = () => setSettingsAnchorEl(null);
+
   return (
-    <ElevatedPaper component={RouterLink} to={journey.profile.url} sx={mergedSx} elevation={seamless ? 0 : undefined}>
+    <ElevatedPaper sx={mergedSx} elevation={seamless ? 0 : undefined}>
       <BadgeCardView
         visual={
           <JourneyAvatar
@@ -77,22 +86,51 @@ const JourneyCardHorizontal = ({
             sx={{ width: gutters(3), height: gutters(3) }}
           />
         }
+        actions={
+          actions && (
+            <>
+              <IconButton
+                aria-label={t('common.settings')}
+                aria-haspopup="true"
+                aria-controls={settingsOpened ? 'settings-menu' : undefined}
+                aria-expanded={settingsOpened ? 'true' : undefined}
+                onClick={handleSettingsOpened}
+              >
+                <MoreVertIcon color="primary" />
+              </IconButton>
+              <Menu
+                aria-labelledby="settings-button"
+                anchorEl={settingsAnchorEl}
+                open={settingsOpened}
+                onClose={handleSettingsClose}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'right',
+                }}
+              >
+                {actions}
+              </Menu>
+            </>
+          )
+        }
       >
-        <BlockTitleWithIcon title={journey.profile.displayName} icon={<Icon />} sx={{ height: gutters(1.5) }}>
-          <FlexSpacer />
-          {communityRole && (
-            <Chip
-              variant="filled"
-              color="primary"
-              label={
-                <Typography variant="button">{t(`common.enums.communityRole.${communityRole}` as const)}</Typography>
-              }
-            />
-          )}
-        </BlockTitleWithIcon>
-        <Caption noWrap component="div" lineHeight={gutters(1.5)}>
-          {journey.profile.tagline}
-        </Caption>
+        <Gutters disableGap disablePadding component={RouterLink} to={journey.profile.url}>
+          <BlockTitleWithIcon title={journey.profile.displayName} icon={<Icon />} sx={{ height: gutters(1.5) }}>
+            <FlexSpacer />
+            {communityRole && (
+              <Chip
+                variant="filled"
+                color="primary"
+                label={
+                  <Typography variant="button">{t(`common.enums.communityRole.${communityRole}` as const)}</Typography>
+                }
+              />
+            )}
+          </BlockTitleWithIcon>
+          <Caption noWrap component="div" lineHeight={gutters(1.5)}>
+            {journey.profile.tagline}
+          </Caption>
+        </Gutters>
       </BadgeCardView>
     </ElevatedPaper>
   );

--- a/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
+++ b/src/domain/journey/space/pages/SpaceAccount/SpaceAccountView.tsx
@@ -23,7 +23,7 @@ import { getPlanTranslations } from '../../../../license/plans/utils/getPlanTran
 import { ROUTE_HOME } from '../../../../platform/routes/constants';
 import DeleteIcon from '@mui/icons-material/Delete';
 import CachedIcon from '@mui/icons-material/Cached';
-import SpaceProfileDeleteDialog from '../SpaceSettings/SpaceProfileDeleteDialog';
+import EntityConfirmDeleteDialog from '../SpaceSettings/EntityConfirmDeleteDialog';
 import { SvgIconComponent } from '@mui/icons-material';
 import { useUserContext } from '../../../../community/user';
 import translateWithElements from '../../../../shared/i18n/TranslateWithElements/TranslateWithElements';
@@ -283,7 +283,7 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
                     onClick={() => setDeleteDialogOpen(true)}
                   >
                     <Caption color={theme => theme.palette.error.dark} textAlign="right">
-                      {t('components.deleteSpace.title')}
+                      {t('components.deleteEntity.title')}
                     </Caption>
                   </LicenseActionBlock>
                 </Gutters>
@@ -298,7 +298,7 @@ const SpaceAccountView: FC<SpaceAccountPageProps> = ({ journeyId }) => {
             </Gutters>
           </PageContentBlock>
           {deleteDialogOpen && (
-            <SpaceProfileDeleteDialog
+            <EntityConfirmDeleteDialog
               entity={t('common.space')}
               open={deleteDialogOpen}
               onClose={() => setDeleteDialogOpen(false)}

--- a/src/domain/journey/space/pages/SpaceSettings/EntityConfirmDeleteDialog.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/EntityConfirmDeleteDialog.tsx
@@ -9,7 +9,7 @@ import { Caption } from '../../../../../core/ui/typography';
 import { gutters } from '../../../../../core/ui/grid/utils';
 import TranslationKey from '../../../../../core/i18n/utils/TranslationKey';
 
-interface SpaceProfileDeleteDialogProps {
+interface EntityConfirmDeleteDialogProps {
   entity: string;
   description?: TranslationKey;
   open: boolean;
@@ -18,7 +18,7 @@ interface SpaceProfileDeleteDialogProps {
   submitting: boolean;
 }
 
-const SpaceProfileDeleteDialog: FC<SpaceProfileDeleteDialogProps> = ({
+const EntityConfirmDeleteDialog: FC<EntityConfirmDeleteDialogProps> = ({
   entity,
   description,
   open,
@@ -31,16 +31,16 @@ const SpaceProfileDeleteDialog: FC<SpaceProfileDeleteDialogProps> = ({
 
   return (
     <Dialog open={open} onClose={onClose}>
-      <DialogHeader onClose={onClose} title={t('components.deleteSpace.confirmDialog.title', { entity: entity })} />
+      <DialogHeader onClose={onClose} title={t('components.deleteEntity.confirmDialog.title', { entity: entity })} />
       <DialogContent>
         <Gutters disablePadding>
           <Box sx={{ wordWrap: 'break-word' }}>
             <Caption>
-              {t(description ?? 'components.deleteSpace.confirmDialog.description', { entity: entity })}{' '}
+              {t(description ?? 'components.deleteEntity.confirmDialog.description', { entity: entity })}{' '}
             </Caption>
             <FormControlLabel
               control={<Checkbox checked={checked} onChange={() => setChecked(!checked)} />}
-              label={<Caption>{t('components.deleteSpace.confirmDialog.checkbox', { entity: entity })}</Caption>}
+              label={<Caption>{t('components.deleteEntity.confirmDialog.checkbox', { entity: entity })}</Caption>}
             />
             <Actions justifyContent="flex-end" paddingTop={gutters()}>
               <Button onClick={onClose}>{t('buttons.cancel')}</Button>
@@ -49,11 +49,11 @@ const SpaceProfileDeleteDialog: FC<SpaceProfileDeleteDialogProps> = ({
                 value={'SPACE'}
                 disabled={!checked}
                 loading={submitting}
-                loadingIndicator={`${t('components.deleteSpace.confirmDialog.confirm')}...`}
+                loadingIndicator={`${t('components.deleteEntity.confirmDialog.confirm')}...`}
                 onClick={onDelete}
                 sx={{ textWrap: 'nowrap' }}
               >
-                {t('components.deleteSpace.confirmDialog.confirm')}
+                {t('components.deleteEntity.confirmDialog.confirm')}
               </LoadingButton>
             </Actions>
           </Box>
@@ -63,4 +63,4 @@ const SpaceProfileDeleteDialog: FC<SpaceProfileDeleteDialogProps> = ({
   );
 };
 
-export default SpaceProfileDeleteDialog;
+export default EntityConfirmDeleteDialog;

--- a/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsView.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsView.tsx
@@ -31,7 +31,7 @@ import { Box, CircularProgress } from '@mui/material';
 import { JourneyTypeName } from '../../../JourneyTypeName';
 import PageContentBlockHeader from '../../../../../core/ui/content/PageContentBlockHeader';
 import DeleteIcon from './icon/DeleteIcon';
-import SpaceProfileDeleteDialog from './SpaceProfileDeleteDialog';
+import EntityConfirmDeleteDialog from './EntityConfirmDeleteDialog';
 import { useSubSpace } from '../../../subspace/hooks/useSubSpace';
 import { useSpace } from '../../SpaceContext/useSpace';
 
@@ -373,15 +373,15 @@ export const SpaceSettingsView: FC<SpaceSettingsViewProps> = ({ journeyId, journ
 
           {isSubspace && canDelete && (
             <PageContentBlock sx={{ borderColor: errorColor }}>
-              <PageContentBlockHeader sx={{ color: errorColor }} title={t('components.deleteSpace.title')} />
+              <PageContentBlockHeader sx={{ color: errorColor }} title={t('components.deleteEntity.title')} />
               <Box display="flex" gap={1} alignItems="center" sx={{ cursor: 'pointer' }} onClick={openDialog}>
                 <DeleteIcon />
-                <Caption>{t('components.deleteSpace.description', { entity: t('common.subspace') })}</Caption>
+                <Caption>{t('components.deleteEntity.description', { entity: t('common.subspace') })}</Caption>
               </Box>
             </PageContentBlock>
           )}
           {openDeleteDialog && (
-            <SpaceProfileDeleteDialog
+            <EntityConfirmDeleteDialog
               entity={t('common.subspace')}
               open={openDeleteDialog}
               onClose={closeDialog}

--- a/src/domain/platform/admin/opportunity/pages/OpportunitySettings/OpportunitySettingsView.tsx
+++ b/src/domain/platform/admin/opportunity/pages/OpportunitySettings/OpportunitySettingsView.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../../../../core/apollo/generated/apollo-hooks';
 import { AuthorizationPrivilege } from '../../../../../../core/apollo/generated/graphql-schema';
 import DeleteIcon from '../../../../../journey/space/pages/SpaceSettings/icon/DeleteIcon';
-import SpaceProfileDeleteDialog from '../../../../../journey/space/pages/SpaceSettings/SpaceProfileDeleteDialog';
+import EntityConfirmDeleteDialog from '../../../../../journey/space/pages/SpaceSettings/EntityConfirmDeleteDialog';
 import { useSubSpace } from '../../../../../journey/subspace/hooks/useSubSpace';
 import PageContent from '../../../../../../core/ui/content/PageContent';
 import { useSpace } from '../../../../../journey/space/SpaceContext/useSpace';
@@ -70,15 +70,15 @@ const OpportunitySettingsView: FC = () => {
     <PageContent background="transparent">
       {canDelete && (
         <PageContentBlock sx={{ borderColor: errorColor }}>
-          <PageContentBlockHeader sx={{ color: errorColor }} title={t('components.deleteSpace.title')} />
+          <PageContentBlockHeader sx={{ color: errorColor }} title={t('components.deleteEntity.title')} />
           <Box display="flex" gap={1} alignItems="center" sx={{ cursor: 'pointer' }} onClick={openDialog}>
             <DeleteIcon />
-            <Caption>{t('components.deleteSpace.description', { entity: t('common.subspace') })}</Caption>
+            <Caption>{t('components.deleteEntity.description', { entity: t('common.subspace') })}</Caption>
           </Box>
         </PageContentBlock>
       )}
       {openDeleteDialog && (
-        <SpaceProfileDeleteDialog
+        <EntityConfirmDeleteDialog
           entity={'Subspace'}
           open={openDeleteDialog}
           onClose={closeDialog}

--- a/src/domain/platform/admin/organization/OrganizationAccountPage.tsx
+++ b/src/domain/platform/admin/organization/OrganizationAccountPage.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import OrganizationAdminLayout from './OrganizationAdminLayout';
 import { SettingsSection } from '../layout/EntitySettingsLayout/constants';
 import { SettingsPageProps } from '../layout/EntitySettingsLayout/types';
-import ContributorAccountView from '../components/Common/ContributorAccountView';
+import ContributorAccountView from '../../../community/contributor/AccountTab/ContributorAccountView';
 import { useUrlParams } from '../../../../core/routing/useUrlParams';
 import {
   useAccountInformationQuery,

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -414,7 +414,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
 
   const [addVirtualContributorToCommunity] = useAddVirtualContributorToCommunityMutation();
   const [createVirtualContributor] = useCreateVirtualContributorOnAccountMutation({
-    refetchQueries: ['MyAccount'],
+    refetchQueries: ['MyAccount', 'AccountInformation'],
   });
 
   const handleCreateVirtualContributor = async (


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6808

- [x] Space Deletion
  - [x] Badge Card was extended to support actions; ⚠️
  - [x] Journey Card Horizontal was extended to support Menu w actions; ⚠️
- [x] VC Deletion
  - [x] Horizontal card extended to support Menu; 
- [x] Packs deletion
  - [x] Inno Pack card extended to support Menu w Actions; 
- [x] Hubs deletion
- [ ] todo: Translate the successful deletion messages;

___
- [x] AccountTabView moved to the domain->community->contributors folder, to be close to the User Settings pages; The ORG settings pages should be there as well; 
- [x] New ActionsMenu component added to the core/ui 