### PR TITLE
renamed space level enum entries

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -1770,14 +1770,18 @@ export const JourneyCommunityFragmentDoc = gql`
   ${RoleSetMemberUserFragmentDoc}
   ${RoleSetMemberOrganizationFragmentDoc}
 `;
-export const JourneyBreadcrumbsProfileFragmentDoc = gql`
-  fragment JourneyBreadcrumbsProfile on Profile {
+export const JourneyBreadcrumbsSpaceFragmentDoc = gql`
+  fragment JourneyBreadcrumbsSpace on Space {
     id
-    url
-    displayName
-    avatar: visual(type: $visualType) {
+    level
+    profile {
       id
-      ...VisualUri
+      url
+      displayName
+      avatar: visual(type: $visualType) {
+        id
+        ...VisualUri
+      }
     }
   }
   ${VisualUriFragmentDoc}
@@ -15307,25 +15311,16 @@ export const JourneyBreadcrumbsSpaceDocument = gql`
     $visualType: VisualType! = AVATAR
   ) {
     space(ID: $spaceNameId) {
-      id
-      profile {
-        ...JourneyBreadcrumbsProfile
-      }
+      ...JourneyBreadcrumbsSpace
       subspace(ID: $subspaceLevel1NameId) @include(if: $includeSubspaceLevel1) {
-        id
-        profile {
-          ...JourneyBreadcrumbsProfile
-        }
+        ...JourneyBreadcrumbsSpace
         subspace(ID: $subspaceLevel2NameId) @include(if: $includeSubspaceLevel2) {
-          id
-          profile {
-            ...JourneyBreadcrumbsProfile
-          }
+          ...JourneyBreadcrumbsSpace
         }
       }
     }
   }
-  ${JourneyBreadcrumbsProfileFragmentDoc}
+  ${JourneyBreadcrumbsSpaceFragmentDoc}
 `;
 
 /**

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -6041,9 +6041,9 @@ export type SpaceFilterInput = {
 };
 
 export enum SpaceLevel {
-  Challenge = 'CHALLENGE',
-  Opportunity = 'OPPORTUNITY',
-  Space = 'SPACE',
+  L0 = 'L0',
+  L1 = 'L1',
+  L2 = 'L2',
 }
 
 export type SpacePendingMembershipInfo = {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -19885,26 +19885,15 @@ export type JourneyBreadcrumbsSpaceQuery = {
   space: {
     __typename?: 'Space';
     id: string;
-    profile: {
-      __typename?: 'Profile';
-      id: string;
-      url: string;
-      displayName: string;
-      avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-    };
+    level: SpaceLevel;
     subspace?: {
       __typename?: 'Space';
       id: string;
-      profile: {
-        __typename?: 'Profile';
-        id: string;
-        url: string;
-        displayName: string;
-        avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-      };
+      level: SpaceLevel;
       subspace?: {
         __typename?: 'Space';
         id: string;
+        level: SpaceLevel;
         profile: {
           __typename?: 'Profile';
           id: string;
@@ -19913,16 +19902,35 @@ export type JourneyBreadcrumbsSpaceQuery = {
           avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
         };
       };
+      profile: {
+        __typename?: 'Profile';
+        id: string;
+        url: string;
+        displayName: string;
+        avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+      };
+    };
+    profile: {
+      __typename?: 'Profile';
+      id: string;
+      url: string;
+      displayName: string;
+      avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
     };
   };
 };
 
-export type JourneyBreadcrumbsProfileFragment = {
-  __typename?: 'Profile';
+export type JourneyBreadcrumbsSpaceFragment = {
+  __typename?: 'Space';
   id: string;
-  url: string;
-  displayName: string;
-  avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+  level: SpaceLevel;
+  profile: {
+    __typename?: 'Profile';
+    id: string;
+    url: string;
+    displayName: string;
+    avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
+  };
 };
 
 export type SubspaceProviderQueryVariables = Exact<{

--- a/src/dev/ui/SearchCardsDemo.tsx
+++ b/src/dev/ui/SearchCardsDemo.tsx
@@ -56,7 +56,7 @@ const searchResults: SearchResult[] = [
         displayName: 'Parent Challenge',
         url: '/space1',
       },
-      level: SpaceLevel.Challenge,
+      level: SpaceLevel.L1,
     },
   },
   {
@@ -90,7 +90,7 @@ const searchResults: SearchResult[] = [
         displayName: 'Parent Space',
         url: '/space2',
       },
-      level: SpaceLevel.Space,
+      level: SpaceLevel.L0,
     },
   },
 ];

--- a/src/domain/access/AvailableContributors/useRoleSetAvailableContributors.ts
+++ b/src/domain/access/AvailableContributors/useRoleSetAvailableContributors.ts
@@ -237,14 +237,14 @@ const useRoleSetAvailableContributors = ({
   ) => {
     const { data, refetch } = await fetchAvailableVirtualContributorsForRoleSet({
       variables: {
-        filterSpace: !all || spaceLevel !== SpaceLevel.Space,
+        filterSpace: !all || spaceLevel !== SpaceLevel.L0,
         filterSpaceId: spaceId,
       },
     });
     const roleSet = data?.lookup?.space?.community?.roleSet;
 
     // Results for Space Level - on Account if !all (filter in the query)
-    if (spaceLevel === SpaceLevel.Space) {
+    if (spaceLevel === SpaceLevel.L0) {
       return mockPaginatedResponse(
         (data?.lookup?.space?.account.virtualContributors ?? data?.virtualContributors ?? []).filter(
           vc => filterByName(vc, filter) && filterExisting(vc)

--- a/src/domain/community/application/applicationButton/ApplicationButton.tsx
+++ b/src/domain/community/application/applicationButton/ApplicationButton.tsx
@@ -140,7 +140,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
       extended
         ? t('components.application-button.extendedMessage', {
             join: verb,
-            journey: spaceLevel !== SpaceLevel.Space ? t('common.subspace') : t('common.community'),
+            journey: spaceLevel !== SpaceLevel.L0 ? t('common.subspace') : t('common.community'),
           })
         : verb;
 

--- a/src/domain/community/contributor/organization/OrganizationPageContainer/OrganizationPageContainer.tsx
+++ b/src/domain/community/contributor/organization/OrganizationPageContainer/OrganizationPageContainer.tsx
@@ -131,7 +131,7 @@ export const OrganizationPageContainer = ({ children }: PropsWithChildren<Organi
   const contributions = useMemo(() => {
     const spaceContributions = (orgRolesData?.rolesOrganization?.spaces ?? []).map<SpaceHostedItem>(x => ({
       spaceID: x.id,
-      spaceLevel: SpaceLevel.Space,
+      spaceLevel: SpaceLevel.L0,
       id: x.id,
       contributorId: organizationId,
       contributorType: RoleSetContributorType.Organization,

--- a/src/domain/community/invitations/InvitationDialog.tsx
+++ b/src/domain/community/invitations/InvitationDialog.tsx
@@ -4,7 +4,7 @@ import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import Gutters from '@/core/ui/grid/Gutters';
 import { CheckOutlined, HdrStrongOutlined } from '@mui/icons-material';
 import JourneyCard from '@/domain/journey/common/JourneyCard/JourneyCard';
-import spaceIcon from '@/domain/shared/components/JourneyIcon/JourneyIcon';
+import { spaceLevelIcon } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
 import JourneyCardTagline from '@/domain/journey/common/JourneyCard/JourneyCardTagline';
 import { BlockSectionTitle, Caption, Text } from '@/core/ui/typography';
 import DetailedActivityDescription from '@/domain/shared/components/ActivityDescription/DetailedActivityDescription';
@@ -96,7 +96,7 @@ const InvitationDialog = ({
                     alignItems={isMobile ? 'center' : 'start'}
                   >
                     <JourneyCard
-                      iconComponent={spaceIcon[getChildJourneyTypeName(invitation.space)]}
+                      iconComponent={spaceLevelIcon[invitation.space.level]}
                       header={invitation.space.profile.displayName}
                       tags={invitation.space.profile.tagset?.tags ?? []}
                       banner={invitation.space.profile.visual}

--- a/src/domain/community/invitations/SingleInvitationFull.tsx
+++ b/src/domain/community/invitations/SingleInvitationFull.tsx
@@ -3,7 +3,7 @@ import { InvitationHydrator, InvitationWithMeta } from '../pendingMembership/Pen
 import Gutters from '@/core/ui/grid/Gutters';
 import { CheckOutlined, HdrStrongOutlined } from '@mui/icons-material';
 import JourneyCard from '@/domain/journey/common/JourneyCard/JourneyCard';
-import spaceIcon from '@/domain/shared/components/JourneyIcon/JourneyIcon';
+import { spaceLevelIcon } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
 import JourneyCardTagline from '@/domain/journey/common/JourneyCard/JourneyCardTagline';
 import { BlockSectionTitle, Caption, Text } from '@/core/ui/typography';
 import DetailedActivityDescription from '@/domain/shared/components/ActivityDescription/DetailedActivityDescription';
@@ -94,7 +94,7 @@ const SingleInvitationFull = ({
                   alignItems={isMobile ? 'center' : 'start'}
                 >
                   <JourneyCard
-                    iconComponent={spaceIcon[getChildJourneyTypeName(invitation.space)]}
+                    iconComponent={spaceLevelIcon[invitation.space.level]}
                     header={invitation.space.profile.displayName}
                     tags={invitation.space.profile.tagset?.tags ?? []}
                     banner={invitation.space.profile.visual}

--- a/src/domain/community/pendingMembership/PendingMemberships.tsx
+++ b/src/domain/community/pendingMembership/PendingMemberships.tsx
@@ -85,7 +85,7 @@ export const InvitationHydrator = ({
       fetchDetails: withJourneyDetails,
       fetchCommunityGuidelines: withCommunityGuidelines,
       visualType:
-        invitation.spacePendingMembershipInfo.level === SpaceLevel.Space && visualType === VisualType.Avatar
+        invitation.spacePendingMembershipInfo.level === SpaceLevel.L0 && visualType === VisualType.Avatar
           ? VisualType.Card
           : visualType, // Spaces don't have avatars
     },
@@ -142,7 +142,7 @@ export const ApplicationHydrator = ({ application, visualType, children }: Appli
       spaceId: application.spacePendingMembershipInfo.id,
       fetchDetails: true,
       visualType:
-        application.spacePendingMembershipInfo.level === SpaceLevel.Space && visualType === VisualType.Avatar
+        application.spacePendingMembershipInfo.level === SpaceLevel.L0 && visualType === VisualType.Avatar
           ? VisualType.Card
           : visualType, // Spaces don't have avatars
     },

--- a/src/domain/community/pendingMembership/PendingMembershipsUserMenuItem.tsx
+++ b/src/domain/community/pendingMembership/PendingMembershipsUserMenuItem.tsx
@@ -13,7 +13,7 @@ import {
 } from './PendingMemberships';
 import InvitationCardHorizontal from '../invitations/InvitationCardHorizontal/InvitationCardHorizontal';
 import JourneyCard from '@/domain/journey/common/JourneyCard/JourneyCard';
-import spaceIcon from '@/domain/shared/components/JourneyIcon/JourneyIcon';
+import { spaceLevelIcon } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
 import ScrollableCardsLayoutContainer from '@/core/ui/card/cardsLayout/ScrollableCardsLayoutContainer';
 import JourneyCardTagline from '@/domain/journey/common/JourneyCard/JourneyCardTagline';
 import InvitationDialog from '../invitations/InvitationDialog';
@@ -23,7 +23,6 @@ import BackButton from '@/core/ui/actions/BackButton';
 import useNavigate from '@/core/routing/useNavigate';
 import { PendingMembershipsDialogType, usePendingMembershipsDialog } from './PendingMembershipsDialogContext';
 import { defer } from 'lodash';
-import { getChildJourneyTypeName } from '@/domain/shared/utils/spaceLevel';
 
 type ButtonImplementationParams = {
   header: ReactNode;
@@ -141,7 +140,7 @@ const PendingMembershipsUserMenuItem = ({ children }: PendingMembershipsUserMenu
                     {({ application: hydratedApplication }) =>
                       hydratedApplication && (
                         <JourneyCard
-                          iconComponent={spaceIcon[getChildJourneyTypeName(hydratedApplication.space)]}
+                          iconComponent={spaceLevelIcon[hydratedApplication.space.level]}
                           header={hydratedApplication.space.profile.displayName}
                           tags={hydratedApplication.space.profile.tagset?.tags ?? []}
                           banner={hydratedApplication.space.profile.visual}

--- a/src/domain/community/profile/ContributionDetails/ContributionDetailsContainer.tsx
+++ b/src/domain/community/profile/ContributionDetails/ContributionDetailsContainer.tsx
@@ -66,7 +66,7 @@ const ContributionDetailsContainer = ({ entities, children }: PropsWithChildren<
       const space = spaceData.lookup.space;
       return {
         displayName: space.profile.displayName!,
-        journeyTypeName: getChildJourneyTypeName({ level: spaceLevel }) as JourneyTypeName,
+        journeyTypeName: getChildJourneyTypeName({ level: spaceLevel }),
         banner: getVisualByType(VisualName.CARD, space.profile.visuals),
         tags: space.profile.tagset?.tags ?? [],
         journeyUri: space.profile.url,

--- a/src/domain/community/user/userContributions/useUserContributions.ts
+++ b/src/domain/community/user/userContributions/useUserContributions.ts
@@ -22,7 +22,7 @@ const useUserContributions = (userId: string | undefined) => {
       contributions.push({
         spaceID: e.id,
         id: e.id,
-        spaceLevel: SpaceLevel.Space,
+        spaceLevel: SpaceLevel.L0,
         contributorId: userId!,
         contributorType: RoleSetContributorType.User,
         roles: e.roles,

--- a/src/domain/community/userAdmin/tabs/UserAdminMembershipPage.tsx
+++ b/src/domain/community/userAdmin/tabs/UserAdminMembershipPage.tsx
@@ -31,7 +31,7 @@ const UserAdminMembershipPage = () => {
       const currentSpace = {
         spaceID: space.id,
         id: space.id,
-        spaceLevel: SpaceLevel.Space,
+        spaceLevel: SpaceLevel.L0,
         contributorId: userId!,
         contributorType: RoleSetContributorType.User,
       };

--- a/src/domain/community/virtualContributor/vcMembershipPage/VCMembershipPage.tsx
+++ b/src/domain/community/virtualContributor/vcMembershipPage/VCMembershipPage.tsx
@@ -45,7 +45,7 @@ const VCMembershipPage = () => {
       const currentSpace = {
         spaceID: space.id,
         id: space.id,
-        spaceLevel: SpaceLevel.Space,
+        spaceLevel: SpaceLevel.L0,
         contributorId: vcId,
         contributorType: RoleSetContributorType.Virtual,
       };

--- a/src/domain/journey/JourneyTypeName.ts
+++ b/src/domain/journey/JourneyTypeName.ts
@@ -40,7 +40,7 @@ export const getJourneyTypeName = (
 };
 
 export const getSpaceLabel = (spaceLevel: SpaceLevel) => {
-  if (spaceLevel === SpaceLevel.Space) {
+  if (spaceLevel === SpaceLevel.L0) {
     return 'space' as const;
   }
   return 'subspace' as const;

--- a/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
+++ b/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
@@ -25,7 +25,7 @@ import OpportunityMetrics from '@/domain/journey/opportunity/utils/useOpportunit
 import { Theme } from '@mui/material/styles';
 import useCurrentBreakpoint from '@/core/ui/utils/useCurrentBreakpoint';
 import PageContentBlockSeamless from '@/core/ui/content/PageContentBlockSeamless';
-import { spaceIconByLevel } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
+import { spaceLevelIcon } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
 import References from '@/domain/shared/components/References/References';
 import { Reference, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
@@ -142,9 +142,7 @@ const JourneyAboutDialog = ({
     [leadUsers]
   );
 
-  // @ts-ignore TS5UPGRADE
-  const JourneyIcon = spaceLevel > -1 ? spaceIconByLevel[spaceLevel] : undefined;
-
+  const JourneyIcon = spaceLevelIcon[spaceLevel];
   const metricsItems = useMetricsItems(metrics, getMetricsSpec(spaceLevel));
 
   const breakpoint = useCurrentBreakpoint();

--- a/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
+++ b/src/domain/journey/common/JourneyAboutDialog/JourneyAboutDialog.tsx
@@ -74,7 +74,7 @@ const getMetricsSpec = (spaceLevel: SpaceLevel | undefined) => {
   if (!spaceLevel) {
     return undefined;
   }
-  if (spaceLevel === SpaceLevel.Opportunity) {
+  if (spaceLevel === SpaceLevel.L2) {
     return OpportunityMetrics;
   }
   return SpaceMetrics;
@@ -114,7 +114,7 @@ const JourneyAboutDialog = ({
 }: JourneyAboutDialogProps) => {
   const { t } = useTranslation();
 
-  const isSpace = spaceLevel === SpaceLevel.Space;
+  const isSpace = spaceLevel === SpaceLevel.L0;
   const leadOrganizationsHeader = isSpace
     ? 'pages.space.sections.dashboard.leadingOrganizations'
     : 'community.leading-organizations';

--- a/src/domain/journey/common/journeyBreadcrumbs/JourneyBreadcrumbs.tsx
+++ b/src/domain/journey/common/journeyBreadcrumbs/JourneyBreadcrumbs.tsx
@@ -1,6 +1,6 @@
 import { useJourneyBreadcrumbs, UseJourneyBreadcrumbsParams } from './useJourneyBreadcrumbs';
 import Breadcrumbs, { BreadcrumbsProps } from '@/core/ui/navigation/Breadcrumbs';
-import { spaceIconByLevel } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
+import { spaceLevelIcon } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
 import BreadcrumbsRootItem from '@/main/ui/breadcrumbs/BreadcrumbsRootItem';
 import BreadcrumbsItem from '@/core/ui/navigation/BreadcrumbsItem';
 import { Expandable } from '@/core/ui/navigation/Expandable';
@@ -30,14 +30,8 @@ const JourneyBreadcrumbs = forwardRef<Collapsible, JourneyBreadcrumbsProps<Expan
     return (
       <Breadcrumbs ref={ref} {...props}>
         <BreadcrumbsRootItem />
-        {breadcrumbs.map(({ displayName, ...item }, level) => (
-          <BreadcrumbsItem
-            key={level}
-            iconComponent={spaceIconByLevel[level]}
-            accent
-            aria-label={displayName}
-            {...item}
-          >
+        {breadcrumbs.map(({ displayName, level, ...item }) => (
+          <BreadcrumbsItem key={level} iconComponent={spaceLevelIcon[level]} accent aria-label={displayName} {...item}>
             {displayName}
           </BreadcrumbsItem>
         ))}

--- a/src/domain/journey/common/journeyBreadcrumbs/journeyBreadcrumbs.graphql
+++ b/src/domain/journey/common/journeyBreadcrumbs/journeyBreadcrumbs.graphql
@@ -7,31 +7,26 @@ query JourneyBreadcrumbsSpace(
   $visualType: VisualType! = AVATAR
 ) {
   space(ID: $spaceNameId) {
-    id
-    profile {
-      ...JourneyBreadcrumbsProfile
-    }
+    ...JourneyBreadcrumbsSpace
     subspace(ID: $subspaceLevel1NameId) @include(if: $includeSubspaceLevel1) {
-      id
-      profile {
-        ...JourneyBreadcrumbsProfile
-      }
+      ...JourneyBreadcrumbsSpace
       subspace(ID: $subspaceLevel2NameId) @include(if: $includeSubspaceLevel2) {
-        id
-        profile {
-          ...JourneyBreadcrumbsProfile
-        }
+        ...JourneyBreadcrumbsSpace
       }
     }
   }
 }
 
-fragment JourneyBreadcrumbsProfile on Profile {
+fragment JourneyBreadcrumbsSpace on Space {
   id
-  url
-  displayName
-  avatar: visual(type: $visualType) {
+  level
+  profile {
     id
-    ...VisualUri
+    url
+    displayName
+    avatar: visual(type: $visualType) {
+      id
+      ...VisualUri
+    }
   }
 }

--- a/src/domain/journey/common/journeyBreadcrumbs/useJourneyBreadcrumbs.ts
+++ b/src/domain/journey/common/journeyBreadcrumbs/useJourneyBreadcrumbs.ts
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
 import { useJourneyBreadcrumbsSpaceQuery } from '@/core/apollo/generated/apollo-hooks';
 import { JourneyPath } from '@/main/routing/resolvers/RouteResolver';
-import { VisualType } from '@/core/apollo/generated/graphql-schema';
+import { SpaceLevel, VisualType } from '@/core/apollo/generated/graphql-schema';
+import { compact } from 'lodash';
 
 export interface BreadcrumbsItem {
   displayName: string;
   uri: string;
+  level: SpaceLevel;
   avatar?: {
     uri?: string;
   };
@@ -31,20 +33,21 @@ export const useJourneyBreadcrumbs = ({ journeyPath, loading = false }: UseJourn
     skip: !journeyPath || journeyPath.length === 0 || loading,
   });
 
-  const journeyProfiles = [data?.space.profile, data?.space.subspace?.profile, data?.space.subspace?.subspace?.profile];
+  const pathSpaces = compact([data?.space, data?.space.subspace, data?.space.subspace?.subspace]);
 
   const breadcrumbs = useMemo<BreadcrumbsItem[]>(() => {
     if (isLoadingBreadcrumbs) {
       return [];
     }
 
-    return journeyProfiles.slice(0, currentJourneyIndex + 1).map(profile => {
-      const displayName = profile?.displayName!;
-      const journeyUri = profile?.url!;
+    return pathSpaces.slice(0, currentJourneyIndex + 1).map(space => {
+      const profile = space.profile;
+      const displayName = profile.displayName!;
+      const journeyUri = profile.url!;
       return {
         displayName,
         uri: journeyUri,
-        // journeyTypeName: JOURNEY_NESTING[journey],
+        level: space.level,
         avatar: profile?.avatar,
       };
     });

--- a/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
+++ b/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
@@ -40,7 +40,7 @@ const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '.
     getAvailableVirtualContributors,
     getAvailableVirtualContributorsInLibrary,
     loading,
-  } = useCommunityAdmin({ spaceId, opportunityId, roleSetId, spaceLevel: SpaceLevel.Opportunity });
+  } = useCommunityAdmin({ spaceId, opportunityId, roleSetId, spaceLevel: SpaceLevel.L2 });
 
   if (!spaceId || isLoadingChallenge) {
     return null;

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
@@ -78,7 +78,7 @@ const SpaceDashboardPage = ({
             )}
             <JourneyAboutDialog
               open={dialog === 'about'}
-              spaceLevel={SpaceLevel.Space}
+              spaceLevel={SpaceLevel.L0}
               displayName={entities.space?.profile.displayName}
               tagline={entities.space?.profile.tagline}
               references={entities.references}

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
@@ -135,7 +135,7 @@ const SpaceDashboardView = ({
                   component={FullWidthButton}
                   extended={hasExtendedApplicationButton}
                   journeyId={spaceId}
-                  spaceLevel={SpaceLevel.Space}
+                  spaceLevel={SpaceLevel.L0}
                 />
               </PageContentColumn>
             );

--- a/src/domain/journey/space/layout/SpacePageLayout.tsx
+++ b/src/domain/journey/space/layout/SpacePageLayout.tsx
@@ -65,7 +65,7 @@ const SpacePageLayout = ({
             description={vision}
             disabled={unauthorizedDialogDisabled}
             leftColumnChildrenTop={<CommunityGuidelinesBlock communityId={communityId} journeyUrl={profile.url} />}
-            spaceLevel={SpaceLevel.Space}
+            spaceLevel={SpaceLevel.L0}
             journeyId={spaceId}
             {...props}
           />

--- a/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
+++ b/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
@@ -68,7 +68,7 @@ const AdminSpaceCommunityPage = ({ routePrefix = '../' }: SettingsPageProps) => 
     loading,
     inviteExternalUser,
     inviteExistingUser,
-  } = useCommunityAdmin({ roleSetId, spaceId, spaceLevel: SpaceLevel.Space });
+  } = useCommunityAdmin({ roleSetId, spaceId, spaceLevel: SpaceLevel.L0 });
 
   const currentApplicationsUserIds = useMemo(
     () =>

--- a/src/domain/journey/subspace/layout/SubspacePageLayout.tsx
+++ b/src/domain/journey/subspace/layout/SubspacePageLayout.tsx
@@ -151,11 +151,11 @@ const SubspacePageLayout = ({
   });
 
   const hasExtendedApplicationButton = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
-  let spaceLevel = SpaceLevel.Space;
+  let spaceLevel = SpaceLevel.L0;
   if (journeyPath.length === 2) {
-    spaceLevel = SpaceLevel.Challenge;
+    spaceLevel = SpaceLevel.L1;
   } else if (journeyPath.length === 3) {
-    spaceLevel = SpaceLevel.Opportunity;
+    spaceLevel = SpaceLevel.L2;
   }
 
   return (

--- a/src/domain/journey/subspace/routing/settings/SubspaceSettingsRoute.tsx
+++ b/src/domain/journey/subspace/routing/settings/SubspaceSettingsRoute.tsx
@@ -8,9 +8,9 @@ const SubspaceSettingsRoute = () => {
   const { spaceLevel } = useRouteResolver();
 
   switch (spaceLevel) {
-    case SpaceLevel.Challenge:
+    case SpaceLevel.L1:
       return <ChallengeRoute />;
-    case SpaceLevel.Opportunity:
+    case SpaceLevel.L2:
       return (
         <OpportunityProvider>
           <OpportunityRoute />

--- a/src/domain/platform/admin/space/storage/useStorageAdminTree.tsx
+++ b/src/domain/platform/admin/space/storage/useStorageAdminTree.tsx
@@ -56,11 +56,11 @@ interface Provided {
 
 export const getStorageAggregatorParentIcon = (level: SpaceLevel | undefined) => {
   switch (level) {
-    case SpaceLevel.Challenge:
+    case SpaceLevel.L1:
       return SubspaceIcon;
-    case SpaceLevel.Opportunity:
+    case SpaceLevel.L2:
       return OpportunityIcon;
-    case SpaceLevel.Space:
+    case SpaceLevel.L0:
     default:
       return SpaceIcon;
   }
@@ -119,7 +119,7 @@ const newStorageAggregatorRow = (storageAggregator: LoadableStorageAggregatorFra
     return {
       id: storageAggregator.id,
       displayName: storageAggregator.parentEntity.displayName,
-      iconComponent: getStorageAggregatorParentIcon(storageAggregator.parentEntity.level ?? SpaceLevel.Space),
+      iconComponent: getStorageAggregatorParentIcon(storageAggregator.parentEntity.level ?? SpaceLevel.L0),
       url: storageAggregator.parentEntity.url,
       size: 0,
       collapsible: true,

--- a/src/domain/platform/admin/subspace/SubspaceSettingsLayout.tsx
+++ b/src/domain/platform/admin/subspace/SubspaceSettingsLayout.tsx
@@ -52,7 +52,7 @@ const SubspaceSettingsLayout: FC<SubspaceSettingsLayoutProps> = props => {
       },
     ];
 
-    if (spaceLevel === SpaceLevel.Challenge) {
+    if (spaceLevel === SpaceLevel.L1) {
       tabs.push({
         section: SettingsSection.Subsubspaces,
         route: 'opportunities',

--- a/src/domain/shared/components/JourneyIcon/JourneyIcon.tsx
+++ b/src/domain/shared/components/JourneyIcon/JourneyIcon.tsx
@@ -23,9 +23,9 @@ export const spaceIconByLevel = [
 ] as const;
 
 export const spaceLevelIcon: Record<SpaceLevel, ComponentType<SvgIconProps>> = {
-  [SpaceLevel.Space]: SpaceIcon,
-  [SpaceLevel.Challenge]: SubspaceIcon,
-  [SpaceLevel.Opportunity]: OpportunityIcon,
+  [SpaceLevel.L0]: SpaceIcon,
+  [SpaceLevel.L1]: SubspaceIcon,
+  [SpaceLevel.L2]: OpportunityIcon,
   // TODO icons below to be defined
   // [SpaceType.BlankSlate]: SpaceIcon,
   // [SpaceType.Knowledge]: SpaceIcon,

--- a/src/domain/shared/components/JourneyIcon/JourneyIcon.tsx
+++ b/src/domain/shared/components/JourneyIcon/JourneyIcon.tsx
@@ -14,21 +14,10 @@ const spaceIcon = {
   subsubspace: OpportunityIcon,
   undefined: SpaceIcon,
 } as const;
-
-export const spaceIconByLevel = [
-  SpaceIcon,
-  SubspaceIcon,
-  OpportunityIcon,
-  undefined, // for Typescript to correctly assume you can get undefined as well
-] as const;
+export default spaceIcon;
 
 export const spaceLevelIcon: Record<SpaceLevel, ComponentType<SvgIconProps>> = {
   [SpaceLevel.L0]: SpaceIcon,
   [SpaceLevel.L1]: SubspaceIcon,
   [SpaceLevel.L2]: OpportunityIcon,
-  // TODO icons below to be defined
-  // [SpaceType.BlankSlate]: SpaceIcon,
-  // [SpaceType.Knowledge]: SpaceIcon,
 };
-
-export default spaceIcon;

--- a/src/domain/shared/components/search-cards/base/SearchBaseJourneyCard.tsx
+++ b/src/domain/shared/components/search-cards/base/SearchBaseJourneyCard.tsx
@@ -51,7 +51,7 @@ const SearchBaseJourneyCard = ({
       expansion={<JourneyCardDescription>{vision}</JourneyCardDescription>}
       expansionActions={
         <CardActions>
-          <JourneyCardGoToButton journeyUri={props.journeyUri} subspace={spaceLevel !== SpaceLevel.Space} />
+          <JourneyCardGoToButton journeyUri={props.journeyUri} subspace={spaceLevel !== SpaceLevel.L0} />
         </CardActions>
       }
       {...props}

--- a/src/domain/shared/utils/spaceLevel.ts
+++ b/src/domain/shared/utils/spaceLevel.ts
@@ -3,11 +3,11 @@ import { JourneyTypeName } from '@/domain/journey/JourneyTypeName';
 
 export const getChildJourneyTypeName = ({ level }: { level: SpaceLevel }): JourneyTypeName => {
   switch (level) {
-    case SpaceLevel.Challenge:
+    case SpaceLevel.L1:
       return 'subspace' as JourneyTypeName;
-    case SpaceLevel.Opportunity:
+    case SpaceLevel.L2:
       return 'subsubspace' as JourneyTypeName;
-    case SpaceLevel.Space:
+    case SpaceLevel.L0:
     default:
       return 'space' as JourneyTypeName;
   }

--- a/src/main/inAppNotifications/views/CollaborationCalloutPublishedView.tsx
+++ b/src/main/inAppNotifications/views/CollaborationCalloutPublishedView.tsx
@@ -26,7 +26,7 @@ export const CollaborationCalloutPublishedView = ({
     const notificationTextValues = {
       defaultValue: '',
       spaceName: space?.profile?.displayName,
-      spaceType: t(`common.${getChildJourneyTypeName({ level: space?.level ?? SpaceLevel.Space })}`),
+      spaceType: t(`common.${getChildJourneyTypeName({ level: space?.level ?? SpaceLevel.L0 })}`),
       calloutName: callout?.framing?.profile?.displayName,
       calloutType: calloutType,
       contributorName: triggeredBy?.profile?.displayName,

--- a/src/main/routing/resolvers/RouteResolver.ts
+++ b/src/main/routing/resolvers/RouteResolver.ts
@@ -76,26 +76,26 @@ const getSpaceLevel = (urlParams: Partial<JourneyLocation>): SpaceLevel => {
   const depth = takeWhile(JOURNEY_PARAM_NESTING, param => urlParams[param]).length - 1;
 
   if (depth === 0) {
-    return SpaceLevel.Space;
+    return SpaceLevel.L0;
   }
   if (depth === 1) {
-    return SpaceLevel.Challenge;
+    return SpaceLevel.L1;
   }
   if (depth === 2) {
-    return SpaceLevel.Opportunity;
+    return SpaceLevel.L2;
   }
   // TODO: should be an error, every space has a level.
-  return SpaceLevel.Space;
+  return SpaceLevel.L0;
 };
 
 const getSpaceDepth = (spaceLevel: SpaceLevel | undefined): number => {
-  if (spaceLevel === SpaceLevel.Space) {
+  if (spaceLevel === SpaceLevel.L0) {
     return 0;
   }
-  if (spaceLevel === SpaceLevel.Challenge) {
+  if (spaceLevel === SpaceLevel.L1) {
     return 1;
   }
-  if (spaceLevel === SpaceLevel.Opportunity) {
+  if (spaceLevel === SpaceLevel.L2) {
     return 2;
   }
   return -1;
@@ -148,9 +148,9 @@ export const useRouteResolver = ({ failOnNotFound = true }: RouteResolverOptions
 
   const getParentSpaceId = () => {
     switch (spaceLevel) {
-      case SpaceLevel.Challenge:
+      case SpaceLevel.L1:
         return data?.space.id;
-      case SpaceLevel.Opportunity:
+      case SpaceLevel.L2:
         return data?.space.subspace?.id;
       default:
         return undefined;

--- a/src/main/search/searchResults/searchResultsCallout/SearchResultsCalloutCardFooter.tsx
+++ b/src/main/search/searchResults/searchResultsCallout/SearchResultsCalloutCardFooter.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { spaceIconByLevel } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
+import { spaceLevelIcon } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
 import { CONTRIBUTION_ICON } from '@/domain/collaboration/callout/calloutCard/calloutIcons';
 import React, { useMemo } from 'react';
 import { CalloutContributionType, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
@@ -84,7 +84,7 @@ const CalloutContributions = ({ callout }: CalloutContributionsProps) => {
 };
 
 const SearchResultsCalloutCardFooter = ({ callout, matchedTerms, space }: SearchResultsCalloutCardFooterProps) => {
-  const JourneyIcon = space && spaceIconByLevel[space.level];
+  const JourneyIcon = space && spaceLevelIcon[space.level];
 
   return (
     <Gutters padding={1} gap={1}>

--- a/src/main/search/searchResults/useHydratedCard.tsx
+++ b/src/main/search/searchResults/useHydratedCard.tsx
@@ -102,7 +102,7 @@ const hydrateSpaceCard = (
       return null;
     }
 
-    const parentIcon = data.parentSpace.level === SpaceLevel.Space ? SpaceIcon : SubspaceIcon;
+    const parentIcon = data.parentSpace.level === SpaceLevel.L0 ? SpaceIcon : SubspaceIcon;
 
     return (
       <CardParentJourneySegment

--- a/src/main/search/searchResults/useHydratedCard.tsx
+++ b/src/main/search/searchResults/useHydratedCard.tsx
@@ -24,7 +24,9 @@ import CardParentJourneySegment from '@/domain/journey/common/SpaceChildJourneyC
 import { CalloutIcon } from '@/domain/collaboration/callout/icon/CalloutIcon';
 import { VisualName } from '@/domain/common/visual/constants/visuals.constants';
 import SearchBaseJourneyCard from '@/domain/shared/components/search-cards/base/SearchBaseJourneyCard';
-import { spaceIconByLevel } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
+import { spaceLevelIcon } from '@/domain/shared/components/JourneyIcon/JourneyIcon';
+import { ComponentType } from 'react';
+import { SvgIconProps } from '@mui/material';
 
 const hydrateUserCard = (data: TypedSearchResult<SearchResultType.User, SearchResultUserFragment>) => {
   const user = data.user;
@@ -133,17 +135,22 @@ const hydrateSpaceCard = (
   );
 };
 
-const getContributionParentInformation = (data: TypedSearchResult<SearchResultType.Post, SearchResultPostFragment>) => {
-  const info = {
+interface ContributionParentInformation {
+  displayName: string;
+  locked: boolean;
+  url: string;
+  icon: ComponentType<SvgIconProps>;
+}
+
+const getContributionParentInformation = (
+  data: TypedSearchResult<SearchResultType.Post, SearchResultPostFragment>
+): ContributionParentInformation => {
+  return {
     displayName: data.space.profile.displayName,
     locked: data.space?.settings.privacy?.mode === SpacePrivacyMode.Private,
     url: data.space.profile.url,
-    icon: SpaceIcon,
+    icon: spaceLevelIcon[data.space.level] ?? SpaceIcon,
   };
-
-  info.icon = spaceIconByLevel[data.space.level];
-
-  return info;
 };
 
 const hydrateContributionPost = (data: TypedSearchResult<SearchResultType.Post, SearchResultPostFragment>) => {

--- a/src/main/topLevelPages/myDashboard/myMemberships/ExpandableSpaceTree.tsx
+++ b/src/main/topLevelPages/myDashboard/myMemberships/ExpandableSpaceTree.tsx
@@ -34,9 +34,9 @@ export const ExpandableSpaceTree = ({ membership }: { membership: MembershipProp
   const toggleExpanded = () => setIsExpanded(wasExpanded => !wasExpanded);
 
   const paddingLeftMap = {
-    [SpaceLevel.Space]: 0,
-    [SpaceLevel.Challenge]: 5,
-    [SpaceLevel.Opportunity]: 10,
+    [SpaceLevel.L0]: 0,
+    [SpaceLevel.L1]: 5,
+    [SpaceLevel.L2]: 10,
   };
   const {
     childMemberships,
@@ -49,7 +49,7 @@ export const ExpandableSpaceTree = ({ membership }: { membership: MembershipProp
   const avatar = cardBanner?.uri;
   const roles = community?.roleSet?.myRoles;
   const paddingLeft = paddingLeftMap[level] ?? 0;
-  const verticalOffset = level === SpaceLevel.Space ? 1 : 0.5;
+  const verticalOffset = level === SpaceLevel.L0 ? 1 : 0.5;
   const communityRoles = roles?.filter(role => VISIBLE_COMMUNITY_ROLES.includes(role)).sort();
 
   return (


### PR DESCRIPTION
Goes with server branch of same name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated space level constants from `SpaceLevel.Space`, `SpaceLevel.Challenge`, and `SpaceLevel.Opportunity` to `SpaceLevel.L0`, `SpaceLevel.L1`, and `SpaceLevel.L2`.
	- Modified space level checks and mappings across multiple components and utility functions.
	- Standardized space level representation using numeric-based naming convention.

- **Impact**
	- Changes affect routing, icon selection, search results, and UI rendering.
	- Consistent space level categorization across the application.
	- No functional changes to core application logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->