### PR TITLE
Partial solution to WB templates problem

### DIFF
--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
@@ -1,4 +1,5 @@
 import type { ExcalidrawElement } from '@alkemio/excalidraw/types/element/types';
+import { PRECEDING_ELEMENT_KEY } from '@alkemio/excalidraw/types/constants';
 import type { BinaryFileData, ExcalidrawImperativeAPI } from '@alkemio/excalidraw/types/types';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -92,6 +93,46 @@ const replaceElementVersion = (version: number) => (element: ExcalidrawElement) 
 });
 
 /**
+ * Returns a function that can be pased to elements.map to replace __preceedingElement__ on the elements that have it
+ * For old versions of whiteboards that sort the elements with the __preceedingElement__ property
+ */
+const replacePreceedingElementsIds = (idsMap: Record<string, string>, lastElementId: string) => {
+  return (element: ExcalidrawElement) => {
+    if (!element[PRECEDING_ELEMENT_KEY]) {
+      return element;
+    }
+    if (element[PRECEDING_ELEMENT_KEY] === '^') {
+      return {
+        ...element,
+        [PRECEDING_ELEMENT_KEY]: lastElementId,
+      };
+    }
+    if (idsMap[element[PRECEDING_ELEMENT_KEY]]) {
+      return {
+        ...element,
+        [PRECEDING_ELEMENT_KEY]: idsMap[element[PRECEDING_ELEMENT_KEY]],
+      };
+    }
+    return element;
+  };
+};
+
+/**
+ * Returns a function that can be pased to elements.map to replace the index on the elements that have it
+ * For new versions of whiteboards that have the index property
+ */
+const replaceIndexes = baseIndex => {
+  return (element: ExcalidrawElement) => {
+    if (baseIndex && typeof element['index'] === 'number') {
+      return {
+        ...element,
+        index: element['index'] + baseIndex,
+      };
+    }
+    return element;
+  };
+};
+/**
  * Returns a function that can be pased to elements.map to replace containerId and boundElements ids
  */
 const replaceBoundElementsIds = (idsMap: Record<string, string>) => {
@@ -149,9 +190,17 @@ const mergeWhiteboard = async (whiteboardApi: ExcalidrawImperativeAPI, whiteboar
 
     const replacedIds: Record<string, string> = {};
 
+    const lastElementId = currentElements[currentElements.length - 1].id ?? '^';
+    const maxIndex = currentElements.reduce(
+      (max, element) => (typeof element['index'] === 'number' ? Math.max(max, element['index']) : max),
+      0
+    );
+
     const insertedElements = parsedWhiteboard.elements
       ?.map(generateNewIds(replacedIds))
       .map(replaceElementVersion(sceneVersion + 1))
+      .map(replaceIndexes(maxIndex + 1))
+      .map(replacePreceedingElementsIds(replacedIds, lastElementId))
       .map(replaceBoundElementsIds(replacedIds))
       .map(displaceElements(displacement));
 


### PR DESCRIPTION
- Replaces the __preceedingElement__ of the first item inserted (that should have a "^") with the last element of the existing elements
- Replaces the index property to be prepared when we upgrade excalidraw