### PR TITLE
Change the copy on explore spaces related to All to Active 

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2149,7 +2149,8 @@
         "placeholder": "Search…",
         "noResults": "No results matched your search terms."
       },
-      "seeAll": "Show all Spaces"
+      "seeAll": "Show more",
+      "activeSpacesFilter": "Most Active Spaces"
     },
     "lead-organization": {
       "search": {

--- a/src/main/topLevelPages/myDashboard/ExploreSpaces/ExploreSpacesUnauthenticatedView.tsx
+++ b/src/main/topLevelPages/myDashboard/ExploreSpaces/ExploreSpacesUnauthenticatedView.tsx
@@ -137,7 +137,7 @@ export const ExploreSpacesUnauthenticatedView: FC<ExploreSpacesUnauthenticatedVi
             sx={{ textTransform: 'none', flexShrink: 1 }}
             onClick={() => onFilterChange(SpacesExplorerMembershipFilter.All)}
           >
-            <Caption noWrap>{t('common.all')}</Caption>
+            <Caption noWrap>{t('pages.exploreSpaces.activeSpacesFilter')}</Caption>
           </Button>
           {enabledFilters.map((filter, i) => (
             <Button


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/7029

Simple text changes.

Note that 'Show more' will be the text on both the global explore space & the home dash for unauthenticated. This is correct in my opinion and works for both search/filters and initial load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new filter option for "Most Active Spaces" to enhance user navigation.
  
- **Text Updates**
	- Updated button label from "Show all Spaces" to "Show more" for improved clarity.

- **Usability Improvements**
	- Enhanced consistency and readability of interface text across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->