### PR TITLE
Check for proper privileges on VC creation

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -4141,6 +4141,10 @@ export const AccountInformationDocument = gql`
         spaces {
           id
           level
+          authorization {
+            id
+            myPrivileges
+          }
           profile {
             ...AccountItemProfile
             cardBanner: visual(type: CARD) {
@@ -4150,6 +4154,10 @@ export const AccountInformationDocument = gql`
           }
           community {
             id
+            authorization {
+              id
+              myPrivileges
+            }
           }
           subspaces {
             id
@@ -24037,11 +24045,19 @@ export const NewVirtualContributorMySpacesDocument = gql`
             id
             community {
               id
+              authorization {
+                id
+                myPrivileges
+              }
             }
             profile {
               id
               displayName
               url
+            }
+            authorization {
+              id
+              myPrivileges
             }
             subspaces {
               id

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -6772,6 +6772,9 @@ export type AccountInformationQuery = {
             __typename?: 'Space';
             id: string;
             level: number;
+            authorization?:
+              | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
             profile: {
               __typename?: 'Profile';
               tagline?: string | undefined;
@@ -6782,7 +6785,13 @@ export type AccountInformationQuery = {
               cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
               avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
             };
-            community: { __typename?: 'Community'; id: string };
+            community: {
+              __typename?: 'Community';
+              id: string;
+              authorization?:
+                | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            };
             subspaces: Array<{
               __typename?: 'Space';
               id: string;
@@ -31207,8 +31216,25 @@ export type NewVirtualContributorMySpacesQuery = {
                 spaces: Array<{
                   __typename?: 'Space';
                   id: string;
-                  community: { __typename?: 'Community'; id: string };
+                  community: {
+                    __typename?: 'Community';
+                    id: string;
+                    authorization?:
+                      | {
+                          __typename?: 'Authorization';
+                          id: string;
+                          myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+                        }
+                      | undefined;
+                  };
                   profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
+                  authorization?:
+                    | {
+                        __typename?: 'Authorization';
+                        id: string;
+                        myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+                      }
+                    | undefined;
                   subspaces: Array<{
                     __typename?: 'Space';
                     id: string;

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -3036,6 +3036,10 @@
       "description": "Which Space or Subspace do you want to bring to life with the Virtual Contributor? Below you'll be able to choose from all Spaces and Subspaces that you are host of.",
       "label": "(Sub)Space",
       "noSpaces": "You need a Space to proceed with this option. To create a Virtual Contributor, please go back and follow the Written Knowledge flow."
+    },
+    "insufficientPrivileges": {
+      "title": "Insufficient Privileges",
+      "description": "You don't have the necessary privileges to complete the creation. Please contact the owners of this account."
     }
   }
 }

--- a/src/core/ui/dialogs/InfoDialog.tsx
+++ b/src/core/ui/dialogs/InfoDialog.tsx
@@ -1,0 +1,63 @@
+import React, { FC, ReactNode } from 'react';
+import Dialog from '@mui/material/Dialog';
+import { LoadingButton } from '@mui/lab';
+import { DialogContent } from '../dialog/deprecated';
+import DialogHeader from '../dialog/DialogHeader';
+import { BlockTitle } from '../typography';
+import { Actions } from '../actions/Actions';
+import { gutters } from '../grid/utils';
+
+// could be merged with ConfirmationDialog
+// however there's no need of this entities, actions, etc. structure
+interface InfoDialogProps {
+  entities: {
+    title?: string | React.ReactNode;
+    content?: ReactNode;
+    confirmButtonText?: string;
+  };
+  actions: {
+    onConfirm: () => void;
+  };
+  options: {
+    show: boolean;
+  };
+  state?: {
+    isLoading: boolean;
+  };
+}
+
+const InfoDialog: FC<InfoDialogProps> = ({ entities, actions, options, state }) => {
+  const title = entities.title;
+  if (!title) {
+    throw new Error('The confirmation dialog needs a title provided');
+  }
+  const content = entities.content;
+  if (!content) {
+    throw new Error('The confirmation dialog needs text content provided');
+  }
+  const confirmButtonText = entities.confirmButtonText;
+  if (!confirmButtonText) {
+    throw new Error('The confirmation dialog needs button text content provided');
+  }
+
+  return (
+    <Dialog open={options.show} aria-labelledby="confirmation-dialog" onClose={actions.onConfirm}>
+      <DialogHeader onClose={actions.onConfirm}>
+        <BlockTitle>{title}</BlockTitle>
+      </DialogHeader>
+      <DialogContent>{content}</DialogContent>
+      <Actions padding={gutters()} sx={{ justifyContent: 'end' }}>
+        <LoadingButton
+          variant="text"
+          loading={state?.isLoading}
+          disabled={state?.isLoading}
+          onClick={actions.onConfirm}
+        >
+          {confirmButtonText}
+        </LoadingButton>
+      </Actions>
+    </Dialog>
+  );
+};
+
+export default InfoDialog;

--- a/src/domain/account/queries/AccountInformation.graphql
+++ b/src/domain/account/queries/AccountInformation.graphql
@@ -12,6 +12,10 @@ query AccountInformation($accountId: UUID!) {
       spaces {
         id
         level
+        authorization {
+          id
+          myPrivileges
+        }
         profile {
           ...AccountItemProfile
           cardBanner: visual(type: CARD) {
@@ -21,6 +25,10 @@ query AccountInformation($accountId: UUID!) {
         }
         community {
           id
+          authorization {
+            id
+            myPrivileges
+          }
         }
         subspaces {
           id

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/newVirtualContributorQueries.graphql
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/newVirtualContributorQueries.graphql
@@ -12,11 +12,19 @@ query NewVirtualContributorMySpaces {
           id
           community {
             id
+            authorization {
+              id
+              myPrivileges
+            }
           }
           profile {
             id
             displayName
             url
+          }
+          authorization {
+            id
+            myPrivileges
           }
           subspaces {
             id

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -66,24 +66,20 @@ export interface UserAccountProps {
     community: {
       id: string;
       authorization?: {
-        id: string;
         myPrivileges?: AuthorizationPrivilege[] | undefined;
       };
     };
     profile: {
-      id: string;
       displayName: string;
       url: string;
     };
     authorization?: {
-      id: string;
       myPrivileges?: AuthorizationPrivilege[] | undefined;
     };
     subspaces: Array<{
       id: string;
       type: SpaceType;
       profile: {
-        id: string;
         displayName: string;
         url: string;
       };

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -14,6 +14,7 @@ import {
   useAssignCommunityRoleToVirtualContributorMutation,
 } from '../../../../core/apollo/generated/apollo-hooks';
 import {
+  AuthorizationPrivilege,
   CalloutGroupName,
   CalloutState,
   CalloutType,
@@ -39,6 +40,7 @@ import {
 import SetupVCInfo from './SetupVCInfo';
 import { info } from '../../../../core/logging/sentry/log';
 import { compact } from 'lodash';
+import InfoDialog from '../../../../core/ui/dialogs/InfoDialog';
 
 const SPACE_LABEL = '(space)';
 const entityNamePostfixes = {
@@ -46,7 +48,13 @@ const entityNamePostfixes = {
   SUBSPACE: "'s Knowledge Subspace",
 };
 
-type Step = 'initial' | 'createSpace' | 'addKnowledge' | 'existingKnowledge' | 'loadingVCSetup';
+type Step =
+  | 'initial'
+  | 'createSpace'
+  | 'addKnowledge'
+  | 'existingKnowledge'
+  | 'loadingVCSetup'
+  | 'insufficientPrivileges';
 
 export interface UserAccountProps {
   id: string;
@@ -57,11 +65,19 @@ export interface UserAccountProps {
     id: string;
     community: {
       id: string;
+      authorization?: {
+        id: string;
+        myPrivileges?: AuthorizationPrivilege[] | undefined;
+      };
     };
     profile: {
       id: string;
       displayName: string;
       url: string;
+    };
+    authorization?: {
+      id: string;
+      myPrivileges?: AuthorizationPrivilege[] | undefined;
     };
     subspaces: Array<{
       id: string;
@@ -143,7 +159,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
 
   // selectableSpaces are space and subspaces
   // subspaces has communityId in order to manually add the VC to it
-  const { selectedExistingSpaceId, myAccountId, selectableSpaces } = useMemo(() => {
+  const { selectedExistingSpaceId, spacePrivileges, myAccountId, selectableSpaces } = useMemo(() => {
     const account = targetAccount ?? data?.me.user?.account;
     const accountId = account?.id;
     const mySpaces = compact(account?.spaces);
@@ -176,6 +192,12 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
     return {
       selectedExistingSpaceId: mySpaces?.[0]?.id, // TODO: auto-selecting the first space, not ideal
       myAccountId: accountId,
+      spacePrivileges: {
+        myPrivileges: account?.spaces?.[0]?.authorization?.myPrivileges,
+        collaboration: {
+          myPrivileges: account?.spaces?.[0]?.community?.authorization?.myPrivileges,
+        },
+      },
       selectableSpaces,
     };
   }, [data, user, targetAccount]);
@@ -222,6 +244,18 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
     [plansData, isPlanAvailable]
   );
 
+  const hasPrivilegesOnSpaceAndCommunity = () => {
+    // todo: check create callout privilege (community) if needed
+    const { myPrivileges: spaceMyPrivileges } = spacePrivileges;
+    const { myPrivileges: collaborationMyPrivileges } = spacePrivileges.collaboration;
+
+    return (
+      spaceMyPrivileges?.includes(AuthorizationPrivilege.CreateSubspace) &&
+      collaborationMyPrivileges?.includes(AuthorizationPrivilege.AccessVirtualContributor) &&
+      collaborationMyPrivileges?.includes(AuthorizationPrivilege.CommunityAddMemberVcFromAccount)
+    );
+  };
+
   const [CreateNewSpace] = useCreateSpaceMutation({
     refetchQueries: ['MyAccount'],
   });
@@ -231,11 +265,16 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
     }
 
     setVirtualContributorInput(values);
-    setStep('createSpace');
 
     // in case of existing space, create subspace as BoK
     // otherwise create a new space
     if (selectedExistingSpaceId && myAccountId) {
+      if (!hasPrivilegesOnSpaceAndCommunity()) {
+        setStep('insufficientPrivileges');
+        return;
+      }
+      setStep('createSpace');
+
       const subspace = await handleSubspaceCreation(selectedExistingSpaceId, values.name);
       setbokId(subspace?.data?.createSubspace.id);
       setBokCommunityId(subspace?.data?.createSubspace.community.id);
@@ -250,6 +289,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
         notify('No available plans for this account. Please, contact support@alkem.io.', 'error');
         return;
       }
+      setStep('createSpace');
 
       const { data: newSpace } = await CreateNewSpace({
         variables: {
@@ -399,7 +439,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
 
     // create VC
     if (virtualContributorInput && myAccountId && bokId && bokCommunityId) {
-      await handleCreateVirtualContributor(
+      const creationSuccess = await handleCreateVirtualContributor(
         virtualContributorInput,
         myAccountId,
         bokId,
@@ -407,8 +447,10 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
         boKParentCommunityId
       );
 
-      const { data } = await getNewSpaceUrl();
-      navigate(data?.space.profile.url ?? '');
+      if (creationSuccess) {
+        const { data } = await getNewSpaceUrl();
+        navigate(data?.space.profile.url ?? '');
+      }
     }
   };
 
@@ -428,62 +470,75 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
       return;
     }
 
-    const { data } = await createVirtualContributor({
-      variables: {
-        virtualContributorData: {
-          accountID: accountId,
-          profileData: {
-            displayName: values.name,
-            tagline: values.tagline,
-            description:
-              values.description ?? t('createVirtualContributorWizard.createdVirtualContributor.description'),
-          },
-          aiPersona: {
-            aiPersonaService: {
-              bodyOfKnowledgeID: vcBoKId,
+    if (!hasPrivilegesOnSpaceAndCommunity()) {
+      setStep('insufficientPrivileges');
+      return false;
+    }
+
+    try {
+      const { data } = await createVirtualContributor({
+        variables: {
+          virtualContributorData: {
+            accountID: accountId,
+            profileData: {
+              displayName: values.name,
+              tagline: values.tagline,
+              description:
+                values.description ?? t('createVirtualContributorWizard.createdVirtualContributor.description'),
+            },
+            aiPersona: {
+              aiPersonaService: {
+                bodyOfKnowledgeID: vcBoKId,
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    const vcId = data?.createVirtualContributor.id;
+      const vcId = data?.createVirtualContributor.id;
 
-    if (vcId) {
-      if (parentCommunityId) {
-        // the VC cannot be added to the BoK community
-        // if it's not part of the parent community
+      if (vcId) {
+        if (parentCommunityId) {
+          // the VC cannot be added to the BoK community
+          // if it's not part of the parent community
+          await addVirtualContributorToCommunity({
+            variables: {
+              communityId: parentCommunityId,
+              virtualContributorId: vcId,
+            },
+          });
+        }
+
+        // add the VC to the BoK community
         await addVirtualContributorToCommunity({
           variables: {
-            communityId: parentCommunityId,
+            communityId: communityId,
             virtualContributorId: vcId,
           },
         });
+
+        // add vc's nameId to the cache for the TryVC dialog
+        if (data?.createVirtualContributor.nameID) {
+          addVCCreationCache(data?.createVirtualContributor.nameID);
+        }
+
+        notify(
+          t('createVirtualContributorWizard.createdVirtualContributor.successMessage', { name: values.name }),
+          'success'
+        );
+
+        return true;
       }
 
-      // add the VC to the BoK community
-      await addVirtualContributorToCommunity({
-        variables: {
-          communityId: communityId,
-          virtualContributorId: vcId,
-        },
-      });
-
-      // add vc's nameId to the cache for the TryVC dialog
-      if (data?.createVirtualContributor.nameID) {
-        addVCCreationCache(data?.createVirtualContributor.nameID);
-      }
-
-      notify(
-        t('createVirtualContributorWizard.createdVirtualContributor.successMessage', { name: values.name }),
-        'success'
-      );
+      return false;
+    } catch (error) {
+      return false;
     }
   };
 
   const handleCreateVCWithExistingKnowledge = async (selectedKnowledge: SelectableKnowledgeProps) => {
     if (selectedKnowledge && selectedKnowledge.communityId && virtualContributorInput) {
-      await handleCreateVirtualContributor(
+      const creationSuccess = await handleCreateVirtualContributor(
         virtualContributorInput,
         selectedKnowledge.accountId,
         selectedKnowledge.id,
@@ -491,7 +546,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
         selectedKnowledge.parentCommunityId
       );
 
-      navigate(selectedKnowledge.url ?? '');
+      creationSuccess && navigate(selectedKnowledge.url ?? '');
     }
   };
 
@@ -528,6 +583,17 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
           />
         )}
         {step === 'loadingVCSetup' && <SetupVCInfo />}
+        {step === 'insufficientPrivileges' && (
+          <InfoDialog
+            entities={{
+              title: t('createVirtualContributorWizard.insufficientPrivileges.title'),
+              content: t('createVirtualContributorWizard.insufficientPrivileges.description'),
+              confirmButtonText: t('buttons.ok'),
+            }}
+            actions={{ onConfirm: onDialogClose }}
+            options={{ show: true }}
+          />
+        )}
       </DialogWithGrid>
     ),
     [dialogOpen, step, loading]


### PR DESCRIPTION
https://github.com/alkem-io/server/issues/4532

As part (on top) of #6844, these changes now complete the Account-Organization Entity creation flow.

If the current user (no matter the global role) doesn't have the required privileges, then show a message for insufficient privileges (VC creation flow).

- [x] Check for CreateSubspace, AccessVirtualContributor and CommunityAddMemberVcFromAccount privileges;
  - the checks are applied before subspace creation (in case of existing space) and before VC creation (in case of use existing BoK);
  - this should be tested from the Account Tab and also from the Home Dash (tested, data coming from different queries);
- [x] A new step in the VC wizard was introduced reveling the insufficient privileges copy in an InfoDialog (new dialog one action 'Ok'); 

![image](https://github.com/user-attachments/assets/7bf9c383-6a30-4209-a01c-16385b2ae967)
