### PR TITLE
IsPrivate Icon adjustements and usage on ExploreSpaces 

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -3527,6 +3527,11 @@ export const ExploreSpacesFragmentDoc = gql`
         ...VisualUri
       }
     }
+    settings {
+      privacy {
+        mode
+      }
+    }
   }
   ${VisualUriFragmentDoc}
 `;

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -943,7 +943,6 @@ export enum AuthorizationPolicyType {
 }
 
 export enum AuthorizationPrivilege {
-  AccessDashboardRefresh = 'ACCESS_DASHBOARD_REFRESH',
   AccessInteractiveGuidance = 'ACCESS_INTERACTIVE_GUIDANCE',
   AccessVirtualContributor = 'ACCESS_VIRTUAL_CONTRIBUTOR',
   AuthorizationReset = 'AUTHORIZATION_RESET',
@@ -987,7 +986,6 @@ export enum AuthorizationPrivilege {
   UpdateCalloutPublisher = 'UPDATE_CALLOUT_PUBLISHER',
   UpdateContent = 'UPDATE_CONTENT',
   UpdateInnovationFlow = 'UPDATE_INNOVATION_FLOW',
-  UpdateWhiteboard = 'UPDATE_WHITEBOARD',
 }
 
 export type Calendar = {
@@ -28807,6 +28805,10 @@ export type ExploreSpacesSearchQuery = {
               displayName: string;
               cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
             };
+            settings: {
+              __typename?: 'SpaceSettings';
+              privacy: { __typename?: 'SpaceSettingsPrivacy'; mode: SpacePrivacyMode };
+            };
           };
         }
       | { __typename?: 'SearchResultUser'; id: string; type: SearchResultType }
@@ -28828,6 +28830,10 @@ export type ExploreSpacesSearchFragment = {
       displayName: string;
       cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
     };
+    settings: {
+      __typename?: 'SpaceSettings';
+      privacy: { __typename?: 'SpaceSettingsPrivacy'; mode: SpacePrivacyMode };
+    };
   };
 };
 
@@ -28845,6 +28851,10 @@ export type ExploreAllSpacesQuery = {
       url: string;
       displayName: string;
       cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+    };
+    settings: {
+      __typename?: 'SpaceSettings';
+      privacy: { __typename?: 'SpaceSettingsPrivacy'; mode: SpacePrivacyMode };
     };
   }>;
 };
@@ -28866,6 +28876,10 @@ export type WelcomeSpaceQuery = {
       displayName: string;
       cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
     };
+    settings: {
+      __typename?: 'SpaceSettings';
+      privacy: { __typename?: 'SpaceSettingsPrivacy'; mode: SpacePrivacyMode };
+    };
   };
 };
 
@@ -28880,6 +28894,7 @@ export type ExploreSpacesFragment = {
     displayName: string;
     cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
   };
+  settings: { __typename?: 'SpaceSettings'; privacy: { __typename?: 'SpaceSettingsPrivacy'; mode: SpacePrivacyMode } };
 };
 
 export type PendingInvitationsQueryVariables = Exact<{ [key: string]: never }>;

--- a/src/domain/journey/common/JourneyCard/JourneyCard.tsx
+++ b/src/domain/journey/common/JourneyCard/JourneyCard.tsx
@@ -1,5 +1,5 @@
-import { memo, ComponentType, PropsWithChildren, ReactNode, useState } from 'react';
-import { Box, Paper, SvgIconProps } from '@mui/material';
+import { ComponentType, PropsWithChildren, ReactNode, useState } from 'react';
+import { Box, SvgIconProps } from '@mui/material';
 import { LockOutlined } from '@mui/icons-material';
 import ContributeCard, { ContributeCardProps } from '../../../../core/ui/card/ContributeCard';
 import BadgeCardView from '../../../../core/ui/list/BadgeCardView';
