### PR TITLE
Fix #7316 Create template permission

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -2137,6 +2137,16 @@ export const SpaceInfoFragmentDoc = gql`
         myPrivileges
       }
     }
+    templatesManager {
+      id
+      templatesSet {
+        id
+        authorization {
+          id
+          myPrivileges
+        }
+      }
+    }
     visibility
   }
   ${SpaceDetailsFragmentDoc}

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -21086,6 +21086,25 @@ export type SpaceProviderQuery = {
         | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
         | undefined;
     };
+    templatesManager?:
+      | {
+          __typename?: 'TemplatesManager';
+          id: string;
+          templatesSet?:
+            | {
+                __typename?: 'TemplatesSet';
+                id: string;
+                authorization?:
+                  | {
+                      __typename?: 'Authorization';
+                      id: string;
+                      myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+        }
+      | undefined;
     profile: {
       __typename?: 'Profile';
       id: string;
@@ -21187,6 +21206,21 @@ export type SpaceInfoFragment = {
       | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
       | undefined;
   };
+  templatesManager?:
+    | {
+        __typename?: 'TemplatesManager';
+        id: string;
+        templatesSet?:
+          | {
+              __typename?: 'TemplatesSet';
+              id: string;
+              authorization?:
+                | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            }
+          | undefined;
+      }
+    | undefined;
   profile: {
     __typename?: 'Profile';
     id: string;

--- a/src/domain/journey/space/SpaceContext/SpaceContext.tsx
+++ b/src/domain/journey/space/SpaceContext/SpaceContext.tsx
@@ -17,6 +17,7 @@ export interface SpacePermissions {
   canReadPosts: boolean;
   canReadSubspaces: boolean;
   canCreateSubspaces: boolean;
+  canCreateTemplates: boolean;
   canCreate: boolean;
   communityReadAccess: boolean;
   canReadCollaboration: boolean;
@@ -55,6 +56,7 @@ const SpaceContext = React.createContext<SpaceContextProps>({
     viewerCanUpdate: false,
     canCreate: false,
     canCreateSubspaces: false,
+    canCreateTemplates: false,
     canReadPosts: false,
     canReadSubspaces: false,
     communityReadAccess: false,
@@ -109,6 +111,9 @@ const SpaceContextProvider: FC<SpaceProviderProps> = ({ children }) => {
 
   const canReadSubspaces = spacePrivileges.includes(AuthorizationPrivilege.Read);
   const canCreateSubspaces = spacePrivileges.includes(AuthorizationPrivilege.CreateSubspace);
+  const canCreateTemplates =
+    data?.space.templatesManager?.templatesSet?.authorization?.myPrivileges?.includes(AuthorizationPrivilege.Create) ??
+    false;
   const canCreate = spacePrivileges.includes(AuthorizationPrivilege.Create);
 
   const communityPrivileges = space?.community?.authorization?.myPrivileges ?? NO_PRIVILEGES;
@@ -119,6 +124,7 @@ const SpaceContextProvider: FC<SpaceProviderProps> = ({ children }) => {
       viewerCanUpdate: spacePrivileges.includes(AuthorizationPrivilege.Update),
       canReadSubspaces,
       canCreateSubspaces: canCreateSubspaces,
+      canCreateTemplates,
       canCreate,
       communityReadAccess: communityPrivileges.includes(AuthorizationPrivilege.Read),
       canReadCollaboration: collaborationPrivileges.includes(AuthorizationPrivilege.Read),

--- a/src/domain/journey/space/SpaceContext/spaceProvider.graphql
+++ b/src/domain/journey/space/SpaceContext/spaceProvider.graphql
@@ -46,6 +46,16 @@ fragment SpaceInfo on Space {
       myPrivileges
     }
   }
+  templatesManager {
+    id
+    templatesSet{
+      id
+      authorization {
+        id
+        myPrivileges
+      }
+    }
+  }
 
   visibility
 }


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new permission property `canCreateTemplates` for enhanced space management.
	- Updated the GraphQL schema to include a `templatesManager` field in the `SpaceInfo` fragment for improved templates management data.

- **Bug Fixes**
	- Adjusted logic for determining the `canSaveAsTemplate` property to improve accuracy in permissions handling.

- **Documentation**
	- Added comments to clarify the behavior related to saving templates and future considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->