### PR TITLE
Try your VC dialog now awaiting Ready state

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -3008,7 +3008,7 @@
     },
     "trySection": {
       "title": "🎉 Try it out!",
-      "subTitle": "Your Virtual Contributor is being created and added it to your personal Space <tooltip><icon /></tooltip>. This process may take a couple of minutes, after which you can interact with it by typing <b>@{{vcName}}</b> in a comment on any post in your Space.",
+      "subTitle": "Your Virtual Contributor is successfully created and we added it to your personal Space <tooltip><icon /></tooltip>. This process may take a couple of minutes, after which you can interact with it by typing <b>@{{vcName}}</b> in a comment on any post in your Space. Give it a try in the preview below!",
       "subTitleInfo": "When you create your first VC, we automatically generate a Space for you. This Space functions like any other Space on Alkemio, and you can customize the settings according to your preferences.",
       "postTitle": "Example post",
       "postDescription": "At Alkemio, we utilize Posts to facilitate collaborative interactions with AI. Unlike private chats, other members within a Space can learn from and contribute to these interactions.\n\nSimilar to mentioning a human contributor, you can use the \"@\" symbol followed by the Virtual Contributor's name.",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -3008,7 +3008,7 @@
     },
     "trySection": {
       "title": "🎉 Try it out!",
-      "subTitle": "Your Virtual Contributor is successfully created and we added it to your personal Space <tooltip><icon /></tooltip>. This process may take a couple of minutes, after which you can interact with it by typing <b>@{{vcName}}</b> in a comment on any post in your Space. Give it a try in the preview below!",
+      "subTitle": "Your Virtual Contributor is successfully created and we added it to your Personal Space <tooltip><icon /></tooltip>. You can interact with it by typing <b>@{{vcName}}</b> in a comment on any post in your Space. Give it a try in the preview below!",
       "subTitleInfo": "When you create your first VC, we automatically generate a Space for you. This Space functions like any other Space on Alkemio, and you can customize the settings according to your preferences.",
       "postTitle": "Example post",
       "postDescription": "At Alkemio, we utilize Posts to facilitate collaborative interactions with AI. Unlike private chats, other members within a Space can learn from and contribute to these interactions.\n\nSimilar to mentioning a human contributor, you can use the \"@\" symbol followed by the Virtual Contributor's name.",

--- a/src/domain/community/virtualContributor/VCAccessibilitySettings/VCAccessibilitySettingsPage.tsx
+++ b/src/domain/community/virtualContributor/VCAccessibilitySettings/VCAccessibilitySettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useUrlParams } from '../../../../core/routing/useUrlParams';
 import {
   useUpdateVirtualContributorMutation,
@@ -19,7 +19,6 @@ import { SearchVisibility } from '../../../../core/apollo/generated/graphql-sche
 import { BlockTitle, Caption } from '../../../../core/ui/typography';
 import { Actions } from '../../../../core/ui/actions/Actions';
 import { LoadingButton } from '@mui/lab';
-import { useSubscribeOnVirtualContributorEvents } from '../useSubscribeOnVirtualContributorEvents';
 
 interface VCAccessibilityProps {
   listedInStore?: boolean;
@@ -38,8 +37,6 @@ export const VCAccessibilitySettingsPage = () => {
       id: vcNameId,
     },
   });
-
-  useSubscribeOnVirtualContributorEvents(vcNameId);
 
   const [updateContributorMutation] = useUpdateVirtualContributorMutation();
   const handleUpdate = (props: VCAccessibilityProps) => {
@@ -77,11 +74,6 @@ export const VCAccessibilitySettingsPage = () => {
       },
     });
   };
