### PR TITLE
Fix template dialog was not going back to Templates index on template deletion

### DIFF
--- a/src/domain/templates/components/TemplatesAdmin/TemplatesAdmin.tsx
+++ b/src/domain/templates/components/TemplatesAdmin/TemplatesAdmin.tsx
@@ -165,6 +165,7 @@ const TemplatesAdmin: FC<TemplatesAdminProps> = ({
     });
 
     setDeletingTemplate(undefined);
+    backToTemplates(baseUrl);
   });
 
   // Import Template


### PR DESCRIPTION
#6923 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Users will now be redirected back to the templates page after successfully deleting a template, enhancing navigation and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->