### PR TITLE
[VC store] the new flow from settings

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -12495,11 +12495,8 @@ export type InviteUserToPlatformAndRoleSetMutationOptions = Apollo.BaseMutationO
   SchemaTypes.InviteUserToPlatformAndRoleSetMutationVariables
 >;
 export const AvailableVirtualContributorsDocument = gql`
-  query AvailableVirtualContributors(
-    $filterSpace: Boolean = false
-    $filterSpaceId: UUID = "00000000-0000-0000-0000-000000000000"
-  ) {
-    lookup @include(if: $filterSpace) {
+  query AvailableVirtualContributors($filterSpaceId: UUID = "00000000-0000-0000-0000-000000000000") {
+    lookup {
       space(ID: $filterSpaceId) {
         id
         community {
@@ -12519,9 +12516,6 @@ export const AvailableVirtualContributorsDocument = gql`
         }
       }
     }
-    virtualContributors @skip(if: $filterSpace) {
-      ...VirtualContributorFull
-    }
   }
   ${VirtualContributorFullFragmentDoc}
 `;
@@ -12538,7 +12532,6 @@ export const AvailableVirtualContributorsDocument = gql`
  * @example
  * const { data, loading, error } = useAvailableVirtualContributorsQuery({
  *   variables: {
- *      filterSpace: // value for 'filterSpace'
  *      filterSpaceId: // value for 'filterSpaceId'
  *   },
  * });

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -17399,13 +17399,12 @@ export type InviteUserToPlatformAndRoleSetMutation = {
 };
 
 export type AvailableVirtualContributorsQueryVariables = Exact<{
-  filterSpace?: InputMaybe<Scalars['Boolean']>;
   filterSpaceId?: InputMaybe<Scalars['UUID']>;
 }>;
 
 export type AvailableVirtualContributorsQuery = {
   __typename?: 'Query';
-  lookup?: {
+  lookup: {
     __typename?: 'LookupQueryResults';
     space?:
       | {
@@ -17494,40 +17493,6 @@ export type AvailableVirtualContributorsQuery = {
         }
       | undefined;
   };
-  virtualContributors?: Array<{
-    __typename?: 'VirtualContributor';
-    id: string;
-    nameID: string;
-    profile: {
-      __typename?: 'Profile';
-      id: string;
-      displayName: string;
-      description?: string | undefined;
-      url: string;
-      avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-      tagsets?:
-        | Array<{
-            __typename?: 'Tagset';
-            id: string;
-            name: string;
-            tags: Array<string>;
-            allowedValues: Array<string>;
-            type: TagsetType;
-          }>
-        | undefined;
-      location?:
-        | { __typename?: 'Location'; id: string; city?: string | undefined; country?: string | undefined }
-        | undefined;
-    };
-    aiPersona?:
-      | {
-          __typename?: 'AiPersona';
-          bodyOfKnowledge?: string | undefined;
-          bodyOfKnowledgeType?: AiPersonaBodyOfKnowledgeType | undefined;
-          bodyOfKnowledgeID?: string | undefined;
-        }
-      | undefined;
-  }>;
 };
 
 export type AvailableVirtualContributorsInLibraryQueryVariables = Exact<{ [key: string]: never }>;

--- a/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
+++ b/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
@@ -122,9 +122,6 @@ const CommunityVirtualContributors = ({
             <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog()}>
               {t('common.add')}
             </Button>
-            <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog()}>
-              {t('community.virtualContributors.inviteExternalVC')}
-            </Button>
           </Actions>
         )}
       </Box>

--- a/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
+++ b/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
@@ -14,14 +14,14 @@ import { gutters } from '@/core/ui/grid/utils';
 import DataGridSkeleton from '@/core/ui/table/DataGridSkeleton';
 import DataGridTable from '@/core/ui/table/DataGridTable';
 import { BlockTitle } from '@/core/ui/typography';
-import CommunityAddMembersDialog from './CommunityAddMembersDialog';
 import { Remove } from '@mui/icons-material';
 import ConfirmationDialog from '@/core/ui/dialogs/ConfirmationDialog';
 import { Actions } from '@/core/ui/actions/Actions';
 import { Identifiable } from '@/core/utils/Identifiable';
-import InviteVirtualContributorDialog from '@/domain/community/invitations/InviteVirtualContributorDialog';
 import { InviteContributorsData } from '@/domain/community/invitations/useInviteUsers';
 import { ContributorViewProps } from '../EntityDashboardContributorsSection/Types';
