### PR TITLE
Retrieve the iframeAllowedUrls from the server

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -2308,6 +2308,7 @@ export type MutationKeySpecifier = (
   | 'updateOrganization'
   | 'updateOrganizationPlatformSettings'
   | 'updateOrganizationSettings'
+  | 'updatePlatformSettings'
   | 'updatePost'
   | 'updatePreferenceOnUser'
   | 'updateProfile'
@@ -2324,6 +2325,7 @@ export type MutationKeySpecifier = (
   | 'updateUserPlatformSettings'
   | 'updateUserSettings'
   | 'updateVirtualContributor'
+  | 'updateVirtualContributorSettings'
   | 'updateVisual'
   | 'updateWhiteboard'
   | 'uploadFileOnLink'
@@ -2477,6 +2479,7 @@ export type MutationFieldPolicy = {
   updateOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   updateOrganizationPlatformSettings?: FieldPolicy<any> | FieldReadFunction<any>;
   updateOrganizationSettings?: FieldPolicy<any> | FieldReadFunction<any>;
+  updatePlatformSettings?: FieldPolicy<any> | FieldReadFunction<any>;
   updatePost?: FieldPolicy<any> | FieldReadFunction<any>;
   updatePreferenceOnUser?: FieldPolicy<any> | FieldReadFunction<any>;
   updateProfile?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2493,6 +2496,7 @@ export type MutationFieldPolicy = {
   updateUserPlatformSettings?: FieldPolicy<any> | FieldReadFunction<any>;
   updateUserSettings?: FieldPolicy<any> | FieldReadFunction<any>;
   updateVirtualContributor?: FieldPolicy<any> | FieldReadFunction<any>;
+  updateVirtualContributorSettings?: FieldPolicy<any> | FieldReadFunction<any>;
   updateVisual?: FieldPolicy<any> | FieldReadFunction<any>;
   updateWhiteboard?: FieldPolicy<any> | FieldReadFunction<any>;
   uploadFileOnLink?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2660,6 +2664,7 @@ export type PlatformKeySpecifier = (
   | 'licensingFramework'
   | 'metadata'
   | 'roleSet'
+  | 'settings'
   | 'storageAggregator'
   | 'templatesManager'
   | 'updatedDate'
@@ -2677,6 +2682,7 @@ export type PlatformFieldPolicy = {
   licensingFramework?: FieldPolicy<any> | FieldReadFunction<any>;
   metadata?: FieldPolicy<any> | FieldReadFunction<any>;
   roleSet?: FieldPolicy<any> | FieldReadFunction<any>;
+  settings?: FieldPolicy<any> | FieldReadFunction<any>;
   storageAggregator?: FieldPolicy<any> | FieldReadFunction<any>;
   templatesManager?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2685,6 +2691,10 @@ export type PlatformFeatureFlagKeySpecifier = ('enabled' | 'name' | PlatformFeat
 export type PlatformFeatureFlagFieldPolicy = {
   enabled?: FieldPolicy<any> | FieldReadFunction<any>;
   name?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type PlatformIntegrationSettingsKeySpecifier = ('iframeAllowedUrls' | PlatformIntegrationSettingsKeySpecifier)[];
+export type PlatformIntegrationSettingsFieldPolicy = {
+  iframeAllowedUrls?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type PlatformInvitationKeySpecifier = (
   | 'authorization'
@@ -2771,6 +2781,10 @@ export type PlatformLocationsFieldPolicy = {
   switchplan?: FieldPolicy<any> | FieldReadFunction<any>;
   terms?: FieldPolicy<any> | FieldReadFunction<any>;
   tips?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type PlatformSettingsKeySpecifier = ('integration' | PlatformSettingsKeySpecifier)[];
+export type PlatformSettingsFieldPolicy = {
+  integration?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type PostKeySpecifier = (
   | 'authorization'
@@ -3920,6 +3934,7 @@ export type VirtualContributorKeySpecifier = (
   | 'profile'
   | 'provider'
   | 'searchVisibility'
+  | 'settings'
   | 'status'
   | 'updatedDate'
   | VirtualContributorKeySpecifier
@@ -3937,8 +3952,20 @@ export type VirtualContributorFieldPolicy = {
   profile?: FieldPolicy<any> | FieldReadFunction<any>;
   provider?: FieldPolicy<any> | FieldReadFunction<any>;
   searchVisibility?: FieldPolicy<any> | FieldReadFunction<any>;
+  settings?: FieldPolicy<any> | FieldReadFunction<any>;
   status?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type VirtualContributorSettingsKeySpecifier = ('privacy' | VirtualContributorSettingsKeySpecifier)[];
+export type VirtualContributorSettingsFieldPolicy = {
+  privacy?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type VirtualContributorSettingsPrivacyKeySpecifier = (
+  | 'knowledgeBaseContentVisible'
+  | VirtualContributorSettingsPrivacyKeySpecifier
+)[];
+export type VirtualContributorSettingsPrivacyFieldPolicy = {
+  knowledgeBaseContentVisible?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type VirtualContributorUpdatedSubscriptionResultKeySpecifier = (
   | 'virtualContributor'
@@ -4714,6 +4741,13 @@ export type StrictTypedTypePolicies = {
     keyFields?: false | PlatformFeatureFlagKeySpecifier | (() => undefined | PlatformFeatureFlagKeySpecifier);
     fields?: PlatformFeatureFlagFieldPolicy;
   };
+  PlatformIntegrationSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PlatformIntegrationSettingsKeySpecifier
+      | (() => undefined | PlatformIntegrationSettingsKeySpecifier);
+    fields?: PlatformIntegrationSettingsFieldPolicy;
+  };
   PlatformInvitation?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | PlatformInvitationKeySpecifier | (() => undefined | PlatformInvitationKeySpecifier);
     fields?: PlatformInvitationFieldPolicy;
@@ -4721,6 +4755,10 @@ export type StrictTypedTypePolicies = {
   PlatformLocations?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | PlatformLocationsKeySpecifier | (() => undefined | PlatformLocationsKeySpecifier);
     fields?: PlatformLocationsFieldPolicy;
+  };
+  PlatformSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | PlatformSettingsKeySpecifier | (() => undefined | PlatformSettingsKeySpecifier);
+    fields?: PlatformSettingsFieldPolicy;
   };
   Post?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | PostKeySpecifier | (() => undefined | PostKeySpecifier);
@@ -5005,6 +5043,20 @@ export type StrictTypedTypePolicies = {
   VirtualContributor?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | VirtualContributorKeySpecifier | (() => undefined | VirtualContributorKeySpecifier);
     fields?: VirtualContributorFieldPolicy;
+  };
+  VirtualContributorSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | VirtualContributorSettingsKeySpecifier
+      | (() => undefined | VirtualContributorSettingsKeySpecifier);
+    fields?: VirtualContributorSettingsFieldPolicy;
+  };
+  VirtualContributorSettingsPrivacy?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | VirtualContributorSettingsPrivacyKeySpecifier
+      | (() => undefined | VirtualContributorSettingsPrivacyKeySpecifier);
+    fields?: VirtualContributorSettingsPrivacyFieldPolicy;
   };
   VirtualContributorUpdatedSubscriptionResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?:

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -18613,6 +18613,11 @@ export const ConfigurationDocument = gql`
       configuration {
         ...Configuration
       }
+      settings {
+        integration {
+          iframeAllowedUrls
+        }
+      }
     }
   }
   ${ConfigurationFragmentDoc}

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -952,6 +952,7 @@ export enum AuthorizationPrivilege {
   MoveContribution = 'MOVE_CONTRIBUTION',
   MovePost = 'MOVE_POST',
   PlatformAdmin = 'PLATFORM_ADMIN',
+  PlatformSettingsAdmin = 'PLATFORM_SETTINGS_ADMIN',
   Read = 'READ',
   ReadAbout = 'READ_ABOUT',
   ReadUsers = 'READ_USERS',
@@ -3927,6 +3928,8 @@ export type Mutation = {
   updateOrganizationPlatformSettings: Organization;
   /** Updates one of the Setting on an Organization */
   updateOrganizationSettings: Organization;
+  /** Updates one of the Setting on the Platform */
+  updatePlatformSettings: PlatformSettings;
   /** Updates the specified Post. */
   updatePost: Post;
   /** Updates one of the Preferences on a Space */
@@ -3959,6 +3962,8 @@ export type Mutation = {
   updateUserSettings: User;
   /** Updates the specified VirtualContributor. */
   updateVirtualContributor: VirtualContributor;
+  /** Updates one of the Setting on an Organization */
+  updateVirtualContributorSettings: VirtualContributor;
   /** Updates the image URI for the specified Visual. */
   updateVisual: Visual;
   /** Updates the specified Whiteboard. */
@@ -4497,6 +4502,10 @@ export type MutationUpdateOrganizationSettingsArgs = {
   settingsData: UpdateOrganizationSettingsInput;
 };
 
+export type MutationUpdatePlatformSettingsArgs = {
+  settingsData: UpdatePlatformSettingsInput;
+};
+
 export type MutationUpdatePostArgs = {
   postData: UpdatePostInput;
 };
@@ -4559,6 +4568,10 @@ export type MutationUpdateUserSettingsArgs = {
 
 export type MutationUpdateVirtualContributorArgs = {
   virtualContributorData: UpdateVirtualContributorInput;
+};
+
+export type MutationUpdateVirtualContributorSettingsArgs = {
+  settingsData: UpdateVirtualContributorSettingsInput;
 };
 
 export type MutationUpdateVisualArgs = {
@@ -4823,6 +4836,8 @@ export type Platform = {
   metadata: Metadata;
   /** The RoleSet for this Platform. */
   roleSet: RoleSet;
+  /** The settings of the Platform. */
+  settings: PlatformSettings;
   /** The StorageAggregator with documents in use by Users + Organizations on the Platform. */
   storageAggregator: StorageAggregator;
   /** The TemplatesManager in use by the Platform */
@@ -4854,6 +4869,12 @@ export enum PlatformFeatureFlagName {
   Subscriptions = 'SUBSCRIPTIONS',
   Whiteboards = 'WHITEBOARDS',
 }
+
+export type PlatformIntegrationSettings = {
+  __typename?: 'PlatformIntegrationSettings';
+  /** The list of allowed URLs for iFrames within Markdown content. */
+  iframeAllowedUrls: Array<Scalars['String']>;
+};
 
 export type PlatformInvitation = {
   __typename?: 'PlatformInvitation';
@@ -4934,6 +4955,12 @@ export type PlatformLocations = {
   terms: Scalars['String'];
   /** URL where users can get tips and tricks */
   tips: Scalars['String'];
+};
+
+export type PlatformSettings = {
+  __typename?: 'PlatformSettings';
+  /** The integration settings for this Platform */
+  integration: PlatformIntegrationSettings;
 };
 
 export type Post = {
@@ -6870,6 +6897,15 @@ export type UpdateOrganizationSettingsPrivacyInput = {
   contributionRolesPubliclyVisible: Scalars['Boolean'];
 };
 
+export type UpdatePlatformSettingsInput = {
+  integration?: InputMaybe<UpdatePlatformSettingsIntegrationInput>;
+};
+
+export type UpdatePlatformSettingsIntegrationInput = {
+  /** Update the list of allowed URLs for iFrames within Markdown content. */
+  iframeAllowedUrls: Array<Scalars['String']>;
+};
+
 export type UpdatePostInput = {
   ID: Scalars['UUID'];
   /** A display identifier, unique within the containing scope. Note: updating the nameID will affect URL on the client. */
@@ -7071,6 +7107,22 @@ export type UpdateVirtualContributorInput = {
   profileData?: InputMaybe<UpdateProfileInput>;
   /** Visibility of the VC in searches. */
   searchVisibility?: InputMaybe<SearchVisibility>;
+};
+
+export type UpdateVirtualContributorSettingsEntityInput = {
+  privacy?: InputMaybe<UpdateVirtualContributorSettingsPrivacyInput>;
+};
+
+export type UpdateVirtualContributorSettingsInput = {
+  /** Update the settings for the VirtualContributor. */
+  settings: UpdateVirtualContributorSettingsEntityInput;
+  /** The identifier for the VirtualCOntributor whose settings are to be updated. */
+  virtualContributorID: Scalars['UUID'];
+};
+
+export type UpdateVirtualContributorSettingsPrivacyInput = {
+  /** Enable the content of knowledge bases to be accessed or not. */
+  knowledgeBaseContentVisible: Scalars['Boolean'];
 };
 
 export type UpdateVisualInput = {
@@ -7282,10 +7334,24 @@ export type VirtualContributor = Contributor & {
   provider: Contributor;
   /** Visibility of the VC in searches. */
   searchVisibility: SearchVisibility;
+  /** The settings of this Virtual Contributor. */
+  settings: VirtualContributorSettings;
   /** The status of the virtual contributor */
   status: VirtualContributorStatus;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']>;
+};
+
+export type VirtualContributorSettings = {
+  __typename?: 'VirtualContributorSettings';
+  /** The privacy settings for this VirtualContributor */
+  privacy: VirtualContributorSettingsPrivacy;
+};
+
+export type VirtualContributorSettingsPrivacy = {
+  __typename?: 'VirtualContributorSettingsPrivacy';
+  /** Are the contents of the knowledge base publicly visible. */
+  knowledgeBaseContentVisible: Scalars['Boolean'];
 };
 
 export enum VirtualContributorStatus {
@@ -23022,6 +23088,10 @@ export type ConfigurationQuery = {
       sentry: { __typename?: 'Sentry'; enabled: boolean; endpoint: string; submitPII: boolean; environment: string };
       apm: { __typename?: 'APM'; rumEnabled: boolean; endpoint: string };
       geo: { __typename?: 'Geo'; endpoint: string };
+    };
+    settings: {
+      __typename?: 'PlatformSettings';
+      integration: { __typename?: 'PlatformIntegrationSettings'; iframeAllowedUrls: Array<string> };
     };
   };
 };

--- a/src/core/ui/forms/MarkdownInputControls/InsertEmbedCodeButton/InsertEmbedCodeButton.tsx
+++ b/src/core/ui/forms/MarkdownInputControls/InsertEmbedCodeButton/InsertEmbedCodeButton.tsx
@@ -14,7 +14,7 @@ import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import DialogWithGrid from '@/core/ui/dialog/DialogWithGrid';
 import { MARKDOWN_TEXT_LENGTH } from '@/core/ui/forms/field-length.constants';
 import { gutters } from '@/core/ui/grid/utils';
-import { ALLOWED_EMBED_URLS } from '@/core/ui/markdown/embed/allowedEmbedUrls';
+import { useConfig } from '@/domain/platform/config/useConfig';
 
 interface InsertEmbedCodeButtonProps extends IconButtonProps {
   editor: Editor | null;
@@ -33,6 +33,9 @@ export const InsertEmbedCodeButton = ({
   const { t } = useTranslation();
 
   const notify = useNotification();
+
+  const { integration } = useConfig();
+  const iframeAllowedUrls = integration?.iframeAllowedUrls || [];
 
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -98,7 +101,7 @@ export const InsertEmbedCodeButton = ({
     }
 
     const srcOrigin = new URL(embedCodeSrc).origin;
-    const isValidSource = ALLOWED_EMBED_URLS.some(vS => vS === srcOrigin);
+    const isValidSource = iframeAllowedUrls.some(vS => vS === srcOrigin);
 
     if (!isValidSource) {
       notify(t('components.wysiwyg-editor.embed.invalidOrUnsupportedEmbed'), 'error');

--- a/src/core/ui/forms/MarkdownInputControls/InsertEmbedCodeButton/InsertEmbedCodeButton.tsx
+++ b/src/core/ui/forms/MarkdownInputControls/InsertEmbedCodeButton/InsertEmbedCodeButton.tsx
@@ -34,8 +34,7 @@ export const InsertEmbedCodeButton = ({
 
   const notify = useNotification();
 
-  const { integration } = useConfig();
-  const iframeAllowedUrls = integration?.iframeAllowedUrls || [];
+  const { integration: { iframeAllowedUrls = [] } = {} } = useConfig();
 
   const buttonRef = useRef<HTMLButtonElement>(null);
 

--- a/src/core/ui/markdown/WrapperMarkdown.tsx
+++ b/src/core/ui/markdown/WrapperMarkdown.tsx
@@ -6,6 +6,7 @@ import PlainText from './PlainText';
 import { MarkdownOptions, MarkdownOptionsProvider } from './MarkdownOptionsContext';
 import { Box } from '@mui/material';
 import { remarkVerifyIframe } from './embed/remarkVerifyIframe';
+import { useConfig } from '@/domain/platform/config/useConfig';
 
 const allowedNodeTypes = ['iframe'] as const;
 
@@ -21,25 +22,33 @@ export const WrapperMarkdown = ({
   caption = false,
   sx,
   ...props
-}: MarkdownProps) => (
-  <MarkdownOptionsProvider
-    card={card}
-    plain={plain}
-    multiline={multiline}
-    disableParagraphPadding={disableParagraphPadding}
-    caption={caption}
-  >
-    <Box sx={{ li: { marginY: caption ? 0 : 1 }, display: plain ? 'inline' : undefined, ...sx }}>
-      <ReactMarkdown
-        components={components}
-        remarkPlugins={[gfm, [PlainText, { enabled: plain }], remarkVerifyIframe]}
-        rehypePlugins={
-          plain ? undefined : ([rehypeRaw, { passThrough: allowedNodeTypes }] as MarkdownProps['rehypePlugins'])
-        }
-        {...props}
-      />
-    </Box>
-  </MarkdownOptionsProvider>
-);
+}: MarkdownProps) => {
+  const { integration: { iframeAllowedUrls = [] } = {} } = useConfig();
+
+  return (
+    <MarkdownOptionsProvider
+      card={card}
+      plain={plain}
+      multiline={multiline}
+      disableParagraphPadding={disableParagraphPadding}
+      caption={caption}
+    >
+      <Box sx={{ li: { marginY: caption ? 0 : 1 }, display: plain ? 'inline' : undefined, ...sx }}>
+        <ReactMarkdown
+          components={components}
+          remarkPlugins={[
+            gfm,
+            [PlainText, { enabled: plain }],
+            [remarkVerifyIframe, { allowedIFrameOrigins: iframeAllowedUrls }],
+          ]}
+          rehypePlugins={
+            plain ? undefined : ([rehypeRaw, { passThrough: allowedNodeTypes }] as MarkdownProps['rehypePlugins'])
+          }
+          {...props}
+        />
+      </Box>
+    </MarkdownOptionsProvider>
+  );
+};
 
 export default WrapperMarkdown;

--- a/src/core/ui/markdown/embed/allowedEmbedUrls.ts
+++ b/src/core/ui/markdown/embed/allowedEmbedUrls.ts
@@ -1,7 +1,0 @@
-export const ALLOWED_EMBED_URLS = [
-  'https://issuu.com',
-  'https://www.youtube.com',
-  'https://player.vimeo.com',
-  'https://www.canva.com',
-  'https://demo.arcade.software',
-] as const;

--- a/src/domain/platform/config/ConfigProvider.tsx
+++ b/src/domain/platform/config/ConfigProvider.tsx
@@ -30,7 +30,14 @@ const ConfigProvider: FC<ConfigProviderProps> = ({ children, url }) => {
   const [requestConfig, loading, error] = useLoadingStateWithHandlers(
     async (url: string) => {
       const result = await queryRequest<ConfigurationQuery>(url, ConfigurationDocument);
-      setConfig(result.data.data.platform.configuration);
+      const platformConfiguration = result.data.data.platform.configuration;
+      const settings = result.data.data.platform.settings;
+      const combinedConfiguration: Configuration = {
+        ...platformConfiguration,
+        ...settings,
+      };
+
+      setConfig(combinedConfiguration);
     },
     {
       onError: err => logWarn(err, { category: TagCategoryValues.CONFIG }),

--- a/src/domain/platform/config/configuration.graphql
+++ b/src/domain/platform/config/configuration.graphql
@@ -3,6 +3,11 @@ query configuration {
     configuration {
       ...Configuration
     }
+    settings {
+      integration {
+        iframeAllowedUrls
+      }
+    }
   }
 }
 

--- a/src/domain/platform/config/configuration.ts
+++ b/src/domain/platform/config/configuration.ts
@@ -41,6 +41,9 @@ export interface Configuration {
   geo: {
     endpoint: string;
   };
+  integration: {
+    iframeAllowedUrls: string[];
+  };
 }
 
 interface AuthenticationProvider {

--- a/src/domain/platform/config/useConfig.ts
+++ b/src/domain/platform/config/useConfig.ts
@@ -17,6 +17,7 @@ export const useConfig = () => {
       authentication: context.config?.authentication,
       locations: context.config?.locations,
       features: context.config?.featureFlags,
+      integration: context.config?.integration,
       sentry: context.config?.sentry,
       apm: context.config?.apm,
       geo: context.config?.geo,


### PR DESCRIPTION
Added retrieval and usage of iframeAllowedUrls from platform settings.

Now the client no longer stores the iframeAllowedUrls. They are part of the config state and are reused in the MarkdownWrapper (the preview of the iframes) and in the iframe injection logic. 


The additional URLs requested in the story are yet to be injected with mutation on every environment.
See the details in the story.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added dynamic configuration for iframe embedding.
	- Introduced new settings field in platform configuration.
	- Enhanced configuration options with integration settings.

- **Improvements**
	- Updated configuration handling to merge platform configuration and settings.
	- Implemented more flexible URL validation for embedded content.

The changes provide more granular control over iframe embedding and configuration management, allowing administrators to define allowed URLs dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->