### PR TITLE
Fix first-child + useEffect dynamic deps array length console errors;

### DIFF
--- a/src/core/ui/card/ContributeCard.tsx
+++ b/src/core/ui/card/ContributeCard.tsx
@@ -35,7 +35,7 @@ const ContributeCard = forwardRef<HTMLDivElement, PropsWithChildren<ContributeCa
           state,
         };
       }
-      return Paper;
+      return {};
     };
 
     return (

--- a/src/core/ui/forms/MarkdownInput/MarkdownInput.tsx
+++ b/src/core/ui/forms/MarkdownInput/MarkdownInput.tsx
@@ -56,7 +56,7 @@ const proseMirrorStyles = {
   outline: 'none',
   minHeight: gutters(4),
   padding: gutters(0.5),
-  '& p:first-child': { marginTop: 0 },
+  '& p:first-of-type': { marginTop: 0 },
   '& p:last-child': { marginBottom: 0 },
   '& img': { maxWidth: '100%' },
 } as const;

--- a/src/domain/communication/room/Comments/FormikCommentInputField.tsx
+++ b/src/domain/communication/room/Comments/FormikCommentInputField.tsx
@@ -148,6 +148,7 @@ export const FormikCommentInputField: FC<FormikCommentInputFieldProps> = ({
         onClick={() => setEmojiSelectorOpen(!isEmojiSelectorOpen)}
         disabled={inactive || readOnly}
         aria-label={t('messaging.insertEmoji')}
+        sx={{ marginLeft: theme => theme.spacing(-1) }}
       >
         <EmojiEmotionsOutlinedIcon fontSize="small" />
       </IconButton>
@@ -194,20 +195,7 @@ export const FormikCommentInputField: FC<FormikCommentInputFieldProps> = ({
                     height: '100%',
                   },
             })}
-            startAdornment={
-              !compactMode && (
-                <InputAdornment
-                  position="start"
-                  sx={{
-                    '& > :first-child': theme => ({
-                      marginLeft: theme.spacing(-1),
-                    }),
-                  }}
-                >
-                  {buttons}
-                </InputAdornment>
-              )
-            }
+            startAdornment={!compactMode && <InputAdornment position="start">{buttons}</InputAdornment>}
             endAdornment={
               <InputAdornment position="end">
                 <IconButton size="small" type="submit" disabled={submitDisabled} aria-label={t('buttons.send')}>

--- a/src/domain/communication/room/Comments/MessageView.tsx
+++ b/src/domain/communication/room/Comments/MessageView.tsx
@@ -30,7 +30,7 @@ const MessageActionsContainer = styled('ul')(({ theme }) => ({
     listStyleType: 'none',
     display: 'flex',
     alignItems: 'center',
-    '&:not(:first-child):before': {
+    '&:not(:first-of-type):before': {
       content: '""',
       width: theme.spacing(0.1),
       marginLeft: theme.spacing(0.4),

--- a/src/domain/journey/dashboardNavigation/DashboardNavigation.tsx
+++ b/src/domain/journey/dashboardNavigation/DashboardNavigation.tsx
@@ -91,7 +91,7 @@ const DashboardNavigation = ({
     for (const key of difference(Object.keys(itemRefs), ids)) {
       itemRefs[key] = null;
     }
-  }, [ids]);
+  }, [ids.join(',')]);
 
   const rootItem = dashboardNavigationRoot && itemRefs[dashboardNavigationRoot.id];
 

--- a/src/domain/journey/space/spaceDashboardNavigation/useSpaceDashboardNavigation.ts
+++ b/src/domain/journey/space/spaceDashboardNavigation/useSpaceDashboardNavigation.ts
@@ -96,7 +96,7 @@ const useSpaceDashboardNavigation = ({
     if (readableChallengeIds.length > 0) {
       refetchOpportunities();
     }
-  }, readableChallengeIds);
+  }, [readableChallengeIds.join(',')]);
 
   const challengesWithOpportunitiesById = useMemo(
     () => keyBy(opportunitiesQueryData?.lookup.space?.subspaces, 'id'),


### PR DESCRIPTION
Fixing the console errors mainly on the Space dash:

- A couple of style fixes tested locally (see screenshots);
- useEffect w dynamic length of the deps array (see useDashboardNavigation, screenshot);

![image](https://github.com/user-attachments/assets/b781a1cf-e151-451b-8eaa-2348766f451b)

![image](https://github.com/user-attachments/assets/54eec555-b373-4736-8d25-1b92a1a498fb)

![image](https://github.com/user-attachments/assets/cfb54999-8775-4aff-a66e-e62df8923409)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated CSS selectors in multiple components for more precise styling
	- Modified `useEffect` hooks to improve dependency tracking by converting array dependencies to strings
	- Simplified component prop handling and input adornment rendering

- **Style**
	- Adjusted styling for message actions and input components
	- Fine-tuned margin and layout of emoji selector button

The changes focus on improving code quality and component rendering without introducing major user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->