### PR TITLE
Create a mapping between crowdin and local file structure

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -2,7 +2,7 @@ name: Build & Deploy to Dev on Hetzner
 
 on:
   push:
-    branches: [develop]
+    branches: [crowdin]
 
 jobs:
   build-and-deploy:

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,6 @@
 files:
-  - source: /src/core/i18n/en/translation.en.json  # This is your local repository structure
-    translation: /src/core/i18n/%two_letters_code%/translation.%two_letters_code%.json
-    export_pattern: '/src/core/i18n/%two_letters_code%/translation.%two_letters_code%.json'
+  - source: /develop/src/core/i18n/en/translation.en.json  # Path in Crowdin
+    translation: /develop/src/core/i18n/%two_letters_code%/translation.%two_letters_code%.json  # Path in Crowdin
+    export_pattern: /src/core/i18n/%two_letters_code%/translation.%two_letters_code%.json  # Map to local project structure
 project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN


### PR DESCRIPTION
- mapped `Crowdin` folder structure (base: `develop/src`) to local structure (base: `src`)
- updated `Crowdin` action

Simplest solution with what we have, only solution with my `Crowdin` access. Could be more elaborate with proper integration between the two systems, but this should work alright.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the CI/CD pipeline to trigger builds and deployments from the `crowdin` branch instead of `develop`.
  
- **Bug Fixes**
	- Adjusted file paths in the Crowdin configuration to ensure correct access to translation resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->