### PR TITLE
Entitlements view based on permissions and limits

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1962,6 +1962,7 @@
             "usageNotice": "You have created {{usage}} out of your {{limit}} available {{type}} in your account.",
             "limitNotice": "Contact the Alkemio team to increase the limits on your account",
             "notAvailable": "Not available",
+            "notAvailableNotice": "Contact the Alkemio team to enable this feature on your account",
             "noTemplates": "This Template Pack doesn't have any template yet",
             "customHomepages": "Custom Homepages",
             "hostTitle": "Host",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1961,6 +1961,7 @@
             "innovationPacks": "$t(common.innovation-packs)",
             "usageNotice": "You have created {{usage}} out of your {{limit}} available {{type}} in your account.",
             "limitNotice": "Contact the Alkemio team to increase the limits on your account",
+            "notAvailable": "Not available",
             "noTemplates": "This Template Pack doesn't have any template yet",
             "customHomepages": "Custom Homepages",
             "hostTitle": "Host",

--- a/src/core/ui/grid/Gutters.tsx
+++ b/src/core/ui/grid/Gutters.tsx
@@ -7,10 +7,11 @@ export interface GuttersProps extends BoxProps {
   row?: boolean;
   disablePadding?: boolean;
   disableGap?: boolean;
+  fullHeight?: boolean;
 }
 
 const Gutters = forwardRef(
-  ({ row = false, disablePadding = false, disableGap = false, ...props }: GuttersProps, ref) => {
+  ({ row = false, disablePadding = false, disableGap = false, fullHeight = false, ...props }: GuttersProps, ref) => {
     return (
       <Box
         ref={ref}
@@ -18,6 +19,12 @@ const Gutters = forwardRef(
         flexDirection={row ? 'row' : 'column'}
         padding={disablePadding ? 0 : gutters()}
         gap={disableGap ? undefined : gutters()}
+        {...(fullHeight
+          ? {
+              height: '100%',
+              justifyContent: 'space-between',
+            }
+          : undefined)}
         {...props}
       />
     );

--- a/src/domain/community/contributor/Account/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/Account/ContributorAccountView.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { makeStyles } from '@mui/styles';
 import PageContentColumn from '@/core/ui/content/PageContentColumn';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
 import { BlockTitle, Caption } from '@/core/ui/typography';
@@ -33,7 +32,6 @@ import {
 } from '@/core/apollo/generated/apollo-hooks';
 import CreationButton from '@/core/ui/button/CreationButton';
 import TextWithTooltip from '@/core/ui/typography/TextWithTooltip';
-import { Text } from '@/core/ui/typography/components';
 import { useNotification } from '@/core/ui/notifications/useNotification';
 import EntityConfirmDeleteDialog from '@/domain/journey/space/pages/SpaceSettings/EntityConfirmDeleteDialog';
 import InnovationPackCardHorizontal, {
@@ -124,19 +122,35 @@ export interface ContributorAccountViewProps {
   account?: AccountTabResourcesProps;
 }
 
-const useStyles = makeStyles(() => ({
-  gutters: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    height: '100%',
-  },
-  guttersRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-}));
+const BlockHeader = ({
+  title,
+  tooltip,
+  usage,
+  limit,
+  isAvailable,
+}: {
+  title: string;
+  tooltip: string;
+  usage: number;
+  limit: number;
+  isAvailable: boolean;
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Gutters disablePadding disableGap row justifyContent="space-between">
+      <BlockTitle>{title}</BlockTitle>
+      {isAvailable || usage > 0 ? (
+        <TextWithTooltip text={`${usage}/${limit}`} tooltip={tooltip} />
+      ) : (
+        <TextWithTooltip
+          text={t('pages.admin.generic.sections.account.notAvailable')}
+          tooltip={t('pages.admin.generic.sections.account.notAvailableNotice')}
+        />
+      )}
+    </Gutters>
+  );
+};
 
 export const ContributorAccountView = ({ accountHostName, account, loading }: ContributorAccountViewProps) => {
   const { t } = useTranslation();
@@ -148,7 +162,7 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
   const [entity, setSelectedEntity] = useState<Entities | undefined>(undefined);
-  const styles = useStyles();
+
   const myAccountEntitlements = account?.license?.availableEntitlements || [];
   const myAccountEntitlementDetails = account?.license?.entitlements || [];
   const externalSubscriptionID = account?.externalSubscriptionID;
@@ -408,19 +422,18 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
   return (
     <PageContentColumn columns={12}>
       <PageContentBlock halfWidth>
-        <Gutters disablePadding disableGap className={styles.guttersRow}>
-          <BlockTitle>{t('pages.admin.generic.sections.account.hostedSpaces')}</BlockTitle>
-          <TextWithTooltip
-            text={`${hostedSpaceUsage}/${hostedSpaceLimit}`}
-            tooltip={t('pages.admin.generic.sections.account.usageNotice', {
-              type: t('pages.admin.generic.sections.account.hostedSpaces'),
-              usage: hostedSpaceUsage,
-              limit: hostedSpaceLimit,
-            })}
-          />
-        </Gutters>
-
-        <Gutters disablePadding disableGap className={styles.gutters}>
+        <BlockHeader
+          title={t('pages.admin.generic.sections.account.hostedSpaces')}
+          usage={hostedSpaceUsage}
+          limit={hostedSpaceLimit}
+          isAvailable={canCreateSpace}
+          tooltip={t('pages.admin.generic.sections.account.usageNotice', {
+            type: t('pages.admin.generic.sections.account.hostedSpaces'),
+            usage: hostedSpaceUsage,
+            limit: hostedSpaceLimit,
+          })}
+        />
+        <Gutters disablePadding disableGap fullHeight>
           {loading && <JourneyCardHorizontalSkeleton />}
           <Gutters disablePadding>
             {!loading &&
@@ -459,18 +472,18 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
         </Actions>
       </PageContentBlock>
       <PageContentBlock halfWidth>
-        <Gutters disablePadding disableGap className={styles.guttersRow}>
-          <BlockTitle>{t('pages.admin.generic.sections.account.virtualContributors')}</BlockTitle>
-          <TextWithTooltip
-            text={`${vcUsage}/${vcLimit}`}
-            tooltip={t('pages.admin.generic.sections.account.usageNotice', {
-              type: t('pages.admin.generic.sections.account.virtualContributors'),
-              usage: vcUsage,
-              limit: vcLimit,
-            })}
-          />
-        </Gutters>
-        <Gutters disablePadding className={styles.gutters}>
+        <BlockHeader
+          title={t('pages.admin.generic.sections.account.virtualContributors')}
+          usage={vcUsage}
+          limit={vcLimit}
+          isAvailable={canCreateVirtualContributor}
+          tooltip={t('pages.admin.generic.sections.account.usageNotice', {
+            type: t('pages.admin.generic.sections.account.virtualContributors'),
+            usage: vcUsage,
+            limit: vcLimit,
+          })}
+        />
+        <Gutters disablePadding fullHeight>
           {loading && <JourneyCardHorizontalSkeleton />}
           <Gutters disablePadding>
             {!loading &&
@@ -497,18 +510,18 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
         </Gutters>
       </PageContentBlock>
       <PageContentBlock halfWidth>
-        <Gutters disablePadding disableGap className={styles.guttersRow}>
-          <BlockTitle>{t('pages.admin.generic.sections.account.innovationPacks')}</BlockTitle>
-          <TextWithTooltip
-            text={`${innovationPackUsage}/${innovationPackLimit}`}
-            tooltip={t('pages.admin.generic.sections.account.usageNotice', {
-              type: t('pages.admin.generic.sections.account.innovationPacks'),
-              usage: innovationPackUsage,
-              limit: innovationPackLimit,
-            })}
-          />
-        </Gutters>
-        <Gutters disablePadding className={styles.gutters}>
+        <BlockHeader
+          title={t('pages.admin.generic.sections.account.innovationPacks')}
+          usage={innovationPackUsage}
+          limit={innovationPackLimit}
+          isAvailable={canCreateInnovationPack}
+          tooltip={t('pages.admin.generic.sections.account.usageNotice', {
+            type: t('pages.admin.generic.sections.account.innovationPacks'),
+            usage: innovationPackUsage,
+            limit: innovationPackLimit,
+          })}
+        />
+        <Gutters disablePadding fullHeight>
           {loading && <InnovationPackCardHorizontalSkeleton />}
           {!loading &&
             innovationPacks?.map(pack => (
@@ -533,22 +546,18 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
         </Gutters>
       </PageContentBlock>
       <PageContentBlock halfWidth>
-        <Gutters disablePadding disableGap className={styles.guttersRow}>
-          <BlockTitle>{t('pages.admin.generic.sections.account.customHomepages')}</BlockTitle>
-          {canCreateInnovationHub || innovationHubUsage > 0 ? (
-            <TextWithTooltip
-              text={`${innovationHubUsage}/${innovationHubLimit}`}
-              tooltip={t('pages.admin.generic.sections.account.usageNotice', {
-                type: t('pages.admin.generic.sections.account.customHomepages'),
-                usage: innovationHubUsage,
-                limit: innovationHubLimit,
-              })}
-            />
-          ) : (
-            <Text>{t('pages.admin.generic.sections.account.notAvailable')}</Text>
-          )}
-        </Gutters>
-        <Gutters disablePadding className={styles.gutters}>
+        <BlockHeader
+          title={t('pages.admin.generic.sections.account.customHomepages')}
+          usage={innovationHubUsage}
+          limit={innovationHubLimit}
+          isAvailable={canCreateInnovationHub}
+          tooltip={t('pages.admin.generic.sections.account.usageNotice', {
+            type: t('pages.admin.generic.sections.account.customHomepages'),
+            usage: innovationHubUsage,
+            limit: innovationHubLimit,
+          })}
+        />
+        <Gutters disablePadding fullHeight>
           {loading && <InnovationHubCardHorizontalSkeleton />}
           {!loading &&
             innovationHubs?.map(hub => (

--- a/src/domain/community/contributor/Account/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/Account/ContributorAccountView.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/core/apollo/generated/apollo-hooks';
 import CreationButton from '@/core/ui/button/CreationButton';
 import TextWithTooltip from '@/core/ui/typography/TextWithTooltip';
+import { Text } from '@/core/ui/typography/components';
 import { useNotification } from '@/core/ui/notifications/useNotification';
 import EntityConfirmDeleteDialog from '@/domain/journey/space/pages/SpaceSettings/EntityConfirmDeleteDialog';
 import InnovationPackCardHorizontal, {
@@ -412,7 +413,7 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
           <TextWithTooltip
             text={`${hostedSpaceUsage}/${hostedSpaceLimit}`}
             tooltip={t('pages.admin.generic.sections.account.usageNotice', {
-              type: t('pages.admin.generic.sections.account.virtualContributors'),
+              type: t('pages.admin.generic.sections.account.hostedSpaces'),
               usage: hostedSpaceUsage,
               limit: hostedSpaceLimit,
             })}
@@ -534,14 +535,18 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
       <PageContentBlock halfWidth>
         <Gutters disablePadding disableGap className={styles.guttersRow}>
           <BlockTitle>{t('pages.admin.generic.sections.account.customHomepages')}</BlockTitle>
-          <TextWithTooltip
-            text={`${innovationHubUsage}/${innovationHubLimit}`}
-            tooltip={t('pages.admin.generic.sections.account.usageNotice', {
-              type: t('pages.admin.generic.sections.account.customHomepages'),
-              usage: innovationHubUsage,
-              limit: innovationHubLimit,
-            })}
-          />
+          {canCreateInnovationHub || innovationHubUsage > 0 ? (
+            <TextWithTooltip
+              text={`${innovationHubUsage}/${innovationHubLimit}`}
+              tooltip={t('pages.admin.generic.sections.account.usageNotice', {
+                type: t('pages.admin.generic.sections.account.customHomepages'),
+                usage: innovationHubUsage,
+                limit: innovationHubLimit,
+              })}
+            />
+          ) : (
+            <Text>{t('pages.admin.generic.sections.account.notAvailable')}</Text>
+          )}
         </Gutters>
         <Gutters disablePadding className={styles.gutters}>
           {loading && <InnovationHubCardHorizontalSkeleton />}


### PR DESCRIPTION
- Created a common component for the 4 blocks
- Only show numbers when we have permission to create the entity. If not available, show the text "Not available" and the tooltip "Contact the Alkemio team to enable this feature on your account" 
- Also fixed a wrong tooltip on Space.
- Removed that makeStyles and added a property to Gutters cause I thought it's useful to have that fullHeight behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added "Not available" message for admin settings menu
  - Enhanced conditional rendering in contributor account view

- **Improvements**
  - Improved user feedback for unavailable features
  - Updated UI logic for displaying innovation hub usage information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->