### PR TITLE
fix can't create a VC from account

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -4835,6 +4835,10 @@ export const AccountInformationDocument = gql`
             id
             roleSet {
               id
+              authorization {
+                id
+                myPrivileges
+              }
             }
           }
           subspaces {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -7792,7 +7792,21 @@ export type AccountInformationQuery = {
               cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
               avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
             };
-            community: { __typename?: 'Community'; id: string; roleSet: { __typename?: 'RoleSet'; id: string } };
+            community: {
+              __typename?: 'Community';
+              id: string;
+              roleSet: {
+                __typename?: 'RoleSet';
+                id: string;
+                authorization?:
+                  | {
+                      __typename?: 'Authorization';
+                      id: string;
+                      myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+                    }
+                  | undefined;
+              };
+            };
             subspaces: Array<{
               __typename?: 'Space';
               id: string;

--- a/src/domain/account/queries/AccountInformation.graphql
+++ b/src/domain/account/queries/AccountInformation.graphql
@@ -27,6 +27,10 @@ query AccountInformation($accountId: UUID!) {
           id
           roleSet {
             id
+            authorization {
+              id
+              myPrivileges
+            }
           }
         }
         subspaces {


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6978
During the roleSet changes the authorization on space was removed in AccountInformation query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `AccountInformation` query to include additional authorization details related to community roles.
	- Added `authorization` field in the `roleSet` object, featuring `id` and `myPrivileges` subfields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->