### PR TITLE
InnovationFlow States names validation

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1087,6 +1087,7 @@
         "editState": "Edit Details",
         "deleteState": "Delete",
         "addState": "Add Phase",
+        "invalidChars": "A phase name cannot contain special characters",
         "noRepeatedStates": "A phase with the same name already exists.",
         "createDialog": {
           "title": "Create Flow Phase"

--- a/src/domain/collaboration/InnovationFlow/InnovationFlowDragNDropEditor/InnovationFlowStateForm.tsx
+++ b/src/domain/collaboration/InnovationFlow/InnovationFlowDragNDropEditor/InnovationFlowStateForm.tsx
@@ -10,6 +10,7 @@ import { LoadingButton } from '@mui/lab';
 import useLoadingState from '@/domain/shared/utils/useLoadingState';
 import MarkdownValidator from '@/core/ui/forms/MarkdownInput/MarkdownValidator';
 import { InnovationFlowState } from '../InnovationFlow';
+import Gutters from '@/core/ui/grid/Gutters';
 
 export interface InnovationFlowStateFormValues extends InnovationFlowState {}
 
@@ -41,6 +42,10 @@ const InnovationFlowStateForm = ({
       .string()
       .required()
       .max(SMALL_TEXT_LENGTH)
+      // Avoid any JSON-related chars:
+      // This validation is also performed on the server: domain/collaboration/innovation-flow-states/innovation.flow.state.service.ts
+      // Keep them in sync
+      .matches(/^[^[\],'"{}\\]+$/, t('components.innovationFlowSettings.stateEditor.invalidChars'))
       .notOneOf(forbiddenFlowStateNames, t('components.innovationFlowSettings.stateEditor.noRepeatedStates')),
     description: MarkdownValidator(MARKDOWN_TEXT_LENGTH),
   });
@@ -53,7 +58,7 @@ const InnovationFlowStateForm = ({
     <Formik initialValues={initialValues} validationSchema={validationSchema} enableReinitialize onSubmit={handleSave}>
       {({ handleSubmit, isValid }) => {
         return (
-          <>
+          <Gutters disablePadding>
             <FormikInputField name="displayName" title={t('common.title')} maxLength={SMALL_TEXT_LENGTH} />
             <FormikMarkdownField name="description" title={t('common.description')} maxLength={MARKDOWN_TEXT_LENGTH} />
             <Actions justifyContent="end">
@@ -64,7 +69,7 @@ const InnovationFlowStateForm = ({
                 {t('buttons.save')}
               </LoadingButton>
             </Actions>
-          </>
+          </Gutters>
         );
       }}
     </Formik>


### PR DESCRIPTION
- Avoiding commas should be enough, but in case we end up serializing tags as JSON string arrays, I have forbidden some JS special characters too that should be fine to live without: `[ ] ' " , { } \`

- Also added a Gutters for better visualization of the form.