### PR TITLE
Invites Section on DashboardWithoutMemberships

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -3380,6 +3380,18 @@ export const ExploreSpacesSearchFragmentDoc = gql`
   }
   ${ExploreSpacesFragmentDoc}
 `;
+export const NewMembershipsBasicSpaceFragmentDoc = gql`
+  fragment NewMembershipsBasicSpace on SpacePendingMembershipInfo {
+    id
+    level
+    profile {
+      id
+      displayName
+      tagline
+      url
+    }
+  }
+`;
 export const InnovationPackProviderProfileWithAvatarFragmentDoc = gql`
   fragment InnovationPackProviderProfileWithAvatar on Contributor {
     id
@@ -3489,18 +3501,6 @@ export const MyMembershipsChildJourneyProfileFragmentDoc = gql`
     }
   }
   ${VisualUriFragmentDoc}
-`;
-export const NewMembershipsBasicSpaceFragmentDoc = gql`
-  fragment NewMembershipsBasicSpace on SpacePendingMembershipInfo {
-    id
-    level
-    profile {
-      id
-      displayName
-      tagline
-      url
-    }
-  }
 `;
 export const RecentJourneyProfileFragmentDoc = gql`
   fragment RecentJourneyProfile on Profile {
@@ -21946,6 +21946,84 @@ export type WelcomeSpaceQueryResult = Apollo.QueryResult<
 >;
 export function refetchWelcomeSpaceQuery(variables: SchemaTypes.WelcomeSpaceQueryVariables) {
   return { query: WelcomeSpaceDocument, variables: variables };
+}
+
+export const PendingInvitationsDocument = gql`
+  query PendingInvitations {
+    me {
+      communityInvitations(states: ["invited"]) {
+        id
+        spacePendingMembershipInfo {
+          ...NewMembershipsBasicSpace
+        }
+        invitation {
+          id
+          welcomeMessage
+          contributorType
+          createdBy {
+            id
+          }
+          lifecycle {
+            id
+            state
+          }
+          createdDate
+        }
+      }
+    }
+  }
+  ${NewMembershipsBasicSpaceFragmentDoc}
+`;
+
+/**
+ * __usePendingInvitationsQuery__
+ *
+ * To run a query within a React component, call `usePendingInvitationsQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePendingInvitationsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePendingInvitationsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function usePendingInvitationsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    SchemaTypes.PendingInvitationsQuery,
+    SchemaTypes.PendingInvitationsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SchemaTypes.PendingInvitationsQuery, SchemaTypes.PendingInvitationsQueryVariables>(
+    PendingInvitationsDocument,
+    options
+  );
+}
+
+export function usePendingInvitationsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.PendingInvitationsQuery,
+    SchemaTypes.PendingInvitationsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SchemaTypes.PendingInvitationsQuery, SchemaTypes.PendingInvitationsQueryVariables>(
+    PendingInvitationsDocument,
+    options
+  );
+}
+
+export type PendingInvitationsQueryHookResult = ReturnType<typeof usePendingInvitationsQuery>;
+export type PendingInvitationsLazyQueryHookResult = ReturnType<typeof usePendingInvitationsLazyQuery>;
+export type PendingInvitationsQueryResult = Apollo.QueryResult<
+  SchemaTypes.PendingInvitationsQuery,
+  SchemaTypes.PendingInvitationsQueryVariables
+>;
+export function refetchPendingInvitationsQuery(variables?: SchemaTypes.PendingInvitationsQueryVariables) {
+  return { query: PendingInvitationsDocument, variables: variables };
 }
 
 export const CampaignBlockCredentialsDocument = gql`

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -28275,6 +28275,41 @@ export type ExploreSpacesFragment = {
   };
 };
 
+export type PendingInvitationsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type PendingInvitationsQuery = {
+  __typename?: 'Query';
+  me: {
+    __typename?: 'MeQueryResults';
+    communityInvitations: Array<{
+      __typename?: 'CommunityInvitationResult';
+      id: string;
+      spacePendingMembershipInfo: {
+        __typename?: 'SpacePendingMembershipInfo';
+        id: string;
+        level: SpaceLevel;
+        profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
+      };
+      invitation: {
+        __typename?: 'Invitation';
+        id: string;
+        welcomeMessage?: string | undefined;
+        contributorType: CommunityContributorType;
+        createdDate: Date;
+        createdBy: { __typename?: 'User'; id: string };
+        lifecycle: { __typename?: 'Lifecycle'; id: string; state?: string | undefined };
+      };
+    }>;
+  };
+};
+
+export type NewMembershipsBasicSpaceFragment = {
+  __typename?: 'SpacePendingMembershipInfo';
+  id: string;
+  level: SpaceLevel;
+  profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
+};
+
 export type CampaignBlockCredentialsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type CampaignBlockCredentialsQuery = {
@@ -29792,13 +29827,6 @@ export type NewMembershipsQuery = {
       };
     }>;
   };
-};
-
-export type NewMembershipsBasicSpaceFragment = {
-  __typename?: 'SpacePendingMembershipInfo';
-  id: string;
-  level: SpaceLevel;
-  profile: { __typename?: 'Profile'; id: string; displayName: string; tagline?: string | undefined; url: string };
 };
 
 export type NewVirtualContributorMySpacesQueryVariables = Exact<{ [key: string]: never }>;

--- a/src/domain/community/invitations/SingleInvitationFull.tsx
+++ b/src/domain/community/invitations/SingleInvitationFull.tsx
@@ -1,0 +1,167 @@
+import React, { ReactNode } from 'react';
+import { InvitationHydrator, InvitationWithMeta } from '../pendingMembership/PendingMemberships';
+import Gutters from '../../../core/ui/grid/Gutters';
+import { CheckOutlined, HdrStrongOutlined } from '@mui/icons-material';
+import JourneyCard from '../../journey/common/JourneyCard/JourneyCard';
+import spaceIcon from '../../shared/components/JourneyIcon/JourneyIcon';
+import JourneyCardTagline from '../../journey/common/JourneyCard/JourneyCardTagline';
+import { BlockSectionTitle, Caption, Text } from '../../../core/ui/typography';
+import DetailedActivityDescription from '../../shared/components/ActivityDescription/DetailedActivityDescription';
+import { LoadingButton } from '@mui/lab';
+import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
+import { InvitationItem } from '../user/providers/UserProvider/InvitationItem';
+import { useTranslation } from 'react-i18next';
+import { CommunityContributorType, VisualType } from '../../../core/apollo/generated/graphql-schema';
+import { Box, useMediaQuery } from '@mui/material';
+import WrapperMarkdown from '../../../core/ui/markdown/WrapperMarkdown';
+import References from '../../shared/components/References/References';
+import { gutters } from '../../../core/ui/grid/utils';
+import FlexSpacer from '../../../core/ui/utils/FlexSpacer';
+import { theme } from '../../../core/ui/themes/default/Theme';
+import { getChildJourneyTypeName } from '../../shared/utils/spaceLevel';
+import { Actions } from '../../../core/ui/actions/Actions';
+
+interface SingleInvitationFullProps {
+  invitation: InvitationItem | undefined;
+  updating: boolean;
+  acceptInvitation: (invitationId: string) => void;
+  accepting: boolean;
+  rejectInvitation: (invitationId: string) => void;
+  rejecting: boolean;
+  actions?: ReactNode;
+}
+
+/**
+ * SingleInvitationFull Component
+ *
+ * This component is a copy of `src/domain/community/invitations/InvitationDialog.tsx`.
+ * It is almost the same but without the Dialog functionalities.
+ * In the future, it could be refactored to use the same component or to be simplified.
+ *
+ * @component
+ */
+const SingleInvitationFull = ({
+  invitation,
+  updating,
+  acceptInvitation,
+  accepting,
+  rejectInvitation,
+  rejecting,
+  actions,
+}: SingleInvitationFullProps) => {
+  const { t } = useTranslation();
+
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const getTitle = (invitation: InvitationWithMeta) => {
+    if (invitation.invitation.contributorType === CommunityContributorType.Virtual) {
+      return t('community.pendingMembership.invitationDialog.vc.title', {
+        journey: invitation?.space.profile.displayName,
+      });
+    }
+
+    return t('community.pendingMembership.invitationDialog.title', {
+      journey: invitation?.space.profile.displayName,
+    });
+  };
+
+  const getAcceptLabel = (invitation: InvitationWithMeta) => {
+    if (invitation.invitation.contributorType === CommunityContributorType.Virtual) {
+      return t('community.pendingMembership.invitationDialog.actions.accept');
+    }
+
+    return t('community.pendingMembership.invitationDialog.actions.join');
+  };
+
+  return (
+    <>
+      {invitation && (
+        <InvitationHydrator
+          invitation={invitation}
+          withJourneyDetails
+          withCommunityGuidelines
+          visualType={VisualType.Card}
+        >
+          {({ invitation, communityGuidelines }) =>
+            invitation && (
+              <>
+                <Gutters row disablePadding sx={{ whiteSpace: 'break-spaces' }}>
+                  <HdrStrongOutlined fontSize="small" />
+                  {getTitle(invitation)}
+                </Gutters>
+                <Gutters
+                  paddingTop={0}
+                  flexDirection={isMobile ? 'column' : 'row'}
+                  alignItems={isMobile ? 'center' : 'start'}
+                >
+                  <JourneyCard
+                    iconComponent={spaceIcon[getChildJourneyTypeName(invitation.space)]}
+                    header={invitation.space.profile.displayName}
+                    tags={invitation.space.profile.tagset?.tags ?? []}
+                    banner={invitation.space.profile.visual}
+                    journeyUri={invitation.space.profile.url}
+                  >
+                    <JourneyCardTagline>{invitation.space.profile.tagline ?? ''}</JourneyCardTagline>
+                  </JourneyCard>
+                  <Gutters disablePadding>
+                    <Caption>
+                      <DetailedActivityDescription
+                        i18nKey="community.pendingMembership.invitationTitle"
+                        journeyDisplayName={invitation.space.profile.displayName}
+                        journeyUrl={invitation.space.profile.url}
+                        journeyTypeName={getChildJourneyTypeName(invitation.space)}
+                        createdDate={invitation.invitation.createdDate}
+                        author={{ displayName: invitation.userDisplayName }}
+                        type={invitation.invitation.contributorType}
+                      />
+                    </Caption>
+                    {invitation.invitation.welcomeMessage && <Text>{invitation.invitation.welcomeMessage}</Text>}
+                    {communityGuidelines && (
+                      <>
+                        <BlockSectionTitle paddingTop={gutters()}>
+                          {communityGuidelines.profile.displayName}
+                        </BlockSectionTitle>
+                        <Gutters disablePadding>
+                          <Box sx={{ wordWrap: 'break-word' }}>
+                            <WrapperMarkdown disableParagraphPadding>
+                              {communityGuidelines?.profile.description ?? ''}
+                            </WrapperMarkdown>
+                          </Box>
+                          <References compact references={communityGuidelines?.profile.references} />
+                        </Gutters>
+                      </>
+                    )}
+                  </Gutters>
+                </Gutters>
+                <Actions>
+                  {actions}
+                  <FlexSpacer />
+                  <LoadingButton
+                    startIcon={<CloseOutlinedIcon />}
+                    onClick={() => rejectInvitation(invitation.invitation.id)}
+                    variant="outlined"
+                    loading={rejecting}
+                    disabled={updating && !rejecting}
+                  >
+                    {t('community.pendingMembership.invitationDialog.actions.reject')}
+                  </LoadingButton>
+                  <LoadingButton
+                    startIcon={<CheckOutlined />}
+                    onClick={() => acceptInvitation(invitation.invitation.id)}
+                    variant="contained"
+                    loading={accepting}
+                    disabled={updating && !accepting}
+                  >
+                    {getAcceptLabel(invitation)}
+                  </LoadingButton>
+                </Actions>
+              </>
+            )
+          }
+        </InvitationHydrator>
+      )}
+    </>
+  );
+};
+
+export default SingleInvitationFull;

--- a/src/main/topLevelPages/myDashboard/InvitationsBlock/InvitationsBlock.tsx
+++ b/src/main/topLevelPages/myDashboard/InvitationsBlock/InvitationsBlock.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import SingleInvitationFull from '../../../../domain/community/invitations/SingleInvitationFull';
+import InvitationActionsContainer from '../../../../domain/community/invitations/InvitationActionsContainer';
+import { InvitationItem } from '../../../../domain/community/user/providers/UserProvider/InvitationItem';
+import { usePendingInvitationsQuery } from '../../../../core/apollo/generated/apollo-hooks';
+import PageContentBlock from '../../../../core/ui/content/PageContentBlock';
+
+export const InvitationsBlock = () => {
+  const { data, refetch: refetchPendingInvitationsQuery } = usePendingInvitationsQuery();
+
+  const communityInvitations = useMemo(
+    () =>
+      data?.me.communityInvitations.map(
+        invitation =>
+          ({
+            type: 0,
+            ...(invitation as InvitationItem),
+          } as const)
+      ) ?? [],
+    [data?.me.communityInvitations]
+  );
+
+  const onInvitationAccept = () => {
+    refetchPendingInvitationsQuery();
+  };
+
+  const onInvitationReject = () => {
+    refetchPendingInvitationsQuery();
+  };
+
+  if (!communityInvitations.length) {
+    return null;
+  }
+
+  return (
+    <PageContentBlock columns={12}>
+      {communityInvitations.map(invitation => (
+        <InvitationActionsContainer key={invitation.id} onAccept={onInvitationAccept} onReject={onInvitationReject}>
+          {props => <SingleInvitationFull invitation={invitation} {...props} />}
+        </InvitationActionsContainer>
+      ))}
+    </PageContentBlock>
+  );
+};

--- a/src/main/topLevelPages/myDashboard/InvitationsBlock/PendingInvitations.graphql
+++ b/src/main/topLevelPages/myDashboard/InvitationsBlock/PendingInvitations.graphql
@@ -1,0 +1,34 @@
+query PendingInvitations {
+  me {
+    communityInvitations(states: ["invited"]) {
+      id
+      spacePendingMembershipInfo {
+        ...NewMembershipsBasicSpace
+      }
+      invitation {
+        id
+        welcomeMessage
+        contributorType
+        createdBy {
+          id
+        }
+        lifecycle {
+          id
+          state
+        }
+        createdDate
+      }
+    }
+  }
+}
+
+fragment NewMembershipsBasicSpace on SpacePendingMembershipInfo {
+  id
+  level
+  profile {
+    id
+    displayName
+    tagline
+    url
+  }
+}

--- a/src/main/topLevelPages/myDashboard/MyDashboardWithoutMemberships.tsx
+++ b/src/main/topLevelPages/myDashboard/MyDashboardWithoutMemberships.tsx
@@ -8,6 +8,7 @@ import ReleaseNotesBanner from './releaseNotesBanner/ReleaseNotesBanner';
 import { DashboardMenu } from './DashboardMenu/DashboardMenu';
 import ExploreSpaces from './ExploreSpaces/ExploreSpaces';
 import PageContentBlock from '../../../core/ui/content/PageContentBlock';
+import { InvitationsBlock } from './InvitationsBlock/InvitationsBlock';
 
 const MyDashboardWithoutMemberships = () => {
   const { data } = useLatestReleaseDiscussionQuery({
@@ -20,9 +21,9 @@ const MyDashboardWithoutMemberships = () => {
         <DashboardMenu compact />
       </InfoColumn>
       <ContentColumn>
-        {data?.platform.latestReleaseDiscussion && <ReleaseNotesBanner />} {/* TODO: tweak to match design */}
-        {/* TODO: implement and import here the pending memberships block */}
+        {data?.platform.latestReleaseDiscussion && <ReleaseNotesBanner />}
         <CampaignBlock />
+        <InvitationsBlock />
         <PageContentBlock columns={12}>
           <ExploreSpaces itemsLimit={16} />
         </PageContentBlock>


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/7078

According to the design, the invites dialog was copied and reused. 
A limited invite data is requested on load.
There is a slight deviation from the design, in the case of more than one invitation, we're showing them in the same block. This was done intentionally.