### PR TITLE
VC invite button in community's VC block

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -610,7 +610,8 @@
       },
       "inviteExternalVC": "Invite External VC",
       "externalVCsInfo": "At the moment, only Alkemio Support can add an external Virtual Contributor to your Space. Please contact Support <click>here</click> if you wish to do so, we are happy to help!",
-      "searchVC": "Find Virtual Contributor"
+      "searchVC": "Find Virtual Contributor",
+      "inviteBtn": "Invite Virtual Contributor"
     },
     "application-form": {
       "title": "Application Form",
@@ -2115,9 +2116,6 @@
             "subtitle": "The order below is the order in which the Spaces will be visible on the Custom Homepage"
           }
         }
-      },
-      "virtualContributors": {
-        "title": "Virtual Contributors"
       }
     },
     "feedback": {

--- a/src/domain/community/community/VirtualContributorsBlock/VirtualContributorsBlock.tsx
+++ b/src/domain/community/community/VirtualContributorsBlock/VirtualContributorsBlock.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ListItemButton, ListItemButtonProps, ListItemButtonTypeMap } from '@mui/material';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
 import PageContentBlockHeader from '@/core/ui/content/PageContentBlockHeader';
 import SeeMore from '@/core/ui/content/SeeMore';
@@ -8,18 +7,28 @@ import Loading from '@/core/ui/loading/Loading';
 import BadgeCardView from '@/core/ui/list/BadgeCardView';
 import Avatar from '@/core/ui/avatar/Avatar';
 import { BlockSectionTitle } from '@/core/ui/typography';
-import RouterLink, { RouterLinkProps } from '@/core/ui/link/RouterLink';
+import RouterLink from '@/core/ui/link/RouterLink';
 import VirtualContributorsDialog, { VirtualContributorProps } from './VirtualContributorsDialog';
 import VCIcon from '@/domain/community/virtualContributor/VirtualContributorsIcons';
+import Gutters from '@/core/ui/grid/Gutters';
+import { DashboardAddButton } from '@/domain/shared/components/DashboardSections/DashboardAddButton';
+import { noop } from 'lodash';
 
 export const VIRTUAL_CONTRIBUTORS_LIMIT = 3;
 
 type VirtualContributorsBlockProps = {
   virtualContributors: VirtualContributorProps[];
   loading: boolean;
+  showInviteOption?: boolean;
+  onInviteClick?: () => void;
 };
 
