### PR TITLE
Add arcadeSoftware to the whitelist of iframes

### DIFF
--- a/src/core/ui/markdown/embed/allowedEmbedUrls.ts
+++ b/src/core/ui/markdown/embed/allowedEmbedUrls.ts
@@ -3,4 +3,5 @@ export const ALLOWED_EMBED_URLS = [
   'https://www.youtube.com',
   'https://player.vimeo.com',
   'https://www.canva.com',
+  'https://demo.arcade.software',
 ] as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded embed URL whitelist to include 'https://demo.arcade.software', enabling content embedding from an additional trusted domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->