### PR TITLE
Use Account name for Spaces created in the VC flow

### DIFF
--- a/src/domain/community/contributor/Account/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/Account/ContributorAccountView.tsx
@@ -460,7 +460,7 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
                 aria-label={t('common.add')}
                 aria-haspopup="true"
                 size="small"
-                onClick={() => startWizard(account)}
+                onClick={() => startWizard(account, accountHostName)}
               >
                 <RoundedIcon component={AddIcon} size="medium" iconSize="small" />
               </IconButton>

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorProps.ts
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorProps.ts
@@ -55,6 +55,6 @@ export interface UserAccountProps {
 interface NewVirtualContributorWizardProps {}
 
 export interface useNewVirtualContributorWizardProvided {
-  startWizard: (initAccount?: UserAccountProps | undefined) => void;
+  startWizard: (initAccount?: UserAccountProps | undefined, accountName?: string) => void;
   NewVirtualContributorWizard: ComponentType<NewVirtualContributorWizardProps>;
 }

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -60,11 +60,13 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
   const [step, setStep] = useState<Step>('initial');
 
   const [targetAccount, setTargetAccount] = useState<UserAccountProps>();
+  const [accountName, setAccountName] = useState<string>();
   const [createdSpaceId, setCreatedSpaceId] = useState<string>();
   const [virtualContributorInput, setVirtualContributorInput] = useState<VirtualContributorFromProps>();
 
-  const startWizard = (initAccount: UserAccountProps | undefined) => {
+  const startWizard = (initAccount: UserAccountProps | undefined, accountName?: string) => {
     setTargetAccount(initAccount);
+    setAccountName(accountName);
     setStep('initial');
     setDialogOpen(true);
   };
@@ -185,7 +187,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
         spaceData: {
           accountID: myAccountId!,
           profileData: {
-            displayName: `${user?.user.profile.displayName} - ${t('common.space')}`,
+            displayName: `${accountName || user?.user.profile.displayName} - ${t('common.space')}`,
           },
           collaborationData: {
             calloutsSetData: {},


### PR DESCRIPTION
A simple change, now the Space name during creation takes the Account Name (if provided). 
This fixes the case not only for organization accounts but also for GA/GS creating entities on other contributors' Accounts.

In case there's no AccountName (triggered from the Campaign block) then the active user's name is used (as previously). 