### PR TITLE
MD fixes - comments not visible with long Post description; `pre` long line not visible;

### DIFF
--- a/src/core/ui/markdown/MarkdownOptionsContext.tsx
+++ b/src/core/ui/markdown/MarkdownOptionsContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, PropsWithChildren, useContext } from 'react';
+import { SxProps } from '@mui/material';
 
 export interface MarkdownOptions {
   card: boolean;
@@ -6,6 +7,7 @@ export interface MarkdownOptions {
   multiline: boolean;
   disableParagraphPadding: boolean;
   caption: boolean;
+  sx?: SxProps;
 }
 
 const MarkdownOptionsContext = createContext<MarkdownOptions | undefined>(undefined);

--- a/src/core/ui/markdown/WrapperMarkdown.tsx
+++ b/src/core/ui/markdown/WrapperMarkdown.tsx
@@ -9,6 +9,8 @@ import { remarkVerifyIframe } from './embed/remarkVerifyIframe';
 
 const allowedNodeTypes = ['iframe'] as const;
 
+export const MARKDOWN_CLASS_NAME = 'markdown'; // global styles applied
+
 export interface MarkdownProps extends ReactMarkdownOptions, Partial<MarkdownOptions> {}
 
 export const WrapperMarkdown = ({

--- a/src/core/ui/markdown/WrapperMarkdown.tsx
+++ b/src/core/ui/markdown/WrapperMarkdown.tsx
@@ -19,6 +19,7 @@ export const WrapperMarkdown = ({
   multiline = !plain,
   disableParagraphPadding = card,
   caption = false,
+  sx,
   ...props
 }: MarkdownProps) => (
   <MarkdownOptionsProvider
@@ -28,7 +29,7 @@ export const WrapperMarkdown = ({
     disableParagraphPadding={disableParagraphPadding}
     caption={caption}
   >
-    <Box sx={{ li: { marginY: caption ? 0 : 1 }, display: plain ? 'inline' : undefined }}>
+    <Box sx={{ li: { marginY: caption ? 0 : 1 }, display: plain ? 'inline' : undefined, ...sx }}>
       <ReactMarkdown
         components={components}
         remarkPlugins={[gfm, [PlainText, { enabled: plain }], remarkVerifyIframe]}

--- a/src/domain/collaboration/callout/comments/CommentsCalloutLayout.tsx
+++ b/src/domain/collaboration/callout/comments/CommentsCalloutLayout.tsx
@@ -12,6 +12,8 @@ import CalloutClosedMarginal from '../calloutBlock/CalloutClosedMarginal';
 import { CalloutLayoutProps } from '../calloutBlock/CalloutLayout';
 import { gutters } from '@/core/ui/grid/utils';
 
+const DESCRIPTION_MAX_HEIGHT = 'calc(100vh - 400px)';
+
 const CommentsCalloutLayout = ({
   callout,
   children,
@@ -36,6 +38,9 @@ const CommentsCalloutLayout = ({
 
   const hasCalloutDetails = callout.authorName && callout.publishedAt;
 
+  // fixes comments not visible when description too long in modal/expanded
+  const expandedStyles = expanded ? { maxHeight: DESCRIPTION_MAX_HEIGHT, overflowY: 'auto' } : undefined;
+
   return (
     <>
       {callout.draft && (
@@ -54,13 +59,13 @@ const CommentsCalloutLayout = ({
         calloutActions={calloutActions}
       />
       {hasCalloutDetails && <BlockTitle noWrap>{callout.framing.profile.displayName}</BlockTitle>}
-      <Box sx={{ wordWrap: 'break-word' }} paddingX={gutters()}>
-        <WrapperMarkdown caption className={MARKDOWN_CLASS_NAME}>
+      <Box sx={{ wordWrap: 'break-word' }} paddingX={gutters()} paddingBottom={gutters(0.5)}>
+        <WrapperMarkdown caption className={MARKDOWN_CLASS_NAME} sx={expandedStyles}>
           {callout.framing.profile.description ?? ''}
         </WrapperMarkdown>
       </Box>
       {!skipReferences && !!callout.framing.profile.references?.length && (
-        <Box padding={gutters()} paddingTop={gutters(0.5)}>
+        <Box paddingX={gutters()} paddingBottom={gutters(0.5)}>
           <References compact references={callout.framing.profile.references} />
         </Box>
       )}

--- a/src/domain/collaboration/callout/comments/CommentsCalloutLayout.tsx
+++ b/src/domain/collaboration/callout/comments/CommentsCalloutLayout.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 import { AuthorizationPrivilege } from '@/core/apollo/generated/graphql-schema';
-import WrapperMarkdown from '@/core/ui/markdown/WrapperMarkdown';
+import WrapperMarkdown, { MARKDOWN_CLASS_NAME } from '@/core/ui/markdown/WrapperMarkdown';
 import { BlockTitle } from '@/core/ui/typography';
 import { Ribbon } from '@/core/ui/card/Ribbon';
 import References from '@/domain/shared/components/References/References';
@@ -55,7 +55,9 @@ const CommentsCalloutLayout = ({
       />
       {hasCalloutDetails && <BlockTitle noWrap>{callout.framing.profile.displayName}</BlockTitle>}
       <Box sx={{ wordWrap: 'break-word' }} paddingX={gutters()}>
-        <WrapperMarkdown caption>{callout.framing.profile.description ?? ''}</WrapperMarkdown>
+        <WrapperMarkdown caption className={MARKDOWN_CLASS_NAME}>
+          {callout.framing.profile.description ?? ''}
+        </WrapperMarkdown>
       </Box>
       {!skipReferences && !!callout.framing.profile.references?.length && (
         <Box padding={gutters()} paddingTop={gutters(0.5)}>

--- a/src/domain/communication/room/Comments/CommentsComponent.tsx
+++ b/src/domain/communication/room/Comments/CommentsComponent.tsx
@@ -17,7 +17,6 @@ import { gutters } from '@/core/ui/grid/utils';
 import { CommentInputFieldProps } from './CommentInputField';
 
 const SCROLL_BOTTOM_MISTAKE_TOLERANCE = 10;
-const MIN_COMMENTS_HEIGHT = '200px'; // fix for long description or device with short height
 
 export interface CommentsComponentProps {
   messages: Message[] | undefined;
@@ -105,15 +104,16 @@ const CommentsComponent = ({
 
   const lastMessage = last(messages);
 
+  const hasMessages = messages.length > 0;
+
   return (
     <>
-      {!isShowingLastMessage && (
+      {!isShowingLastMessage && hasMessages && (
         <ScrollerWithGradient
           maxHeight={maxHeight}
           scrollerRef={commentsContainerRef}
           onScroll={handleScroll}
           margin={0}
-          sx={{ minHeight: MIN_COMMENTS_HEIGHT }}
         >
           <Gutters gap={0}>
             <MessagesThread

--- a/src/domain/communication/room/Comments/CommentsComponent.tsx
+++ b/src/domain/communication/room/Comments/CommentsComponent.tsx
@@ -17,6 +17,7 @@ import { gutters } from '@/core/ui/grid/utils';
 import { CommentInputFieldProps } from './CommentInputField';
 
 const SCROLL_BOTTOM_MISTAKE_TOLERANCE = 10;
+const MIN_COMMENTS_HEIGHT = '200px'; // fix for long description or device with short height
 
 export interface CommentsComponentProps {
   messages: Message[] | undefined;
@@ -112,6 +113,7 @@ const CommentsComponent = ({
           scrollerRef={commentsContainerRef}
           onScroll={handleScroll}
           margin={0}
+          sx={{ minHeight: MIN_COMMENTS_HEIGHT }}
         >
           <Gutters gap={0}>
             <MessagesThread

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -28,6 +28,7 @@ import { GlobalErrorDialog } from './core/lazyLoading/GlobalErrorDialog';
 import { InAppNotificationsProvider } from './main/inAppNotifications/InAppNotificationsContext';
 import { InAppNotificationsDialog } from './main/inAppNotifications/InAppNotificationsDialog';
 
+// MARKDOWN_CLASS_NAME used in the styles below
 const useGlobalStyles = makeStyles(theme => ({
   '@global': {
     '*': {
@@ -59,6 +60,9 @@ const useGlobalStyles = makeStyles(theme => ({
       flexDirection: 'column',
     },
     '[aria-role="heading"]': subHeading,
+    '.markdown > pre': {
+      whiteSpace: 'pre-wrap',
+    },
   },
 }));
 


### PR DESCRIPTION
Fixes:

1. [x] hidden comments on a long POST description; https://github.com/alkem-io/client-web/issues/7421
2. [x] pasting code with long lines in `pre` tag results in hidden content; https://github.com/alkem-io/client-web/issues/7424

#1. Fix by introducing maxHeight on description (MarkdownWrapper) in case of expanded state.
#2. MD global style was added to break the long lines in `pre` tag. Currently, passed where we want to, but we can set it directly in our MarkdownWrapper if we want that treatment everywhere. 

Now the MarkdownWrapper (the ReactMarkdown Box wrapper) receives `sx`, which I think it's quite useful. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added styling customization options for markdown components
	- Improved comments layout and visibility

- **Bug Fixes**
	- Enhanced scrolling behavior in comments when messages are present
	- Fixed text wrapping for preformatted markdown content

- **Style**
	- Updated padding and layout consistency in comment components
	- Added flexible styling options for markdown elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->