### PR TITLE
BUGFIX: Missing padding for the items on the left block on space and subspaces

### DIFF
--- a/src/core/ui/list/LinksList.tsx
+++ b/src/core/ui/list/LinksList.tsx
@@ -58,7 +58,7 @@ const LinksList = ({ items = [], emptyListCaption, loading = false }: LinksListP
       {!loading && items.length > COLLAPSED_LIST_ITEM_LIMIT && (
         <Collapse in={isExpanded}>
           {items.slice(COLLAPSED_LIST_ITEM_LIMIT).map(item => (
-            <ListItem key={item.id} component={RouterLink} to={item.uri}>
+            <ListItem key={item.id} component={RouterLink} to={item.uri} sx={{ marginTop: gutters(0.5) }}>
               <Avatar variant="rounded" alt="subspace avatar" src={item.cardBanner} aria-label="Subspace avatar" />
 
               <BlockSectionTitle minWidth={0} noWrap>


### PR DESCRIPTION
BUGFIX: Missing padding for the items on the left block on space and subspaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated styling for list items in the expanded view
	- Added top margin to list items for improved visual spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->