### PR TITLE
Fix missing callouts in create subspace template preview

### DIFF
--- a/src/domain/templates/components/Previews/CollaborationTemplatePreview.tsx
+++ b/src/domain/templates/components/Previews/CollaborationTemplatePreview.tsx
@@ -15,7 +15,9 @@ interface CollaborationTemplatePreviewProps {
       innovationFlow?: {
         states: InnovationFlowState[];
       };
-      callouts?: InnovationFlowCalloutsPreviewProps['callouts'];
+      calloutsSet?: {
+        callouts?: InnovationFlowCalloutsPreviewProps['callouts'];
+      };
     };
   };
 }
@@ -23,6 +25,7 @@ interface CollaborationTemplatePreviewProps {
 const CollaborationTemplatePreview = ({ template, loading }: CollaborationTemplatePreviewProps) => {
   const [selectedState, setSelectedState] = useState<string | undefined>(undefined);
   const templateStates = template?.collaboration?.innovationFlow?.states ?? [];
+  const callouts = template?.collaboration?.calloutsSet?.callouts ?? [];
 
   useEffect(() => {
     if (
@@ -55,11 +58,7 @@ const CollaborationTemplatePreview = ({ template, loading }: CollaborationTempla
           onSelectState={state => setSelectedState(state.displayName)}
         />
       )}
-      <InnovationFlowCalloutsPreview
-        callouts={template?.collaboration?.callouts}
-        selectedState={selectedState}
-        loading={loading}
-      />
+      <InnovationFlowCalloutsPreview callouts={callouts} selectedState={selectedState} loading={loading} />
     </PageContentBlock>
   );
 };


### PR DESCRIPTION
The calloutSet changes were missing for the TemplatePrivew.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated data structure for accessing collaboration template callouts
	- Modified how callouts are retrieved and passed to preview components

The changes primarily involve internal restructuring of template data access, ensuring consistent handling of collaboration template preview information without altering the core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->