+import { CommunityContributorType } from '@/core/apollo/generated/graphql-schema';
+import InviteContributorsDialog from '@/domain/community/inviteContributors/InviteContributorsDialog';
 
 type RenderParams = GridRenderCellParams<string, ContributorViewProps>;
 type GetterParams = GridValueGetterParams<string, ContributorViewProps>;
@@ -66,12 +66,7 @@ const CommunityVirtualContributors = ({
   virtualContributors = [],
   onRemoveMember,
   canAddVirtualContributors,
-  fetchAvailableVirtualContributors,
-  fetchAvailableVirtualContributorsOnAccount,
-  onAddMember,
   loading,
-  inviteExistingUser,
-  spaceDisplayName = '',
 }: CommunityVirtualContributorsProps) => {
   const { t } = useTranslation();
 
@@ -113,35 +108,10 @@ const CommunityVirtualContributors = ({
 
   const [deletingMemberId, setDeletingMemberId] = useState<string>();
   const [isAddingNewMember, setAddingNewMember] = useState(false);
-  const [isInvitingExternal, setIsInvitingExternal] = useState(false);
-  const [allVirtualContributors, setAllVirtualContributors] = useState(false);
-  const [selectedVirtualContributorId, setSelectedVirtualContributorId] = useState<string>('');
 
-  const openAvailableContributorsDialog = (external: boolean = false) => {
-    setAllVirtualContributors(external);
-
+  const openAvailableContributorsDialog = () => {
     setAddingNewMember(true);
   };
-
-  const getFilteredVirtualContributors = async (filter?: string) => {
-    if (allVirtualContributors) {
-      return fetchAvailableVirtualContributors(filter);
-    } else {
-      return fetchAvailableVirtualContributorsOnAccount(filter, false);
-    }
-  };
-
-  const onAddClick = (virtualContributorId: string) => {
-    if (allVirtualContributors) {
-      setAddingNewMember(false);
-      setIsInvitingExternal(true);
-      setSelectedVirtualContributorId(virtualContributorId);
-    } else {
-      onAddMember(virtualContributorId);
-    }
-  };
-
-  const closeInvitationDialog = () => setIsInvitingExternal(false);
 
   return (
     <>
@@ -152,7 +122,7 @@ const CommunityVirtualContributors = ({
             <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog()}>
               {t('common.add')}
             </Button>
-            <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog(true)}>
+            <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog()}>
               {t('community.virtualContributors.inviteExternalVC')}
             </Button>
           </Actions>
@@ -212,21 +182,12 @@ const CommunityVirtualContributors = ({
         />
       )}
       {isAddingNewMember && (
-        <CommunityAddMembersDialog
-          onAdd={onAddClick}
-          fetchAvailableEntities={getFilteredVirtualContributors}
-          allowSearchByURL
-          onClose={() => setAddingNewMember(false)}
-        />
-      )}
-      {isInvitingExternal && (
-        <InviteVirtualContributorDialog
-          title={t('components.invitations.inviteExistingVCDialog.title')}
-          spaceDisplayName={spaceDisplayName}
-          open={isInvitingExternal}
-          onClose={closeInvitationDialog}
-          contributorId={selectedVirtualContributorId}
-          onInviteUser={inviteExistingUser}
+        <InviteContributorsDialog
+          open={isAddingNewMember}
+          onClose={() => {
+            setAddingNewMember(false);
+          }}
+          type={CommunityContributorType.Virtual}
         />
       )}
     </>

--- a/src/domain/community/inviteContributors/VirtualContributors.graphql
+++ b/src/domain/community/inviteContributors/VirtualContributors.graphql
@@ -1,8 +1,7 @@
 query AvailableVirtualContributors(
-  $filterSpace: Boolean = false
   $filterSpaceId: UUID = "00000000-0000-0000-0000-000000000000"
 ) {
-  lookup @include(if: $filterSpace) {
+  lookup {
     space(ID: $filterSpaceId) {
       id
       community {
@@ -21,9 +20,6 @@ query AvailableVirtualContributors(
         }
       }
     }
-  }
-  virtualContributors @skip(if: $filterSpace) {
-    ...VirtualContributorFull
   }
 }
 


### PR DESCRIPTION
Now the _(Sub)(Sub)Space -> Settings -> Community_ uses the new VC Store dialog.

- The functionality of adding/removing/inviting works as expected.
- The logic for gathering/filtering VCs was further simplified (it was too complex). 
- There's one button - Add - similar to the other tables in the Layout (the invite one was removed as both are showin the same dialog).

However, there are a couple of **drawbacks**:
- In the new flow there's **no search** ⚠️
- The _On Account_ list shows **all** VC under the account. On SubSpace level this could cause an error on attempt to ad a VC not part of the parent community.