### PR TITLE
Add enableComments to the CreateCallout mutation

### DIFF
--- a/src/domain/collaboration/callout/creationDialog/useCalloutCreation/useCalloutCreation.ts
+++ b/src/domain/collaboration/callout/creationDialog/useCalloutCreation/useCalloutCreation.ts
@@ -53,6 +53,9 @@ export interface CalloutCreationUtils {
   canCreateCallout: boolean;
 }
 
+// Only Posts have comments for now.
+const CALLOUTS_WITH_COMMENTS = [CalloutType.Post];
+
 export const useCalloutCreation = ({
   journeyId,
   collabId,
@@ -112,6 +115,7 @@ export const useCalloutCreation = ({
           variables: {
             calloutData: {
               collaborationID: collabId ?? collaborationId ?? '',
+              enableComments: CALLOUTS_WITH_COMMENTS.includes(callout.type),
               ...callout,
             },
           },

--- a/src/domain/collaboration/callout/creationDialog/useCalloutCreation/useCalloutCreation.ts
+++ b/src/domain/collaboration/callout/creationDialog/useCalloutCreation/useCalloutCreation.ts
@@ -38,7 +38,7 @@ export interface CalloutCreationType {
 
 export interface CalloutCreationParams {
   journeyId: string | undefined;
-  collabId?: string;
+  overrideCollaborationId?: string;
   initialOpened?: boolean;
 }
 
@@ -58,23 +58,25 @@ const CALLOUTS_WITH_COMMENTS = [CalloutType.Post];
 
 export const useCalloutCreation = ({
   journeyId,
-  collabId,
+  overrideCollaborationId,
   initialOpened = false,
 }: CalloutCreationParams): CalloutCreationUtils => {
   const [isCalloutCreationDialogOpen, setIsCalloutCreationDialogOpen] = useState(initialOpened);
   const [isCreating, setIsCreating] = useState(false);
   const { collaborationId, canCreateCallout, loading } = useCollaborationAuthorization({ journeyId });
 
+  const collaborationID = overrideCollaborationId ?? collaborationId;
+
   const [createCallout] = useCreateCalloutMutation({
     update: (cache, { data }) => {
-      if (!data || !(collabId || collaborationId)) {
+      if (!data || !collaborationID) {
         return;
       }
       const { createCalloutOnCollaboration } = data;
 
       const collabRefId = cache.identify({
         __typename: 'Collaboration',
-        id: collabId ?? collaborationId,
+        id: collaborationID,
       });
 
       if (!collabRefId) {
@@ -104,7 +106,7 @@ export const useCalloutCreation = ({
 
   const handleCreateCallout = useCallback(
     async (callout: CalloutCreationType) => {
-      if (!collaborationId && !collabId) {
+      if (!collaborationID) {
         return;
       }
 
@@ -114,7 +116,7 @@ export const useCalloutCreation = ({
         const result = await createCallout({
           variables: {
             calloutData: {
-              collaborationID: collabId ?? collaborationId ?? '',
+              collaborationID,
               enableComments: CALLOUTS_WITH_COMMENTS.includes(callout.type),
               ...callout,
             },
@@ -128,7 +130,7 @@ export const useCalloutCreation = ({
         setIsCreating(false);
       }
     },
-    [collabId, collaborationId, createCallout]
+    [collaborationID, createCallout]
   );
 
   return {

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -335,12 +335,12 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
     skip: !bokId,
   });
 
-  const callabId = subspaceProfile?.lookup.space?.collaboration?.id;
+  const collaborationId = subspaceProfile?.lookup.space?.collaboration?.id;
 
   // load the following hook either with bokId (created subspace) or spaceId (created/existing space)
   const { handleCreateCallout, canCreateCallout } = useCalloutCreation({
     journeyId: bokId,
-    collabId: callabId,
+    overrideCollaborationId: collaborationId,
   });
 
   const calloutDetails: CalloutCreationType = {


### PR DESCRIPTION
- I have confirmed that after templates changes `enableComments` is required to create a matrix room (a `comments` object) for the Post callouts. 
- I have checked the acceptance database, all the post callouts had a `commentsId` set, and all the other callout types had `commentsId` column set to null: 
```
SELECT type, count(*), commentsId is null as `IsNull` 
FROM alkemio.callout
GROUP BY type, `IsNull`;
```
- I have confirmed that all the callouts are created using this hook `useCalloutCreation`.

- [X] Added an array to `useCalloutCreation` with the callout types that require `comments` creation.
- [X] Refactor a bit a variable called `collabId` that confused me

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced callout creation process with the ability to override collaboration IDs.
	- Introduced support for comments on specific callout types.
  
- **Bug Fixes**
	- Improved variable naming for better clarity in collaboration-related functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->