### PR TITLE
knowledgebase-disable-new-posts

### DIFF
--- a/src/domain/collaboration/callout/CalloutForm.tsx
+++ b/src/domain/collaboration/callout/CalloutForm.tsx
@@ -91,7 +91,7 @@ export interface CalloutFormProps {
   journeyTypeName: JourneyTypeName;
   temporaryLocation?: boolean;
   disableRichMedia?: boolean; // images, videos, iframe, etc.
-  acceptNewResponses?: boolean;
+  disablePostResponses?: boolean;
 }
 
 const CalloutForm = ({
@@ -105,7 +105,7 @@ const CalloutForm = ({
   children,
   temporaryLocation = false,
   disableRichMedia,
-  acceptNewResponses = true,
+  disablePostResponses = false,
 }: CalloutFormProps) => {
   const { t } = useTranslation();
 
@@ -129,7 +129,7 @@ const CalloutForm = ({
       type: calloutType,
       tagsets,
       references: callout?.references ?? [],
-      opened: acceptNewResponses && (callout?.state ?? CalloutState.Open) === CalloutState.Open,
+      opened: !disablePostResponses && (callout?.state ?? CalloutState.Open) === CalloutState.Open,
       groupName: callout?.groupName ?? CalloutGroupName.Knowledge,
       postDescription: callout.postDescription ?? '',
       whiteboardContent: callout.whiteboardContent ?? EmptyWhiteboardString,
@@ -196,7 +196,7 @@ const CalloutForm = ({
     tags: true,
     postTemplate: calloutType === CalloutType.PostCollection,
     whiteboardTemplate: calloutType === CalloutType.WhiteboardCollection,
-    newResponses: acceptNewResponses && calloutType !== CalloutType.Whiteboard,
+    newResponses: !disablePostResponses && calloutType !== CalloutType.Whiteboard,
     locationChange: editMode && Boolean(canChangeCalloutLocation),
     whiteboard: calloutType === CalloutType.Whiteboard,
   };

--- a/src/domain/collaboration/callout/CalloutView/CalloutView.tsx
+++ b/src/domain/collaboration/callout/CalloutView/CalloutView.tsx
@@ -29,7 +29,7 @@ const CalloutView = ({ callout, ...props }: CalloutViewProps) => {
         </WhiteboardCollectionCalloutContainer>
       );
     case CalloutType.Post:
-      return <CommentsCallout callout={callout} {...props} />;
+      return <CommentsCallout callout={callout} disablePostResponses {...props} />;
     case CalloutType.LinkCollection:
       return <LinkCollectionCallout callout={callout} {...props} />;
     case CalloutType.Whiteboard:

--- a/src/domain/collaboration/callout/CalloutViewTypes.tsx
+++ b/src/domain/collaboration/callout/CalloutViewTypes.tsx
@@ -35,5 +35,5 @@ export interface BaseCalloutViewProps extends CalloutLayoutEvents, Partial<Callo
   onCalloutUpdate?: () => void;
   disableMarginal?: boolean;
   disableRichMedia?: boolean;
-  acceptNewResponses?: boolean;
+  disablePostResponses?: boolean;
 }

--- a/src/domain/collaboration/callout/calloutBlock/CalloutSettingsContainer.tsx
+++ b/src/domain/collaboration/callout/calloutBlock/CalloutSettingsContainer.tsx
@@ -119,7 +119,7 @@ export interface CalloutSettingsContainerProps
   onExpand?: () => void;
   journeyTypeName: JourneyTypeName;
   disableRichMedia?: boolean;
-  acceptNewResponses?: boolean;
+  disablePostResponses?: boolean;
 }
 
 const CalloutSettingsContainer = ({
@@ -139,7 +139,7 @@ const CalloutSettingsContainer = ({
   journeyTypeName,
   children,
   disableRichMedia,
-  acceptNewResponses,
+  disablePostResponses,
 }: CalloutSettingsContainerProps) => {
   const { t } = useTranslation();
 
@@ -448,7 +448,7 @@ const CalloutSettingsContainer = ({
           canChangeCalloutLocation
           journeyTypeName={journeyTypeName}
           disableRichMedia={disableRichMedia}
-          acceptNewResponses={acceptNewResponses}
+          disablePostResponses={disablePostResponses && callout.type === CalloutType.Post}
         />
       )}
       <ConfirmationDialog

--- a/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
+++ b/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
@@ -57,7 +57,7 @@ export interface CalloutCreationDialogProps {
   journeyTypeName: JourneyTypeName;
   availableCalloutTypes?: CalloutType[];
   disableRichMedia?: boolean;
-  acceptNewResponses?: boolean;
+  disablePostResponses?: boolean;
 }
 
 const CalloutCreationDialog = ({
@@ -70,7 +70,7 @@ const CalloutCreationDialog = ({
   journeyTypeName,
   availableCalloutTypes,
   disableRichMedia,
-  acceptNewResponses,
+  disablePostResponses,
 }: CalloutCreationDialogProps) => {
   const { t } = useTranslation();
   const [callout, setCallout] = useState<CalloutCreationDialogFields>({});
@@ -281,7 +281,7 @@ const CalloutCreationDialog = ({
               journeyTypeName={journeyTypeName}
               temporaryLocation // Always true for callout creation
               disableRichMedia={disableRichMedia}
-              acceptNewResponses={acceptNewResponses}
+              disablePostResponses={disablePostResponses && selectedCalloutType === CalloutType.Post}
             />
           </DialogContent>
 

--- a/src/domain/collaboration/callout/edit/editDialog/CalloutEditDialog.tsx
+++ b/src/domain/collaboration/callout/edit/editDialog/CalloutEditDialog.tsx
@@ -24,7 +24,7 @@ export interface CalloutEditDialogProps {
   canChangeCalloutLocation?: boolean;
   journeyTypeName: JourneyTypeName;
   disableRichMedia?: boolean;
-  acceptNewResponses?: boolean;
+  disablePostResponses?: boolean;
 }
 
 const CalloutEditDialog = ({
@@ -37,7 +37,7 @@ const CalloutEditDialog = ({
   canChangeCalloutLocation,
   journeyTypeName,
   disableRichMedia,
-  acceptNewResponses = true,
+  disablePostResponses = false,
 }: CalloutEditDialogProps) => {
   const { t } = useTranslation();
 
@@ -113,7 +113,7 @@ const CalloutEditDialog = ({
               canChangeCalloutLocation={canChangeCalloutLocation}
               journeyTypeName={journeyTypeName}
               disableRichMedia={disableRichMedia}
-              acceptNewResponses={acceptNewResponses}
+              disablePostResponses={disablePostResponses}
             />
           </StorageConfigContextProvider>
         </DialogContent>

--- a/src/domain/collaboration/calloutsSet/CalloutsInContext/CalloutsGroupView.tsx
+++ b/src/domain/collaboration/calloutsSet/CalloutsInContext/CalloutsGroupView.tsx
@@ -14,7 +14,7 @@ interface CalloutsGroupProps extends CalloutsViewProps {
   createButtonPlace?: 'top' | 'bottom';
   availableCalloutTypes?: CalloutType[];
   disableRichMedia?: boolean;
-  acceptNewResponses?: boolean;
+  disablePostResponses?: boolean;
 }
 
 const CalloutsGroupView = ({
@@ -26,7 +26,7 @@ const CalloutsGroupView = ({
   calloutsSetId,
   availableCalloutTypes,
   disableRichMedia,
-  acceptNewResponses,
+  disablePostResponses,
   ...calloutsViewProps
 }: CalloutsGroupProps) => {
   const {
@@ -57,7 +57,7 @@ const CalloutsGroupView = ({
       <CalloutsView
         journeyTypeName={journeyTypeName}
         disableRichMedia={disableRichMedia}
-        acceptNewResponses={acceptNewResponses}
+        disablePostResponses={disablePostResponses}
         {...calloutsViewProps}
       />
       {canCreateCallout && createButtonPlace === 'bottom' && createButton}
@@ -71,7 +71,7 @@ const CalloutsGroupView = ({
         journeyTypeName={journeyTypeName}
         availableCalloutTypes={availableCalloutTypes}
         disableRichMedia={disableRichMedia}
-        acceptNewResponses={acceptNewResponses}
+        disablePostResponses={disablePostResponses}
       />
     </>
   );

--- a/src/domain/collaboration/calloutsSet/CalloutsView/CalloutsView.tsx
+++ b/src/domain/collaboration/calloutsSet/CalloutsView/CalloutsView.tsx
@@ -41,7 +41,7 @@ export interface CalloutsViewProps {
     | ((callout: TypedCallout, index: number) => Partial<PageContentBlockProps> | undefined);
   disableMarginal?: boolean;
   disableRichMedia?: boolean;
-  acceptNewResponses?: boolean;
+  disablePostResponses?: boolean;
 }
 
 const CalloutsView = ({
@@ -53,7 +53,7 @@ const CalloutsView = ({
   blockProps,
   disableMarginal,
   disableRichMedia,
-  acceptNewResponses,
+  disablePostResponses,
 }: CalloutsViewProps) => {
   const { handleEdit, handleVisibilityChange, handleDelete } = useCalloutEdit();
 
@@ -140,7 +140,7 @@ const CalloutsView = ({
                         onExpand={() => handleExpand(calloutDetails)}
                         disableMarginal={disableMarginal}
                         disableRichMedia={disableRichMedia}
-                        acceptNewResponses={acceptNewResponses}
+                        disablePostResponses={disablePostResponses}
                         {...sortEvents}
                         {...sortProps}
                       />

--- a/src/domain/community/virtualContributor/knowledgeBase/KnowledgeBaseDialog.tsx
+++ b/src/domain/community/virtualContributor/knowledgeBase/KnowledgeBaseDialog.tsx
@@ -59,7 +59,7 @@ const KnowledgeBaseDialog = ({ onClose, title, id }: KnowledgeBaseDialogProps) =
               createButtonPlace="bottom"
               availableCalloutTypes={AVAILABLE_CALLOUT_TYPES}
               disableRichMedia
-              acceptNewResponses={false}
+              disablePostResponses
             />
           </Gutters>
         </StorageConfigContextProvider>


### PR DESCRIPTION
- old implementation fixed collection of...
- changed enable.. to disable...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
	- Renamed `acceptNewResponses` property to `disablePostResponses` across multiple components
	- Updated default behavior from accepting new responses to potentially disabling post responses

- **Refactoring**
	- Modified response handling logic in callout-related components
	- Adjusted prop interfaces to reflect new response management approach

- **Impact**
	- Changes affect how responses are managed in callouts and collaboration features
	- Developers will need to update prop usage when working with these components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->