### PR TITLE
Add Callouts preview accordion on SubspacesList default subspace template selector

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -17767,6 +17767,23 @@ export const AdminSpaceSubspacesPageDocument = gql`
             }
             collaboration {
               id
+              callouts {
+                id
+                type
+                sortOrder
+                framing {
+                  id
+                  profile {
+                    id
+                    displayName
+                    description
+                    flowStateTagset: tagset(tagsetName: FLOW_STATE) {
+                      id
+                      tags
+                    }
+                  }
+                }
+              }
               innovationFlow {
                 id
                 profile {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -23008,6 +23008,23 @@ export type AdminSpaceSubspacesPageQuery = {
                     | {
                         __typename?: 'Collaboration';
                         id: string;
+                        callouts: Array<{
+                          __typename?: 'Callout';
+                          id: string;
+                          type: CalloutType;
+                          sortOrder: number;
+                          framing: {
+                            __typename?: 'CalloutFraming';
+                            id: string;
+                            profile: {
+                              __typename?: 'Profile';
+                              id: string;
+                              displayName: string;
+                              description: string;
+                              flowStateTagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
+                            };
+                          };
+                        }>;
                         innovationFlow: {
                           __typename?: 'InnovationFlow';
                           id: string;

--- a/src/domain/collaboration/callout/CalloutsPreview/InnovationFlowCalloutsPreview.tsx
+++ b/src/domain/collaboration/callout/CalloutsPreview/InnovationFlowCalloutsPreview.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Accordion, AccordionDetails, AccordionSummary, Box, styled } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import RoundedIcon from '@/core/ui/icon/RoundedIcon';
+import { gutters } from '@/core/ui/grid/utils';
+import { CalloutType } from '@/core/apollo/generated/graphql-schema';
+import WrapperMarkdown from '@/core/ui/markdown/WrapperMarkdown';
+import { Text, CaptionSmall } from '@/core/ui/typography';
+import { getCalloutTypeIcon } from '@/domain/collaboration/callout/calloutCard/calloutIcons';
+import WhiteboardPreview from '@/domain/collaboration/whiteboard/WhiteboardPreview/WhiteboardPreview';
+
+type CalloutPreview = {
+  id: string;
+  type: CalloutType;
+  framing: {
+    profile: {
+      displayName: string;
+      description?: string;
+      flowStateTagset?: {
+        tags: string[];
+      };
+    };
+    whiteboard?: {
+      profile: {
+        preview?: {
+          uri: string;
+        };
+      };
+    };
+  };
+  sortOrder: number;
+};
+
+export interface InnovationFlowCalloutsPreviewProps {
+  selectedState: string | undefined;
+  callouts: CalloutPreview[] | undefined;
+  loading?: boolean;
+}
+
+const StyledAccordion = styled(Accordion)(({ theme }) => ({
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.shape.borderRadius,
+  marginBottom: gutters(1)(theme),
+  boxShadow: 'none',
+}));
+
+const CalloutDescription = ({ callout }: { callout: CalloutPreview }) => {
+  const { t } = useTranslation();
+
+  switch (callout.type) {
+    case CalloutType.Whiteboard:
+    case CalloutType.WhiteboardCollection:
+      if (callout.framing.whiteboard?.profile.preview?.uri) {
+        return (
+          <WhiteboardPreview
+            whiteboard={callout.framing.whiteboard}
+            displayName={callout.framing.profile.displayName}
+          />
+        );
+      }
+      return null;
+    default:
+      return callout.framing.profile.description?.trim() ? (
+        <WrapperMarkdown>{callout.framing.profile.description}</WrapperMarkdown>
+      ) : (
+        <CaptionSmall>{t('common.noDescription')}</CaptionSmall>
+      );
+  }
+};
+
+const InnovationFlowCalloutsPreview = ({ callouts, selectedState, loading }: InnovationFlowCalloutsPreviewProps) => {
+  const [selectedCallout, setSelectedCallout] = useState<string | false>(false);
+  const handleSelectedCalloutChange = (calloutId: string) => (_event, isExpanded: boolean) =>
+    setSelectedCallout(isExpanded ? calloutId : false);
+
+  return (
+    <>
+      {!loading && callouts && (
+        <Box>
+          {callouts
+            .filter(
+              callout =>
+                selectedState &&
+                callout.framing.profile.flowStateTagset?.tags &&
+                callout.framing.profile.flowStateTagset?.tags.includes(selectedState)
+            )
+            .sort((a, b) => a.sortOrder - b.sortOrder)
+            .map(callout => {
+              return (
+                <StyledAccordion
+                  key={callout.id}
+                  expanded={selectedCallout === callout.id}
+                  onChange={handleSelectedCalloutChange(callout.id)}
+                >
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <RoundedIcon
+                      size="small"
+                      component={getCalloutTypeIcon({ type: callout.type, contributionPolicy: undefined })}
+                    />
+                    <Text marginLeft={gutters()}>{callout.framing.profile.displayName}</Text>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <CalloutDescription callout={callout} />
+                  </AccordionDetails>
+                </StyledAccordion>
+              );
+            })}
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default InnovationFlowCalloutsPreview;

--- a/src/domain/collaboration/callout/CalloutsPreview/InnovationFlowCalloutsPreview.tsx
+++ b/src/domain/collaboration/callout/CalloutsPreview/InnovationFlowCalloutsPreview.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Accordion, AccordionDetails, AccordionSummary, Box, styled } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -45,7 +45,7 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
   boxShadow: 'none',
 }));
 
-const CalloutDescription = ({ callout }: { callout: CalloutPreview }) => {
+const CalloutDescription = memo(({ callout }: { callout: CalloutPreview }) => {
   const { t } = useTranslation();
 
   switch (callout.type) {
@@ -67,7 +67,7 @@ const CalloutDescription = ({ callout }: { callout: CalloutPreview }) => {
         <CaptionSmall>{t('common.noDescription')}</CaptionSmall>
       );
   }
-};
+});
 
 const InnovationFlowCalloutsPreview = ({ callouts, selectedState, loading }: InnovationFlowCalloutsPreviewProps) => {
   const [selectedCallout, setSelectedCallout] = useState<string | false>(false);
@@ -84,15 +84,6 @@ const InnovationFlowCalloutsPreview = ({ callouts, selectedState, loading }: Inn
       )
       .sort((a, b) => a.sortOrder - b.sortOrder);
   }, [callouts, selectedState]);
-
-  const calloutDescriptions: Record<string, ReactNode> = useMemo(
-    () =>
-      visibleCallouts?.reduce(
-        (obj, callout) => ({ ...obj, [callout.id]: <CalloutDescription callout={callout} /> }),
-        {}
-      ) ?? {},
-    [visibleCallouts]
-  );
 
   return (
     <>
@@ -112,7 +103,9 @@ const InnovationFlowCalloutsPreview = ({ callouts, selectedState, loading }: Inn
                   />
                   <Text marginLeft={gutters()}>{callout.framing.profile.displayName}</Text>
                 </AccordionSummary>
-                <AccordionDetails>{selectedCallout === callout.id && calloutDescriptions[callout.id]}</AccordionDetails>
+                <AccordionDetails>
+                  {selectedCallout === callout.id && <CalloutDescription callout={callout} />}
+                </AccordionDetails>
               </StyledAccordion>
             );
           })}

--- a/src/domain/journey/space/pages/SpaceSubspaces/AdminChallengesPage.graphql
+++ b/src/domain/journey/space/pages/SpaceSubspaces/AdminChallengesPage.graphql
@@ -27,6 +27,23 @@ query AdminSpaceSubspacesPage($spaceId: UUID_NAMEID!) {
           }
           collaboration {
             id
+            callouts {
+              id
+              type
+              sortOrder
+              framing  {
+                id
+                profile {
+                  id
+                  displayName
+                  description
+                  flowStateTagset: tagset(tagsetName: FLOW_STATE) {
+                    id
+                    tags
+                  }
+                }
+              }
+            }
             innovationFlow {
               id
               profile {

--- a/src/domain/journey/space/pages/SpaceSubspaces/SubspaceListView.tsx
+++ b/src/domain/journey/space/pages/SpaceSubspaces/SubspaceListView.tsx
@@ -37,6 +37,7 @@ import { AuthorizationPrivilege, TemplateDefaultType, TemplateType } from '@/cor
 import { CollaborationTemplateFormSubmittedValues } from '@/domain/templates/components/Forms/CollaborationTemplateForm';
 import { useCreateCollaborationTemplate } from '@/domain/templates/hooks/useCreateCollaborationTemplate';
 import { useSubspaceCreation } from '@/domain/shared/utils/useSubspaceCreation/useSubspaceCreation';
+import InnovationFlowCalloutsPreview from '@/domain/collaboration/callout/CalloutsPreview/InnovationFlowCalloutsPreview';
 
 export const SubspaceListView = () => {
   const { t } = useTranslation();
@@ -226,7 +227,14 @@ export const SubspaceListView = () => {
             <InnovationFlowStates
               states={defaultSubspaceTemplate.template.collaboration?.innovationFlow.states}
               selectedState={selectedState}
-              onSelectState={state => setSelectedState(state.displayName)}
+              onSelectState={state =>
+                setSelectedState(currentState => (currentState === state.displayName ? undefined : state.displayName))
+              }
+            />
+            <InnovationFlowCalloutsPreview
+              callouts={defaultSubspaceTemplate.template.collaboration?.callouts}
+              selectedState={selectedState}
+              loading={loading}
             />
           </>
         ) : (

--- a/src/domain/templates/components/Previews/CollaborationTemplatePreview.tsx
+++ b/src/domain/templates/components/Previews/CollaborationTemplatePreview.tsx
@@ -1,40 +1,12 @@
-import { Accordion, AccordionDetails, AccordionSummary, Box, styled } from '@mui/material';
-import { FC, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { Box } from '@mui/material';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
 import Loading from '@/core/ui/loading/Loading';
 import { InnovationFlowState } from '@/domain/collaboration/InnovationFlow/InnovationFlow';
 import InnovationFlowChips from '@/domain/collaboration/InnovationFlow/InnovationFlowVisualizers/InnovationFlowChips';
-import { CalloutType } from '@/core/apollo/generated/graphql-schema';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Text, CaptionSmall } from '@/core/ui/typography';
-import { useTranslation } from 'react-i18next';
-import { getCalloutTypeIcon } from '@/domain/collaboration/callout/calloutCard/calloutIcons';
-import WrapperMarkdown from '@/core/ui/markdown/WrapperMarkdown';
-import RoundedIcon from '@/core/ui/icon/RoundedIcon';
-import { gutters } from '@/core/ui/grid/utils';
-import WhiteboardPreview from '@/domain/collaboration/whiteboard/WhiteboardPreview/WhiteboardPreview';
-
-interface CalloutPreview {
-  id: string;
-  type: CalloutType;
-  framing: {
-    profile: {
-      displayName: string;
-      description?: string;
-      flowStateTagset?: {
-        tags: string[];
-      };
-    };
-    whiteboard?: {
-      profile: {
-        preview?: {
-          uri: string;
-        };
-      };
-    };
-  };
-  sortOrder: number;
-}
+import InnovationFlowCalloutsPreview, {
+  InnovationFlowCalloutsPreviewProps,
+} from '../../../collaboration/callout/CalloutsPreview/InnovationFlowCalloutsPreview';
 
 interface CollaborationTemplatePreviewProps {
   loading?: boolean;
@@ -43,45 +15,13 @@ interface CollaborationTemplatePreviewProps {
       innovationFlow?: {
         states: InnovationFlowState[];
       };
-      callouts?: CalloutPreview[];
+      callouts?: InnovationFlowCalloutsPreviewProps['callouts'];
     };
   };
 }
 
-const StyledAccordion = styled(Accordion)(({ theme }) => ({
-  border: `1px solid ${theme.palette.divider}`,
-  borderRadius: theme.shape.borderRadius,
-  marginBottom: gutters(1)(theme),
-  boxShadow: 'none',
-}));
-
-const CalloutDescription = ({ callout }: { callout: CalloutPreview }) => {
-  const { t } = useTranslation();
-
-  switch (callout.type) {
-    case CalloutType.Whiteboard:
-    case CalloutType.WhiteboardCollection:
-      if (callout.framing.whiteboard?.profile.preview?.uri) {
-        return (
-          <WhiteboardPreview
-            whiteboard={callout.framing.whiteboard}
-            displayName={callout.framing.profile.displayName}
-          />
-        );
-      }
-      return null;
-    default:
-      return callout.framing.profile.description?.trim() ? (
-        <WrapperMarkdown>{callout.framing.profile.description}</WrapperMarkdown>
-      ) : (
-        <CaptionSmall>{t('common.noDescription')}</CaptionSmall>
-      );
-  }
-};
-
-const CollaborationTemplatePreview: FC<CollaborationTemplatePreviewProps> = ({ template, loading }) => {
+const CollaborationTemplatePreview = ({ template, loading }: CollaborationTemplatePreviewProps) => {
   const [selectedState, setSelectedState] = useState<string | undefined>(undefined);
-  const [selectedCallout, setSelectedCallout] = useState<string | false>(false);
   const templateStates = template?.collaboration?.innovationFlow?.states ?? [];
 
   useEffect(() => {
@@ -94,9 +34,6 @@ const CollaborationTemplatePreview: FC<CollaborationTemplatePreviewProps> = ({ t
       setSelectedState(templateStates[0]?.displayName);
     }
   }, [selectedState, templateStates]);
-
-  const handleSelectedCalloutChange = (calloutId: string) => (_event, isExpanded: boolean) =>
-    setSelectedCallout(isExpanded ? calloutId : false);
 
   useEffect(() => {
     if (!selectedState && templateStates.length > 0) {
@@ -118,38 +55,11 @@ const CollaborationTemplatePreview: FC<CollaborationTemplatePreviewProps> = ({ t
           onSelectState={state => setSelectedState(state.displayName)}
         />
       )}
-      {!loading && template?.collaboration?.callouts && (
-        <Box>
-          {template?.collaboration?.callouts
-            .filter(
-              callout =>
-                selectedState &&
-                callout.framing.profile.flowStateTagset?.tags &&
-                callout.framing.profile.flowStateTagset?.tags.includes(selectedState)
-            )
-            .sort((a, b) => a.sortOrder - b.sortOrder)
-            .map(callout => {
-              return (
-                <StyledAccordion
-                  key={callout.id}
-                  expanded={selectedCallout === callout.id}
-                  onChange={handleSelectedCalloutChange(callout.id)}
-                >
-                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    <RoundedIcon
-                      size="small"
-                      component={getCalloutTypeIcon({ type: callout.type, contributionPolicy: undefined })}
-                    />
-                    <Text marginLeft={gutters()}>{callout.framing.profile.displayName}</Text>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <CalloutDescription callout={callout} />
-                  </AccordionDetails>
-                </StyledAccordion>
-              );
-            })}
-        </Box>
-      )}
+      <InnovationFlowCalloutsPreview
+        callouts={template?.collaboration?.callouts}
+        selectedState={selectedState}
+        loading={loading}
+      />
     </PageContentBlock>
   );
 };


### PR DESCRIPTION
#6879

- moved the Callouts accordion from the CollaborationTemplatePreview to its own file as a component.
- Added that new component to SubspacesList

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced the `InnovationFlowCalloutsPreview` component for displaying callouts in an expandable format.
	- Enhanced the `AdminChallengesPage` GraphQL query to include detailed callout information.
	- Integrated the `InnovationFlowCalloutsPreview` component into the `SubspaceListView` for improved callout visualization.

- **Bug Fixes**
	- Updated state management in `SubspaceListView` to handle selected state toggling correctly.

- **Refactor**
	- Simplified the `CollaborationTemplatePreview` component by replacing the accordion structure with the new callouts preview component, improving maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->