### PR TITLE
fix subspace visuals on explore page

### DIFF
--- a/src/main/topLevelPages/topLevelSpaces/SpaceExplorerView.tsx
+++ b/src/main/topLevelPages/topLevelSpaces/SpaceExplorerView.tsx
@@ -56,6 +56,7 @@ interface ParentSpace extends Identifiable {
     displayName: string;
     avatar?: Visual;
     cardBanner?: Visual;
+    cardBanner2?: Visual;
   };
 }
 
@@ -74,6 +75,7 @@ interface Space extends Identifiable {
     };
     avatar?: Visual;
     cardBanner?: Visual;
+    cardBanner2?: Visual;
   };
   context?: {
     vision?: string;
@@ -90,15 +92,15 @@ interface Space extends Identifiable {
 }
 
 interface WithBanner {
-  profile: { avatar?: Visual; cardBanner?: Visual };
+  profile: { avatar?: Visual; cardBanner?: Visual; avatar2?: Visual; cardBanner2?: Visual };
 }
 
 const collectParentAvatars = <Journey extends WithBanner & WithParent<WithBanner>>(
   { profile, parent }: Journey,
   initial: string[] = []
 ) => {
-  const { cardBanner, avatar = cardBanner } = profile;
-  const collected = [avatar?.uri ?? '', ...initial];
+  const { cardBanner, avatar = cardBanner, cardBanner2, avatar2 = cardBanner2 } = profile;
+  const collected = [avatar?.uri ?? avatar2?.uri ?? '', ...initial];
 
   if (!parent) {
     return collected;
@@ -217,7 +219,7 @@ export const SpaceExplorerView: FC<SpaceExplorerViewProps> = ({
                 vision={space.context?.vision ?? ''}
                 journeyUri={space.profile.url}
                 type={space.profile.type!}
-                banner={space.profile.cardBanner}
+                banner={space.profile.cardBanner ?? space.profile.cardBanner2}
                 avatarUris={collectParentAvatars(space)}
                 tags={space.matchedTerms ?? space.profile.tagset?.tags.length ? space.profile.tagset?.tags : undefined}
                 spaceDisplayName={space.parent?.profile?.displayName}


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6948

I'm not sure when this regression came in.
We have these avatar2 and cardBanner2 for the subspaces in the query for quite some time, but we didn't have anything in the components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation for spaces with additional optional properties for banners and avatars.
	- Improved flexibility in displaying space visuals by allowing fallback options for banners and avatars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->