### PR TITLE
fix privilege for initial VC creation on acc

### DIFF
--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -242,6 +242,12 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
   );
 
   const hasPrivilegesOnSpaceAndCommunity = () => {
+    // in case of clean creation, the user is an admin of the space
+    // no way and need to check the privileges
+    if (!selectedExistingSpaceId) {
+      return true;
+    }
+
     // todo: check create callout privilege (community) if needed
     const { myPrivileges: spaceMyPrivileges } = spacePrivileges;
     const { myPrivileges: collaborationMyPrivileges } = spacePrivileges.collaboration;


### PR DESCRIPTION
no need of privilege check if there's no space initially

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the virtual contributor wizard to allow users to bypass privilege checks when no existing space is selected, facilitating easier creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->