### PR TITLE
Fix subspace visuals on explore page

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -3656,7 +3656,7 @@ export const SpaceExplorerSubspaceFragmentDoc = gql`
       tagline
       displayName
       description
-      cardBanner2: visual(type: CARD) {
+      cardBanner: visual(type: CARD) {
         ...VisualUri
       }
       type
@@ -3664,7 +3664,7 @@ export const SpaceExplorerSubspaceFragmentDoc = gql`
         id
         tags
       }
-      avatar2: visual(type: AVATAR) {
+      avatar: visual(type: AVATAR) {
         ...VisualUri
       }
     }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -29553,9 +29553,9 @@ export type SpaceExplorerMemberSpacesQuery = {
         displayName: string;
         description?: string | undefined;
         type?: ProfileType | undefined;
-        cardBanner2?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+        cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
         tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-        avatar2?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+        avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
       };
       context: { __typename?: 'Context'; id: string; vision?: string | undefined };
       community: { __typename?: 'Community'; id: string; myMembershipStatus?: CommunityMembershipStatus | undefined };
@@ -29651,9 +29651,9 @@ export type SpaceExplorerSubspacesQuery = {
         displayName: string;
         description?: string | undefined;
         type?: ProfileType | undefined;
-        cardBanner2?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+        cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
         tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-        avatar2?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+        avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
       };
       context: { __typename?: 'Context'; id: string; vision?: string | undefined };
       community: { __typename?: 'Community'; id: string; myMembershipStatus?: CommunityMembershipStatus | undefined };
@@ -29700,9 +29700,9 @@ export type SpaceExplorerSubspaceFragment = {
     displayName: string;
     description?: string | undefined;
     type?: ProfileType | undefined;
-    cardBanner2?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+    cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
     tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-    avatar2?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+    avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
   };
   context: { __typename?: 'Context'; id: string; vision?: string | undefined };
   community: { __typename?: 'Community'; id: string; myMembershipStatus?: CommunityMembershipStatus | undefined };

--- a/src/main/topLevelPages/topLevelSpaces/SpaceExplorerQueries.graphql
+++ b/src/main/topLevelPages/topLevelSpaces/SpaceExplorerQueries.graphql
@@ -102,7 +102,7 @@ fragment SpaceExplorerSubspace on Space {
     tagline
     displayName
     description
-    cardBanner2: visual(type: CARD) {
+    cardBanner: visual(type: CARD) {
       ...VisualUri
     }
     type
@@ -110,7 +110,7 @@ fragment SpaceExplorerSubspace on Space {
       id
       tags
     }
-    avatar2: visual(type: AVATAR) {
+    avatar: visual(type: AVATAR) {
       ...VisualUri
     }
   }


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6948

I don't know when this regression came in.
We have these avatar2 and cardBanner2 for the subspaces in the query for quite some time, but we didn't have anything in the components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated field names in the Space Explorer component for improved clarity: `cardBanner2` is now `cardBanner` and `avatar2` is now `avatar`.
  
These changes enhance the user experience by ensuring consistency in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->