### PR TITLE
Create Space Link - entitlements check added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.79.6",
+  "version": "0.79.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/client-web",
-      "version": "0.79.6",
+      "version": "0.79.7",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/excalidraw": "0.17.1-alkemio-8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.79.6",
+  "version": "0.79.7",
   "description": "Alkemio client, enabling users to interact with Challenges hosted on the Alkemio platform.",
   "repository": {
     "type": "git",

--- a/src/main/topLevelPages/myDashboard/useCreateSpaceLink/useCreateSpaceLink.tsx
+++ b/src/main/topLevelPages/myDashboard/useCreateSpaceLink/useCreateSpaceLink.tsx
@@ -1,12 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { useUserContext } from '@/domain/community/user';
-import { AuthorizationPrivilege } from '@/core/apollo/generated/graphql-schema';
+import { AuthorizationPrivilege, LicenseEntitlementType } from '@/core/apollo/generated/graphql-schema';
 import { TopLevelRoutePath } from '@/main/routing/TopLevelRoutePath';
 import { useMemo } from 'react';
 
 export const useCreateSpaceLink = () => {
   const { t } = useTranslation();
-  const { accountPrivileges, loading } = useUserContext();
+  const { accountPrivileges, loading, accountEntitlements } = useUserContext();
 
   const STATIC_PAGE_LINK = t('pages.home.sections.startingSpace.url');
 
@@ -15,12 +15,18 @@ export const useCreateSpaceLink = () => {
       return STATIC_PAGE_LINK;
     }
 
-    if (accountPrivileges.includes(AuthorizationPrivilege.CreateSpace)) {
+    const isEntitledToCreateSpace = [
+      LicenseEntitlementType.AccountSpaceFree,
+      LicenseEntitlementType.AccountSpacePlus,
+      LicenseEntitlementType.AccountSpacePremium,
+    ].some(entitlement => accountEntitlements.includes(entitlement));
+
+    if (accountPrivileges.includes(AuthorizationPrivilege.CreateSpace) && isEntitledToCreateSpace) {
       return `/${TopLevelRoutePath.CreateSpace}`;
     }
 
     return STATIC_PAGE_LINK;
-  }, [accountPrivileges, loading, t]);
+  }, [accountPrivileges, accountEntitlements, loading, t]);
 
   return { loading, link };
 };


### PR DESCRIPTION
Fixing the missing check for entitlements in the Create Space link.
Used in the Dashboard Menu, My Spaces Dialog and on the bottom of the dashboard for some users.