### PR TITLE
Platform Banner extended to show terms and privacy

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -34,7 +34,8 @@
   },
   "releaseNotes": {
     "title": "<small><icon/>Our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy> have been updated. Click on the titles to review them, or dismiss this notification.</small>",
-    "url": "termsUpdateOct.24?NOT_CLICKABLE"
+    "url": "NotClickableTermsUpdate-Oct-2024",
+    "isClickable": "FALSE"
   },
   "cookie": {
     "consent": "By clicking \"Accept All Cookies\", you agree to the storing of cookies on your device to enhance site navigation and analyze site usage.",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -33,8 +33,8 @@
     ]
   },
   "releaseNotes": {
-    "title": "<big>🎉 Platform update!</big> <small>We have some exciting news for you… Click here to read all about it!</small>",
-    "url": "/forum/releases/latest"
+    "title": "<small><icon/>Our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy> have been updated. Click on the titles to review them, or dismiss this notification.</small>",
+    "url": "termsUpdateOct.24?NOT_CLICKABLE"
   },
   "cookie": {
     "consent": "By clicking \"Accept All Cookies\", you agree to the storing of cookies on your device to enhance site navigation and analyze site usage.",

--- a/src/core/ui/content/DashboardBanner.tsx
+++ b/src/core/ui/content/DashboardBanner.tsx
@@ -1,24 +1,25 @@
-import PageContentBlock from './PageContentBlock';
 import React from 'react';
+import PageContentBlock from './PageContentBlock';
 import Gutters from '../grid/Gutters';
 import RouterLink, { RouterLinkProps } from '../link/RouterLink';
-import { BoxProps, IconButton } from '@mui/material';
+import { Box, BoxProps, IconButton } from '@mui/material';
 import { CloseOutlined } from '@mui/icons-material';
 import { gutters } from '../grid/utils';
 
 interface DashboardBannerProps extends RouterLinkProps {
   onClose?: () => void;
+  isLink?: boolean;
   containerProps?: BoxProps;
 }
 
-const DashboardBanner = ({ children, onClose, containerProps, ...props }: DashboardBannerProps) => {
+const DashboardBanner = ({ children, onClose, containerProps, isLink = true, ...props }: DashboardBannerProps) => {
   return (
     <PageContentBlock row accent disablePadding sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
-      <RouterLink {...props} sx={{ flexGrow: 1 }}>
+      <Box {...props} sx={{ flexGrow: 1 }} component={isLink ? RouterLink : Box}>
         <Gutters row flexWrap="wrap" {...containerProps}>
           {children}
         </Gutters>
-      </RouterLink>
+      </Box>
       {onClose && (
         <IconButton color="primary" onClick={onClose} sx={{ marginX: gutters(0.5) }}>
           <CloseOutlined />

--- a/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.md
+++ b/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.md
@@ -4,7 +4,7 @@
 
 1. platform.latestReleaseDiscussion from LatestReleaseDiscussion query;
 2. the `releaseNotes.url` value from the translations (it's added to the local storage once closed, so make sure it's unique);
-   1. note that you can control the banner wrapper to be static (not clickable) by passing an optional parameter 'NOT_CLICKABLE' in the url value e.g. `termsUpdateOct.24?NOT_CLICKABLE`; The default behaviour is clickable navigating to the URL value;
+   1. note that you can control the banner wrapper to be static (not clickable) by setting the `releaseNotes.isClickable` value to "FALSE" and to "TRUE" if you want to be clickable (navigating to the url value); The `releaseNotes.isClickable: "FALSE"` is useful if you're updating the users with terms and privacy (internal links);
 
 ##### Regarding formatting you can use the following tags:
 

--- a/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.md
+++ b/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.md
@@ -1,0 +1,15 @@
+### ReleaseNotesBanner
+
+##### The banner visibility logic depends on:
+
+1. platform.latestReleaseDiscussion from LatestReleaseDiscussion query;
+2. the `releaseNotes.url` value from the translations (it's added to the local storage once closed, so make sure it's unique);
+   1. note that you can control the banner wrapper to be static (not clickable) by passing an optional parameter 'NOT_CLICKABLE' in the url value e.g. `termsUpdateOct.24?NOT_CLICKABLE`; The default behaviour is clickable navigating to the URL value;
+
+##### Regarding formatting you can use the following tags:
+
+- `<small></small>`
+- `<big></big>`
+- `<terms></terms>`
+- `<privacy></privacy>`
+- `<icon />` - currently displaying CampaignOutlinedIcon

--- a/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.tsx
+++ b/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.tsx
@@ -1,27 +1,38 @@
 import { Trans, useTranslation } from 'react-i18next';
+import CampaignOutlinedIcon from '@mui/icons-material/CampaignOutlined';
 import { BlockTitle, Caption } from '../../../../core/ui/typography';
 import React from 'react';
 import DashboardBanner from '../../../../core/ui/content/DashboardBanner';
 import useReleaseNotes from '../../../../domain/platform/metadata/useReleaseNotes';
+import RouterLink from '../../../../core/ui/link/RouterLink';
+import { useConfig } from '../../../../domain/platform/config/useConfig';
+
+const URL_NOT_CLICKABLE_MARKER = 'NOT_CLICKABLE';
 
 const ReleaseNotesBanner = () => {
   const { t } = useTranslation();
+  const { locations } = useConfig();
 
   const releaseNotesUrl = t('releaseNotes.url');
 
   const { open, onClose } = useReleaseNotes(releaseNotesUrl);
+
+  const notClicable = releaseNotesUrl.includes(URL_NOT_CLICKABLE_MARKER);
 
   if (!open) {
     return null;
   }
 
   return (
-    <DashboardBanner to={releaseNotesUrl} onClose={onClose}>
+    <DashboardBanner to={releaseNotesUrl} isLink={!notClicable} onClose={onClose}>
       <Trans
         i18nKey="releaseNotes.title"
         components={{
+          icon: <CampaignOutlinedIcon fontSize="small" sx={{ marginRight: '8px', verticalAlign: 'bottom' }} />,
           big: <BlockTitle />,
           small: <Caption />,
+          terms: <RouterLink to={locations?.terms ?? ''} underline="always" />,
+          privacy: <RouterLink to={locations?.privacy ?? ''} underline="always" />,
         }}
       />
     </DashboardBanner>

--- a/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.tsx
+++ b/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.tsx
@@ -7,24 +7,23 @@ import useReleaseNotes from '../../../../domain/platform/metadata/useReleaseNote
 import RouterLink from '../../../../core/ui/link/RouterLink';
 import { useConfig } from '../../../../domain/platform/config/useConfig';
 
-const URL_NOT_CLICKABLE_MARKER = 'NOT_CLICKABLE';
+const IS_CLICKABLE = 'true';
 
 const ReleaseNotesBanner = () => {
   const { t } = useTranslation();
   const { locations } = useConfig();
 
   const releaseNotesUrl = t('releaseNotes.url');
+  const isClickable = t('releaseNotes.isClickable').toLocaleLowerCase() === IS_CLICKABLE;
 
   const { open, onClose } = useReleaseNotes(releaseNotesUrl);
-
-  const notClickable = releaseNotesUrl.includes(URL_NOT_CLICKABLE_MARKER);
 
   if (!open) {
     return null;
   }
 
   return (
-    <DashboardBanner to={releaseNotesUrl} isLink={!notClickable} onClose={onClose}>
+    <DashboardBanner to={releaseNotesUrl} isLink={isClickable} onClose={onClose}>
       <Trans
         i18nKey="releaseNotes.title"
         components={{

--- a/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.tsx
+++ b/src/main/topLevelPages/myDashboard/releaseNotesBanner/ReleaseNotesBanner.tsx
@@ -17,14 +17,14 @@ const ReleaseNotesBanner = () => {
 
   const { open, onClose } = useReleaseNotes(releaseNotesUrl);
 
-  const notClicable = releaseNotesUrl.includes(URL_NOT_CLICKABLE_MARKER);
+  const notClickable = releaseNotesUrl.includes(URL_NOT_CLICKABLE_MARKER);
 
   if (!open) {
     return null;
   }
 
   return (
-    <DashboardBanner to={releaseNotesUrl} isLink={!notClicable} onClose={onClose}>
+    <DashboardBanner to={releaseNotesUrl} isLink={!notClickable} onClose={onClose}>
       <Trans
         i18nKey="releaseNotes.title"
         components={{


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6988

Based on the requirements the existing Platform Banner was extended to:

- [x] Support terms and privacy links;
- [x] Support non-clickable updates;
  - use NOT_CLICKABLE in the `releaseNotes.url` i18n value;
  
Additional .md was created for ease of understanding the visibility logic and the available configurations behind the feature.

Final design approved by Simone.
![image](https://github.com/user-attachments/assets/b994581e-4916-48fb-8ac4-2176fd83aca6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated release notes now highlight changes to the Terms of Service and Privacy Policy with non-clickable links.
	- Enhanced `ReleaseNotesBanner` component to control banner interactivity based on new parameters.

- **Improvements**
	- Enhanced `DashboardBanner` component for flexible rendering based on a new optional property.
	- Improved interactivity and visual elements in the `ReleaseNotesBanner` component.

- **Documentation**
	- Added documentation for the `ReleaseNotesBanner` component detailing its functionality and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->