### PR TITLE
Remove VC entitlement check for adding VC to community

### DIFF
--- a/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
+++ b/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
@@ -20,7 +20,6 @@ import {
 import {
   AuthorizationPrivilege,
   CommunityRoleType,
-  LicenseEntitlementType,
   SearchVisibility,
   SpaceLevel,
 } from '@/core/apollo/generated/graphql-schema';
@@ -29,7 +28,6 @@ import { CommunityMemberUserFragmentWithRoles } from '@/domain/community/communi
 import useInviteUsers from '@/domain/community/invitations/useInviteUsers';
 import { getJourneyTypeName } from '@/domain/journey/JourneyTypeName';
 import { Identifiable } from '@/core/utils/Identifiable';
-import { useUserContext } from '@/domain/community/user';
 
 const MAX_AVAILABLE_MEMBERS = 100;
 const buildUserFilterObject = (filter: string | undefined) =>
@@ -89,13 +87,6 @@ const useRoleSetAdmin = ({ roleSetId, spaceId, challengeId, opportunityId, space
   const leadRoleDefinition = roleSet?.leadRoleDefinition;
   const roleSetMyPrivileges = roleSet?.authorization?.myPrivileges ?? [];
 
-  const { accountEntitlements } = useUserContext();
-
-  const entitlements = {
-    virtualContributorsEnabled: accountEntitlements.some(
-      priv => priv === LicenseEntitlementType.AccountVirtualContributor
-    ),
-  };
   const permissions = {
     canAddMembers: roleSetMyPrivileges.some(priv => priv === AuthorizationPrivilege.CommunityAddMember),
     // the following privilege allows Admins of a space without CommunityAddMember privilege, to
@@ -512,7 +503,6 @@ const useRoleSetAdmin = ({ roleSetId, spaceId, challengeId, opportunityId, space
     memberRoleDefinition,
     leadRoleDefinition,
     permissions,
-    entitlements,
     applications: roleSetPending?.applications,
     invitations: roleSetPending?.invitations,
     platformInvitations: roleSetPending?.platformInvitations,

--- a/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
+++ b/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
@@ -25,7 +25,6 @@ const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '.
     memberRoleDefinition,
     leadRoleDefinition,
     permissions,
-    entitlements,
     onUserLeadChange,
     onUserAuthorizationChange,
     onOrganizationLeadChange,
@@ -81,7 +80,7 @@ const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '.
             />
           </PageContentBlock>
         </PageContentColumn>
-        {entitlements.virtualContributorsEnabled && (
+        {
           <PageContentColumn columns={6}>
             <PageContentBlock>
               <CommunityVirtualContributors
@@ -98,7 +97,7 @@ const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '.
               />
             </PageContentBlock>
           </PageContentColumn>
-        )}
+        }
       </PageContent>
     </SubspaceSettingsLayout>
   );

--- a/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
+++ b/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
@@ -49,7 +49,6 @@ const AdminSpaceCommunityPage = ({ routePrefix = '../' }: SettingsPageProps) => 
     memberRoleDefinition,
     leadRoleDefinition,
     permissions,
-    entitlements,
     onApplicationStateChange,
     onInvitationStateChange,
     onDeleteInvitation,
@@ -263,7 +262,7 @@ const AdminSpaceCommunityPage = ({ routePrefix = '../' }: SettingsPageProps) => 
             />
           </PageContentBlock>
         </PageContentColumn>
-        {entitlements.virtualContributorsEnabled && (
+        {
           <PageContentColumn columns={6}>
             <PageContentBlock>
               <CommunityVirtualContributors
@@ -281,7 +280,7 @@ const AdminSpaceCommunityPage = ({ routePrefix = '../' }: SettingsPageProps) => 
               />
             </PageContentBlock>
           </PageContentColumn>
-        )}
+        }
       </PageContent>
     </SpaceSettingsLayout>
   );

--- a/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
+++ b/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
@@ -52,7 +52,6 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
     memberRoleDefinition,
     leadRoleDefinition,
     permissions,
-    entitlements,
     onApplicationStateChange,
     onInvitationStateChange,
     onDeleteInvitation,
@@ -203,7 +202,7 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
             />
           </PageContentBlock>
         </PageContentColumn>
-        {entitlements.virtualContributorsEnabled && (
+        {
           <PageContentColumn columns={6}>
             <PageContentBlock>
               <CommunityVirtualContributors
@@ -220,7 +219,7 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
               />
             </PageContentBlock>
           </PageContentColumn>
-        )}
+        }
       </PageContent>
     </SubspaceSettingsLayout>
   );


### PR DESCRIPTION
- removed check of entitlements for adding VCs to community
- this is error prone, as the `isAvailable` field on the entitlement is checked, and that returns `false` when we run out of slots
- regardless, the check is on the `User` `Account` and that may be wrong, because the VC may be coming from `Org` `Account` - so that requires discussion...