### PR TITLE
Increase the max limit of searchable list from 50 to 1000

### DIFF
--- a/src/domain/platform/admin/components/SearchableList.tsx
+++ b/src/domain/platform/admin/components/SearchableList.tsx
@@ -8,6 +8,8 @@ import LoadingListItem from '../../../shared/components/SearchableList/LoadingLi
 import ListItemLink, { ListItemLinkProps } from '../../../shared/components/SearchableList/ListItemLink';
 import { omit } from 'lodash';
 
+const MAX_ITEMS_LIMIT = 1000;
+
 export interface SearchableListProps<
   ItemViewProps extends {},
   Item extends SearchableListItem & Omit<ItemViewProps, keyof ListItemLinkProps>
@@ -132,8 +134,12 @@ export const SearchableList = <
         onConfirm={handleRemoveItem}
         text={`Are you sure you want to remove: ${itemToRemove?.value}`}
       />
-      {filteredData.length > limit && limit < 50 && (
-        <Button onClick={() => setLimit(x => (x >= 50 ? x : x + 10))} variant="outlined" sx={{ alignSelf: 'start' }}>
+      {filteredData.length > limit && limit < MAX_ITEMS_LIMIT && (
+        <Button
+          onClick={() => setLimit(x => (x >= MAX_ITEMS_LIMIT ? x : x + 10))}
+          variant="outlined"
+          sx={{ alignSelf: 'start' }}
+        >
           {t('components.searchableList.load-more')}
         </Button>
       )}


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/5653

The component is reused in the following places:
![image](https://github.com/user-attachments/assets/0c593a18-11f6-4bef-ae32-0c9a80e96610)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the threshold for displaying the "load more" button in the Searchable List component from 50 to 1000 items, allowing users to load a larger dataset seamlessly.
  
- **Bug Fixes**
	- Updated the click handler for the "load more" button to ensure the item limit does not exceed 1000, improving user experience and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->