### PR TITLE
add canva to the whitelist of iframe embed urls

### DIFF
--- a/src/core/ui/markdown/embed/allowedEmbedUrls.ts
+++ b/src/core/ui/markdown/embed/allowedEmbedUrls.ts
@@ -2,5 +2,5 @@ export const ALLOWED_EMBED_URLS = [
   'https://issuu.com',
   'https://www.youtube.com',
   'https://player.vimeo.com',
-  'https://demo.arcade.software',
+  'https://www.canva.com',
 ] as const;


### PR DESCRIPTION
Requested by Simone.

Code for testing:
```

<iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0;margin: 0;"
    src="https://www.canva.com/design/DAGZjbaYpVc/_TcjLJQIUnLnrssRxI0vUA/view?embed" allowfullscreen="allowfullscreen" allow="fullscreen">
</iframe>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the list of allowed embed URLs to include Canva.
- **Bug Fixes**
	- Removed outdated embed URL to ensure compliance with current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->