### PR TITLE
[Simple Homepage] Redirect to space on Join clk + update the dash

### DIFF
--- a/src/domain/community/invitations/InvitationActionsContainer.tsx
+++ b/src/domain/community/invitations/InvitationActionsContainer.tsx
@@ -1,10 +1,13 @@
 import useLoadingState from '../../shared/utils/useLoadingState';
-import { useInvitationStateEventMutation } from '../../../core/apollo/generated/apollo-hooks';
+import {
+  refetchLatestContributionsSpacesFlatQuery,
+  useInvitationStateEventMutation,
+} from '../../../core/apollo/generated/apollo-hooks';
 import { SimpleContainerProps } from '../../../core/container/SimpleContainer';
 
 interface InvitationActionsContainerProvided {
   updating: boolean;
-  acceptInvitation: (invitationId: string) => void;
+  acceptInvitation: (invitationId: string, spaceUrl: string) => void;
   accepting: boolean;
   rejectInvitation: (invitationId: string) => void;
   rejecting: boolean;
@@ -12,7 +15,7 @@ interface InvitationActionsContainerProvided {
 
 interface InvitationActionsContainerProps extends SimpleContainerProps<InvitationActionsContainerProvided> {
   onUpdate?: () => void;
-  onAccept?: () => void;
+  onAccept?: (spaceUrl: string) => void;
   onReject?: () => void;
 }
 
@@ -26,15 +29,16 @@ const InvitationActionsContainer = ({ onUpdate, onAccept, onReject, children }: 
     }
   );
 
-  const [acceptInvitation, isAccepting] = useLoadingState((invitationId: string) =>
+  const [acceptInvitation, isAccepting] = useLoadingState((invitationId: string, spaceUrl: string) =>
     updateInvitationState({
       variables: {
         invitationId,
         eventName: 'ACCEPT',
       },
       onCompleted: () => {
-        onAccept?.();
+        onAccept?.(spaceUrl);
       },
+      refetchQueries: [refetchLatestContributionsSpacesFlatQuery()],
     })
   );
 

--- a/src/domain/community/invitations/InvitationDialog.tsx
+++ b/src/domain/community/invitations/InvitationDialog.tsx
@@ -26,7 +26,7 @@ interface InvitationDialogProps {
   onClose: () => void;
   invitation: InvitationItem | undefined;
   updating: boolean;
-  acceptInvitation: (invitationId: string) => void;
+  acceptInvitation: (invitationId: string, spaceUrl: string) => void;
   accepting: boolean;
   rejectInvitation: (invitationId: string) => void;
   rejecting: boolean;
@@ -149,7 +149,7 @@ const InvitationDialog = ({
                   </LoadingButton>
                   <LoadingButton
                     startIcon={<CheckOutlined />}
-                    onClick={() => acceptInvitation(invitation.invitation.id)}
+                    onClick={() => acceptInvitation(invitation.invitation.id, invitation.space.profile.url)}
                     variant="contained"
                     loading={accepting}
                     disabled={updating && !accepting}

--- a/src/domain/community/invitations/SingleInvitationFull.tsx
+++ b/src/domain/community/invitations/SingleInvitationFull.tsx
@@ -23,7 +23,7 @@ import { Actions } from '../../../core/ui/actions/Actions';
 interface SingleInvitationFullProps {
   invitation: InvitationItem | undefined;
   updating: boolean;
-  acceptInvitation: (invitationId: string) => void;
+  acceptInvitation: (invitationId: string, spaceUrl: string) => void;
   accepting: boolean;
   rejectInvitation: (invitationId: string) => void;
   rejecting: boolean;
@@ -146,7 +146,7 @@ const SingleInvitationFull = ({
                   </LoadingButton>
                   <LoadingButton
                     startIcon={<CheckOutlined />}
-                    onClick={() => acceptInvitation(invitation.invitation.id)}
+                    onClick={() => acceptInvitation(invitation.invitation.id, invitation.space.profile.url)}
                     variant="contained"
                     loading={accepting}
                     disabled={updating && !accepting}

--- a/src/main/topLevelPages/myDashboard/InvitationsBlock/InvitationsBlock.tsx
+++ b/src/main/topLevelPages/myDashboard/InvitationsBlock/InvitationsBlock.tsx
@@ -4,9 +4,11 @@ import InvitationActionsContainer from '../../../../domain/community/invitations
 import { InvitationItem } from '../../../../domain/community/user/providers/UserProvider/InvitationItem';
 import { usePendingInvitationsQuery } from '../../../../core/apollo/generated/apollo-hooks';
 import PageContentBlock from '../../../../core/ui/content/PageContentBlock';
+import useNavigate from '../../../../core/routing/useNavigate';
 
 export const InvitationsBlock = () => {
   const { data, refetch: refetchPendingInvitationsQuery } = usePendingInvitationsQuery();
+  const navigate = useNavigate();
 
   const communityInvitations = useMemo(
     () =>
@@ -20,8 +22,9 @@ export const InvitationsBlock = () => {
     [data?.me.communityInvitations]
   );
 
-  const onInvitationAccept = () => {
+  const onInvitationAccept = (spaceUrl: string) => {
     refetchPendingInvitationsQuery();
+    navigate(spaceUrl);
   };
 
   const onInvitationReject = () => {


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/7155

- [x] On every join click (successful)  - invite dialog, dashboard inline invites - redirect to the space;
- [x] Refetch the Dashboard query - this will ensure that users without memberships will be presented with the dashboard for users with memberships after successfully accepting.   