-
-  useEffect(() => {
-    // TODO: Use the status wehere needed when defined
-    console.info(data?.virtualContributor.status);
-  }, [data]);
 
   if (!data?.virtualContributor) {
     return null;

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
@@ -30,11 +30,11 @@ import ContentColumn from '../../../../core/ui/content/ContentColumn';
 import PageContentBlock from '../../../../core/ui/content/PageContentBlock';
 import PageContentColumn from '../../../../core/ui/content/PageContentColumn';
 import { ContributorViewProps } from '../../../community/community/EntityDashboardContributorsSection/Types';
-import TryVCInfoDialog from '../../../../main/topLevelPages/myDashboard/newVirtualContributorWizard/TryVCInfoDialog';
 import {
   getVCCreationCache,
   removeVCCreationCache,
 } from '../../../../main/topLevelPages/myDashboard/newVirtualContributorWizard/vcCreationUtil';
+import TryVirtualContributorDialog from '../../../../main/topLevelPages/myDashboard/newVirtualContributorWizard/TryVirtualContributorDialog';
 
 interface SpaceWelcomeBlockContributor {
   profile: SpaceWelcomeBlockContributorProfileFragment;
@@ -89,7 +89,7 @@ const SpaceDashboardView = ({
   const { t } = useTranslation();
 
   const [tryVirtualContributorOpen, setTryVirtualContributorOpen] = useState(false);
-  const [vcName, setVcName] = useState<string>('');
+  const [vcNameId, setVcNameId] = useState<string>('');
 
   const hasExtendedApplicationButton = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
 
@@ -111,7 +111,7 @@ const SpaceDashboardView = ({
     const cachedVC = getVCCreationCache();
 
     if (cachedVC) {
-      setVcName(cachedVC);
+      setVcNameId(cachedVC);
       setTryVirtualContributorOpen(true);
     }
 
@@ -185,11 +185,11 @@ const SpaceDashboardView = ({
           />
         </ContentColumn>
         {spaceId && tryVirtualContributorOpen && (
-          <TryVCInfoDialog
+          <TryVirtualContributorDialog
             open={tryVirtualContributorOpen}
             onClose={onCloseTryVirtualContributor}
             spaceId={spaceId}
-            vcName={vcName}
+            vcNameId={vcNameId}
           />
         )}
       </PageContent>

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/TryVirtualContributorDialog.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/TryVirtualContributorDialog.tsx
@@ -162,10 +162,6 @@ const TryVirtualContributorDialog: React.FC<TryVirtualContributorDialogProps> = 
     }
   }, [spaceId, open, canCreateCallout, vcData]);
 
-  useEffect(() => {
-    console.info(vcData?.virtualContributor.status);
-  }, [vcData]);
-
   if (calloutError || hasError || vcError) {
     setDemoCalloutCreationLoading(false);
     removeVCCreationCache();

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -406,7 +406,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
         bokCommunityId,
         boKParentCommunityId
       );
-      addVCCreationCache(virtualContributorInput.name);
+
       const { data } = await getNewSpaceUrl();
       navigate(data?.space.profile.url ?? '');
     }
@@ -469,6 +469,11 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
         },
       });
 
+      // add vc's nameId to the cache for the TryVC dialog
+      if (data?.createVirtualContributor.nameID) {
+        addVCCreationCache(data?.createVirtualContributor.nameID);
+      }
+
       notify(
         t('createVirtualContributorWizard.createdVirtualContributor.successMessage', { name: values.name }),
         'success'
@@ -485,7 +490,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
         selectedKnowledge.communityId,
         selectedKnowledge.parentCommunityId
       );
-      addVCCreationCache(virtualContributorInput.name);
+
       navigate(selectedKnowledge.url ?? '');
     }
   };

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/vcCreationUtil.ts
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/vcCreationUtil.ts
@@ -1,7 +1,7 @@
 const VC_CREATION_CACHE_KEY = 'TRYVC';
 
-export const addVCCreationCache = (name: string) => {
-  localStorage.setItem(VC_CREATION_CACHE_KEY, name);
+export const addVCCreationCache = (nameId: string) => {
+  localStorage.setItem(VC_CREATION_CACHE_KEY, nameId);
 };
 
 export const getVCCreationCache = () => {


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6830

- [x] Now the Try Dialog uses the subscription for the ingestion state and shows the Callout after the state is READY;
- [x] Now we are caching the nameID instead of the name (used for VC data request and sub); 
- [x] the VCAccountSettings file was cleaned up;
- [x] The copy change was approved by Simone;

![image](https://github.com/user-attachments/assets/462e3333-7380-407a-89d5-18e1c5abcb35)

 