@@ -28,7 +28,6 @@ export interface JourneyCardProps extends ContributeCardProps {
   actions?: ReactNode;
   matchedTerms?: boolean; // TODO pass ComponentType<CardTags> instead
   visual?: ReactNode;
-  isPrivate?: boolean;
 }
 
 const JourneyCard = ({
@@ -45,7 +44,6 @@ const JourneyCard = ({
   actions,
   children,
   visual,
-  isPrivate,
   ...containerProps
 }: PropsWithChildren<JourneyCardProps>) => {
   const { t } = useTranslation();
@@ -65,8 +63,6 @@ const JourneyCard = ({
 
   return (
     <ContributeCard sx={{ position: 'relative' }} {...containerProps}>
-      {isPrivate && <PrivacyIcon />}
-
       <Box {...wrapperProps}>
         <CardBanner
           src={banner?.uri || defaultCardBanner}
@@ -100,39 +96,3 @@ const JourneyCard = ({
 };
 
 export default JourneyCard;
-
-type PrivacyIconProps = {
-  size?: number;
-  top?: number;
-  right?: number;
-  ariaLabel?: string;
-};
-
-export const PrivacyIcon = memo(
-  ({ top = 10, size = 25, right = 10, ariaLabel = 'Private journey' }: PrivacyIconProps) => {
-    return (
-      <Paper
-        elevation={3}
-        sx={theme => ({
-          position: 'absolute',
-          zIndex: theme.zIndex.fab,
-          top: theme.spacing(top / 10),
-          right: theme.spacing(right / 10),
-
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-
-          width: size,
-          height: size,
-          borderRadius: '50%',
-          padding: theme.spacing(1.8),
-          backgroundColor: theme.palette.background.paper,
-        })}
-        aria-label={ariaLabel}
-      >
-        <LockOutlined fontSize="medium" color="primary" />
-      </Paper>
-    );
-  }
-);

--- a/src/domain/journey/common/JourneyTile/JourneyTile.tsx
+++ b/src/domain/journey/common/JourneyTile/JourneyTile.tsx
@@ -11,7 +11,7 @@ import webkitLineClamp from '../../../../core/ui/utils/webkitLineClamp';
 import { BlockTitle } from '../../../../core/ui/typography';
 import InsertPhotoOutlinedIcon from '@mui/icons-material/InsertPhotoOutlined';
 import defaultJourneyCardBanner from '../../../../domain/journey/defaultVisuals/Card.jpg';
-import { PrivacyIcon } from '../JourneyCard/JourneyCard';
+import { PrivacyIcon } from './PrivacyIcon';
 
 type JourneyTileProps = {
   journey:

--- a/src/domain/journey/common/JourneyTile/PrivacyIcon.tsx
+++ b/src/domain/journey/common/JourneyTile/PrivacyIcon.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react';
+import { LockOutlined } from '@mui/icons-material';
+import { Paper } from '@mui/material';
+import { gutters } from '../../../../core/ui/grid/utils';
+
+type PrivacyIconProps = {
+  size?: number;
+  top?: number;
+  right?: number;
+  ariaLabel?: string;
+};
+
+export const PrivacyIcon = memo(({ top = 8, size = 8, right = 8, ariaLabel = 'Private journey' }: PrivacyIconProps) => {
+  return (
+    <Paper
+      elevation={3}
+      sx={theme => ({
+        position: 'absolute',
+        zIndex: theme.zIndex.fab,
+        top: theme.spacing(top / 10),
+        right: theme.spacing(right / 10),
+
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        padding: gutters(0.7),
+        backgroundColor: theme.palette.background.paper,
+        opacity: 0.8,
+      })}
+      aria-label={ariaLabel}
+    >
+      <LockOutlined fontSize="small" color="primary" />
+    </Paper>
+  );
+});

--- a/src/main/topLevelPages/myDashboard/ExploreSpaces/ExploreSpaces.graphql
+++ b/src/main/topLevelPages/myDashboard/ExploreSpaces/ExploreSpaces.graphql
@@ -39,4 +39,9 @@ fragment ExploreSpaces on Space {
       ...VisualUri
     }
   }
+  settings {
+    privacy {
+      mode
+    }
+  }
 }

--- a/src/main/topLevelPages/myDashboard/ExploreSpaces/ExploreSpacesTypes.ts
+++ b/src/main/topLevelPages/myDashboard/ExploreSpaces/ExploreSpacesTypes.ts
@@ -1,6 +1,7 @@
 import { Visual } from '../../../../domain/common/visual/Visual';
 import { SimpleContainerProps } from '../../../../core/container/SimpleContainer';
 import { Identifiable } from '../../../../core/utils/Identifiable';
+import { SpacePrivacyMode } from '../../../../core/apollo/generated/graphql-schema';
 
 export interface ExploreSpacesContainerEntities {
   spaces: SpaceWithParent[] | undefined;
@@ -28,6 +29,11 @@ interface ParentSpace extends Identifiable {
     displayName: string;
     avatar?: Visual;
     cardBanner?: Visual;
+  };
+  settings: {
+    privacy?: {
+      mode: SpacePrivacyMode;
+    };
   };
 }
 

--- a/src/main/topLevelPages/myDashboard/ExploreSpaces/ExploreSpacesView.tsx
+++ b/src/main/topLevelPages/myDashboard/ExploreSpaces/ExploreSpacesView.tsx
@@ -12,6 +12,7 @@ import SeeMoreExpandable from '../../../../core/ui/content/SeeMoreExpandable';
 import JourneyTile from '../../../../domain/journey/common/JourneyTile/JourneyTile';
 import { ExploreSpacesViewProps } from './ExploreSpacesTypes';
 import { useColumns } from '../../../../core/ui/grid/GridContext';
+import { SpacePrivacyMode } from '../../../../core/apollo/generated/graphql-schema';
 
 const DEFAULT_ITEMS_LIMIT = 15; // 3 rows of 5 but without the welcome space
 
@@ -61,6 +62,8 @@ export const ExploreSpacesView = ({
   const onFilterChange = (filter: string) => {
     setSelectedFilter(filter);
   };
+
+  const isPrivate = (space): boolean => space?.settings.privacy?.mode === SpacePrivacyMode.Private;
 
   const renderSkeleton = (size: number) =>
     Array.from({ length: size }).map((_, index) => (
@@ -121,7 +124,13 @@ export const ExploreSpacesView = ({
           <>
             {visibleSpaces!.map(space =>
               visibleFirstWelcomeSpace && space.id === welcomeSpace?.id ? null : (
-                <JourneyTile key={space.id} journey={space} journeyTypeName="space" columns={cardColumns} />
+                <JourneyTile
+                  key={space.id}
+                  journey={space}
+                  isPrivate={isPrivate(space)}
+                  journeyTypeName="space"
+                  columns={cardColumns}
+                />
               )
             )}
             {enableLazyLoading && loader}


### PR DESCRIPTION
1. The icon is now used on Explore Spaces dashboards (unauthenticated and without memberships);
2. The styles were adjusted to reduce the focus of the Privacy state;

![image](https://github.com/user-attachments/assets/0e68f242-2bdf-4de6-a22f-c8a238a83643)
 ->
 
![image](https://github.com/user-attachments/assets/577b8c72-5204-40a5-8220-51fadd72d6b4)
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `PrivacyIcon` component for visual representation of privacy settings.
	- Enhanced `JourneyTile` to include a privacy status check for spaces.

- **Improvements**
	- Updated GraphQL schema to include new privacy settings for spaces.
	- Simplified `JourneyCard` by removing privacy-related features.

- **Bug Fixes**
	- Adjusted import paths for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->