### PR TITLE
Wb fix merged to master

### DIFF
--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/SingleUserWhiteboardDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/SingleUserWhiteboardDialog.tsx
@@ -177,7 +177,7 @@ const SingleUserWhiteboardDialog = <Whiteboard extends WhiteboardWithContent>({
   const handleImportTemplate = async (template: WhiteboardTemplateContent) => {
     if (excalidrawAPI && options.canEdit) {
       try {
-        mergeWhiteboard(excalidrawAPI, template.whiteboard.content);
+        await mergeWhiteboard(excalidrawAPI, template.whiteboard.content);
       } catch (err) {
         notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
 

--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
@@ -192,7 +192,7 @@ const WhiteboardDialog = <Whiteboard extends WhiteboardWithContent>({
   const handleImportTemplate = async (template: WhiteboardTemplateContent) => {
     if (excalidrawAPI) {
       try {
-        mergeWhiteboard(excalidrawAPI, template.whiteboard.content);
+        await mergeWhiteboard(excalidrawAPI, template.whiteboard.content);
       } catch (err) {
         notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
         logError(new Error(`Error importing whiteboard template: '${err}'`), {

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
@@ -24,6 +24,9 @@ import { useTick } from '../../../../core/utils/time/tick';
 import useWhiteboardDefaults from './useWhiteboardDefaults';
 import Loading from '../../../../core/ui/loading/Loading';
 
+const FILE_IMPORT_ENABLED = false;
+const SAVE_FILE_TO_DISK = true;
+
 const Excalidraw = React.lazy(async () => {
   const { Excalidraw } = await import('@alkemio/excalidraw');
   return { default: Excalidraw };
@@ -130,9 +133,9 @@ const CollaborativeExcalidrawWrapper = ({
   const UIOptions: ExcalidrawProps['UIOptions'] = useMemo(
     () => ({
       canvasActions: {
-        loadScene: false,
+        loadScene: FILE_IMPORT_ENABLED,
         export: {
-          saveFileToDisk: true,
+          saveFileToDisk: SAVE_FILE_TO_DISK,
         },
       },
     }),

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
@@ -130,6 +130,7 @@ const CollaborativeExcalidrawWrapper = ({
   const UIOptions: ExcalidrawProps['UIOptions'] = useMemo(
     () => ({
       canvasActions: {
+        loadScene: false,
         export: {
           saveFileToDisk: true,
         },

--- a/src/domain/common/whiteboard/excalidraw/collab/Portal.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Portal.ts
@@ -106,8 +106,6 @@ class Portal {
         eventHandlers['idle-state'](decryptedData.payload);
       });
 
-      this.socket.on('room-saved', eventHandlers['room-saved']);
-
       this.socket.on('client-broadcast', eventHandlers['client-broadcast']);
 
       this.socket.on('connect', () => {


### PR DESCRIPTION
Original https://github.com/alkem-io/client-web/pull/6973

- Imported elements from template had a `version` field that could be lower than the current version of the scene (the sum of the versions of all the elements(deleted or not) of the whiteboard.
- Now on import they all get their versions replaced
- Disabled file import for now. Created a task to try to enable it again https://github.com/alkem-io/client-web/issues/6977
- Fixed a warning on the browser console