### PR TITLE
Fix Tutorials Iframes

### DIFF
--- a/src/core/ui/markdown/embed/remarkVerifyIframe.ts
+++ b/src/core/ui/markdown/embed/remarkVerifyIframe.ts
@@ -23,27 +23,48 @@ const isAllowedUrl = (url: string) => {
 
 export const remarkVerifyIframe: Pluggable = () => {
   return tree => {
-    visit(tree, 'html', (node: Node) => {
-      // @ts-ignore
-      if (typeof node.value === 'string') {
-        // @ts-ignore
+    visit(tree, 'html', (node: { value: string }) => {
+      if (node && typeof node.value === 'string') {
         const nodeValue: string = node.value;
         if (nodeValue.toLowerCase().includes('<iframe')) {
-          const srcMatch = nodeValue.match(/src="([^"]*)"/i);
-          if (!srcMatch) {
-            // Iframe without src at all? just remove it
-            // @ts-ignore
-            node.value = '';
-          } else if (!isAllowedUrl(srcMatch[1])) {
-            // @ts-ignore
-            node.value = node.value.replace(/src="[^"]*"/i, 'src="about:blank"');
-          }
-        }
-        const sandboxMatch = nodeValue.match(/sandbox="([^"]*)"/i);
-        if (sandboxMatch) {
-          // We are not using sandbox attribute for now, so this may be comming from someone trying to tamper with our cookies. Remove the entire thing for now:
-          // @ts-ignore
-          node.value = '';
+          const filters = [
+            {
+              regex: /src="([^"]*)"/i,
+              action: match => {
+                if (!nodeValue.includes('src=')) {
+                  node.value = ''; // Iframe without src at all? just remove it
+                  return;
+                }
+                if (match && !isAllowedUrl(match[1])) {
+                  node.value = nodeValue.replace(/src="[^"]*"/i, 'src="about:blank"');
+                }
+              },
+            },
+            {
+              // Same as above, but for single quotes
+              regex: /src='([^']*)'/i,
+              action: match => {
+                if (!nodeValue.includes('src=')) {
+                  node.value = '';
+                  return;
+                }
+                if (match && !isAllowedUrl(match[1])) {
+                  node.value = nodeValue.replace(/src='[^']*'/i, "src='about:blank'");
+                }
+              },
+            },
+            {
+              // We are not using sandbox attribute for now,
+              // so this may be comming from someone trying to tamper with our cookies. Remove the entire thing for now:
+              regex: /sandbox/i,
+              action: match => {
+                if (match) {
+                  node.value = '';
+                }
+              },
+            },
+          ];
+          filters.forEach(filter => filter.action(nodeValue.match(filter.regex)));
         }
       }
     });


### PR DESCRIPTION
- `remarkVerifyIframe` is a filter for `WrapperMarkdown` to avoid showing iframes from unknown sources (we only allow youtube, vimeo and a couple more for now).
- The first code yesterday had 3 ifs, I've restructured it to an HTML parser which makes more sense
- Cleaned up those `@ts-ignore`s too. 

It's made to catch things like 
```
mutation {
  updateCallout(calloutData:{
    ID:"...",
    framing:{
      profile:{
        description:"Malicius <iframe SRC='https://youtube.com/embed/...' src=\"https://malicius.website.com\" title='Test' frameborder='0' loading='lazy' webkitallowfullscreen mozallowfullscreen allowfullscreen allow='clipboard-write' style='position: absolute; top: 0; left: 0; width: 100%; height: 100%;color-scheme: light;'></iframe>"
      }
    }
  }){
    id
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced iframe processing logic for improved security and handling of `src` attributes.
- **Bug Fixes**
	- Improved error handling for invalid URLs within iframes.
- **Refactor**
	- Modularized and clarified the iframe verification logic for better readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->