### PR TITLE
Fix: ENTITY_NOT_FOUND Error is triggered after first login server #4790

### DIFF
--- a/src/domain/community/user/providers/UserProvider/UserProvider.tsx
+++ b/src/domain/community/user/providers/UserProvider/UserProvider.tsx
@@ -45,7 +45,7 @@ const UserProvider: FC = ({ children }) => {
   const { data: meData, loading: loadingMe } = useUserProviderQuery({ skip: !isAuthenticated });
 
   const { data: platformLevelAuthorizationData, loading: isLoadingPlatformLevelAuthorization } =
-    usePlatformLevelAuthorizationQuery({ skip: !isAuthenticated });
+    usePlatformLevelAuthorizationQuery({ skip: !isAuthenticated || !meData?.me?.user });
   const platformLevelAuthorization = platformLevelAuthorizationData?.platform.authorization;
 
   const [createUserProfile, { loading: loadingCreateUser, error }] = useCreateUserNewRegistrationMutation({


### PR DESCRIPTION
- Server:  [#4790](https://github.com/alkem-io/server/issues/4790)
- Do not request myPrivileges if the user is not yet fully created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved platform-level authorization query execution by adding an additional check for user data availability
  - Enhanced loading state logic to ensure more precise user context rendering

The changes refine the authorization process, ensuring that platform-level queries are only triggered when both user authentication and user data are confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->