### PR TITLE
Handle missing privileges for add VC to community.

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -3744,6 +3744,10 @@ export const SpaceProfileCommunityDetailsFragmentDoc = gql`
       id
       roleSet {
         id
+        authorization {
+          id
+          myPrivileges
+        }
       }
     }
   }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -31592,7 +31592,21 @@ export type NewVirtualContributorMySpacesQuery = {
                       }
                     | undefined;
                   profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
-                  community: { __typename?: 'Community'; id: string; roleSet: { __typename?: 'RoleSet'; id: string } };
+                  community: {
+                    __typename?: 'Community';
+                    id: string;
+                    roleSet: {
+                      __typename?: 'RoleSet';
+                      id: string;
+                      authorization?:
+                        | {
+                            __typename?: 'Authorization';
+                            id: string;
+                            myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+                          }
+                        | undefined;
+                    };
+                  };
                 }>;
               }
             | undefined;
@@ -31623,13 +31637,55 @@ export type AccountSpacesQuery = {
                 __typename?: 'Space';
                 id: string;
                 profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
-                community: { __typename?: 'Community'; id: string; roleSet: { __typename?: 'RoleSet'; id: string } };
+                community: {
+                  __typename?: 'Community';
+                  id: string;
+                  roleSet: {
+                    __typename?: 'RoleSet';
+                    id: string;
+                    authorization?:
+                      | {
+                          __typename?: 'Authorization';
+                          id: string;
+                          myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+                        }
+                      | undefined;
+                  };
+                };
               }>;
               profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
-              community: { __typename?: 'Community'; id: string; roleSet: { __typename?: 'RoleSet'; id: string } };
+              community: {
+                __typename?: 'Community';
+                id: string;
+                roleSet: {
+                  __typename?: 'RoleSet';
+                  id: string;
+                  authorization?:
+                    | {
+                        __typename?: 'Authorization';
+                        id: string;
+                        myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+                      }
+                    | undefined;
+                };
+              };
             }>;
             profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
-            community: { __typename?: 'Community'; id: string; roleSet: { __typename?: 'RoleSet'; id: string } };
+            community: {
+              __typename?: 'Community';
+              id: string;
+              roleSet: {
+                __typename?: 'RoleSet';
+                id: string;
+                authorization?:
+                  | {
+                      __typename?: 'Authorization';
+                      id: string;
+                      myPrivileges?: Array<AuthorizationPrivilege> | undefined;
+                    }
+                  | undefined;
+              };
+            };
           }>;
         }
       | undefined;
@@ -31640,7 +31696,17 @@ export type SpaceProfileCommunityDetailsFragment = {
   __typename?: 'Space';
   id: string;
   profile: { __typename?: 'Profile'; id: string; displayName: string; url: string };
-  community: { __typename?: 'Community'; id: string; roleSet: { __typename?: 'RoleSet'; id: string } };
+  community: {
+    __typename?: 'Community';
+    id: string;
+    roleSet: {
+      __typename?: 'RoleSet';
+      id: string;
+      authorization?:
+        | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+        | undefined;
+    };
+  };
 };
 
 export type RecentSpacesQueryVariables = Exact<{

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/newVirtualContributorQueries.graphql
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/newVirtualContributorQueries.graphql
@@ -53,6 +53,10 @@ fragment spaceProfileCommunityDetails on Space {
     id
     roleSet {
       id
+      authorization {
+        id
+        myPrivileges
+      }
     }
   }
 }

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useNewVirtualContributorWizard.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/core/apollo/generated/apollo-hooks';
 import {
   AiPersonaBodyOfKnowledgeType,
+  AuthorizationPrivilege,
   CommunityRoleType,
   CreateCalloutInput,
   CreateVirtualContributorOnAccountMutationVariables,
@@ -65,6 +66,9 @@ export type SelectableSpace = {
   community: {
     roleSet: {
       id: string;
+      authorization?: {
+        myPrivileges?: AuthorizationPrivilege[];
+      };
     };
   };
   subspaces?: SelectableSpace[];
@@ -113,12 +117,19 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
     fetchPolicy: 'cache-and-network',
   });
 
-  const { myAccountId, accountSpaces } = useMemo(() => {
+  const hasCommunityPrivilege = (space: SelectableSpace) => {
+    return space.community.roleSet?.authorization?.myPrivileges?.includes(
+      AuthorizationPrivilege.CommunityAddMemberVcFromAccount
+    );
+  };
+
+  const { myAccountId, allAccountSpaces, availableSpaces } = useMemo(() => {
     const account = targetAccount ?? data?.me.user?.account; // contextual or self by default
 
     return {
       myAccountId: account?.id,
-      accountSpaces: account?.spaces ?? [],
+      allAccountSpaces: account?.spaces ?? [],
+      availableSpaces: account?.spaces?.filter(hasCommunityPrivilege) ?? [],
     };
   }, [data, user, targetAccount]);
 
@@ -137,7 +148,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
   );
 
   // get plans data todo: make lazy, usePlanAvailability is temp
-  const skipPlansQueries = Boolean(accountSpaces.length);
+  const skipPlansQueries = Boolean(allAccountSpaces.length);
   const { data: plansData } = usePlansTableQuery({ skip: skipPlansQueries });
   const { isPlanAvailable } = usePlanAvailability({ skip: skipPlansQueries });
 
@@ -434,7 +445,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
     // Refresh explicitly the ingestion after callouts creation
     refreshIngestion(createdVC.id);
 
-    setStep(steps.chooseCommunity);
+    setChooseCommunityStep();
   };
 
   // ###STEP 'chooseCommunityStep' - Choose Community
@@ -457,6 +468,17 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
     } else {
       notifyErrorOnAddToCommunity();
       handleCloseWizard();
+    }
+  };
+
+  // If there are spaces under the account, but there are no spaces with the privilege to add a VC
+  // navigate to the try info VC step
+  // otherwise, navigate to the choose community step
+  const setChooseCommunityStep = () => {
+    if (allAccountSpaces.length > 0 && availableSpaces.length === 0) {
+      setStep(steps.tryVcInfo);
+    } else {
+      setStep(steps.chooseCommunity);
     }
   };
 
@@ -543,7 +565,7 @@ const useNewVirtualContributorWizard = (): useNewVirtualContributorWizardProvide
             <ChooseCommunity
               onClose={handleCloseChooseCommunity}
               vcName={virtualContributorInput?.name}
-              spaces={accountSpaces}
+              spaces={availableSpaces}
               onSubmit={onChooseCommunity}
               loading={loading || availableSpacesLoading}
             />


### PR DESCRIPTION
In case of missing privileges on all spaces - don't show the Add to community chooser, directly the try info dialog.
In case there are no spaces, or there's at least one space with the privilege - show the choose community dialog presenting only the filtered by privilege spaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced authorization checks for virtual contributor creation
	- Improved space selection logic based on community privileges

- **Improvements**
	- Added more detailed authorization information for community spaces
	- Refined user experience in virtual contributor wizard by filtering available spaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->