### PR TITLE
disable new posts on knowledgebase callouts

### DIFF
--- a/src/domain/collaboration/callout/CalloutForm.tsx
+++ b/src/domain/collaboration/callout/CalloutForm.tsx
@@ -91,6 +91,7 @@ export interface CalloutFormProps {
   journeyTypeName: JourneyTypeName;
   temporaryLocation?: boolean;
   disableRichMedia?: boolean; // images, videos, iframe, etc.
+  acceptNewResponses?: boolean;
 }
 
 const CalloutForm = ({
@@ -104,6 +105,7 @@ const CalloutForm = ({
   children,
   temporaryLocation = false,
   disableRichMedia,
+  acceptNewResponses = true,
 }: CalloutFormProps) => {
   const { t } = useTranslation();
 
@@ -127,7 +129,7 @@ const CalloutForm = ({
       type: calloutType,
       tagsets,
       references: callout?.references ?? [],
-      opened: (callout?.state ?? CalloutState.Open) === CalloutState.Open,
+      opened: acceptNewResponses && (callout?.state ?? CalloutState.Open) === CalloutState.Open,
       groupName: callout?.groupName ?? CalloutGroupName.Knowledge,
       postDescription: callout.postDescription ?? '',
       whiteboardContent: callout.whiteboardContent ?? EmptyWhiteboardString,
@@ -194,7 +196,7 @@ const CalloutForm = ({
     tags: true,
     postTemplate: calloutType === CalloutType.PostCollection,
     whiteboardTemplate: calloutType === CalloutType.WhiteboardCollection,
-    newResponses: calloutType !== CalloutType.Whiteboard,
+    newResponses: acceptNewResponses && calloutType !== CalloutType.Whiteboard,
     locationChange: editMode && Boolean(canChangeCalloutLocation),
     whiteboard: calloutType === CalloutType.Whiteboard,
   };

--- a/src/domain/collaboration/callout/CalloutViewTypes.tsx
+++ b/src/domain/collaboration/callout/CalloutViewTypes.tsx
@@ -35,4 +35,5 @@ export interface BaseCalloutViewProps extends CalloutLayoutEvents, Partial<Callo
   onCalloutUpdate?: () => void;
   disableMarginal?: boolean;
   disableRichMedia?: boolean;
+  acceptNewResponses?: boolean;
 }

--- a/src/domain/collaboration/callout/calloutBlock/CalloutSettingsContainer.tsx
+++ b/src/domain/collaboration/callout/calloutBlock/CalloutSettingsContainer.tsx
@@ -119,6 +119,7 @@ export interface CalloutSettingsContainerProps
   onExpand?: () => void;
   journeyTypeName: JourneyTypeName;
   disableRichMedia?: boolean;
+  acceptNewResponses?: boolean;
 }
 
 const CalloutSettingsContainer = ({
@@ -138,6 +139,7 @@ const CalloutSettingsContainer = ({
   journeyTypeName,
   children,
   disableRichMedia,
+  acceptNewResponses,
 }: CalloutSettingsContainerProps) => {
   const { t } = useTranslation();
 
@@ -446,6 +448,7 @@ const CalloutSettingsContainer = ({
           canChangeCalloutLocation
           journeyTypeName={journeyTypeName}
           disableRichMedia={disableRichMedia}
+          acceptNewResponses={acceptNewResponses}
         />
       )}
       <ConfirmationDialog

--- a/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
+++ b/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
@@ -57,6 +57,7 @@ export interface CalloutCreationDialogProps {
   journeyTypeName: JourneyTypeName;
   availableCalloutTypes?: CalloutType[];
   disableRichMedia?: boolean;
+  acceptNewResponses?: boolean;
 }
 
 const CalloutCreationDialog = ({
@@ -69,6 +70,7 @@ const CalloutCreationDialog = ({
   journeyTypeName,
   availableCalloutTypes,
   disableRichMedia,
+  acceptNewResponses,
 }: CalloutCreationDialogProps) => {
   const { t } = useTranslation();
   const [callout, setCallout] = useState<CalloutCreationDialogFields>({});
@@ -279,6 +281,7 @@ const CalloutCreationDialog = ({
               journeyTypeName={journeyTypeName}
               temporaryLocation // Always true for callout creation
               disableRichMedia={disableRichMedia}
+              acceptNewResponses={acceptNewResponses}
             />
           </DialogContent>
 

--- a/src/domain/collaboration/callout/edit/editDialog/CalloutEditDialog.tsx
+++ b/src/domain/collaboration/callout/edit/editDialog/CalloutEditDialog.tsx
@@ -24,6 +24,7 @@ export interface CalloutEditDialogProps {
   canChangeCalloutLocation?: boolean;
   journeyTypeName: JourneyTypeName;
   disableRichMedia?: boolean;
+  acceptNewResponses?: boolean;
 }
 
 const CalloutEditDialog = ({
@@ -36,6 +37,7 @@ const CalloutEditDialog = ({
   canChangeCalloutLocation,
   journeyTypeName,
   disableRichMedia,
+  acceptNewResponses = true,
 }: CalloutEditDialogProps) => {
   const { t } = useTranslation();
 
@@ -111,6 +113,7 @@ const CalloutEditDialog = ({
               canChangeCalloutLocation={canChangeCalloutLocation}
               journeyTypeName={journeyTypeName}
               disableRichMedia={disableRichMedia}
+              acceptNewResponses={acceptNewResponses}
             />
           </StorageConfigContextProvider>
         </DialogContent>

--- a/src/domain/collaboration/calloutsSet/CalloutsInContext/CalloutsGroupView.tsx
+++ b/src/domain/collaboration/calloutsSet/CalloutsInContext/CalloutsGroupView.tsx
@@ -14,6 +14,7 @@ interface CalloutsGroupProps extends CalloutsViewProps {
   createButtonPlace?: 'top' | 'bottom';
   availableCalloutTypes?: CalloutType[];
   disableRichMedia?: boolean;
+  acceptNewResponses?: boolean;
 }
 
 const CalloutsGroupView = ({
@@ -25,6 +26,7 @@ const CalloutsGroupView = ({
   calloutsSetId,
   availableCalloutTypes,
   disableRichMedia,
+  acceptNewResponses,
   ...calloutsViewProps
 }: CalloutsGroupProps) => {
   const {
@@ -52,7 +54,12 @@ const CalloutsGroupView = ({
   return (
     <>
       {canCreateCallout && createButtonPlace === 'top' && createButton}
-      <CalloutsView journeyTypeName={journeyTypeName} disableRichMedia={disableRichMedia} {...calloutsViewProps} />
+      <CalloutsView
+        journeyTypeName={journeyTypeName}
+        disableRichMedia={disableRichMedia}
+        acceptNewResponses={acceptNewResponses}
+        {...calloutsViewProps}
+      />
       {canCreateCallout && createButtonPlace === 'bottom' && createButton}
       <CalloutCreationDialog
         open={isCalloutCreationDialogOpen}
@@ -64,6 +71,7 @@ const CalloutsGroupView = ({
         journeyTypeName={journeyTypeName}
         availableCalloutTypes={availableCalloutTypes}
         disableRichMedia={disableRichMedia}
+        acceptNewResponses={acceptNewResponses}
       />
     </>
   );

--- a/src/domain/collaboration/calloutsSet/CalloutsView/CalloutsView.tsx
+++ b/src/domain/collaboration/calloutsSet/CalloutsView/CalloutsView.tsx
@@ -41,6 +41,7 @@ export interface CalloutsViewProps {
     | ((callout: TypedCallout, index: number) => Partial<PageContentBlockProps> | undefined);
   disableMarginal?: boolean;
   disableRichMedia?: boolean;
+  acceptNewResponses?: boolean;
 }
 
 const CalloutsView = ({
@@ -52,6 +53,7 @@ const CalloutsView = ({
   blockProps,
   disableMarginal,
   disableRichMedia,
+  acceptNewResponses,
 }: CalloutsViewProps) => {
   const { handleEdit, handleVisibilityChange, handleDelete } = useCalloutEdit();
 
@@ -138,6 +140,7 @@ const CalloutsView = ({
                         onExpand={() => handleExpand(calloutDetails)}
                         disableMarginal={disableMarginal}
                         disableRichMedia={disableRichMedia}
+                        acceptNewResponses={acceptNewResponses}
                         {...sortEvents}
                         {...sortProps}
                       />

--- a/src/domain/community/virtualContributor/knowledgeBase/KnowledgeBaseDialog.tsx
+++ b/src/domain/community/virtualContributor/knowledgeBase/KnowledgeBaseDialog.tsx
@@ -59,6 +59,7 @@ const KnowledgeBaseDialog = ({ onClose, title, id }: KnowledgeBaseDialogProps) =
               createButtonPlace="bottom"
               availableCalloutTypes={AVAILABLE_CALLOUT_TYPES}
               disableRichMedia
+              acceptNewResponses={false}
             />
           </Gutters>
         </StorageConfigContextProvider>


### PR DESCRIPTION
added `acceptNewResponses` property in several places to remove the usage of messages on knowledgebase callouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `acceptNewResponses` property across multiple callout-related components
	- Enables fine-grained control over accepting new responses in callouts

- **Improvements**
	- Added optional boolean flag to manage response acceptance in callout forms, views, and dialogs
	- Default behavior set to allow new responses (`true`)

- **Use Cases**
	- Provides flexibility in configuring callout response settings
	- Allows disabling new responses for specific callout contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->