### PR TITLE
package-lock.json version fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.75.3",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@alkemio/excalidraw": "^0.17.1-alkemio-8",
+        "@alkemio/excalidraw": "0.17.1-alkemio-8",
         "@apollo/client": "^3.10.8",
         "@elastic/apm-rum": "^5.12.0",
         "@elastic/apm-rum-react": "^1.4.2",


### PR DESCRIPTION
"@alkemio/excalidraw": "^0.17.1-alkemio-8" -> "0.17.1-alkemio-8",