### PR TITLE
display usage-limit of spaces in the account page

### DIFF
--- a/src/domain/community/contributor/Account/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/Account/ContributorAccountView.tsx
@@ -182,9 +182,9 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
 
   // Temporarily we're ordering the priority in this way: Display usage/limit from FREE / PLUS / PREMIUM
   const { limit: hostedSpaceLimit = 0, usage: hostedSpaceUsage = 0 } =
-    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpaceFree) ||
-    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpacePlus) ||
-    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpacePremium) ||
+    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpaceFree) ??
+    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpacePlus) ??
+    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpacePremium) ??
     {};
 
   const { limit: vcLimit = 0, usage: vcUsage = 0 } =

--- a/src/domain/community/contributor/Account/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/Account/ContributorAccountView.tsx
@@ -180,13 +180,12 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
 
   const canDeleteEntities = privileges.includes(AuthorizationPrivilege.Delete);
 
+  // Temporarily we're ordering the priority in this way: Display usage/limit from FREE / PLUS / PREMIUM
   const { limit: hostedSpaceLimit = 0, usage: hostedSpaceUsage = 0 } =
-    myAccountEntitlementDetails.find(
-      entitlement =>
-        entitlement.type === LicenseEntitlementType.AccountSpaceFree ||
-        entitlement.type === LicenseEntitlementType.AccountSpacePlus ||
-        entitlement.type === LicenseEntitlementType.AccountSpacePremium
-    ) ?? {};
+    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpaceFree) ||
+    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpacePlus) ||
+    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpacePremium) ||
+    {};
 
   const { limit: vcLimit = 0, usage: vcUsage = 0 } =
     myAccountEntitlementDetails.find(


### PR DESCRIPTION
display usage-limit of spaces in the account page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the method for retrieving hosted space limits and usage from account entitlement details.
	- Improved logic for finding and processing entitlement information with more explicit searching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->