### PR TITLE
Handling of scroll and page change in documentation.

### DIFF
--- a/src/domain/documentation/DocumentationPage.tsx
+++ b/src/domain/documentation/DocumentationPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import TopLevelLayout from '@/main/ui/layout/TopLevelLayout';
 import TopLevelPageBreadcrumbs from '@/main/topLevelPages/topLevelPageBreadcrumbs/TopLevelPageBreadcrumbs';
 import PageContent from '@/core/ui/content/PageContent';
@@ -8,14 +9,68 @@ import Gutters from '@/core/ui/grid/Gutters';
 import { useConfig } from '../platform/config/useConfig';
 import { TopLevelRoutePath } from '@/main/routing/TopLevelRoutePath';
 import { useTranslation } from 'react-i18next';
+import scrollToTop from '@/core/ui/utils/scrollToTop';
+import useNavigate from '@/core/routing/useNavigate';
+
+const DEFAULT_HEIGHT = '100vh';
+const enum SupportedMessageTypes {
+  PageHeight = 'PAGE_HEIGHT',
+  PageChange = 'PAGE_CHANGE',
+}
+
+const getCurrentOriginWithoutPort = () => {
+  const { protocol, hostname } = window.location;
+  return `${protocol}//${hostname}`;
+};
 
 const DocumentationPage = () => {
   const { t } = useTranslation();
   const { locations } = useConfig();
   const { pathname } = useLocation();
+  const navigate = useNavigate();
+  // used only for the initial loading
   const docsInternalPath = pathname.split(`/${TopLevelRoutePath.Docs}/`)[1] ?? '';
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(DEFAULT_HEIGHT);
+  const [src, setSrc] = useState('');
 
-  let src = `${locations?.documentation}/${docsInternalPath}`;
+  let srcIndex = `${locations?.documentation}/`;
+  // use for local development
+  // let srcIndex = `http://localhost:3010/documentation/`;
+
+  useEffect(() => {
+    // set the source once, and then listen for messages
+    setSrc(`${srcIndex}${docsInternalPath ?? ''}`);
+
+    const handleMessage = (event: MessageEvent) => {
+      if (!event.origin.startsWith(getCurrentOriginWithoutPort())) {
+        return;
+      }
+
+      switch (event.data.type) {
+        case SupportedMessageTypes.PageHeight:
+          if (event.data.height) {
+            setHeight(`${event.data.height}px`);
+          }
+          break;
+        case SupportedMessageTypes.PageChange:
+          // on page change just replace the path (used for sharing)
+          // the actual navigation is internal for the iframe
+          const newPath = `/${TopLevelRoutePath.Docs}${event.data.url}`;
+          navigate(newPath, { replace: true });
+          scrollToTop();
+          break;
+        default:
+          console.log('Unsupported: ', event);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
 
   return (
     <TopLevelLayout
@@ -24,12 +79,21 @@ const DocumentationPage = () => {
     >
       <PageContent>
         <PageContentBlock fullHeight>
-          <Gutters height={'100vh'}>
-            <iframe
-              src={src}
-              title={t('pages.documentation.title')}
-              style={{ width: '100%', height: '100%', border: 'none' }}
-            />
+          <Gutters
+            disablePadding
+            height={height}
+            sx={{
+              overflow: 'hidden',
+            }}
+          >
+            {src && (
+              <iframe
+                src={src}
+                ref={iframeRef}
+                title={t('pages.documentation.title')}
+                style={{ width: '100%', height: '100%', border: 'none' }}
+              />
+            )}
           </Gutters>
         </PageContentBlock>
       </PageContent>


### PR DESCRIPTION
It depends on a PR in documentation repo: https://github.com/alkem-io/documentation/pull/19

With the following changes:

- there's no internal scroll and the page resizes based on information from the frame;
- the page path changes accordingly allowing sharing a link to specific docs page;
- on every page change there's a scroll to top;

Drawback:
- the page height is getting only higher, I couldn't find a solution for reducing the height based on the content;
I'm open to suggestions.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced iframe communication with support for message types.
	- Dynamic iframe height adjustment based on received messages.
	- Improved navigation without page reloads.
	- Conditional rendering of the iframe based on source availability.

- **Bug Fixes**
	- Corrected iframe rendering logic to display only when the source is set.

- **Documentation**
	- Added new enum for message type categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->