### PR TITLE
Fix: Deleting subspace l2 from its settings throws errors on space dashboard

### DIFF
--- a/src/domain/platform/admin/opportunity/pages/OpportunitySettings/OpportunitySettingsView.tsx
+++ b/src/domain/platform/admin/opportunity/pages/OpportunitySettings/OpportunitySettingsView.tsx
@@ -35,10 +35,10 @@ const OpportunitySettingsView = () => {
   const [deleteOpportunity] = useDeleteSpaceMutation({
     refetchQueries: [
       refetchSubspacesInSpaceQuery({
-        spaceId: spaceId,
+        spaceId,
       }),
       refetchSpaceDashboardNavigationChallengesQuery({
-        spaceId: spaceNameId,
+        spaceId,
       }),
     ],
     onCompleted: data => {


### PR DESCRIPTION
#6805 