### PR TITLE
BUGFix: Template Mappings bugs

### DIFF
--- a/src/domain/templates/components/Forms/common/mappings.ts
+++ b/src/domain/templates/components/Forms/common/mappings.ts
@@ -249,7 +249,7 @@ export const toCreateTemplateFromCollaborationMutationVariables = (
         description: ref.description,
       })),
     },
-    tags: values.profile.tagsets?.[0]?.tags ?? [],
+    tags: handleCreateTags(values),
   };
   return result;
 };

--- a/src/domain/templates/components/Forms/common/mappings.ts
+++ b/src/domain/templates/components/Forms/common/mappings.ts
@@ -191,8 +191,8 @@ export const toCreateTemplateMutationVariables = (
           break;
         }
         case CalloutType.WhiteboardCollection: {
-          delete calloutTemplateData.callout.framing.whiteboard;
-          delete calloutTemplateData.callout.contributionDefaults?.postDescription;
+          delete callout.framing.whiteboard;
+          delete callout.contributionDefaults?.postDescription;
           break;
         }
       }


### PR DESCRIPTION
#7147 Importing subspace template to space, doesn't import tags - Just a wrong mapping of the tags
#7259 Importing WB collections templates from an innovationPack into Space Templates was not working - Wrongly deleting a property of an object that couldn't be deleted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved tag handling in the template creation process to enhance maintainability.
	- Adjusted handling of whiteboard and contribution defaults for better data management.
	- Preserved error handling for missing collaboration IDs to ensure consistent functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->