### PR TITLE
Fix the save as template option missing due to missing array deps

### DIFF
--- a/src/domain/collaboration/calloutsSet/useCallouts/useCallouts.ts
+++ b/src/domain/collaboration/calloutsSet/useCallouts/useCallouts.ts
@@ -152,6 +152,7 @@ const useCallouts = ({
           tagset => tagset.name === CALLOUT_DISPLAY_LOCATION_TAGSET_NAME
         );
         const flowStates = innovationFlowTagset?.tags;
+
         return {
           ...callout,
           framing: {
@@ -167,7 +168,7 @@ const useCallouts = ({
           groupName: getCalloutGroupNameValue(groupNameTagset?.tags),
         } as TypedCallout;
       }),
-    [calloutsSet]
+    [calloutsSet, canSaveAsTemplate, entitledToSaveAsTemplate]
   );
 
   const submitCalloutsSortOrder = useCallback(

--- a/src/domain/journey/space/SpaceContext/SpaceContext.tsx
+++ b/src/domain/journey/space/SpaceContext/SpaceContext.tsx
@@ -151,12 +151,13 @@ const SpaceContextProvider: FC<SpaceProviderProps> = ({ children }) => {
     };
   }, [
     spacePrivileges,
-    contextPrivileges,
     canReadSubspaces,
-    communityPrivileges,
-    canCreate,
     canCreateSubspaces,
+    canCreateTemplates,
+    canCreate,
+    communityPrivileges,
     collaborationPrivileges,
+    contextPrivileges,
   ]);
 
   const profile = useMemo(() => {

--- a/src/domain/templates/components/Dialogs/CreateEditTemplateDialog/CreateTemplateDialog.tsx
+++ b/src/domain/templates/components/Dialogs/CreateEditTemplateDialog/CreateTemplateDialog.tsx
@@ -28,6 +28,7 @@ const CreateTemplateDialog = ({
   const { t } = useTranslation();
   const [confirmCloseDialogOpen, setConfirmCloseDialogOpen] = useState<boolean>(false);
   const [defaultValues, setDefaultValues] = useState<AnyTemplate | undefined>();
+
   useEffect(() => {
     (async () => {
       if (open) {
@@ -73,7 +74,10 @@ const CreateTemplateDialog = ({
         }}
         actions={{
           onCancel: () => setConfirmCloseDialogOpen(false),
-          onConfirm: () => onClose?.(),
+          onConfirm: () => {
+            onClose?.();
+            setConfirmCloseDialogOpen(false);
+          },
         }}
         options={{
           show: confirmCloseDialogOpen,


### PR DESCRIPTION
Fixing:

- Save as template not available for callouts - missing deps in useMemo deps array (Space Context);
- Deps added into the callouts as well - potential issues (useCallouts);
- Confirm Discard template creation Dialog not closing after the user confirms the choice. 

![image](https://github.com/user-attachments/assets/cb1b820a-1b9d-4642-8d85-2a485ea584ae)

![image](https://github.com/user-attachments/assets/725a8de1-2f6d-4058-858e-57e59fc85ac6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced memoization for callouts computation
	- Updated Space Context to include more profile details
	- Refined dialog close behavior in template creation flow

- **Technical Updates**
	- Added more comprehensive dependency tracking for context and hook calculations
	- Expanded profile information tracking in Space Context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->