### PR TITLE
Аdd skeleton loading indicators in the innovation library page

### DIFF
--- a/src/core/ui/card/ContributeCardSkeleton.tsx
+++ b/src/core/ui/card/ContributeCardSkeleton.tsx
@@ -1,5 +1,4 @@
 import { Skeleton } from '@mui/material';
-import React from 'react';
 import ContributeCard, { ContributeCardProps } from './ContributeCard';
 import CardHeader from './CardHeader';
 import { gutters } from '../grid/utils';

--- a/src/domain/InnovationPack/DashboardInnovationPacks/DashboardInnovationPacks.tsx
+++ b/src/domain/InnovationPack/DashboardInnovationPacks/DashboardInnovationPacks.tsx
@@ -1,24 +1,25 @@
-import React, { ReactNode, useMemo, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import { InnovationPackCardProps } from '../InnovationPackCard/InnovationPackCard';
 import { Identifiable } from '../../../core/utils/Identifiable';
 import filterFn, { ValueType } from '../../../core/utils/filtering/filterFn';
 import InnovationPacksView from './InnovationPacksView';
 import DialogWithGrid from '../../../core/ui/dialog/DialogWithGrid';
 
-interface DashboardInnovationPacksProps {
+type DashboardInnovationPacksProps = {
   headerTitle: ReactNode;
   dialogTitle: ReactNode;
   innovationPacks: (Identifiable & InnovationPackCardProps)[] | undefined;
-}
-
-const innovationPackValueGetter = (innovationPack: Identifiable & InnovationPackCardProps): ValueType => ({
-  id: innovationPack.id,
-  values: [innovationPack.displayName, ...(innovationPack.tags ?? [])],
-});
+  loading?: boolean;
+};
 
 const MAX_PACKS_WHEN_NOT_EXPANDED = 10;
 
-const DashboardInnovationPacks = ({ headerTitle, dialogTitle, innovationPacks }: DashboardInnovationPacksProps) => {
+const DashboardInnovationPacks = ({
+  loading,
+  headerTitle,
+  dialogTitle,
+  innovationPacks,
+}: DashboardInnovationPacksProps) => {
   const [filter, onFilterChange] = useState<string[]>([]);
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -38,7 +39,9 @@ const DashboardInnovationPacks = ({ headerTitle, dialogTitle, innovationPacks }:
         expanded={isDialogOpen}
         onDialogOpen={() => setIsDialogOpen(true)}
         hasMore={filteredInnovationPacks.length > MAX_PACKS_WHEN_NOT_EXPANDED}
+        loading={loading}
       />
+
       <DialogWithGrid open={isDialogOpen} onClose={() => setIsDialogOpen(false)} columns={12}>
         <InnovationPacksView
           filter={filter}
@@ -55,3 +58,10 @@ const DashboardInnovationPacks = ({ headerTitle, dialogTitle, innovationPacks }:
 };
 
 export default DashboardInnovationPacks;
+
+function innovationPackValueGetter(innovationPack: Identifiable & InnovationPackCardProps): ValueType {
+  return {
+    id: innovationPack.id,
+    values: [innovationPack.displayName, ...(innovationPack.tags ?? [])],
+  };
+}

--- a/src/domain/InnovationPack/DashboardInnovationPacks/InnovationPacksView.tsx
+++ b/src/domain/InnovationPack/DashboardInnovationPacks/InnovationPacksView.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, ReactNode } from 'react';
+import { Dispatch, ReactNode } from 'react';
 import PageContentBlockHeaderWithDialogAction from '../../../core/ui/content/PageContentBlockHeaderWithDialogAction';
 import MultipleSelect from '../../../core/ui/search/MultipleSelect';
 import InnovationPackCard, { InnovationPackCardProps } from '../InnovationPackCard/InnovationPackCard';
@@ -10,8 +10,9 @@ import ScrollableCardsLayoutContainer from '../../../core/ui/card/cardsLayout/Sc
 import { Box, Button, Theme, useMediaQuery } from '@mui/material';
 import { CONTRIBUTE_CARD_COLUMNS } from '../../../core/ui/card/ContributeCard';
 import GridItem from '../../../core/ui/grid/GridItem';
+import { Skeleton } from '@mui/material';
 
-interface InnovationPacksViewProps {
+interface InnovationPacksViewProps extends PageContentBlockProps {
   filter: string[];
   headerTitle: ReactNode;
   innovationPacks: (Identifiable & InnovationPackCardProps)[] | undefined;
@@ -20,6 +21,7 @@ interface InnovationPacksViewProps {
   onDialogOpen?: () => void;
   onDialogClose?: () => void;
   hasMore?: boolean;
+  loading?: boolean;
 }
 
 const InnovationPacksView = ({
@@ -31,8 +33,9 @@ const InnovationPacksView = ({
   onDialogOpen,
   onDialogClose,
   hasMore = false,
+  loading,
   ...props
-}: InnovationPacksViewProps & PageContentBlockProps) => {
+}: InnovationPacksViewProps) => {
   const { t } = useTranslation();
   const isMobile = useMediaQuery<Theme>(theme => theme.breakpoints.down('sm'));
 
@@ -45,29 +48,39 @@ const InnovationPacksView = ({
         expanded={expanded}
         actions={<MultipleSelect onChange={onFilterChange} value={filter} minLength={2} size="xsmall" inlineTerms />}
       />
-      {innovationPacks && (
-        <ScrollableCardsLayoutContainer minHeight={0} orientation={expanded ? 'vertical' : undefined} sameHeight>
-          {innovationPacks.map(({ id, ...cardProps }) => (
-            <InnovationPackCard key={id} {...cardProps} />
-          ))}
-          {isMobile && hasMore && (
-            <GridItem columns={CONTRIBUTE_CARD_COLUMNS}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirections: 'column',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                }}
-              >
-                <Button variant="contained" onClick={onDialogOpen}>
-                  {t('common.show-all')}
-                </Button>
-              </Box>
-            </GridItem>
-          )}
-        </ScrollableCardsLayoutContainer>
-      )}
+
+      <ScrollableCardsLayoutContainer minHeight={0} orientation={expanded ? 'vertical' : undefined} sameHeight>
+        {loading
+          ? Array.from({ length: 5 }).map((_, idx) => (
+              <Skeleton
+                key={idx}
+                width={240}
+                height={300}
+                animation="pulse"
+                variant="rectangular"
+                sx={{ borderRadius: 1 }}
+              />
+            ))
+          : innovationPacks?.map(({ id, ...cardProps }) => <InnovationPackCard key={id} {...cardProps} />)}
+
+        {isMobile && hasMore && (
+          <GridItem columns={CONTRIBUTE_CARD_COLUMNS}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirections: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <Button variant="contained" onClick={onDialogOpen}>
+                {t('common.show-all')}
+              </Button>
+            </Box>
+          </GridItem>
+        )}
+      </ScrollableCardsLayoutContainer>
+
       {!isMobile && hasMore && <SeeMore subject={t('common.innovation-packs')} onClick={onDialogOpen} />}
     </PageContentBlock>
   );

--- a/src/domain/InnovationPack/DashboardLibraryTemplates/DashboardLibraryTemplates.tsx
+++ b/src/domain/InnovationPack/DashboardLibraryTemplates/DashboardLibraryTemplates.tsx
@@ -6,11 +6,12 @@ import PreviewTemplateDialog from '../../templates/components/Dialogs/PreviewTem
 import LibraryTemplatesView, { LibraryTemplatesFilter } from './LibraryTemplatesView';
 import { AnyTemplate, AnyTemplateWithInnovationPack } from '../../templates/models/TemplateBase';
 
-interface DashboardLibraryTemplatesProps {
+type DashboardLibraryTemplatesProps = {
   headerTitle: ReactNode;
   dialogTitle: ReactNode;
   templates: AnyTemplateWithInnovationPack[] | undefined;
-}
+  loading?: boolean;
+};
 
 const templatesValueGetter = (template: AnyTemplateWithInnovationPack): ValueType => ({
   id: template.template.id,
@@ -24,7 +25,12 @@ const templatesValueGetter = (template: AnyTemplateWithInnovationPack): ValueTyp
 
 const MAX_TEMPLATES_WHEN_NOT_EXPANDED = 10;
 
-const DashboardLibraryTemplates = ({ headerTitle, dialogTitle, templates }: DashboardLibraryTemplatesProps) => {
+const DashboardLibraryTemplates = ({
+  loading,
+  templates,
+  headerTitle,
+  dialogTitle,
+}: DashboardLibraryTemplatesProps) => {
   const [filter, onFilterChange] = useState<LibraryTemplatesFilter>({
     templateTypes: [],
     searchTerms: [],
@@ -64,6 +70,7 @@ const DashboardLibraryTemplates = ({ headerTitle, dialogTitle, templates }: Dash
           setSelectedTemplate(template);
         }}
         hasMore={filteredLibraryTemplates.length > MAX_TEMPLATES_WHEN_NOT_EXPANDED}
+        loading={loading}
       />
       <DialogWithGrid open={isDialogOpen} onClose={() => setIsDialogOpen(false)} columns={12}>
         <LibraryTemplatesView

--- a/src/domain/InnovationPack/DashboardLibraryTemplates/LibraryTemplatesView.tsx
+++ b/src/domain/InnovationPack/DashboardLibraryTemplates/LibraryTemplatesView.tsx
@@ -1,5 +1,5 @@
-import React, { Dispatch, ReactNode } from 'react';
-import { Box, Button, Theme, useMediaQuery } from '@mui/material';
+import { Dispatch, ReactNode } from 'react';
+import { Box, Theme, Button, Skeleton, useMediaQuery } from '@mui/material';
 import PageContentBlockHeaderWithDialogAction from '../../../core/ui/content/PageContentBlockHeaderWithDialogAction';
 import MultipleSelect from '../../../core/ui/search/MultipleSelect';
 import PageContentBlock, { PageContentBlockProps } from '../../../core/ui/content/PageContentBlock';
@@ -19,7 +19,7 @@ export interface LibraryTemplatesFilter {
   searchTerms: string[];
 }
 
-interface LibraryTemplatesViewProps {
+type LibraryTemplatesViewProps = {
   filter: LibraryTemplatesFilter;
   headerTitle: ReactNode;
   templates: AnyTemplateWithInnovationPack[] | undefined;
@@ -29,7 +29,8 @@ interface LibraryTemplatesViewProps {
   onDialogOpen?: () => void;
   onDialogClose?: () => void;
   hasMore?: boolean;
-}
+  loading?: boolean;
+};
 
 const LibraryTemplatesView = ({
   headerTitle,
@@ -41,6 +42,7 @@ const LibraryTemplatesView = ({
   onDialogClose,
   onClick,
   hasMore = false,
+  loading,
   ...props
 }: Omit<PageContentBlockProps, 'onClick'> & LibraryTemplatesViewProps) => {
   const { t } = useTranslation();
@@ -85,34 +87,46 @@ const LibraryTemplatesView = ({
           inlineTerms
         />
       </Box>
-      {templates && (
-        <ScrollableCardsLayoutContainer minHeight={0} orientation={expanded ? 'vertical' : undefined} sameHeight>
-          {templates.map(({ template, innovationPack }) => (
-            <TemplateCard
-              key={template.id}
-              template={template}
-              innovationPack={innovationPack}
-              onClick={() => onClick(template)}
-            />
-          ))}
-          {isMobile && hasMore && (
-            <GridItem columns={CONTRIBUTE_CARD_COLUMNS}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirections: 'column',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                }}
-              >
-                <Button variant="contained" onClick={onDialogOpen}>
-                  {t('common.show-all')}
-                </Button>
-              </Box>
-            </GridItem>
-          )}
-        </ScrollableCardsLayoutContainer>
-      )}
+
+      <ScrollableCardsLayoutContainer minHeight={0} orientation={expanded ? 'vertical' : undefined} sameHeight>
+        {loading
+          ? Array.from({ length: 5 }).map((_, idx) => (
+              <Skeleton
+                key={idx}
+                width={248}
+                height={262}
+                animation="pulse"
+                variant="rectangular"
+                sx={{ borderRadius: 1 }}
+              />
+            ))
+          : templates?.map(({ template, innovationPack }) => (
+              <TemplateCard
+                key={template.id}
+                template={template}
+                innovationPack={innovationPack}
+                onClick={() => onClick(template)}
+              />
+            ))}
+
+        {isMobile && hasMore && (
+          <GridItem columns={CONTRIBUTE_CARD_COLUMNS}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirections: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <Button variant="contained" onClick={onDialogOpen}>
+                {t('common.show-all')}
+              </Button>
+            </Box>
+          </GridItem>
+        )}
+      </ScrollableCardsLayoutContainer>
+
       {!isMobile && hasMore && <SeeMore subject={t('common.templates')} onClick={onDialogOpen} />}
     </PageContentBlock>
   );

--- a/src/main/topLevelPages/InnovationLibraryPage/InnovationLibraryPage.tsx
+++ b/src/main/topLevelPages/InnovationLibraryPage/InnovationLibraryPage.tsx
@@ -14,7 +14,9 @@ import BreadcrumbsItem from '../../../core/ui/navigation/BreadcrumbsItem';
 import TopLevelPageBreadcrumbs from '../topLevelPageBreadcrumbs/TopLevelPageBreadcrumbs';
 
 const InnovationLibraryPage = () => {
-  const { data: innovationLibraryData } = useInnovationLibraryQuery();
+  const { data: innovationLibraryData, loading: innovationLibraryLoading } = useInnovationLibraryQuery({
+    fetchPolicy: 'network-only',
+  });
 
   const innovationPacks = useInnovationPackCardProps(innovationLibraryData?.platform.library.innovationPacks);
   const templates = innovationLibraryData?.platform.library.templates;
@@ -44,11 +46,14 @@ const InnovationLibraryPage = () => {
           headerTitle={t('pages.innovationLibrary.innovationPacks.headerTitle')}
           dialogTitle={t('pages.innovationLibrary.innovationPacks.dialogTitle')}
           innovationPacks={innovationPacks}
+          loading={innovationLibraryLoading}
         />
+
         <DashboardLibraryTemplates
           headerTitle={t('pages.innovationLibrary.libraryTemplates.headerTitle')}
           dialogTitle={t('pages.innovationLibrary.libraryTemplates.dialogTitle')}
           templates={templates}
+          loading={innovationLibraryLoading}
         />
       </PageContentColumn>
     </TopLevelPageLayout>


### PR DESCRIPTION
- Аdd skeleton loading indicators in the innovation library page
- Fetch innovation packs on page visit rather than using just the cached data - this fixes the problem where the user creates a new innovation flow -> goes to the innovation library page -> not seeing the new pack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced loading state management across multiple components, enhancing user experience during data fetching.
  - Added loading indicators using skeleton components in `InnovationPacksView` and `LibraryTemplatesView`.

- **Bug Fixes**
  - Improved organization and clarity in component structure without altering existing functionalities.

- **Documentation**
  - Updated prop interfaces to include optional loading properties for better state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->