### PR TITLE
Add Updates from leads block to the subspaces page (l1 & l2).

### DIFF
--- a/src/domain/journey/subspace/subspaceHome/SubspaceHomeContainer.tsx
+++ b/src/domain/journey/subspace/subspaceHome/SubspaceHomeContainer.tsx
@@ -3,7 +3,7 @@ import useInnovationFlowStates, {
   UseInnovationFlowStatesProvided,
 } from '@/domain/collaboration/InnovationFlow/InnovationFlowStates/useInnovationFlowStates';
 import { UseCalloutsProvided } from '@/domain/collaboration/calloutsSet/useCallouts/useCallouts';
-import { SubspacePageSpaceFragment } from '@/core/apollo/generated/graphql-schema';
+import { AuthorizationPrivilege, SubspacePageSpaceFragment } from '@/core/apollo/generated/graphql-schema';
 import { JourneyTypeName } from '@/domain/journey/JourneyTypeName';
 import { useSubspacePageQuery } from '@/core/apollo/generated/apollo-hooks';
 import useCanReadSpace, { SpaceReadAccess } from '@/domain/journey/common/authorization/useCanReadSpace';
@@ -14,6 +14,8 @@ interface SubspaceHomeContainerProvided {
   callouts: UseCalloutsProvided;
   subspace?: SubspacePageSpaceFragment;
   spaceReadAccess: SpaceReadAccess;
+  communityReadAccess: boolean;
+  communityId: string | undefined;
 }
 
 interface SubspaceHomeContainerProps extends SimpleContainerProps<SubspaceHomeContainerProvided> {
@@ -41,7 +43,21 @@ const SubspaceHomeContainer = ({ journeyId, children }: SubspaceHomeContainerPro
     collaborationId,
   });
 
-  return <>{children({ innovationFlow, callouts, subspace: data?.lookup.space, spaceReadAccess })}</>;
+  const community = data?.lookup.space?.community;
+  const communityReadAccess = (community?.authorization?.myPrivileges ?? []).includes(AuthorizationPrivilege.Read);
+
+  return (
+    <>
+      {children({
+        innovationFlow,
+        callouts,
+        subspace: data?.lookup.space,
+        spaceReadAccess,
+        communityReadAccess,
+        communityId: community?.id,
+      })}
+    </>
+  );
 };
 
 export default SubspaceHomeContainer;

--- a/src/domain/journey/subspace/subspaceHome/SubspaceHomePage.tsx
+++ b/src/domain/journey/subspace/subspaceHome/SubspaceHomePage.tsx
@@ -30,6 +30,7 @@ import DashboardNavigation, {
 import { useConsumeAction } from '../layout/SubspacePageLayout';
 import { useColumns } from '@/core/ui/grid/GridContext';
 import CreateJourney from './dialogs/CreateJourney';
+import DashboardUpdatesSection from '@/domain/shared/components/DashboardSections/DashboardUpdatesSection';
 
 const Outline = (props: DashboardNavigationProps) => {
   useConsumeAction(SubspaceDialog.Outline);
@@ -81,7 +82,7 @@ const SubspaceHomePage = ({ dialog }: { dialog?: SubspaceDialog }) => {
 
   return (
     <SubspaceHomeContainer journeyId={journeyId} journeyTypeName={journeyTypeName}>
-      {({ innovationFlow, callouts, subspace, spaceReadAccess }) => {
+      {({ innovationFlow, callouts, subspace, spaceReadAccess, communityReadAccess, communityId }) => {
         const { collaboration, community, profile } = subspace ?? {};
 
         return (
@@ -163,12 +164,17 @@ const SubspaceHomePage = ({ dialog }: { dialog?: SubspaceDialog }) => {
                 </>
               }
               infoColumnChildren={
-                <Outline
-                  currentItemId={journeyId}
-                  dashboardNavigation={dashboardNavigation.dashboardNavigation}
-                  onCreateSubspace={openCreateSubspace}
-                  onCurrentItemNotFound={dashboardNavigation.refetch}
-                />
+                <>
+                  <Outline
+                    currentItemId={journeyId}
+                    dashboardNavigation={dashboardNavigation.dashboardNavigation}
+                    onCreateSubspace={openCreateSubspace}
+                    onCurrentItemNotFound={dashboardNavigation.refetch}
+                  />
+                  {communityReadAccess && communityId && (
+                    <DashboardUpdatesSection communityId={communityId} shareUrl={''} />
+                  )}
+                </>
               }
             >
               <SubspaceHomeView

--- a/src/domain/journey/subspace/subspaceHome/SubspaceHomePage.tsx
+++ b/src/domain/journey/subspace/subspaceHome/SubspaceHomePage.tsx
@@ -31,6 +31,7 @@ import { useConsumeAction } from '../layout/SubspacePageLayout';
 import { useColumns } from '@/core/ui/grid/GridContext';
 import CreateJourney from './dialogs/CreateJourney';
 import DashboardUpdatesSection from '@/domain/shared/components/DashboardSections/DashboardUpdatesSection';
+import { buildUpdatesUrl } from '@/main/routing/urlBuilders';
 
 const Outline = (props: DashboardNavigationProps) => {
   useConsumeAction(SubspaceDialog.Outline);
@@ -172,7 +173,7 @@ const SubspaceHomePage = ({ dialog }: { dialog?: SubspaceDialog }) => {
                     onCurrentItemNotFound={dashboardNavigation.refetch}
                   />
                   {communityReadAccess && communityId && (
-                    <DashboardUpdatesSection communityId={communityId} shareUrl={''} />
+                    <DashboardUpdatesSection communityId={communityId} shareUrl={buildUpdatesUrl(profile?.url ?? '')} />
                   )}
                 </>
               }


### PR DESCRIPTION
https://github.com/alkem-io/notifications/issues/365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced subspace home page with community access and identification information.
	- Added conditional rendering of the dashboard updates section based on community read access.

- **Improvements**
	- Expanded component props to include community-related context.
	- Introduced more granular access control for community-specific content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->