-const VirtualContributorsBlock = ({ virtualContributors, loading }: VirtualContributorsBlockProps) => {
+const VirtualContributorsBlock = ({
+  virtualContributors,
+  loading,
+  showInviteOption = false,
+  onInviteClick = noop,
+}: VirtualContributorsBlockProps) => {
   const { t } = useTranslation();
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -28,24 +37,32 @@ const VirtualContributorsBlock = ({ virtualContributors, loading }: VirtualContr
 
   const visibleVCs = virtualContributors.slice(0, VIRTUAL_CONTRIBUTORS_LIMIT);
 
-  const Wrapper = <D extends React.ElementType = ListItemButtonTypeMap['defaultComponent'], P = {}>(
-    props: ListItemButtonProps<D, P> & RouterLinkProps
-  ) => <ListItemButton component={RouterLink} {...props} />;
-
   return (
     <PageContentBlock>
-      <PageContentBlockHeader title={t('pages.admin.virtualContributors.title')} icon={<VCIcon />} />
+      <PageContentBlockHeader title={t('pages.contributors.virtualContributors.title')} icon={<VCIcon />} />
       {loading && <Loading />}
-      {visibleVCs?.map(vc => (
-        <BadgeCardView
-          variant="rounded"
-          visual={<Avatar src={vc.profile.avatar?.uri} alt={t('common.avatar-of', { user: vc.profile.displayName })} />}
-          component={Wrapper}
-          to={vc.profile.url}
-        >
-          <BlockSectionTitle>{vc.profile.displayName}</BlockSectionTitle>
-        </BadgeCardView>
-      ))}
+      <Gutters disablePadding>
+        {showInviteOption && (
+          <DashboardAddButton
+            sx={{ padding: 0, textAlign: 'left' }}
+            translationKey="community.virtualContributors.inviteBtn"
+            onClick={onInviteClick}
+          />
+        )}
+        {visibleVCs?.map(vc => (
+          <BadgeCardView
+            key={vc.profile.displayName}
+            variant="rounded"
+            visual={
+              <Avatar src={vc.profile.avatar?.uri} alt={t('common.avatar-of', { user: vc.profile.displayName })} />
+            }
+            component={RouterLink}
+            to={vc.profile.url}
+          >
+            <BlockSectionTitle>{vc.profile.displayName}</BlockSectionTitle>
+          </BadgeCardView>
+        ))}
+      </Gutters>
       {virtualContributors.length > VIRTUAL_CONTRIBUTORS_LIMIT && (
         <SeeMore label="buttons.see-more" onClick={openDialog} />
       )}

--- a/src/domain/community/community/VirtualContributorsBlock/VirtualContributorsDialog.tsx
+++ b/src/domain/community/community/VirtualContributorsBlock/VirtualContributorsDialog.tsx
@@ -51,7 +51,7 @@ const VirtualContributorsDialog = ({ open, onClose, virtualContributors }: Virtu
 
   return (
     <DialogWithGrid open={open} onClose={onClose} columns={6}>
-      <DialogHeader onClose={onClose} title={t('pages.admin.virtualContributors.title')} icon={<VCIcon />} />
+      <DialogHeader onClose={onClose} title={t('pages.contributors.virtualContributors.title')} icon={<VCIcon />} />
       <SearchField
         value={filter}
         onChange={event => setFilter(event.target.value)}

--- a/src/domain/journey/common/AboutPageContainer/AboutPageContainer.tsx
+++ b/src/domain/journey/common/AboutPageContainer/AboutPageContainer.tsx
@@ -43,6 +43,7 @@ export interface AboutPageContainerEntities {
   references: ReferenceDetailsFragment[] | undefined;
   virtualContributors?: VirtualContributorProps[];
   hasReadPrivilege?: boolean;
+  hasInvitePrivilege?: boolean;
 }
 
 export interface AboutPageContainerActions {}
@@ -92,6 +93,10 @@ const AboutPageContainer = ({ journeyId, children }: PropsWithChildren<AboutPage
   );
   const hasReadPrivilege = membersData?.lookup.space?.authorization?.myPrivileges?.includes(
     AuthorizationPrivilege.Read
+  );
+
+  const hasInvitePrivilege = membersData?.lookup.space?.community?.roleSet.authorization?.myPrivileges?.includes(
+    AuthorizationPrivilege.CommunityInvite
   );
 
   const context = nonMemberContext;
@@ -155,6 +160,7 @@ const AboutPageContainer = ({ journeyId, children }: PropsWithChildren<AboutPage
           references,
           virtualContributors,
           hasReadPrivilege,
+          hasInvitePrivilege,
           ...contributors,
         },
         { loading, error },

--- a/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
+++ b/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
@@ -59,6 +59,7 @@ export interface JourneyAboutDialogProps extends EntityDashboardLeads {
   shareUrl?: string;
   virtualContributors?: VirtualContributorProps[];
   hasReadPrivilege?: boolean;
+  hasInvitePrivilege?: boolean;
 }
 
 interface DialogHeaderItemProps extends BoxProps {
@@ -109,6 +110,7 @@ const JourneyAboutDialog = ({
   shareUrl,
   virtualContributors,
   hasReadPrivilege,
+  hasInvitePrivilege,
 }: JourneyAboutDialogProps) => {
   const { t } = useTranslation();
 
@@ -289,7 +291,11 @@ const JourneyAboutDialog = ({
             </PageContentBlockSeamless>
             {leftColumnChildrenBottom}
             {hasReadPrivilege && virtualContributors && virtualContributors?.length > 0 && (
-              <VirtualContributorsBlock virtualContributors={virtualContributors} loading={loading} />
+              <VirtualContributorsBlock
+                virtualContributors={virtualContributors}
+                loading={loading}
+                showInviteOption={hasInvitePrivilege}
+              />
             )}
           </PageContentColumn>
         </Gutters>

--- a/src/domain/journey/dashboardNavigation/DashboardNavigationItemView.tsx
+++ b/src/domain/journey/dashboardNavigation/DashboardNavigationItemView.tsx
@@ -9,8 +9,8 @@ import RouterLink from '@/core/ui/link/RouterLink';
 import { getIndentStyle } from './utils';
 import { DashboardNavigationItem } from '../space/spaceDashboardNavigation/useSpaceDashboardNavigation';
 import { Identifiable } from '@/core/utils/Identifiable';
-import DashboardNavigationAddSubspace from './DashboardNavigationAddSubspace';
 import { last } from 'lodash';
+import { DashboardAddButton } from '@/domain/shared/components/DashboardSections/DashboardAddButton';
 
 export interface DashboardNavigationItemViewProps extends DashboardNavigationItem {
   tooltipPlacement?: TooltipProps['placement'];
@@ -191,9 +191,7 @@ const DashboardNavigationItemView = forwardRef<DashboardNavigationItemViewApi, D
             onExited={() => onToggle?.(isExpanded)}
           >
             <Box ref={childrenContainerRef}>
-              {hasCreateButton && (
-                <DashboardNavigationAddSubspace level={level + 1} onClick={() => onCreateSubspace?.({ id })} />
-              )}
+              {hasCreateButton && <DashboardAddButton level={level + 1} onClick={() => onCreateSubspace?.({ id })} />}
               {children?.map(child => (
                 <DashboardNavigationItemView
                   key={child.id}

--- a/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPage.tsx
+++ b/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPage.tsx
@@ -82,6 +82,10 @@ const SpaceCommunityPage = () => {
       ) ?? [];
   }
 
+  const hasInvitePrivilege = data?.space.community?.roleSet.authorization?.myPrivileges?.includes(
+    AuthorizationPrivilege.CommunityInvite
+  );
+
   return (
     <SpacePageLayout journeyPath={journeyPath} currentSection={EntityPageSection.Community}>
       <SpaceCommunityContainer collaborationId={collaborationId}>
@@ -105,7 +109,14 @@ const SpaceCommunityPage = () => {
                 messageReceivers={messageReceivers}
               />
               {hasReadPrivilege && virtualContributors?.length > 0 && (
-                <VirtualContributorsBlock virtualContributors={virtualContributors} loading={loading} />
+                <VirtualContributorsBlock
+                  virtualContributors={virtualContributors}
+                  loading={loading}
+                  showInviteOption={hasInvitePrivilege}
+                  onInviteClick={() => {
+                    console.log('TODO: impl w #7256');
+                  }}
+                />
               )}
               <CommunityGuidelinesBlock communityId={communityId} journeyUrl={data?.space.profile.url} />
             </InfoColumn>

--- a/src/domain/journey/subspace/dialogs/ContributorsToggleDialog.tsx
+++ b/src/domain/journey/subspace/dialogs/ContributorsToggleDialog.tsx
@@ -69,7 +69,7 @@ const ContributorsToggleDialog = ({ open = false, journeyId, onClose }: Contribu
             />
             {virtualContributors && virtualContributors?.length > 0 && (
               <>
-                <BlockTitle>{t('pages.admin.virtualContributors.title')}</BlockTitle>
+                <BlockTitle>{t('pages.contributors.virtualContributors.title')}</BlockTitle>
                 <CommunityVirtualContributorsBlockWide virtualContributors={virtualContributors} />
               </>
             )}

--- a/src/domain/journey/subspace/pages/SubspaceAboutPage.tsx
+++ b/src/domain/journey/subspace/pages/SubspaceAboutPage.tsx
@@ -45,6 +45,7 @@ const SubspaceAboutPage = () => {
             memberOrganizationsCount,
             virtualContributors,
             hasReadPrivilege,
+            hasInvitePrivilege,
           },
           state
         ) => (
@@ -85,6 +86,7 @@ const SubspaceAboutPage = () => {
             }
             virtualContributors={virtualContributors}
             hasReadPrivilege={hasReadPrivilege}
+            hasInvitePrivilege={hasInvitePrivilege}
           />
         )}
       </AboutPageContainer>

--- a/src/domain/shared/components/DashboardSections/DashboardAddButton.tsx
+++ b/src/domain/shared/components/DashboardSections/DashboardAddButton.tsx
@@ -35,7 +35,7 @@ export const DashboardAddButton = ({ url, level = 0, onClick, translationKey, sx
       sx={{ ...getIndentStyle(level), ...sx }}
     >
       <CaptionSmall>
-        {Boolean(translationKey)
+        {translationKey
           ? t(translationKey as TranslationKey)
           : t('buttons.addSubject', { subject: t('common.subspace') })}
       </CaptionSmall>

--- a/src/domain/shared/components/DashboardSections/DashboardAddButton.tsx
+++ b/src/domain/shared/components/DashboardSections/DashboardAddButton.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from 'react-i18next';
 import { CaptionSmall } from '@/core/ui/typography';
 import { getIndentStyle } from '../../../journey/dashboardNavigation/utils';
 import { ButtonBase, SxProps, Theme } from '@mui/material';
-import TranslationKey from '@/core/i18n/utils/TranslationKey';
 
 interface DashboardAddButtonProps {
   url?: string;
@@ -36,7 +35,7 @@ export const DashboardAddButton = ({ url, level = 0, onClick, translationKey, sx
     >
       <CaptionSmall>
         {translationKey
-          ? t(translationKey as TranslationKey)
+          ? t(translationKey, { defaultValue: t('common.add') })
           : t('buttons.addSubject', { subject: t('common.subspace') })}
       </CaptionSmall>
     </BadgeCardView>

--- a/src/domain/shared/components/DashboardSections/DashboardAddButton.tsx
+++ b/src/domain/shared/components/DashboardSections/DashboardAddButton.tsx
@@ -5,17 +5,20 @@ import Avatar from '@/core/ui/avatar/Avatar';
 import { AddCircleOutlineOutlined } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import { CaptionSmall } from '@/core/ui/typography';
-import { getIndentStyle } from './utils';
-import { ButtonBase } from '@mui/material';
+import { getIndentStyle } from '../../../journey/dashboardNavigation/utils';
+import { ButtonBase, SxProps, Theme } from '@mui/material';
+import TranslationKey from '@/core/i18n/utils/TranslationKey';
 
-interface DashboardNavigationAddSubspaceProps {
+interface DashboardAddButtonProps {
   url?: string;
   onClick?: MouseEventHandler;
   level?: number;
   compact?: boolean;
+  translationKey?: TranslationKey;
+  sx?: SxProps<Theme>;
 }
 
-const DashboardNavigationAddSubspace = ({ url, level = 0, onClick }: DashboardNavigationAddSubspaceProps) => {
+export const DashboardAddButton = ({ url, level = 0, onClick, translationKey, sx }: DashboardAddButtonProps) => {
   const { t } = useTranslation();
 
   return (
@@ -28,13 +31,14 @@ const DashboardNavigationAddSubspace = ({ url, level = 0, onClick }: DashboardNa
           <AddCircleOutlineOutlined />
         </Avatar>
       }
-      padding
       square
-      sx={getIndentStyle(level)}
+      sx={{ ...getIndentStyle(level), ...sx }}
     >
-      <CaptionSmall>{t('buttons.addSubject', { subject: t('common.subspace') })}</CaptionSmall>
+      <CaptionSmall>
+        {Boolean(translationKey)
+          ? t(translationKey as TranslationKey)
+          : t('buttons.addSubject', { subject: t('common.subspace') })}
+      </CaptionSmall>
     </BadgeCardView>
   );
 };
-
-export default DashboardNavigationAddSubspace;

--- a/src/domain/shared/components/DashboardSections/DashboardAddButton.tsx
+++ b/src/domain/shared/components/DashboardSections/DashboardAddButton.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { CaptionSmall } from '@/core/ui/typography';
 import { getIndentStyle } from '../../../journey/dashboardNavigation/utils';
 import { ButtonBase, SxProps, Theme } from '@mui/material';
+import TranslationKey from '@/core/i18n/utils/TranslationKey';
 
 interface DashboardAddButtonProps {
   url?: string;


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/6941

This is the initiation of the new VC store modal: https://github.com/alkem-io/client-web/issues/7256

In this PR:
- [x] An invite VC button on top of the Virtual Contributors Block (Community page);
- [x] The button will appear if the proper privilege is available:  AuthorizationPrivilege.CommunityInvite; Some prop drilling was required to follow the current implementation.
- [x] The add sub/space dashboard button was extended to support other dashboard add/invite options (DashboardNavigationAddSubspace - DashboardAddButton);
- [x] A redundant string in the translations was removed; 

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an invite button for virtual contributors, enhancing user engagement.
  - Introduced privilege checks for inviting users to the community across various components.

- **Improvements**
  - Updated user interface text for clarity and consistency in multiple sections.
  - Enhanced rendering logic for components to conditionally display invite options based on user privileges.

- **Component Changes**
  - Replaced the previous subspace creation button with a new dashboard add button.
  - Adjusted titles in dialogs to reflect updated localization keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->