### PR TITLE
Invitations private subspace

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -3107,8 +3107,17 @@ export type SpaceDefaultsFieldPolicy = {
   innovationFlowTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SpaceInfoKeySpecifier = ('context' | 'id' | 'level' | 'nameID' | 'profile' | SpaceInfoKeySpecifier)[];
+export type SpaceInfoKeySpecifier = (
+  | 'communityGuidelines'
+  | 'context'
+  | 'id'
+  | 'level'
+  | 'nameID'
+  | 'profile'
+  | SpaceInfoKeySpecifier
+)[];
 export type SpaceInfoFieldPolicy = {
+  communityGuidelines?: FieldPolicy<any> | FieldReadFunction<any>;
   context?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   level?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -986,13 +986,13 @@ export type CommunityApplicationForRoleResultFieldPolicy = {
 export type CommunityApplicationResultKeySpecifier = (
   | 'application'
   | 'id'
-  | 'space'
+  | 'spaceInfo'
   | CommunityApplicationResultKeySpecifier
 )[];
 export type CommunityApplicationResultFieldPolicy = {
   application?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
-  space?: FieldPolicy<any> | FieldReadFunction<any>;
+  spaceInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CommunityGuidelinesKeySpecifier = (
   | 'authorization'
@@ -1041,13 +1041,13 @@ export type CommunityInvitationForRoleResultFieldPolicy = {
 export type CommunityInvitationResultKeySpecifier = (
   | 'id'
   | 'invitation'
-  | 'space'
+  | 'spaceInfo'
   | CommunityInvitationResultKeySpecifier
 )[];
 export type CommunityInvitationResultFieldPolicy = {
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   invitation?: FieldPolicy<any> | FieldReadFunction<any>;
-  space?: FieldPolicy<any> | FieldReadFunction<any>;
+  spaceInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CommunityMembershipResultKeySpecifier = (
   | 'childMemberships'
@@ -3107,6 +3107,14 @@ export type SpaceDefaultsFieldPolicy = {
   innovationFlowTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
 };
+export type SpaceInfoKeySpecifier = ('context' | 'id' | 'level' | 'nameID' | 'profile' | SpaceInfoKeySpecifier)[];
+export type SpaceInfoFieldPolicy = {
+  context?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  level?: FieldPolicy<any> | FieldReadFunction<any>;
+  nameID?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+};
 export type SpaceSettingsKeySpecifier = ('collaboration' | 'membership' | 'privacy' | SpaceSettingsKeySpecifier)[];
 export type SpaceSettingsFieldPolicy = {
   collaboration?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -4360,6 +4368,10 @@ export type StrictTypedTypePolicies = {
   SpaceDefaults?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | SpaceDefaultsKeySpecifier | (() => undefined | SpaceDefaultsKeySpecifier);
     fields?: SpaceDefaultsFieldPolicy;
+  };
+  SpaceInfo?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | SpaceInfoKeySpecifier | (() => undefined | SpaceInfoKeySpecifier);
+    fields?: SpaceInfoFieldPolicy;
   };
   SpaceSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | SpaceSettingsKeySpecifier | (() => undefined | SpaceSettingsKeySpecifier);

--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -986,13 +986,13 @@ export type CommunityApplicationForRoleResultFieldPolicy = {
 export type CommunityApplicationResultKeySpecifier = (
   | 'application'
   | 'id'
-  | 'spaceInfo'
+  | 'spacePendingMembershipInfo'
   | CommunityApplicationResultKeySpecifier
 )[];
 export type CommunityApplicationResultFieldPolicy = {
   application?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
-  spaceInfo?: FieldPolicy<any> | FieldReadFunction<any>;
+  spacePendingMembershipInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CommunityGuidelinesKeySpecifier = (
   | 'authorization'
@@ -1041,13 +1041,13 @@ export type CommunityInvitationForRoleResultFieldPolicy = {
 export type CommunityInvitationResultKeySpecifier = (
   | 'id'
   | 'invitation'
-  | 'spaceInfo'
+  | 'spacePendingMembershipInfo'
   | CommunityInvitationResultKeySpecifier
 )[];
 export type CommunityInvitationResultFieldPolicy = {
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   invitation?: FieldPolicy<any> | FieldReadFunction<any>;
-  spaceInfo?: FieldPolicy<any> | FieldReadFunction<any>;
+  spacePendingMembershipInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CommunityMembershipResultKeySpecifier = (
   | 'childMemberships'
@@ -3107,21 +3107,19 @@ export type SpaceDefaultsFieldPolicy = {
   innovationFlowTemplate?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SpaceInfoKeySpecifier = (
+export type SpacePendingMembershipInfoKeySpecifier = (
   | 'communityGuidelines'
   | 'context'
   | 'id'
   | 'level'
-  | 'nameID'
   | 'profile'
-  | SpaceInfoKeySpecifier
+  | SpacePendingMembershipInfoKeySpecifier
 )[];
-export type SpaceInfoFieldPolicy = {
+export type SpacePendingMembershipInfoFieldPolicy = {
   communityGuidelines?: FieldPolicy<any> | FieldReadFunction<any>;
   context?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   level?: FieldPolicy<any> | FieldReadFunction<any>;
-  nameID?: FieldPolicy<any> | FieldReadFunction<any>;
   profile?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type SpaceSettingsKeySpecifier = ('collaboration' | 'membership' | 'privacy' | SpaceSettingsKeySpecifier)[];
@@ -4378,9 +4376,12 @@ export type StrictTypedTypePolicies = {
     keyFields?: false | SpaceDefaultsKeySpecifier | (() => undefined | SpaceDefaultsKeySpecifier);
     fields?: SpaceDefaultsFieldPolicy;
   };
-  SpaceInfo?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
-    keyFields?: false | SpaceInfoKeySpecifier | (() => undefined | SpaceInfoKeySpecifier);
-    fields?: SpaceInfoFieldPolicy;
+  SpacePendingMembershipInfo?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | SpacePendingMembershipInfoKeySpecifier
+      | (() => undefined | SpacePendingMembershipInfoKeySpecifier);
+    fields?: SpacePendingMembershipInfoFieldPolicy;
   };
   SpaceSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | SpaceSettingsKeySpecifier | (() => undefined | SpaceSettingsKeySpecifier);

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -1686,7 +1686,7 @@ export const UserRolesDetailsFragmentDoc = gql`
 export const InvitationDataFragmentDoc = gql`
   fragment InvitationData on CommunityInvitationResult {
     id
-    spaceInfo {
+    spacePendingMembershipInfo {
       id
       level
       profile {
@@ -2062,8 +2062,8 @@ export const SpaceDetailsFragmentDoc = gql`
   ${FullLocationFragmentDoc}
   ${ContextDetailsFragmentDoc}
 `;
-export const SpaceInfoFragmentDoc = gql`
-  fragment SpaceInfo on Space {
+export const SpacePendingMembershipInfoFragmentDoc = gql`
+  fragment SpacePendingMembershipInfo on Space {
     ...SpaceDetails
     authorization {
       id
@@ -2431,8 +2431,8 @@ export const MyMembershipsRoleSetFragmentDoc = gql`
     myRoles
   }
 `;
-export const SubspaceInfoFragmentDoc = gql`
-  fragment SubspaceInfo on Space {
+export const SubspacePendingMembershipInfoFragmentDoc = gql`
+  fragment SubspacePendingMembershipInfo on Space {
     id
     nameID
     profile {
@@ -3490,7 +3490,7 @@ export const MyMembershipsChildJourneyProfileFragmentDoc = gql`
   ${VisualUriFragmentDoc}
 `;
 export const NewMembershipsBasicSpaceFragmentDoc = gql`
-  fragment NewMembershipsBasicSpace on SpaceInfo {
+  fragment NewMembershipsBasicSpace on SpacePendingMembershipInfo {
     id
     level
     profile {
@@ -13573,7 +13573,7 @@ export const UserPendingMembershipsDocument = gql`
       }
       communityApplications(states: ["new"]) {
         id
-        spaceInfo {
+        spacePendingMembershipInfo {
           id
           level
           profile {
@@ -15768,10 +15768,10 @@ export function refetchSpaceCommunityPageQuery(variables: SchemaTypes.SpaceCommu
 export const SpaceProviderDocument = gql`
   query SpaceProvider($spaceNameId: UUID_NAMEID!) {
     space(ID: $spaceNameId) {
-      ...SpaceInfo
+      ...SpacePendingMembershipInfo
     }
   }
-  ${SpaceInfoFragmentDoc}
+  ${SpacePendingMembershipInfoFragmentDoc}
 `;
 
 /**
@@ -17743,61 +17743,71 @@ export function refetchSpaceDashboardNavigationOpportunitiesQuery(
   return { query: SpaceDashboardNavigationOpportunitiesDocument, variables: variables };
 }
 
-export const SubspaceInfoDocument = gql`
-  query SubspaceInfo($subspaceId: UUID!) {
+export const SubspacePendingMembershipInfoDocument = gql`
+  query SubspacePendingMembershipInfo($subspaceId: UUID!) {
     lookup {
       space(ID: $subspaceId) {
-        ...SubspaceInfo
+        ...SubspacePendingMembershipInfo
       }
     }
   }
-  ${SubspaceInfoFragmentDoc}
+  ${SubspacePendingMembershipInfoFragmentDoc}
 `;
 
 /**
- * __useSubspaceInfoQuery__
+ * __useSubspacePendingMembershipInfoQuery__
  *
- * To run a query within a React component, call `useSubspaceInfoQuery` and pass it any options that fit your needs.
- * When your component renders, `useSubspaceInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSubspacePendingMembershipInfoQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSubspacePendingMembershipInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSubspaceInfoQuery({
+ * const { data, loading, error } = useSubspacePendingMembershipInfoQuery({
  *   variables: {
  *      subspaceId: // value for 'subspaceId'
  *   },
  * });
  */
-export function useSubspaceInfoQuery(
-  baseOptions: Apollo.QueryHookOptions<SchemaTypes.SubspaceInfoQuery, SchemaTypes.SubspaceInfoQueryVariables>
+export function useSubspacePendingMembershipInfoQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    SchemaTypes.SubspacePendingMembershipInfoQuery,
+    SchemaTypes.SubspacePendingMembershipInfoQueryVariables
+  >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<SchemaTypes.SubspaceInfoQuery, SchemaTypes.SubspaceInfoQueryVariables>(
-    SubspaceInfoDocument,
-    options
-  );
+  return Apollo.useQuery<
+    SchemaTypes.SubspacePendingMembershipInfoQuery,
+    SchemaTypes.SubspacePendingMembershipInfoQueryVariables
+  >(SubspacePendingMembershipInfoDocument, options);
 }
 
-export function useSubspaceInfoLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<SchemaTypes.SubspaceInfoQuery, SchemaTypes.SubspaceInfoQueryVariables>
+export function useSubspacePendingMembershipInfoLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.SubspacePendingMembershipInfoQuery,
+    SchemaTypes.SubspacePendingMembershipInfoQueryVariables
+  >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<SchemaTypes.SubspaceInfoQuery, SchemaTypes.SubspaceInfoQueryVariables>(
-    SubspaceInfoDocument,
-    options
-  );
+  return Apollo.useLazyQuery<
+    SchemaTypes.SubspacePendingMembershipInfoQuery,
+    SchemaTypes.SubspacePendingMembershipInfoQueryVariables
+  >(SubspacePendingMembershipInfoDocument, options);
 }
 
-export type SubspaceInfoQueryHookResult = ReturnType<typeof useSubspaceInfoQuery>;
-export type SubspaceInfoLazyQueryHookResult = ReturnType<typeof useSubspaceInfoLazyQuery>;
-export type SubspaceInfoQueryResult = Apollo.QueryResult<
-  SchemaTypes.SubspaceInfoQuery,
-  SchemaTypes.SubspaceInfoQueryVariables
+export type SubspacePendingMembershipInfoQueryHookResult = ReturnType<typeof useSubspacePendingMembershipInfoQuery>;
+export type SubspacePendingMembershipInfoLazyQueryHookResult = ReturnType<
+  typeof useSubspacePendingMembershipInfoLazyQuery
 >;
-export function refetchSubspaceInfoQuery(variables: SchemaTypes.SubspaceInfoQueryVariables) {
-  return { query: SubspaceInfoDocument, variables: variables };
+export type SubspacePendingMembershipInfoQueryResult = Apollo.QueryResult<
+  SchemaTypes.SubspacePendingMembershipInfoQuery,
+  SchemaTypes.SubspacePendingMembershipInfoQueryVariables
+>;
+export function refetchSubspacePendingMembershipInfoQuery(
+  variables: SchemaTypes.SubspacePendingMembershipInfoQueryVariables
+) {
+  return { query: SubspacePendingMembershipInfoDocument, variables: variables };
 }
 
 export const SubspaceCommunityAndRoleSetIdDocument = gql`
@@ -22694,7 +22704,7 @@ export const NewMembershipsDocument = gql`
     me {
       communityApplications(states: ["new", "approved"]) {
         id
-        spaceInfo {
+        spacePendingMembershipInfo {
           ...NewMembershipsBasicSpace
         }
         application {
@@ -22708,7 +22718,7 @@ export const NewMembershipsDocument = gql`
       }
       communityInvitations(states: ["invited", "accepted"]) {
         id
-        spaceInfo {
+        spacePendingMembershipInfo {
           ...NewMembershipsBasicSpace
         }
         invitation {

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -1686,7 +1686,7 @@ export const UserRolesDetailsFragmentDoc = gql`
 export const InvitationDataFragmentDoc = gql`
   fragment InvitationData on CommunityInvitationResult {
     id
-    space {
+    spaceInfo {
       id
       level
       profile {
@@ -3490,7 +3490,7 @@ export const MyMembershipsChildJourneyProfileFragmentDoc = gql`
   ${VisualUriFragmentDoc}
 `;
 export const NewMembershipsBasicSpaceFragmentDoc = gql`
-  fragment NewMembershipsBasicSpace on Space {
+  fragment NewMembershipsBasicSpace on SpaceInfo {
     id
     level
     profile {
@@ -13573,7 +13573,7 @@ export const UserPendingMembershipsDocument = gql`
       }
       communityApplications(states: ["new"]) {
         id
-        space {
+        spaceInfo {
           id
           level
           profile {
@@ -22694,7 +22694,7 @@ export const NewMembershipsDocument = gql`
     me {
       communityApplications(states: ["new", "approved"]) {
         id
-        space {
+        spaceInfo {
           ...NewMembershipsBasicSpace
         }
         application {
@@ -22708,7 +22708,7 @@ export const NewMembershipsDocument = gql`
       }
       communityInvitations(states: ["invited", "accepted"]) {
         id
-        space {
+        spaceInfo {
           ...NewMembershipsBasicSpace
         }
         invitation {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -1424,8 +1424,8 @@ export type CommunityApplicationResult = {
   application: Application;
   /** ID for the pending membership */
   id: Scalars['UUID'];
-  /** The space that the application is for */
-  space: Space;
+  /** The key information for the Space that the application/invitation is for */
+  spaceInfo: SpaceInfo;
 };
 
 export enum CommunityContributorType {
@@ -1482,8 +1482,8 @@ export type CommunityInvitationResult = {
   id: Scalars['UUID'];
   /** The invitation itself */
   invitation: Invitation;
-  /** The space that the application is for */
-  space: Space;
+  /** The key information for the Space that the application/invitation is for */
+  spaceInfo: SpaceInfo;
 };
 
 export enum CommunityMembershipPolicy {
@@ -2259,6 +2259,7 @@ export type DeleteUserGroupInput = {
 
 export type DeleteUserInput = {
   ID: Scalars['UUID_NAMEID_EMAIL'];
+  deleteIdentity?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type DeleteVirtualContributorInput = {
@@ -5471,6 +5472,20 @@ export type SpaceDefaults = {
 export type SpaceFilterInput = {
   /** Return Spaces with a Visibility matching one of the provided types. */
   visibilities?: InputMaybe<Array<SpaceVisibility>>;
+};
+
+export type SpaceInfo = {
+  __typename?: 'SpaceInfo';
+  /** The Context of the Space */
+  context: Context;
+  /** The Space ID */
+  id: Scalars['UUID'];
+  /** The Level of the Space */
+  level: SpaceLevel;
+  /** The Space nameID */
+  nameID: Scalars['NameID'];
+  /** The Profile of the Space */
+  profile: Profile;
 };
 
 export enum SpaceLevel {
@@ -18137,10 +18152,10 @@ export type UserPendingMembershipsQuery = {
     communityApplications: Array<{
       __typename?: 'CommunityApplicationResult';
       id: string;
-      space: {
-        __typename?: 'Space';
+      spaceInfo: {
+        __typename?: 'SpaceInfo';
         id: string;
-        level: number;
+        level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
       };
       application: {
@@ -18153,10 +18168,10 @@ export type UserPendingMembershipsQuery = {
     communityInvitations: Array<{
       __typename?: 'CommunityInvitationResult';
       id: string;
-      space: {
-        __typename?: 'Space';
+      spaceInfo: {
+        __typename?: 'SpaceInfo';
         id: string;
-        level: number;
+        level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
       };
       invitation: {
@@ -18179,10 +18194,10 @@ export type UserPendingMembershipsQuery = {
 export type InvitationDataFragment = {
   __typename?: 'CommunityInvitationResult';
   id: string;
-  space: {
-    __typename?: 'Space';
+  spaceInfo: {
+    __typename?: 'SpaceInfo';
     id: string;
-    level: number;
+    level: SpaceLevel;
     profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
   };
   invitation: {
@@ -18586,10 +18601,10 @@ export type VcMembershipsQuery = {
     communityInvitations: Array<{
       __typename?: 'CommunityInvitationResult';
       id: string;
-      space: {
-        __typename?: 'Space';
+      spaceInfo: {
+        __typename?: 'SpaceInfo';
         id: string;
-        level: number;
+        level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
       };
       invitation: {
@@ -29753,10 +29768,10 @@ export type NewMembershipsQuery = {
     communityApplications: Array<{
       __typename?: 'CommunityApplicationResult';
       id: string;
-      space: {
-        __typename?: 'Space';
+      spaceInfo: {
+        __typename?: 'SpaceInfo';
         id: string;
-        level: number;
+        level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
       };
       application: {
@@ -29769,10 +29784,10 @@ export type NewMembershipsQuery = {
     communityInvitations: Array<{
       __typename?: 'CommunityInvitationResult';
       id: string;
-      space: {
-        __typename?: 'Space';
+      spaceInfo: {
+        __typename?: 'SpaceInfo';
         id: string;
-        level: number;
+        level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
       };
       invitation: {
@@ -29789,9 +29804,9 @@ export type NewMembershipsQuery = {
 };
 
 export type NewMembershipsBasicSpaceFragment = {
-  __typename?: 'Space';
+  __typename?: 'SpaceInfo';
   id: string;
-  level: number;
+  level: SpaceLevel;
   profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
 };
 

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -1425,7 +1425,7 @@ export type CommunityApplicationResult = {
   /** ID for the pending membership */
   id: Scalars['UUID'];
   /** The key information for the Space that the application/invitation is for */
-  spaceInfo: SpaceInfo;
+  spacePendingMembershipInfo: SpacePendingMembershipInfo;
 };
 
 export enum CommunityContributorType {
@@ -1483,7 +1483,7 @@ export type CommunityInvitationResult = {
   /** The invitation itself */
   invitation: Invitation;
   /** The key information for the Space that the application/invitation is for */
-  spaceInfo: SpaceInfo;
+  spacePendingMembershipInfo: SpacePendingMembershipInfo;
 };
 
 export enum CommunityMembershipPolicy {
@@ -5474,8 +5474,14 @@ export type SpaceFilterInput = {
   visibilities?: InputMaybe<Array<SpaceVisibility>>;
 };
 
-export type SpaceInfo = {
-  __typename?: 'SpaceInfo';
+export enum SpaceLevel {
+  Challenge = 'CHALLENGE',
+  Opportunity = 'OPPORTUNITY',
+  Space = 'SPACE',
+}
+
+export type SpacePendingMembershipInfo = {
+  __typename?: 'SpacePendingMembershipInfo';
   /** The CommunityGuidelines for the Space */
   communityGuidelines: CommunityGuidelines;
   /** The Context of the Space */
@@ -5484,17 +5490,9 @@ export type SpaceInfo = {
   id: Scalars['UUID'];
   /** The Level of the Space */
   level: SpaceLevel;
-  /** The Space nameID */
-  nameID: Scalars['NameID'];
   /** The Profile of the Space */
   profile: Profile;
 };
-
-export enum SpaceLevel {
-  Challenge = 'CHALLENGE',
-  Opportunity = 'OPPORTUNITY',
-  Space = 'SPACE',
-}
 
 export enum SpacePrivacyMode {
   Private = 'PRIVATE',
@@ -18154,8 +18152,8 @@ export type UserPendingMembershipsQuery = {
     communityApplications: Array<{
       __typename?: 'CommunityApplicationResult';
       id: string;
-      spaceInfo: {
-        __typename?: 'SpaceInfo';
+      spacePendingMembershipInfo: {
+        __typename?: 'SpacePendingMembershipInfo';
         id: string;
         level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
@@ -18170,8 +18168,8 @@ export type UserPendingMembershipsQuery = {
     communityInvitations: Array<{
       __typename?: 'CommunityInvitationResult';
       id: string;
-      spaceInfo: {
-        __typename?: 'SpaceInfo';
+      spacePendingMembershipInfo: {
+        __typename?: 'SpacePendingMembershipInfo';
         id: string;
         level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
@@ -18196,8 +18194,8 @@ export type UserPendingMembershipsQuery = {
 export type InvitationDataFragment = {
   __typename?: 'CommunityInvitationResult';
   id: string;
-  spaceInfo: {
-    __typename?: 'SpaceInfo';
+  spacePendingMembershipInfo: {
+    __typename?: 'SpacePendingMembershipInfo';
     id: string;
     level: SpaceLevel;
     profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
@@ -18603,8 +18601,8 @@ export type VcMembershipsQuery = {
     communityInvitations: Array<{
       __typename?: 'CommunityInvitationResult';
       id: string;
-      spaceInfo: {
-        __typename?: 'SpaceInfo';
+      spacePendingMembershipInfo: {
+        __typename?: 'SpacePendingMembershipInfo';
         id: string;
         level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
@@ -20731,7 +20729,7 @@ export type SpaceUrlQuery = {
   space: { __typename?: 'Space'; id: string; profile: { __typename?: 'Profile'; id: string; url: string } };
 };
 
-export type SpaceInfoFragment = {
+export type SpacePendingMembershipInfoFragment = {
   __typename?: 'Space';
   visibility: SpaceVisibility;
   id: string;
@@ -22769,11 +22767,11 @@ export type SpaceDashboardNavigationProfileFragment = {
   avatar?: { __typename?: 'Visual'; id: string; uri: string; alternativeText?: string | undefined } | undefined;
 };
 
-export type SubspaceInfoQueryVariables = Exact<{
+export type SubspacePendingMembershipInfoQueryVariables = Exact<{
   subspaceId: Scalars['UUID'];
 }>;
 
-export type SubspaceInfoQuery = {
+export type SubspacePendingMembershipInfoQuery = {
   __typename?: 'Query';
   lookup: {
     __typename?: 'LookupQueryResults';
@@ -22854,7 +22852,7 @@ export type SubspaceInfoQuery = {
   };
 };
 
-export type SubspaceInfoFragment = {
+export type SubspacePendingMembershipInfoFragment = {
   __typename?: 'Space';
   id: string;
   nameID: string;
@@ -29770,8 +29768,8 @@ export type NewMembershipsQuery = {
     communityApplications: Array<{
       __typename?: 'CommunityApplicationResult';
       id: string;
-      spaceInfo: {
-        __typename?: 'SpaceInfo';
+      spacePendingMembershipInfo: {
+        __typename?: 'SpacePendingMembershipInfo';
         id: string;
         level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
@@ -29786,8 +29784,8 @@ export type NewMembershipsQuery = {
     communityInvitations: Array<{
       __typename?: 'CommunityInvitationResult';
       id: string;
-      spaceInfo: {
-        __typename?: 'SpaceInfo';
+      spacePendingMembershipInfo: {
+        __typename?: 'SpacePendingMembershipInfo';
         id: string;
         level: SpaceLevel;
         profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
@@ -29806,7 +29804,7 @@ export type NewMembershipsQuery = {
 };
 
 export type NewMembershipsBasicSpaceFragment = {
-  __typename?: 'SpaceInfo';
+  __typename?: 'SpacePendingMembershipInfo';
   id: string;
   level: SpaceLevel;
   profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -4842,7 +4842,7 @@ export type RelayPaginatedSpace = {
   /** The ID of the entity */
   id: Scalars['UUID'];
   /** The level of this Space, representing the number of Spaces above this one. */
-  level: Scalars['Float'];
+  level: SpaceLevel;
   /** The ID of the level zero space for this tree. */
   levelZeroSpaceID: Scalars['String'];
   /** The Library in use by this Space */
@@ -5097,7 +5097,7 @@ export type RolesResultCommunity = {
   /** A unique identifier for this membership result. */
   id: Scalars['String'];
   /** The level of the Space e.g. space/challenge/opportunity. */
-  level: Scalars['Float'];
+  level: SpaceLevel;
   /** Name Identifier of the entity */
   nameID: Scalars['NameID'];
   /** The roles held by the contributor */
@@ -5129,7 +5129,7 @@ export type RolesResultSpace = {
   /** A unique identifier for this membership result. */
   id: Scalars['String'];
   /** The level of the Space e.g. space/challenge/opportunity. */
-  level: Scalars['Float'];
+  level: SpaceLevel;
   /** Name Identifier of the entity */
   nameID: Scalars['NameID'];
   /** The roles held by the contributor */
@@ -5412,7 +5412,7 @@ export type Space = {
   /** The ID of the entity */
   id: Scalars['UUID'];
   /** The level of this Space, representing the number of Spaces above this one. */
-  level: Scalars['Float'];
+  level: SpaceLevel;
   /** The ID of the level zero space for this tree. */
   levelZeroSpaceID: Scalars['String'];
   /** The Library in use by this Space */
@@ -5476,6 +5476,8 @@ export type SpaceFilterInput = {
 
 export type SpaceInfo = {
   __typename?: 'SpaceInfo';
+  /** The CommunityGuidelines for the Space */
+  communityGuidelines: CommunityGuidelines;
   /** The Context of the Space */
   context: Context;
   /** The Space ID */
@@ -7819,7 +7821,7 @@ export type AccountInformationQuery = {
           spaces: Array<{
             __typename?: 'Space';
             id: string;
-            level: number;
+            level: SpaceLevel;
             authorization?:
               | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
               | undefined;
@@ -16373,7 +16375,7 @@ export type RolesOrganizationQuery = {
         id: string;
         displayName: string;
         roles: Array<string>;
-        level: number;
+        level: SpaceLevel;
       }>;
     }>;
   };
@@ -18365,7 +18367,7 @@ export type UserContributionsQuery = {
         id: string;
         nameID: string;
         type: SpaceType;
-        level: number;
+        level: SpaceLevel;
         roles: Array<string>;
       }>;
     }>;
@@ -18592,7 +18594,7 @@ export type VcMembershipsQuery = {
       __typename?: 'RolesResultSpace';
       id: string;
       nameID: string;
-      subspaces: Array<{ __typename?: 'RolesResultCommunity'; id: string; nameID: string; level: number }>;
+      subspaces: Array<{ __typename?: 'RolesResultCommunity'; id: string; nameID: string; level: SpaceLevel }>;
     }>;
   };
   me: {
@@ -27200,7 +27202,7 @@ export type SearchQuery = {
           space: {
             __typename?: 'Space';
             id: string;
-            level: number;
+            level: SpaceLevel;
             profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
           };
         }
@@ -27531,7 +27533,7 @@ export type SearchResultCalloutFragment = {
   space: {
     __typename?: 'Space';
     id: string;
-    level: number;
+    level: SpaceLevel;
     profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
   };
 };
@@ -27541,7 +27543,7 @@ export type CalloutParentFragment = {
   space: {
     __typename?: 'Space';
     id: string;
-    level: number;
+    level: SpaceLevel;
     profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
   };
 };
@@ -29610,7 +29612,7 @@ export type MyAccountQuery = {
                 spaces: Array<{
                   __typename?: 'Space';
                   id: string;
-                  level: number;
+                  level: SpaceLevel;
                   profile: {
                     __typename?: 'Profile';
                     id: string;
@@ -29640,7 +29642,7 @@ export type MyMembershipsQuery = {
       space: {
         __typename?: 'Space';
         id: string;
-        level: number;
+        level: SpaceLevel;
         authorization?:
           | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
           | undefined;
@@ -29668,7 +29670,7 @@ export type MyMembershipsQuery = {
         space: {
           __typename?: 'Space';
           id: string;
-          level: number;
+          level: SpaceLevel;
           authorization?:
             | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
             | undefined;
@@ -29696,7 +29698,7 @@ export type MyMembershipsQuery = {
           space: {
             __typename?: 'Space';
             id: string;
-            level: number;
+            level: SpaceLevel;
             authorization?:
               | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
               | undefined;
@@ -29727,7 +29729,7 @@ export type MyMembershipsQuery = {
 export type SpaceMembershipFragment = {
   __typename?: 'Space';
   id: string;
-  level: number;
+  level: SpaceLevel;
   authorization?:
     | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
     | undefined;

--- a/src/dev/ui/SearchCardsDemo.tsx
+++ b/src/dev/ui/SearchCardsDemo.tsx
@@ -9,7 +9,12 @@ import CalloutCard, { CalloutCardCallout } from '../../domain/collaboration/call
 import SearchResultsCalloutCardFooter, {
   SearchResultsCalloutCardFooterProps,
 } from '../../main/search/searchResults/searchResultsCallout/SearchResultsCalloutCardFooter';
-import { CalloutContributionType, CalloutState, CalloutType } from '../../core/apollo/generated/graphql-schema';
+import {
+  CalloutContributionType,
+  CalloutState,
+  CalloutType,
+  SpaceLevel,
+} from '../../core/apollo/generated/graphql-schema';
 
 const loremIpsum =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
@@ -56,7 +61,7 @@ const searchResults: SearchResult[] = [
         displayName: 'Parent Challenge',
         url: '/space1',
       },
-      level: 1,
+      level: SpaceLevel.Challenge,
     },
   },
   {
@@ -90,7 +95,7 @@ const searchResults: SearchResult[] = [
         displayName: 'Parent Space',
         url: '/space2',
       },
-      level: 0,
+      level: SpaceLevel.Space,
     },
   },
 ];

--- a/src/domain/community/application/applicationButton/ApplicationButton.tsx
+++ b/src/domain/community/application/applicationButton/ApplicationButton.tsx
@@ -14,7 +14,7 @@ import InvitationActionsContainer from '../../invitations/InvitationActionsConta
 import InvitationDialog from '../../invitations/InvitationDialog';
 import useNavigate from '../../../../core/routing/useNavigate';
 import ApplicationDialog from './ApplicationDialog';
-import { JourneyLevel } from '../../../../main/routing/resolvers/RouteResolver';
+import { SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 
 export interface ApplicationButtonProps {
   journeyId: string | undefined;
@@ -37,7 +37,7 @@ export interface ApplicationButtonProps {
   loading: boolean;
   component?: typeof MuiButton;
   extended?: boolean;
-  journeyLevel: JourneyLevel | -1;
+  spaceLevel: SpaceLevel | undefined;
   onUpdateInvitation?: () => void | Promise<void>;
 }
 
@@ -61,7 +61,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
       canJoinParentCommunity,
       canApplyToParentCommunity,
       onJoin,
-      journeyLevel,
+      spaceLevel,
       loading = false,
       component: Button = MuiButton,
       extended = false,
@@ -76,6 +76,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
     const [isApplicationSubmittedDialogOpen, setIsApplicationSubmittedDialogOpen] = useState(false);
     const [isJoinParentDialogOpen, setIsJoinParentDialogOpen] = useState(false);
     const [isInvitationDialogOpen, setIsInvitationDialogOpen] = useState(false);
+    const isSpace = spaceLevel === SpaceLevel.Space;
 
     const handleClickApply = () => setIsApplicationDialogOpen(true);
     const handleClickApplyParent = () => setIsApplyParentDialogOpen(true);
@@ -140,7 +141,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
       extended
         ? t('components.application-button.extendedMessage', {
             join: verb,
-            journey: journeyLevel > 0 ? t('common.subspace') : t('common.community'),
+            journey: isSpace ? t('common.subspace') : t('common.community'),
           })
         : verb;
 

--- a/src/domain/community/application/applicationButton/ApplicationButton.tsx
+++ b/src/domain/community/application/applicationButton/ApplicationButton.tsx
@@ -76,7 +76,6 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
     const [isApplicationSubmittedDialogOpen, setIsApplicationSubmittedDialogOpen] = useState(false);
     const [isJoinParentDialogOpen, setIsJoinParentDialogOpen] = useState(false);
     const [isInvitationDialogOpen, setIsInvitationDialogOpen] = useState(false);
-    const isSpace = spaceLevel === SpaceLevel.Space;
 
     const handleClickApply = () => setIsApplicationDialogOpen(true);
     const handleClickApplyParent = () => setIsApplyParentDialogOpen(true);
@@ -141,7 +140,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
       extended
         ? t('components.application-button.extendedMessage', {
             join: verb,
-            journey: isSpace ? t('common.community') : t('common.subspace'),
+            journey: spaceLevel !== SpaceLevel.Space ? t('common.subspace') : t('common.community'),
           })
         : verb;
 

--- a/src/domain/community/application/applicationButton/ApplicationButton.tsx
+++ b/src/domain/community/application/applicationButton/ApplicationButton.tsx
@@ -141,7 +141,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
       extended
         ? t('components.application-button.extendedMessage', {
             join: verb,
-            journey: isSpace ? t('common.subspace') : t('common.community'),
+            journey: isSpace ? t('common.community') : t('common.subspace'),
           })
         : verb;
 

--- a/src/domain/community/application/containers/ApplicationButtonContainer.tsx
+++ b/src/domain/community/application/containers/ApplicationButtonContainer.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import useCanReadSpace from '../../../journey/common/authorization/useCanReadSpace';
 
 interface ApplicationContainerEntities {
-  applicationButtonProps: Omit<ApplicationButtonProps, 'journeyId' | 'journeyLevel'>;
+  applicationButtonProps: Omit<ApplicationButtonProps, 'journeyId' | 'spaceLevel'>;
 }
 
 interface ApplicationContainerActions {}
@@ -114,13 +114,13 @@ export const ApplicationButtonContainer: FC<ApplicationButtonContainerProps> = (
     update: cache => clearCacheForType(cache, 'Authorization'),
   });
 
-  const userApplication = pendingApplications?.find(x => x.space.id === journeyId);
+  const userApplication = pendingApplications?.find(x => x.spaceInfo.id === journeyId);
 
-  const userInvitation = pendingInvitations?.find(x => x.space.id === journeyId);
+  const userInvitation = pendingInvitations?.find(x => x.spaceInfo.id === journeyId);
 
   // find an application which does not have a challengeID, meaning it's on space level,
   // but you are at least at challenge level to have a parent application
-  const parentApplication = pendingApplications?.find(x => x.space.id === parentSpaceId);
+  const parentApplication = pendingApplications?.find(x => x.spaceInfo.id === parentSpaceId);
 
   const isMember = space?.community.roleSet?.myMembershipStatus === CommunityMembershipStatus.Member;
 
@@ -170,7 +170,7 @@ export const ApplicationButtonContainer: FC<ApplicationButtonContainerProps> = (
     notify(t('components.application-button.dialogApplicationSuccessful.join.body'), 'success');
   };
 
-  const applicationButtonProps: Omit<ApplicationButtonProps, 'journeyId' | 'journeyLevel'> = {
+  const applicationButtonProps: Omit<ApplicationButtonProps, 'journeyId' | 'spaceLevel'> = {
     isAuthenticated,
     isMember,
     isParentMember,

--- a/src/domain/community/application/containers/ApplicationButtonContainer.tsx
+++ b/src/domain/community/application/containers/ApplicationButtonContainer.tsx
@@ -114,13 +114,13 @@ export const ApplicationButtonContainer: FC<ApplicationButtonContainerProps> = (
     update: cache => clearCacheForType(cache, 'Authorization'),
   });
 
-  const userApplication = pendingApplications?.find(x => x.spaceInfo.id === journeyId);
+  const userApplication = pendingApplications?.find(x => x.spacePendingMembershipInfo.id === journeyId);
 
-  const userInvitation = pendingInvitations?.find(x => x.spaceInfo.id === journeyId);
+  const userInvitation = pendingInvitations?.find(x => x.spacePendingMembershipInfo.id === journeyId);
 
   // find an application which does not have a challengeID, meaning it's on space level,
   // but you are at least at challenge level to have a parent application
-  const parentApplication = pendingApplications?.find(x => x.spaceInfo.id === parentSpaceId);
+  const parentApplication = pendingApplications?.find(x => x.spacePendingMembershipInfo.id === parentSpaceId);
 
   const isMember = space?.community.roleSet?.myMembershipStatus === CommunityMembershipStatus.Member;
 

--- a/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
+++ b/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
@@ -21,12 +21,12 @@ import {
   AuthorizationPrivilege,
   CommunityRoleType,
   SearchVisibility,
+  SpaceLevel,
 } from '../../../../core/apollo/generated/graphql-schema';
 import { OrganizationDetailsFragmentWithRoles } from '../../../community/community/CommunityAdmin/CommunityOrganizations';
 import { CommunityMemberUserFragmentWithRoles } from '../../../community/community/CommunityAdmin/CommunityUsers';
 import useInviteUsers from '../../../community/invitations/useInviteUsers';
 import { getJourneyTypeName } from '../../../journey/JourneyTypeName';
-import { JourneyLevel } from '../../../../main/routing/resolvers/RouteResolver';
 import { Identifiable } from '../../../../core/utils/Identifiable';
 
 const MAX_AVAILABLE_MEMBERS = 100;
@@ -51,7 +51,7 @@ interface useRoleSetAdminParams {
   spaceId?: string;
   challengeId?: string;
   opportunityId?: string;
-  journeyLevel: JourneyLevel | -1;
+  spaceLevel: SpaceLevel | undefined;
 }
 
 interface VirtualContributorNameProps extends Identifiable {
@@ -61,7 +61,7 @@ interface VirtualContributorNameProps extends Identifiable {
   };
 }
 
-const useRoleSetAdmin = ({ roleSetId, spaceId, challengeId, opportunityId, journeyLevel }: useRoleSetAdminParams) => {
+const useRoleSetAdmin = ({ roleSetId, spaceId, challengeId, opportunityId, spaceLevel }: useRoleSetAdminParams) => {
   const journeyTypeName = getJourneyTypeName({
     spaceNameId: spaceId,
     challengeNameId: challengeId,
@@ -251,14 +251,14 @@ const useRoleSetAdmin = ({ roleSetId, spaceId, challengeId, opportunityId, journ
   const getAvailableVirtualContributors = async (filter: string | undefined, all: boolean = false) => {
     const { data } = await fetchAllVirtualContributors({
       variables: {
-        filterSpace: !all || journeyLevel > 0,
+        filterSpace: !all || spaceLevel !== SpaceLevel.Space,
         filterSpaceId: spaceId,
       },
     });
     const roleSet = data?.lookup?.space?.community?.roleSet;
 
     // Results for Space Level - on Account if !all (filter in the query)
-    if (journeyLevel === 0) {
+    if (spaceLevel === SpaceLevel.Space) {
       return (data?.lookup?.space?.account.virtualContributors ?? data?.virtualContributors ?? []).filter(
         vc => filterExisting(vc, virtualContributors) && filterByName(vc, filter)
       );

--- a/src/domain/community/contributor/Account/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/Account/ContributorAccountView.tsx
@@ -19,7 +19,12 @@ import RoundedIcon from '../../../../core/ui/icon/RoundedIcon';
 import CreateSpaceDialog from '../../../journey/space/createSpace/CreateSpaceDialog';
 import useNewVirtualContributorWizard from '../../../../main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard';
 import CreateInnovationHubDialog from '../../../innovationHub/CreateInnovationHub/CreateInnovationHubDialog';
-import { AuthorizationPrivilege, SpaceType, SpaceVisibility } from '../../../../core/apollo/generated/graphql-schema';
+import {
+  AuthorizationPrivilege,
+  SpaceLevel,
+  SpaceType,
+  SpaceVisibility,
+} from '../../../../core/apollo/generated/graphql-schema';
 import { VIRTUAL_CONTRIBUTORS_LIMIT } from '../../../../main/topLevelPages/myDashboard/myAccount/MyAccountBlockVCCampaignUser';
 import MenuItemWithIcon from '../../../../core/ui/menu/MenuItemWithIcon';
 import { DeleteOutline } from '@mui/icons-material';
@@ -60,7 +65,7 @@ export interface AccountTabResourcesProps {
   authorization?: { myPrivileges?: AuthorizationPrivilege[] };
   spaces: {
     id: string;
-    level: number;
+    level: SpaceLevel;
     profile: AccountProfile & {
       cardBanner?: { uri: string };
       tagline?: string;

--- a/src/domain/community/contributor/organization/OrganizationPageContainer/OrganizationPageContainer.tsx
+++ b/src/domain/community/contributor/organization/OrganizationPageContainer/OrganizationPageContainer.tsx
@@ -20,6 +20,7 @@ import {
   AuthorizationPrivilege,
   CommunityContributorType,
   OrganizationInfoFragment,
+  SpaceLevel,
 } from '../../../../../core/apollo/generated/graphql-schema';
 import { buildUserProfileUrl } from '../../../../../main/routing/urlBuilders';
 import { useTranslation } from 'react-i18next';
@@ -28,7 +29,6 @@ import {
   MEMBER_TRANSLATION_KEY,
   OWNER_TRANSLATION_KEY,
 } from '../../../user/constants/translation.constants';
-import { JourneyLevel } from '../../../../../main/routing/resolvers/RouteResolver';
 
 export interface OrganizationContainerEntities {
   organization?: OrganizationInfoFragment;
@@ -155,7 +155,7 @@ export const OrganizationPageContainer: FC<OrganizationPageContainerProps> = ({ 
   const contributions = useMemo(() => {
     const spaceContributions = (orgRolesData?.rolesOrganization?.spaces ?? []).map<SpaceHostedItem>(x => ({
       spaceID: x.id,
-      spaceLevel: 0,
+      spaceLevel: SpaceLevel.Space,
       id: x.id,
       contributorId: organizationId,
       contributorType: CommunityContributorType.Organization,
@@ -166,7 +166,7 @@ export const OrganizationPageContainer: FC<OrganizationPageContainerProps> = ({ 
       orgRolesData?.rolesOrganization?.spaces.flatMap<SpaceHostedItem>(h =>
         h.subspaces.map<SpaceHostedItem>(c => ({
           spaceID: c.id,
-          spaceLevel: c.level as JourneyLevel,
+          spaceLevel: c.level,
           id: c.id,
           contributorId: organizationId,
           contributorType: CommunityContributorType.Organization,

--- a/src/domain/community/invitations/InvitationDialog.tsx
+++ b/src/domain/community/invitations/InvitationDialog.tsx
@@ -8,7 +8,7 @@ import DialogHeader from '../../../core/ui/dialog/DialogHeader';
 import Gutters from '../../../core/ui/grid/Gutters';
 import { CheckOutlined, HdrStrongOutlined } from '@mui/icons-material';
 import JourneyCard from '../../journey/common/JourneyCard/JourneyCard';
-import journeyIcon from '../../shared/components/JourneyIcon/JourneyIcon';
+import spaceIcon from '../../shared/components/JourneyIcon/JourneyIcon';
 import JourneyCardTagline from '../../journey/common/JourneyCard/JourneyCardTagline';
 import { BlockSectionTitle, Caption, Text } from '../../../core/ui/typography';
 import DetailedActivityDescription from '../../shared/components/ActivityDescription/DetailedActivityDescription';
@@ -100,7 +100,7 @@ const InvitationDialog = ({
                     alignItems={isMobile ? 'center' : 'start'}
                   >
                     <JourneyCard
-                      iconComponent={journeyIcon[getChildJourneyTypeName(invitation.space)]}
+                      iconComponent={spaceIcon[getChildJourneyTypeName(invitation.space)]}
                       header={invitation.space.profile.displayName}
                       tags={invitation.space.profile.tagset?.tags ?? []}
                       banner={invitation.space.profile.visual}

--- a/src/domain/community/invitations/InvitationOptionsBlock.tsx
+++ b/src/domain/community/invitations/InvitationOptionsBlock.tsx
@@ -21,7 +21,6 @@ interface InvitationOptionsBlockProps {
   currentInvitationsUserIds: string[];
   currentMembersIds: string[];
   spaceId: string | undefined;
-  isParentPrivate?: boolean | undefined;
   isSubspace?: boolean;
 }
 
@@ -38,7 +37,6 @@ const InvitationOptionsBlock = ({
   currentInvitationsUserIds,
   currentMembersIds,
   spaceId,
-  isParentPrivate,
   isSubspace = false,
 }: InvitationOptionsBlockProps) => {
   const [currentInvitation, setCurrentInvitation] = useState<UserInvite>();
@@ -55,7 +53,7 @@ const InvitationOptionsBlock = ({
   });
 
   const allowSubspaceAdminsToInviteMembers = data?.lookup.space?.settings.membership.allowSubspaceAdminsToInviteMembers;
-  const showInviteBlock = isSubspace ? !isParentPrivate && allowSubspaceAdminsToInviteMembers : true; // for Spaces the block is always visible
+  const showInviteBlock = isSubspace ? allowSubspaceAdminsToInviteMembers : true; // for Spaces the block is always visible
 
   return loading ? (
     <Box marginX="auto">

--- a/src/domain/community/pendingMembership/PendingMemberships.tsx
+++ b/src/domain/community/pendingMembership/PendingMemberships.tsx
@@ -89,11 +89,11 @@ export const InvitationHydrator = ({
 }: InvitationHydratorProps) => {
   const { data: spaceData } = usePendingMembershipsSpaceQuery({
     variables: {
-      spaceId: invitation.spaceInfo.id,
+      spaceId: invitation.spacePendingMembershipInfo.id,
       fetchDetails: withJourneyDetails,
       fetchCommunityGuidelines: withCommunityGuidelines,
       visualType:
-        invitation.spaceInfo.level === SpaceLevel.Space && visualType === VisualType.Avatar
+        invitation.spacePendingMembershipInfo.level === SpaceLevel.Space && visualType === VisualType.Avatar
           ? VisualType.Card
           : visualType, // Spaces don't have avatars
     },
@@ -118,11 +118,11 @@ export const InvitationHydrator = ({
       ...invitation,
       userDisplayName: createdBy?.profile.displayName,
       space: {
-        ...invitation.spaceInfo,
+        ...invitation.spacePendingMembershipInfo,
         ...journey,
-        level: invitation.spaceInfo.level,
+        level: invitation.spacePendingMembershipInfo.level,
         profile: {
-          ...invitation.spaceInfo.profile,
+          ...invitation.spacePendingMembershipInfo.profile,
           ...journey?.profile,
         },
       },
@@ -147,10 +147,10 @@ interface ApplicationHydratorProps {
 export const ApplicationHydrator = ({ application, visualType, children }: ApplicationHydratorProps) => {
   const { data: spaceData } = usePendingMembershipsSpaceQuery({
     variables: {
-      spaceId: application.spaceInfo.id,
+      spaceId: application.spacePendingMembershipInfo.id,
       fetchDetails: true,
       visualType:
-        application.spaceInfo.level === SpaceLevel.Space && visualType === VisualType.Avatar
+        application.spacePendingMembershipInfo.level === SpaceLevel.Space && visualType === VisualType.Avatar
           ? VisualType.Card
           : visualType, // Spaces don't have avatars
     },
@@ -165,11 +165,11 @@ export const ApplicationHydrator = ({ application, visualType, children }: Appli
     return {
       ...application,
       space: {
-        ...application.spaceInfo,
+        ...application.spacePendingMembershipInfo,
         ...journey,
-        level: application.spaceInfo.level,
+        level: application.spacePendingMembershipInfo.level,
         profile: {
-          ...application.spaceInfo.profile,
+          ...application.spacePendingMembershipInfo.profile,
           ...journey?.profile,
         },
       },

--- a/src/domain/community/pendingMembership/PendingMemberships.tsx
+++ b/src/domain/community/pendingMembership/PendingMemberships.tsx
@@ -76,7 +76,7 @@ type InvitationHydratorProps = {
 );
 
 export const getChildJourneyTypeName = ({ level }: { level: SpaceLevel }): JourneyTypeName =>
-  ['space', 'subspace', 'subsubspace'][level] as JourneyTypeName;
+  level.toLocaleLowerCase() as JourneyTypeName;
 
 export const InvitationHydrator = ({
   invitation,

--- a/src/domain/community/pendingMembership/PendingMemberships.tsx
+++ b/src/domain/community/pendingMembership/PendingMemberships.tsx
@@ -75,8 +75,17 @@ type InvitationHydratorProps = {
     }
 );
 
-export const getChildJourneyTypeName = ({ level }: { level: SpaceLevel }): JourneyTypeName =>
-  level.toLocaleLowerCase() as JourneyTypeName;
+export const getChildJourneyTypeName = ({ level }: { level: SpaceLevel }): JourneyTypeName => {
+  switch (level) {
+    case SpaceLevel.Challenge:
+      return 'subspace' as JourneyTypeName;
+    case SpaceLevel.Opportunity:
+      return 'subsubspace' as JourneyTypeName;
+    case SpaceLevel.Space:
+    default:
+      return 'space' as JourneyTypeName;
+  }
+};
 
 export const InvitationHydrator = ({
   invitation,

--- a/src/domain/community/pendingMembership/PendingMemberships.tsx
+++ b/src/domain/community/pendingMembership/PendingMemberships.tsx
@@ -8,12 +8,15 @@ import { JourneyTypeName } from '../../journey/JourneyTypeName';
 import { PendingApplication } from '../user';
 import { Visual } from '../../common/visual/Visual';
 import { InvitationItem } from '../user/providers/UserProvider/InvitationItem';
-import { CommunityGuidelinesSummaryFragment, VisualType } from '../../../core/apollo/generated/graphql-schema';
-import { JourneyLevel } from '../../../main/routing/resolvers/RouteResolver';
+import {
+  CommunityGuidelinesSummaryFragment,
+  SpaceLevel,
+  VisualType,
+} from '../../../core/apollo/generated/graphql-schema';
 import { Identifiable } from '../../../core/utils/Identifiable';
 import { useAuthenticationContext } from '../../../core/auth/authentication/hooks/useAuthenticationContext';
 
-export interface JourneyDetails {
+export interface SpaceDetails {
   profile: {
     displayName: string;
     tagline?: string;
@@ -23,16 +26,16 @@ export interface JourneyDetails {
     };
     visual?: Visual | undefined;
   };
-  level: JourneyLevel;
+  level: SpaceLevel;
 }
 
 export interface InvitationWithMeta extends Omit<InvitationItem, 'space'> {
   userDisplayName: string | undefined;
-  space: JourneyDetails;
+  space: SpaceDetails;
 }
 
 interface ApplicationWithMeta extends Identifiable {
-  space: JourneyDetails;
+  space: SpaceDetails;
 }
 
 interface UsePendingMembershipsProvided {
@@ -72,7 +75,7 @@ type InvitationHydratorProps = {
     }
 );
 
-export const getChildJourneyTypeName = ({ level }: { level: JourneyLevel }): JourneyTypeName =>
+export const getChildJourneyTypeName = ({ level }: { level: SpaceLevel }): JourneyTypeName =>
   ['space', 'subspace', 'subsubspace'][level] as JourneyTypeName;
 
 export const InvitationHydrator = ({
@@ -86,10 +89,13 @@ export const InvitationHydrator = ({
 }: InvitationHydratorProps) => {
   const { data: spaceData } = usePendingMembershipsSpaceQuery({
     variables: {
-      spaceId: invitation.space.id,
+      spaceId: invitation.spaceInfo.id,
       fetchDetails: withJourneyDetails,
       fetchCommunityGuidelines: withCommunityGuidelines,
-      visualType: invitation.space.level === 0 && visualType === VisualType.Avatar ? VisualType.Card : visualType, // Spaces don't have avatars
+      visualType:
+        invitation.spaceInfo.level === SpaceLevel.Space && visualType === VisualType.Avatar
+          ? VisualType.Card
+          : visualType, // Spaces don't have avatars
     },
   });
 
@@ -112,11 +118,11 @@ export const InvitationHydrator = ({
       ...invitation,
       userDisplayName: createdBy?.profile.displayName,
       space: {
-        ...invitation.space,
+        ...invitation.spaceInfo,
         ...journey,
-        level: invitation.space.level as JourneyLevel,
+        level: invitation.spaceInfo.level,
         profile: {
-          ...invitation.space.profile,
+          ...invitation.spaceInfo.profile,
           ...journey?.profile,
         },
       },
@@ -141,9 +147,12 @@ interface ApplicationHydratorProps {
 export const ApplicationHydrator = ({ application, visualType, children }: ApplicationHydratorProps) => {
   const { data: spaceData } = usePendingMembershipsSpaceQuery({
     variables: {
-      spaceId: application.space.id,
+      spaceId: application.spaceInfo.id,
       fetchDetails: true,
-      visualType: application.space.level === 0 && visualType === VisualType.Avatar ? VisualType.Card : visualType, // Spaces don't have avatars
+      visualType:
+        application.spaceInfo.level === SpaceLevel.Space && visualType === VisualType.Avatar
+          ? VisualType.Card
+          : visualType, // Spaces don't have avatars
     },
   });
 
@@ -156,11 +165,11 @@ export const ApplicationHydrator = ({ application, visualType, children }: Appli
     return {
       ...application,
       space: {
-        ...application.space,
+        ...application.spaceInfo,
         ...journey,
-        level: application.space.level as JourneyLevel,
+        level: application.spaceInfo.level,
         profile: {
-          ...application.space.profile,
+          ...application.spaceInfo.profile,
           ...journey?.profile,
         },
       },

--- a/src/domain/community/pendingMembership/PendingMembershipsUserMenuItem.tsx
+++ b/src/domain/community/pendingMembership/PendingMembershipsUserMenuItem.tsx
@@ -14,7 +14,7 @@ import {
 } from './PendingMemberships';
 import InvitationCardHorizontal from '../invitations/InvitationCardHorizontal/InvitationCardHorizontal';
 import JourneyCard from '../../journey/common/JourneyCard/JourneyCard';
-import journeyIcon from '../../shared/components/JourneyIcon/JourneyIcon';
+import spaceIcon from '../../shared/components/JourneyIcon/JourneyIcon';
 import ScrollableCardsLayoutContainer from '../../../core/ui/card/cardsLayout/ScrollableCardsLayoutContainer';
 import JourneyCardTagline from '../../journey/common/JourneyCard/JourneyCardTagline';
 import InvitationDialog from '../invitations/InvitationDialog';
@@ -147,7 +147,7 @@ const PendingMembershipsUserMenuItem = ({ children }: PendingMembershipsUserMenu
                     {({ application: hydratedApplication }) =>
                       hydratedApplication && (
                         <JourneyCard
-                          iconComponent={journeyIcon[getChildJourneyTypeName(hydratedApplication.space)]}
+                          iconComponent={spaceIcon[getChildJourneyTypeName(hydratedApplication.space)]}
                           header={hydratedApplication.space.profile.displayName}
                           tags={hydratedApplication.space.profile.tagset?.tags ?? []}
                           banner={hydratedApplication.space.profile.visual}

--- a/src/domain/community/profile/ContributionDetails/ContributionDetailsCard.tsx
+++ b/src/domain/community/profile/ContributionDetails/ContributionDetailsCard.tsx
@@ -9,7 +9,7 @@ import webkitLineClamp from '../../../../core/ui/utils/webkitLineClamp';
 import CardActions from '../../../../core/ui/card/CardActions';
 import JourneyCardTagline from '../../../journey/common/JourneyCard/JourneyCardTagline';
 import { JourneyTypeName } from '../../../journey/JourneyTypeName';
-import journeyIcon from '../../../shared/components/JourneyIcon/JourneyIcon';
+import spaceIcon from '../../../shared/components/JourneyIcon/JourneyIcon';
 import CardRibbon from '../../../../core/ui/card/CardRibbon';
 import { SpaceVisibility } from '../../../../core/apollo/generated/graphql-schema';
 import DialogHeader from '../../../../core/ui/dialog/DialogHeader';
@@ -51,7 +51,7 @@ const ContributionDetailsCard = ({
     <>
       <JourneyCard
         {...props}
-        iconComponent={journeyIcon[journeyTypeName]}
+        iconComponent={spaceIcon[journeyTypeName]}
         header={
           <BlockTitle component="div" sx={webkitLineClamp(2)}>
             {displayName}

--- a/src/domain/community/user/hooks/useUserMetadataWrapper.ts
+++ b/src/domain/community/user/hooks/useUserMetadataWrapper.ts
@@ -2,14 +2,14 @@ import { KEYWORDS_TAGSET, SKILLS_TAGSET } from '../../../common/tags/tagset.cons
 import {
   AuthorizationPrivilege,
   MyPrivilegesFragment,
+  SpaceLevel,
   UserDetailsFragment,
 } from '../../../../core/apollo/generated/graphql-schema';
-import { JourneyLevel } from '../../../../main/routing/resolvers/RouteResolver';
 import { Identifiable } from '../../../../core/utils/Identifiable';
 
 export interface PendingApplication extends Identifiable {
-  space: Identifiable & {
-    level: JourneyLevel | number;
+  spaceInfo: Identifiable & {
+    level: SpaceLevel;
     profile: {
       displayName: string;
       tagline?: string;

--- a/src/domain/community/user/hooks/useUserMetadataWrapper.ts
+++ b/src/domain/community/user/hooks/useUserMetadataWrapper.ts
@@ -8,7 +8,7 @@ import {
 import { Identifiable } from '../../../../core/utils/Identifiable';
 
 export interface PendingApplication extends Identifiable {
-  spaceInfo: Identifiable & {
+  spacePendingMembershipInfo: Identifiable & {
     level: SpaceLevel;
     profile: {
       displayName: string;

--- a/src/domain/community/user/pages/UserMembershipPage.tsx
+++ b/src/domain/community/user/pages/UserMembershipPage.tsx
@@ -64,8 +64,8 @@ const UserMembershipPage: FC<UserMembershipPageProps> = () => {
     } else {
       return pendingMembershipsData.me.communityApplications.map(application => ({
         id: application.id,
-        spaceID: application.spaceInfo.id,
-        spaceLevel: application.spaceInfo.level,
+        spaceID: application.spacePendingMembershipInfo.id,
+        spaceLevel: application.spacePendingMembershipInfo.level,
         contributorId: userMetadata.user.id,
         contributorType: CommunityContributorType.User,
       }));

--- a/src/domain/community/user/pages/UserMembershipPage.tsx
+++ b/src/domain/community/user/pages/UserMembershipPage.tsx
@@ -9,12 +9,11 @@ import { useUserMetadata } from '../hooks/useUserMetadata';
 import GridProvider from '../../../../core/ui/grid/GridProvider';
 import SectionSpacer from '../../../shared/components/Section/SectionSpacer';
 import { SpaceHostedItem } from '../../../journey/utils/SpaceHostedItem';
-import { CommunityContributorType, SpaceType } from '../../../../core/apollo/generated/graphql-schema';
+import { CommunityContributorType, SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 import {
   useUserContributionsQuery,
   useUserPendingMembershipsQuery,
 } from '../../../../core/apollo/generated/apollo-hooks';
-import { JourneyLevel } from '../../../../main/routing/resolvers/RouteResolver';
 
 export interface UserMembershipPageProps {}
 
@@ -39,7 +38,7 @@ const UserMembershipPage: FC<UserMembershipPageProps> = () => {
       const currentSpace = {
         spaceID: space.id,
         id: space.id,
-        spaceLevel: 0 as JourneyLevel,
+        spaceLevel: SpaceLevel.Space,
         contributorId: userMetadata?.user.id!,
         contributorType: CommunityContributorType.User,
       };
@@ -48,12 +47,7 @@ const UserMembershipPage: FC<UserMembershipPageProps> = () => {
       const subspaces = space.subspaces.map(subspace => ({
         id: subspace.id,
         spaceID: subspace.id,
-        spaceLevel:
-          subspace.type === SpaceType.Challenge
-            ? (1 as JourneyLevel)
-            : subspace.type === SpaceType.Opportunity
-            ? (2 as JourneyLevel)
-            : (1 as JourneyLevel),
+        spaceLevel: subspace.level,
         contributorId: userMetadata?.user.id!,
         contributorType: CommunityContributorType.User,
       }));
@@ -70,8 +64,8 @@ const UserMembershipPage: FC<UserMembershipPageProps> = () => {
     } else {
       return pendingMembershipsData.me.communityApplications.map(application => ({
         id: application.id,
-        spaceID: application.space.id,
-        spaceLevel: application.space.level as JourneyLevel,
+        spaceID: application.spaceInfo.id,
+        spaceLevel: application.spaceInfo.level,
         contributorId: userMetadata.user.id,
         contributorType: CommunityContributorType.User,
       }));

--- a/src/domain/community/user/providers/UserProvider/InvitationItem.ts
+++ b/src/domain/community/user/providers/UserProvider/InvitationItem.ts
@@ -2,7 +2,7 @@ import { CommunityContributorType, SpaceLevel } from '../../../../../core/apollo
 import { Identifiable } from '../../../../../core/utils/Identifiable';
 
 export interface InvitationItem extends Identifiable {
-  spaceInfo: Identifiable & {
+  spacePendingMembershipInfo: Identifiable & {
     level: SpaceLevel;
     profile: {
       url: string;

--- a/src/domain/community/user/providers/UserProvider/InvitationItem.ts
+++ b/src/domain/community/user/providers/UserProvider/InvitationItem.ts
@@ -1,10 +1,9 @@
-import { CommunityContributorType } from '../../../../../core/apollo/generated/graphql-schema';
+import { CommunityContributorType, SpaceLevel } from '../../../../../core/apollo/generated/graphql-schema';
 import { Identifiable } from '../../../../../core/utils/Identifiable';
-import { JourneyLevel } from '../../../../../main/routing/resolvers/RouteResolver';
 
 export interface InvitationItem extends Identifiable {
-  space: Identifiable & {
-    level: JourneyLevel | number;
+  spaceInfo: Identifiable & {
+    level: SpaceLevel;
     profile: {
       url: string;
       displayName: string;

--- a/src/domain/community/user/providers/UserProvider/UserProvider.graphql
+++ b/src/domain/community/user/providers/UserProvider/UserProvider.graphql
@@ -16,7 +16,7 @@ query UserPendingMemberships {
     }
     communityApplications(states: ["new"]) {
       id
-      spaceInfo {
+      spacePendingMembershipInfo {
         id
         level
         profile {
@@ -43,7 +43,7 @@ query UserPendingMemberships {
 
 fragment InvitationData on CommunityInvitationResult {
   id
-  spaceInfo {
+  spacePendingMembershipInfo {
     id
     level
     profile {

--- a/src/domain/community/user/providers/UserProvider/UserProvider.graphql
+++ b/src/domain/community/user/providers/UserProvider/UserProvider.graphql
@@ -16,7 +16,7 @@ query UserPendingMemberships {
     }
     communityApplications(states: ["new"]) {
       id
-      space {
+      spaceInfo {
         id
         level
         profile {
@@ -43,7 +43,7 @@ query UserPendingMemberships {
 
 fragment InvitationData on CommunityInvitationResult {
   id
-  space {
+  spaceInfo {
     id
     level
     profile {

--- a/src/domain/community/user/userContributions/useUserContributions.ts
+++ b/src/domain/community/user/userContributions/useUserContributions.ts
@@ -1,6 +1,5 @@
 import { useUserContributionsQuery } from '../../../../core/apollo/generated/apollo-hooks';
-import { CommunityContributorType } from '../../../../core/apollo/generated/graphql-schema';
-import { JourneyLevel } from '../../../../main/routing/resolvers/RouteResolver';
+import { CommunityContributorType, SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 import { SpaceHostedItem } from '../../../journey/utils/SpaceHostedItem';
 import { useMemo } from 'react';
 
@@ -23,7 +22,7 @@ const useUserContributions = (userId: string | undefined) => {
       contributions.push({
         spaceID: e.id,
         id: e.id,
-        spaceLevel: 0,
+        spaceLevel: SpaceLevel.Space,
         contributorId: userId!,
         contributorType: CommunityContributorType.User,
         roles: e.roles,
@@ -33,7 +32,7 @@ const useUserContributions = (userId: string | undefined) => {
         contributions.push({
           id: ss.id,
           spaceID: ss.id,
-          spaceLevel: ss.level as JourneyLevel,
+          spaceLevel: ss.level,
           contributorId: userId!,
           contributorType: CommunityContributorType.User,
           roles: ss.roles,

--- a/src/domain/community/virtualContributor/vcMembershipPage/VCMembershipPage.tsx
+++ b/src/domain/community/virtualContributor/vcMembershipPage/VCMembershipPage.tsx
@@ -5,9 +5,12 @@ import { ContributionsView } from '../../profile/views/ProfileView';
 import { SettingsSection } from '../../../platform/admin/layout/EntitySettingsLayout/constants';
 import VCSettingsPageLayout from '../layout/VCSettingsPageLayout';
 import { SpaceHostedItem } from '../../../journey/utils/SpaceHostedItem';
-import { AuthorizationPrivilege, CommunityContributorType } from '../../../../core/apollo/generated/graphql-schema';
+import {
+  AuthorizationPrivilege,
+  CommunityContributorType,
+  SpaceLevel,
+} from '../../../../core/apollo/generated/graphql-schema';
 import { useVcMembershipsQuery } from '../../../../core/apollo/generated/apollo-hooks';
-import { JourneyLevel } from '../../../../main/routing/resolvers/RouteResolver';
 import {
   PendingMembershipsDialogType,
   usePendingMembershipsDialog,
@@ -40,7 +43,7 @@ const UserMembershipPage: FC<UserMembershipPageProps> = () => {
       const currentSpace = {
         spaceID: space.id,
         id: space.id,
-        spaceLevel: 0 as JourneyLevel,
+        spaceLevel: SpaceLevel.Space,
         contributorId: data.virtualContributor.id,
         contributorType: CommunityContributorType.Virtual,
       };
@@ -49,7 +52,7 @@ const UserMembershipPage: FC<UserMembershipPageProps> = () => {
       const subspaces = space.subspaces.map(subspace => ({
         id: subspace.id,
         spaceID: subspace.id,
-        spaceLevel: subspace.level as JourneyLevel,
+        spaceLevel: subspace.level,
         contributorId: data.virtualContributor.id,
         contributorType: CommunityContributorType.Virtual,
       }));
@@ -67,8 +70,8 @@ const UserMembershipPage: FC<UserMembershipPageProps> = () => {
       )
       .map(invitation => ({
         id: invitation.id,
-        spaceID: invitation.space.id,
-        spaceLevel: invitation.space.level as JourneyLevel,
+        spaceID: invitation.spaceInfo.id,
+        spaceLevel: invitation.spaceInfo.level,
         contributorId: data.virtualContributor.id,
         contributorType: CommunityContributorType.Virtual,
       }));

--- a/src/domain/community/virtualContributor/vcMembershipPage/VCMembershipPage.tsx
+++ b/src/domain/community/virtualContributor/vcMembershipPage/VCMembershipPage.tsx
@@ -70,8 +70,8 @@ const UserMembershipPage: FC<UserMembershipPageProps> = () => {
       )
       .map(invitation => ({
         id: invitation.id,
-        spaceID: invitation.spaceInfo.id,
-        spaceLevel: invitation.spaceInfo.level,
+        spaceID: invitation.spacePendingMembershipInfo.id,
+        spaceLevel: invitation.spacePendingMembershipInfo.level,
         contributorId: data.virtualContributor.id,
         contributorType: CommunityContributorType.Virtual,
       }));

--- a/src/domain/journey/JourneyTypeName.ts
+++ b/src/domain/journey/JourneyTypeName.ts
@@ -1,5 +1,4 @@
-import { ProfileType } from '../../core/apollo/generated/graphql-schema';
-import { JourneyLevel } from '../../main/routing/resolvers/RouteResolver';
+import { ProfileType, SpaceLevel } from '../../core/apollo/generated/graphql-schema';
 
 export type JourneyTypeName = 'space' | 'subspace' | 'subsubspace';
 
@@ -40,8 +39,8 @@ export const getJourneyTypeName = (
   }
 };
 
-export const getSpaceLabel = (journeyLevel: JourneyLevel | -1) => {
-  if (journeyLevel === 0) {
+export const getSpaceLabel = (spaceLevel: SpaceLevel) => {
+  if (spaceLevel === SpaceLevel.Space) {
     return 'space' as const;
   }
   return 'subspace' as const;

--- a/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
+++ b/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
@@ -25,22 +25,21 @@ import OpportunityMetrics from '../../opportunity/utils/useOpportunityMetricsIte
 import { Theme } from '@mui/material/styles';
 import useCurrentBreakpoint from '../../../../core/ui/utils/useCurrentBreakpoint';
 import PageContentBlockSeamless from '../../../../core/ui/content/PageContentBlockSeamless';
-import { journeyIconByJourneyLevel } from '../../../shared/components/JourneyIcon/JourneyIcon';
+import { spaceIconByLevel } from '../../../shared/components/JourneyIcon/JourneyIcon';
 import References from '../../../shared/components/References/References';
-import { Reference } from '../../../../core/apollo/generated/graphql-schema';
+import { Reference, SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import useDirectMessageDialog from '../../../communication/messaging/DirectMessaging/useDirectMessageDialog';
 import ShareButton from '../../../shared/components/ShareDialog/ShareButton';
 import { getSpaceLabel } from '../../JourneyTypeName';
 import Loading from '../../../../core/ui/loading/Loading';
-import { JourneyLevel } from '../../../../main/routing/resolvers/RouteResolver';
 import VirtualContributorsBlock from '../../../community/community/VirtualContributorsBlock/VirtualContributorsBlock';
 import { VirtualContributorProps } from '../../../community/community/VirtualContributorsBlock/VirtualContributorsDialog';
 
 export interface JourneyAboutDialogProps extends EntityDashboardLeads {
   open: boolean;
-  journeyLevel: JourneyLevel | -1;
+  spaceLevel: SpaceLevel;
   displayName: ReactNode;
   tagline: ReactNode;
   references: Reference[] | undefined;
@@ -70,11 +69,11 @@ const DialogHeaderItem = ({ align = 'center', ...props }: DialogHeaderItemProps)
   return <Box {...props} flexGrow={1} display="flex" justifyContent={align} alignItems="center" gap={gutters()} />;
 };
 
-const getMetricsSpec = (journeyLevel: JourneyLevel | -1) => {
-  if (journeyLevel === -1) {
+const getMetricsSpec = (spaceLevel: SpaceLevel | undefined) => {
+  if (!spaceLevel) {
     return undefined;
   }
-  if (journeyLevel === 2) {
+  if (spaceLevel === SpaceLevel.Opportunity) {
     return OpportunityMetrics;
   }
   return SpaceMetrics;
@@ -91,7 +90,7 @@ const JourneyAboutDialog = ({
   tagline,
   references,
   ribbon,
-  journeyLevel,
+  spaceLevel,
   leadUsers,
   leadOrganizations,
   leadVirtualContributors,
@@ -114,7 +113,7 @@ const JourneyAboutDialog = ({
 }: JourneyAboutDialogProps) => {
   const { t } = useTranslation();
 
-  const isSpace = journeyLevel === 0;
+  const isSpace = spaceLevel === SpaceLevel.Space;
   const leadOrganizationsHeader = isSpace
     ? 'pages.space.sections.dashboard.leadingOrganizations'
     : 'community.leading-organizations';
@@ -143,9 +142,9 @@ const JourneyAboutDialog = ({
   );
 
   // @ts-ignore TS5UPGRADE
-  const JourneyIcon = journeyLevel > -1 ? journeyIconByJourneyLevel[journeyLevel] : undefined;
+  const JourneyIcon = spaceLevel > -1 ? spaceIconByLevel[spaceLevel] : undefined;
 
-  const metricsItems = useMetricsItems(metrics, getMetricsSpec(journeyLevel));
+  const metricsItems = useMetricsItems(metrics, getMetricsSpec(spaceLevel));
 
   const breakpoint = useCurrentBreakpoint();
 
@@ -155,7 +154,7 @@ const JourneyAboutDialog = ({
     dialogTitle: t('send-message-dialog.direct-message-title'),
   });
 
-  const journeyTypeName = getSpaceLabel(journeyLevel);
+  const journeyTypeName = getSpaceLabel(spaceLevel);
 
   return (
     <DialogWithGrid

--- a/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
+++ b/src/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal.tsx
@@ -16,7 +16,7 @@ import { Visual } from '../../../common/visual/Visual';
 import withElevationOnHover from '../../../shared/components/withElevationOnHover';
 import RouterLink, { RouterLinkProps } from '../../../../core/ui/link/RouterLink';
 import { JourneyTypeName } from '../../JourneyTypeName';
-import JourneyIcon from '../../../shared/components/JourneyIcon/JourneyIcon';
+import spaceIcon from '../../../shared/components/JourneyIcon/JourneyIcon';
 import BlockTitleWithIcon from '../../../../core/ui/content/BlockTitleWithIcon';
 import { CommunityRoleType } from '../../../../core/apollo/generated/graphql-schema';
 import { useTranslation } from 'react-i18next';
@@ -79,7 +79,7 @@ const JourneyCardHorizontal = ({
   size,
   disableHoverState = false,
 }: JourneyCardHorizontalProps) => {
-  const Icon = JourneyIcon[journeyTypeName];
+  const Icon = spaceIcon[journeyTypeName];
 
   const { t } = useTranslation();
 

--- a/src/domain/journey/common/JourneyUnauthorizedDialog/JourneyUnauthorizedDialog.tsx
+++ b/src/domain/journey/common/JourneyUnauthorizedDialog/JourneyUnauthorizedDialog.tsx
@@ -27,7 +27,7 @@ const JourneyUnauthorizedDialog = ({
   disabled = false,
   journeyId,
   parentSpaceId,
-  journeyLevel,
+  spaceLevel,
   ...aboutDialogProps
 }: JourneyUnauthorizedDialogProps) => {
   const { t } = useTranslation();
@@ -57,7 +57,7 @@ const JourneyUnauthorizedDialog = ({
               {...e?.applicationButtonProps}
               loading={s.loading}
               journeyId={journeyId}
-              journeyLevel={journeyLevel}
+              spaceLevel={spaceLevel}
             />
           )}
         </ApplicationButtonContainer>
@@ -72,7 +72,7 @@ const JourneyUnauthorizedDialog = ({
           </PageContentRibbon>
         )
       }
-      journeyLevel={journeyLevel}
+      spaceLevel={spaceLevel}
       {...aboutDialogProps}
     />
   );

--- a/src/domain/journey/common/journeyBreadcrumbs/JourneyBreadcrumbs.tsx
+++ b/src/domain/journey/common/journeyBreadcrumbs/JourneyBreadcrumbs.tsx
@@ -1,6 +1,6 @@
 import { useJourneyBreadcrumbs, UseJourneyBreadcrumbsParams } from './useJourneyBreadcrumbs';
 import Breadcrumbs, { BreadcrumbsProps } from '../../../../core/ui/navigation/Breadcrumbs';
-import { journeyIconByJourneyLevel } from '../../../shared/components/JourneyIcon/JourneyIcon';
+import { spaceIconByLevel } from '../../../shared/components/JourneyIcon/JourneyIcon';
 import BreadcrumbsRootItem from '../../../../main/ui/breadcrumbs/BreadcrumbsRootItem';
 import BreadcrumbsItem from '../../../../core/ui/navigation/BreadcrumbsItem';
 import { Expandable } from '../../../../core/ui/navigation/Expandable';
@@ -33,7 +33,7 @@ const JourneyBreadcrumbs = forwardRef<Collapsible, JourneyBreadcrumbsProps<Expan
         {breadcrumbs.map(({ displayName, ...item }, level) => (
           <BreadcrumbsItem
             key={level}
-            iconComponent={journeyIconByJourneyLevel[level]}
+            iconComponent={spaceIconByLevel[level]}
             accent
             aria-label={displayName}
             {...item}

--- a/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
+++ b/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
@@ -11,6 +11,7 @@ import { useOpportunity } from '../hooks/useOpportunity';
 import SubspaceSettingsLayout from '../../../platform/admin/subspace/SubspaceSettingsLayout';
 import CommunityVirtualContributors from '../../../community/community/CommunityAdmin/CommunityVirtualContributors';
 import { useSpace } from '../../space/SpaceContext/useSpace';
+import { SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 
 const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' }) => {
   const { loading: isLoadingChallenge, roleSetId, opportunityId } = useOpportunity();
@@ -39,7 +40,7 @@ const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '.
     getAvailableVirtualContributors,
     getAvailableVirtualContributorsInLibrary,
     loading,
-  } = useRoleSetAdmin({ spaceId, opportunityId, roleSetId, journeyLevel: 2 });
+  } = useRoleSetAdmin({ spaceId, opportunityId, roleSetId, spaceLevel: SpaceLevel.Opportunity });
 
   if (!spaceId || isLoadingChallenge) {
     return null;

--- a/src/domain/journey/space/SpaceContext/SpaceContext.tsx
+++ b/src/domain/journey/space/SpaceContext/SpaceContext.tsx
@@ -6,7 +6,7 @@ import { useSpaceProviderQuery } from '../../../../core/apollo/generated/apollo-
 import {
   AuthorizationPrivilege,
   CommunityMembershipStatus,
-  SpaceInfoFragment,
+  SpacePendingMembershipInfoFragment,
   SpacePrivacyMode,
   SpaceVisibility,
 } from '../../../../core/apollo/generated/graphql-schema';
@@ -34,8 +34,8 @@ interface SpaceContextProps {
   refetchSpace: () => void;
   // TODO Some components just randomly access SpaceContext instead of just querying the data the usual way.
   // TODO This Context should provide as little data as possible or just be removed.
-  context?: SpaceInfoFragment['context'];
-  profile: SpaceInfoFragment['profile'];
+  context?: SpacePendingMembershipInfoFragment['context'];
+  profile: SpacePendingMembershipInfoFragment['profile'];
   visibility: SpaceVisibility;
   myMembershipStatus: CommunityMembershipStatus | undefined;
 }

--- a/src/domain/journey/space/SpaceContext/spaceProvider.graphql
+++ b/src/domain/journey/space/SpaceContext/spaceProvider.graphql
@@ -1,6 +1,6 @@
 query SpaceProvider($spaceNameId: UUID_NAMEID!) {
   space(ID: $spaceNameId) {
-    ...SpaceInfo
+    ...SpacePendingMembershipInfo
   }
 }
 
@@ -14,7 +14,7 @@ query SpaceUrl($spaceNameId: UUID_NAMEID!) {
   }
 }
 
-fragment SpaceInfo on Space {
+fragment SpacePendingMembershipInfo on Space {
   ...SpaceDetails
   authorization {
     id

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
@@ -16,6 +16,7 @@ import { buildAboutUrl, buildUpdatesUrl } from '../../../../main/routing/urlBuil
 import { useTranslation } from 'react-i18next';
 import { useRouteResolver } from '../../../../main/routing/resolvers/RouteResolver';
 import CommunityGuidelinesBlock from '../../../community/community/CommunityGuidelines/CommunityGuidelinesBlock';
+import { SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 
 export interface SpaceDashboardPageProps {
   dialog?: 'about' | 'updates' | 'contributors' | 'calendar';
@@ -77,7 +78,7 @@ const SpaceDashboardPage: FC<SpaceDashboardPageProps> = ({ dialog }) => {
             )}
             <JourneyAboutDialog
               open={dialog === 'about'}
-              journeyLevel={0}
+              spaceLevel={SpaceLevel.Space}
               displayName={entities.space?.profile.displayName}
               tagline={entities.space?.profile.tagline}
               references={entities.references}

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
@@ -4,6 +4,7 @@ import {
   CalloutGroupName,
   CalloutsQueryVariables,
   CommunityMembershipStatus,
+  SpaceLevel,
 } from '../../../../core/apollo/generated/graphql-schema';
 import DashboardUpdatesSection from '../../../shared/components/DashboardSections/DashboardUpdatesSection';
 import PageContent from '../../../../core/ui/content/PageContent';
@@ -132,7 +133,7 @@ const SpaceDashboardView = ({
                   component={FullWidthButton}
                   extended={hasExtendedApplicationButton}
                   journeyId={spaceId}
-                  journeyLevel={0}
+                  spaceLevel={SpaceLevel.Space}
                 />
               </PageContentColumn>
             );

--- a/src/domain/journey/space/layout/SpacePageLayout.tsx
+++ b/src/domain/journey/space/layout/SpacePageLayout.tsx
@@ -14,6 +14,7 @@ import CommunityGuidelinesBlock from '../../../community/community/CommunityGuid
 import { JourneyPath } from '../../../../main/routing/resolvers/RouteResolver';
 import { StorageConfigContextProvider } from '../../../storage/StorageBucket/StorageConfigContext';
 import useCanReadSpace from '../../common/authorization/useCanReadSpace';
+import { SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 
 export interface SpacePageLayoutProps {
   currentSection: EntityPageSection;
@@ -64,7 +65,7 @@ const SpacePageLayout = ({
             description={vision}
             disabled={unauthorizedDialogDisabled}
             leftColumnChildrenTop={<CommunityGuidelinesBlock communityId={communityId} journeyUrl={profile.url} />}
-            journeyLevel={0}
+            spaceLevel={SpaceLevel.Space}
             journeyId={spaceId}
             {...props}
           />

--- a/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
+++ b/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
@@ -27,7 +27,7 @@ import CommunityGuidelinesContainer, {
 } from '../../../community/community/CommunityGuidelines/CommunityGuidelinesContainer';
 import { useUrlParams } from '../../../../core/routing/useUrlParams';
 import ImportTemplatesDialog from '../../../templates/components/Dialogs/ImportTemplateDialog/ImportTemplatesDialog';
-import { TemplateType } from '../../../../core/apollo/generated/graphql-schema';
+import { SpaceLevel, TemplateType } from '../../../../core/apollo/generated/graphql-schema';
 import { LoadingButton } from '@mui/lab';
 import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt';
 import {
@@ -72,7 +72,7 @@ const AdminSpaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' })
     loading,
     inviteExternalUser,
     inviteExistingUser,
-  } = useRoleSetAdmin({ roleSetId, spaceId, journeyLevel: 0 });
+  } = useRoleSetAdmin({ roleSetId, spaceId, spaceLevel: SpaceLevel.Space });
 
   const currentApplicationsUserIds = useMemo(
     () =>

--- a/src/domain/journey/subspace/context/SubspaceProvider.tsx
+++ b/src/domain/journey/subspace/context/SubspaceProvider.tsx
@@ -2,10 +2,10 @@ import React, { FC, useMemo } from 'react';
 import {
   AuthorizationPrivilege,
   CommunityMembershipStatus,
-  SubspaceInfoFragment,
+  SubspacePendingMembershipInfoFragment,
 } from '../../../../core/apollo/generated/graphql-schema';
 import { useRouteResolver } from '../../../../main/routing/resolvers/RouteResolver';
-import { useSubspaceInfoQuery } from '../../../../core/apollo/generated/apollo-hooks';
+import { useSubspacePendingMembershipInfoQuery } from '../../../../core/apollo/generated/apollo-hooks';
 
 interface SubspacePermissions {
   canUpdate: boolean;
@@ -16,14 +16,14 @@ interface SubspacePermissions {
 }
 
 interface SubspaceContextProps {
-  subspace?: SubspaceInfoFragment;
+  subspace?: SubspacePendingMembershipInfoFragment;
   subspaceId: string;
   subspaceNameId: string;
   communityId: string;
   roleSetId: string;
   loading: boolean;
   permissions: SubspacePermissions;
-  profile: SubspaceInfoFragment['profile'];
+  profile: SubspacePendingMembershipInfoFragment['profile'];
   myMembershipStatus: CommunityMembershipStatus | undefined;
 }
 
@@ -55,7 +55,7 @@ interface SubspaceProviderProps {}
 const SubspaceProvider: FC<SubspaceProviderProps> = ({ children }) => {
   const { journeyId } = useRouteResolver();
 
-  const { data, loading } = useSubspaceInfoQuery({
+  const { data, loading } = useSubspacePendingMembershipInfoQuery({
     variables: { subspaceId: journeyId! },
     errorPolicy: 'all',
     skip: !journeyId,

--- a/src/domain/journey/subspace/context/subspaceInfo.graphql
+++ b/src/domain/journey/subspace/context/subspaceInfo.graphql
@@ -1,7 +1,7 @@
-query SubspaceInfo($subspaceId: UUID!) {
+query SubspacePendingMembershipInfo($subspaceId: UUID!) {
   lookup {
     space(ID: $subspaceId) {
-      ...SubspaceInfo
+      ...SubspacePendingMembershipInfo
     }
   }
 }

--- a/src/domain/journey/subspace/context/subspaceInfoFragment.graphql
+++ b/src/domain/journey/subspace/context/subspaceInfoFragment.graphql
@@ -1,4 +1,4 @@
-fragment SubspaceInfo on Space {
+fragment SubspacePendingMembershipInfo on Space {
   id
   nameID
   profile {

--- a/src/domain/journey/subspace/layout/SubspacePageLayout.tsx
+++ b/src/domain/journey/subspace/layout/SubspacePageLayout.tsx
@@ -13,7 +13,7 @@ import JourneyUnauthorizedDialog from '../../common/JourneyUnauthorizedDialog/Jo
 import JourneyUnauthorizedDialogContainer from '../../common/JourneyUnauthorizedDialog/JourneyUnauthorizedDialogContainer';
 import JourneyBreadcrumbs from '../../common/journeyBreadcrumbs/JourneyBreadcrumbs';
 import PageContent from '../../../../core/ui/content/PageContent';
-import { JourneyLevel, JourneyPath } from '../../../../main/routing/resolvers/RouteResolver';
+import { JourneyPath } from '../../../../main/routing/resolvers/RouteResolver';
 import PageContentColumnBase from '../../../../core/ui/content/PageContentColumnBase';
 import { useTranslation } from 'react-i18next';
 import { KeyboardTab, Menu } from '@mui/icons-material';
@@ -48,6 +48,7 @@ import ApplicationButtonContainer from '../../../community/application/container
 import PageContentColumn from '../../../../core/ui/content/PageContentColumn';
 import { StorageConfigContextProvider } from '../../../storage/StorageBucket/StorageConfigContext';
 import { SpaceReadAccess } from '../../common/authorization/useCanReadSpace';
+import { SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 
 export interface SubspacePageLayoutProps {
   journeyId: string | undefined;
@@ -159,6 +160,12 @@ const SubspacePageLayout = ({
   });
 
   const hasExtendedApplicationButton = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
+  let spaceLevel = SpaceLevel.Space;
+  if (journeyPath.length === 2) {
+    spaceLevel = SpaceLevel.Challenge;
+  } else if (journeyPath.length === 3) {
+    spaceLevel = SpaceLevel.Opportunity;
+  }
 
   return (
     <StorageConfigContextProvider locationType="journey" spaceId={journeyId}>
@@ -237,7 +244,7 @@ const SubspacePageLayout = ({
                               component={FullWidthButton}
                               extended={hasExtendedApplicationButton}
                               journeyId={journeyId}
-                              journeyLevel={(journeyPath.length - 1) as JourneyLevel}
+                              spaceLevel={spaceLevel}
                             />
                           </PageContentColumn>
                         );
@@ -283,7 +290,7 @@ const SubspacePageLayout = ({
                     parentSpaceId={parentJourneyId}
                     description={vision}
                     disabled={unauthorizedDialogDisabled}
-                    journeyLevel={(journeyPath.length - 1) as JourneyLevel}
+                    spaceLevel={spaceLevel}
                     {...props}
                   />
                 )}

--- a/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
+++ b/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
@@ -36,7 +36,7 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
     subspaceId: challengeId,
     subspaceNameId,
   } = useSubSpace();
-  const { isPrivate, loading: isLoadingSpace } = useSpace();
+  const { loading: isLoadingSpace } = useSpace();
 
   const [communityGuidelinesTemplatesDialogOpen, setCommunityGuidelinesTemplatesDialogOpen] = useState(false);
 
@@ -122,7 +122,6 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
               currentInvitationsUserIds={currentInvitationsContributorIds}
               currentMembersIds={currentMembersIds}
               spaceId={spaceId}
-              isParentPrivate={isPrivate}
               isSubspace
             />
           </PageContentBlockSeamless>

--- a/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
+++ b/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
@@ -40,7 +40,7 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
 
   const [communityGuidelinesTemplatesDialogOpen, setCommunityGuidelinesTemplatesDialogOpen] = useState(false);
 
-  const { spaceId, journeyLevel } = useRouteResolver();
+  const { spaceId, spaceLevel } = useRouteResolver();
 
   const {
     users,
@@ -72,7 +72,7 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
     loading,
     inviteExternalUser,
     inviteExistingUser,
-  } = useRoleSetAdmin({ roleSetId, spaceId, challengeId, journeyLevel });
+  } = useRoleSetAdmin({ roleSetId, spaceId, challengeId, spaceLevel });
 
   const currentApplicationsUserIds = useMemo(
     () =>

--- a/src/domain/journey/subspace/pages/SubspaceAboutPage.tsx
+++ b/src/domain/journey/subspace/pages/SubspaceAboutPage.tsx
@@ -26,7 +26,7 @@ const SubspaceAboutPage: FC = () => {
 
   const { t } = useTranslation();
 
-  const { journeyId, journeyLevel } = useRouteResolver();
+  const { journeyId, spaceLevel } = useRouteResolver();
 
   return (
     <>
@@ -51,7 +51,7 @@ const SubspaceAboutPage: FC = () => {
         ) => (
           <JourneyAboutDialog
             open
-            journeyLevel={journeyLevel}
+            spaceLevel={spaceLevel}
             displayName={profile?.displayName}
             tagline={profile?.tagline}
             references={references}

--- a/src/domain/journey/subspace/routing/settings/SubspaceSettingsRoute.tsx
+++ b/src/domain/journey/subspace/routing/settings/SubspaceSettingsRoute.tsx
@@ -4,21 +4,22 @@ import { ChallengeRoute } from '../../../settings/routes/ChallengeRoute';
 import { useSubspaceCommunityAndRoleSetIdQuery } from '../../../../../core/apollo/generated/apollo-hooks';
 import { OpportunityRoute } from '../../../settings/routes/OpportunityRoute';
 import { OpportunityProvider } from '../../../opportunity/context/OpportunityProvider';
+import { SpaceLevel } from '../../../../../core/apollo/generated/graphql-schema';
 
 const SubspaceSettingsRoute = () => {
-  const { journeyLevel, parentJourneyId } = useRouteResolver();
+  const { spaceLevel, parentJourneyId } = useRouteResolver();
 
   const { data } = useSubspaceCommunityAndRoleSetIdQuery({
     variables: {
       spaceId: parentJourneyId!,
     },
-    skip: !parentJourneyId || journeyLevel !== 2,
+    skip: !parentJourneyId || spaceLevel !== SpaceLevel.Opportunity,
   });
 
-  switch (journeyLevel) {
-    case 1:
+  switch (spaceLevel) {
+    case SpaceLevel.Challenge:
       return <ChallengeRoute />;
-    case 2:
+    case SpaceLevel.Opportunity:
       return (
         <OpportunityProvider>
           <OpportunityRoute parentCommunityId={data?.lookup.space?.community.id} />

--- a/src/domain/journey/utils/SpaceHostedItem.ts
+++ b/src/domain/journey/utils/SpaceHostedItem.ts
@@ -1,10 +1,9 @@
-import { CommunityContributorType } from '../../../core/apollo/generated/graphql-schema';
+import { CommunityContributorType, SpaceLevel } from '../../../core/apollo/generated/graphql-schema';
 import { Identifiable } from '../../../core/utils/Identifiable';
-import { JourneyLevel } from '../../../main/routing/resolvers/RouteResolver';
 
 export interface SpaceHostedItem extends Identifiable {
   spaceID: string;
-  spaceLevel: JourneyLevel;
+  spaceLevel: SpaceLevel;
   contributorId: string;
   contributorType: CommunityContributorType;
   roles?: string[];

--- a/src/domain/platform/admin/subspace/SubspaceSettingsLayout.tsx
+++ b/src/domain/platform/admin/subspace/SubspaceSettingsLayout.tsx
@@ -14,6 +14,7 @@ import ChildJourneyPageBanner from '../../../journey/common/childJourneyPageBann
 import JourneyBreadcrumbs from '../../../journey/common/journeyBreadcrumbs/JourneyBreadcrumbs';
 import { useRouteResolver } from '../../../../main/routing/resolvers/RouteResolver';
 import BackButton from '../../../../core/ui/actions/BackButton';
+import { SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 
 interface SubspaceSettingsLayoutProps {
   currentTab: SettingsSection;
@@ -25,7 +26,7 @@ const SubspaceSettingsLayout: FC<SubspaceSettingsLayoutProps> = props => {
 
   const { t } = useTranslation();
 
-  const { journeyId, journeyPath, journeyLevel } = useRouteResolver();
+  const { journeyId, journeyPath, spaceLevel } = useRouteResolver();
 
   const tabs = useMemo(() => {
     const tabs: TabDefinition<SettingsSection>[] = [
@@ -51,7 +52,7 @@ const SubspaceSettingsLayout: FC<SubspaceSettingsLayoutProps> = props => {
       },
     ];
 
-    if (journeyLevel === 1) {
+    if (spaceLevel === SpaceLevel.Challenge) {
       tabs.push({
         section: SettingsSection.Subsubspaces,
         route: 'opportunities',
@@ -66,7 +67,7 @@ const SubspaceSettingsLayout: FC<SubspaceSettingsLayoutProps> = props => {
     });
 
     return tabs;
-  }, [journeyLevel]);
+  }, [spaceLevel]);
 
   return (
     <EntitySettingsLayout

--- a/src/domain/shared/components/ActivityDescription/DetailedActivityDescription.tsx
+++ b/src/domain/shared/components/ActivityDescription/DetailedActivityDescription.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import TranslationKey from '../../../../core/i18n/utils/TranslationKey';
 import { JourneyTypeName } from '../../../journey/JourneyTypeName';
 import { formatTimeElapsed } from '../../utils/formatTimeElapsed';
-import journeyIcon from '../JourneyIcon/JourneyIcon';
+import spaceIcon from '../JourneyIcon/JourneyIcon';
 import RouterLink from '../../../../core/ui/link/RouterLink';
 import { CommunityContributorType } from '../../../../core/apollo/generated/graphql-schema';
 
@@ -72,7 +72,7 @@ const DetailedActivityDescription = ({
       mergedValues['journeyDisplayName'] = truncatedParentName;
     }
 
-    const JourneyIcon = journeyTypeName ? journeyIcon[journeyTypeName] : undefined;
+    const JourneyIcon = journeyTypeName ? spaceIcon[journeyTypeName] : undefined;
     if (JourneyIcon) {
       mergedComponents['parenticon'] = <JourneyIcon fontSize="small" sx={{ verticalAlign: 'bottom' }} />;
       mergedComponents['journeyicon'] = <JourneyIcon fontSize="inherit" />;

--- a/src/domain/shared/components/JourneyIcon/JourneyIcon.tsx
+++ b/src/domain/shared/components/JourneyIcon/JourneyIcon.tsx
@@ -8,13 +8,13 @@ import { SvgIconProps } from '@mui/material';
 /**
  * @deprecated
  */
-const journeyIcon = {
+const spaceIcon = {
   space: SpaceIcon,
   subspace: SubspaceIcon,
   subsubspace: OpportunityIcon,
 } as const;
 
-export const journeyIconByJourneyLevel = [
+export const spaceIconByLevel = [
   SpaceIcon,
   SubspaceIcon,
   OpportunityIcon,
@@ -30,4 +30,4 @@ export const spaceTypeIcon: Record<SpaceType, ComponentType<SvgIconProps>> = {
   [SpaceType.Knowledge]: SpaceIcon,
 };
 
-export default journeyIcon;
+export default spaceIcon;

--- a/src/main/search/SearchView.tsx
+++ b/src/main/search/SearchView.tsx
@@ -170,6 +170,8 @@ const SearchView = ({ searchRoute, journeyFilterConfig, journeyFilterTitle }: Se
     skip: !spaceNameId,
   });
 
+  const convertedCalloutResults = calloutResults as SearchResultCalloutFragment[];
+
   return (
     <>
       <PageContentColumn columns={12}>
@@ -216,7 +218,7 @@ const SearchView = ({ searchRoute, journeyFilterConfig, journeyFilterTitle }: Se
           filterTitle={t('common.type')}
           count={calloutResultsCount}
           filterConfig={undefined /* TODO: Callout filtering disabled for now calloutFilterConfig */}
-          results={calloutResults as SearchResultCalloutFragment[]}
+          results={convertedCalloutResults}
           currentFilter={calloutFilter}
           onFilterChange={setCalloutFilter}
           loading={isSearching}

--- a/src/main/search/searchResults/searchResultsCallout/SearchResultsCalloutCardFooter.tsx
+++ b/src/main/search/searchResults/searchResultsCallout/SearchResultsCalloutCardFooter.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material';
-import { journeyIconByJourneyLevel } from '../../../../domain/shared/components/JourneyIcon/JourneyIcon';
+import { spaceIconByLevel } from '../../../../domain/shared/components/JourneyIcon/JourneyIcon';
 import { CONTRIBUTION_ICON } from '../../../../domain/collaboration/callout/calloutCard/calloutIcons';
 import React, { useMemo } from 'react';
-import { CalloutContributionType } from '../../../../core/apollo/generated/graphql-schema';
+import { CalloutContributionType, SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 import { Identifiable } from '../../../../core/utils/Identifiable';
 import { Caption } from '../../../../core/ui/typography';
 import Gutters from '../../../../core/ui/grid/Gutters';
@@ -18,7 +18,7 @@ export interface SearchResultsCalloutCardFooterProps {
       displayName: string;
       url: string;
     };
-    level: number;
+    level: SpaceLevel;
   };
 }
 
@@ -84,7 +84,7 @@ const CalloutContributions = ({ callout }: CalloutContributionsProps) => {
 };
 
 const SearchResultsCalloutCardFooter = ({ callout, matchedTerms, space }: SearchResultsCalloutCardFooterProps) => {
-  const JourneyIcon = space && journeyIconByJourneyLevel[space.level];
+  const JourneyIcon = space && spaceIconByLevel[space.level];
 
   return (
     <Gutters padding={1} gap={1}>

--- a/src/main/topLevelPages/myDashboard/myMemberships/ExpandableSpaceTree.tsx
+++ b/src/main/topLevelPages/myDashboard/myMemberships/ExpandableSpaceTree.tsx
@@ -64,12 +64,13 @@ const ExpandableSpaceTree = ({
   const columns = useColumns();
 
   const verticalOffset = level === SpaceLevel.Space ? 1 : 0.5;
-  let paddingLeft = 0;
-  if (level === SpaceLevel.Challenge) {
-    paddingLeft = 5;
-  } else if (level === SpaceLevel.Opportunity) {
-    paddingLeft = 10;
-  }
+
+  const paddingLeftMap = {
+    [SpaceLevel.Space]: 0,
+    [SpaceLevel.Challenge]: 5,
+    [SpaceLevel.Opportunity]: 10,
+  };
+  const paddingLeft = paddingLeftMap[level] ?? 0;
 
   const renderSubSpaces = (childMembership: MembershipProps) => {
     return <ExpandableSpaceTree key={childMembership.space.id} membership={childMembership} />;

--- a/src/main/topLevelPages/myDashboard/myMemberships/ExpandableSpaceTree.tsx
+++ b/src/main/topLevelPages/myDashboard/myMemberships/ExpandableSpaceTree.tsx
@@ -10,7 +10,7 @@ import BadgeCardView from '../../../../core/ui/list/BadgeCardView';
 import Avatar from '../../../../core/ui/avatar/Avatar';
 import RouterLink from '../../../../core/ui/link/RouterLink';
 import { BlockSectionTitle, BlockTitle, Caption } from '../../../../core/ui/typography';
-import { CommunityRoleType } from '../../../../core/apollo/generated/graphql-schema';
+import { CommunityRoleType, SpaceLevel } from '../../../../core/apollo/generated/graphql-schema';
 import webkitLineClamp from '../../../../core/ui/utils/webkitLineClamp';
 import { gutters } from '../../../../core/ui/grid/utils';
 import { useColumns } from '../../../../core/ui/grid/GridContext';
@@ -31,7 +31,7 @@ interface MembershipProps {
         myRoles?: CommunityRoleType[] | undefined;
       };
     };
-    level: number;
+    level: SpaceLevel;
   };
   childMemberships?: MembershipProps[] | undefined;
 }
@@ -63,7 +63,13 @@ const ExpandableSpaceTree = ({
 
   const columns = useColumns();
 
-  const verticalOffset = level === 0 ? 1 : 0.5;
+  const verticalOffset = level === SpaceLevel.Space ? 1 : 0.5;
+  let paddingLeft = 0;
+  if (level === SpaceLevel.Challenge) {
+    paddingLeft = 5;
+  } else if (level === SpaceLevel.Opportunity) {
+    paddingLeft = 10;
+  }
 
   const renderSubSpaces = (childMembership: MembershipProps) => {
     return <ExpandableSpaceTree key={childMembership.space.id} membership={childMembership} />;
@@ -75,7 +81,7 @@ const ExpandableSpaceTree = ({
         <Gutters
           flexDirection="row"
           paddingY={gutters(verticalOffset)}
-          paddingLeft={level * 5}
+          paddingLeft={paddingLeft}
           paddingRight={0}
           marginY={0}
         >

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipCard.tsx
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipCard.tsx
@@ -1,5 +1,5 @@
 import BadgeCardView from '../../../../core/ui/list/BadgeCardView';
-import { JourneyDetails } from '../../../../domain/community/pendingMembership/PendingMemberships';
+import { SpaceDetails } from '../../../../domain/community/pendingMembership/PendingMemberships';
 import { Avatar, ButtonBase, ListItemButton, ListItemButtonProps, ListItemButtonTypeMap } from '@mui/material';
 import { Caption } from '../../../../core/ui/typography';
 import { Trans, useTranslation } from 'react-i18next';
@@ -7,7 +7,7 @@ import { gutters } from '../../../../core/ui/grid/utils';
 import defaultJourneyAvatar from '../../../../domain/journey/defaultVisuals/Avatar.jpg';
 
 interface NewMembershipCardProps {
-  space: JourneyDetails | undefined;
+  space: SpaceDetails | undefined;
   to?: string;
   onClick?: () => void;
   membershipType: 'application' | 'invitation' | 'membership';

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
@@ -2,7 +2,7 @@ query NewMemberships {
   me {
     communityApplications(states: ["new", "approved"]) {
       id
-      spaceInfo {
+      spacePendingMembershipInfo {
         ...NewMembershipsBasicSpace
       }
       application {
@@ -16,7 +16,7 @@ query NewMemberships {
     }
     communityInvitations(states: ["invited", "accepted"]) {
       id
-      spaceInfo {
+      spacePendingMembershipInfo {
         ...NewMembershipsBasicSpace
       }
       invitation {
@@ -36,7 +36,7 @@ query NewMemberships {
   }
 }
 
-fragment NewMembershipsBasicSpace on SpaceInfo {
+fragment NewMembershipsBasicSpace on SpacePendingMembershipInfo {
   id
   level
   profile {

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMemberships.graphql
@@ -2,7 +2,7 @@ query NewMemberships {
   me {
     communityApplications(states: ["new", "approved"]) {
       id
-      space {
+      spaceInfo {
         ...NewMembershipsBasicSpace
       }
       application {
@@ -16,7 +16,7 @@ query NewMemberships {
     }
     communityInvitations(states: ["invited", "accepted"]) {
       id
-      space {
+      spaceInfo {
         ...NewMembershipsBasicSpace
       }
       invitation {
@@ -36,7 +36,7 @@ query NewMemberships {
   }
 }
 
-fragment NewMembershipsBasicSpace on Space {
+fragment NewMembershipsBasicSpace on SpaceInfo {
   id
   level
   profile {

--- a/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
+++ b/src/main/topLevelPages/myDashboard/newMemberships/NewMembershipsBlock.tsx
@@ -19,7 +19,7 @@ import Gutters from '../../../../core/ui/grid/Gutters';
 import { HdrStrongOutlined } from '@mui/icons-material';
 import ScrollableCardsLayoutContainer from '../../../../core/ui/card/cardsLayout/ScrollableCardsLayoutContainer';
 import JourneyCard from '../../../../domain/journey/common/JourneyCard/JourneyCard';
-import journeyIcon from '../../../../domain/shared/components/JourneyIcon/JourneyIcon';
+import spaceIcon from '../../../../domain/shared/components/JourneyIcon/JourneyIcon';
 import JourneyCardTagline from '../../../../domain/journey/common/JourneyCard/JourneyCardTagline';
 import InvitationActionsContainer from '../../../../domain/community/invitations/InvitationActionsContainer';
 import InvitationDialog from '../../../../domain/community/invitations/InvitationDialog';
@@ -275,7 +275,7 @@ const NewMembershipsBlock = ({ hiddenIfEmpty = false }: NewMembershipsBlockProps
                     {({ application: hydratedApplication }) =>
                       hydratedApplication && (
                         <JourneyCard
-                          iconComponent={journeyIcon[getChildJourneyTypeName(hydratedApplication.space)]}
+                          iconComponent={spaceIcon[getChildJourneyTypeName(hydratedApplication.space)]}
                           header={hydratedApplication.space.profile.displayName}
                           tags={hydratedApplication.space.profile.tagset?.tags ?? []}
                           banner={hydratedApplication.space.profile.visual}

--- a/src/main/topLevelPages/myDashboard/recentSpaces/RecentJourneyCard.tsx
+++ b/src/main/topLevelPages/myDashboard/recentSpaces/RecentJourneyCard.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Visual } from '../../../../domain/common/visual/Visual';
 import { Avatar, Paper, Skeleton } from '@mui/material';
 import RouterLink from '../../../../core/ui/link/RouterLink';
@@ -6,9 +7,8 @@ import withElevationOnHover from '../../../../domain/shared/components/withEleva
 import RoundedIcon from '../../../../core/ui/icon/RoundedIcon';
 import { gutters } from '../../../../core/ui/grid/utils';
 import BadgeCardView from '../../../../core/ui/list/BadgeCardView';
-import React from 'react';
 import { JourneyTypeName } from '../../../../domain/journey/JourneyTypeName';
-import JourneyIcon from '../../../../domain/shared/components/JourneyIcon/JourneyIcon';
+import spaceIcon from '../../../../domain/shared/components/JourneyIcon/JourneyIcon';
 import { alpha } from '@mui/material/styles';
 import webkitLineClamp from '../../../../core/ui/utils/webkitLineClamp';
 import { BlockTitle } from '../../../../core/ui/typography';
@@ -36,7 +36,7 @@ const JOURNEY_TITLE_CLASS_NAME = 'JourneyTitle';
 const ElevatedPaper = withElevationOnHover(Paper) as typeof Paper;
 
 const RecentJourneyCard = ({ journey, journeyTypeName }: RecentJourneyCardProps) => {
-  const Icon = JourneyIcon[journeyTypeName];
+  const Icon = spaceIcon[journeyTypeName];
 
   const columns = useColumns();
 


### PR DESCRIPTION
Relates/Blocked by: https://github.com/alkem-io/server/pull/4614

To get the information needed about an invitation to a subspace from the returned field, not a direct lookup.

Remove usage of JourneyLevel, replaced with the actual SpaceLevel enum that is provided by the api. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `SpaceLevel` enum for improved categorization of search results and community interactions.
	- Enhanced rendering logic to utilize `SpaceLevel` across various components, improving user experience in navigation and membership features.

- **Bug Fixes**
	- Resolved inconsistencies by replacing `journeyLevel` with `spaceLevel` in multiple interfaces and components.

- **Chores**
	- Updated types and imports to streamline code and enhance maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->