### PR TITLE
BugFix anonymous user access to public space

### DIFF
--- a/src/domain/access/RoleSetAdmin/useRoleSetAdmin.ts
+++ b/src/domain/access/RoleSetAdmin/useRoleSetAdmin.ts
@@ -102,6 +102,9 @@ const useRoleSetAdmin = ({
   });
 
   const myPrivileges = roleSetDetails?.lookup.roleSet?.authorization?.myPrivileges;
+  const canReadRoleSet =
+    (myPrivileges?.includes(AuthorizationPrivilege.Read) && myPrivileges?.includes(AuthorizationPrivilege.ReadUsers)) ??
+    false;
 
   const validRoles = roleSetDetails?.lookup.roleSet?.roleNames;
   if (!skip && !loadingRoleSet && validRoles) {
@@ -124,7 +127,7 @@ const useRoleSetAdmin = ({
       includeOrganizations: contributorTypes.includes(RoleSetContributorType.Organization),
       includeVirtualContributors: contributorTypes.includes(RoleSetContributorType.Virtual),
     },
-    skip: skip || !roleSetId || loadingRoleSet || !relevantRoles || relevantRoles.length === 0,
+    skip: skip || !canReadRoleSet || !roleSetId || loadingRoleSet || !relevantRoles || relevantRoles.length === 0,
   });
 
   const data = useMemo(() => {

--- a/src/domain/journey/space/SpaceContext/SpaceContext.tsx
+++ b/src/domain/journey/space/SpaceContext/SpaceContext.tsx
@@ -139,7 +139,9 @@ const SpaceContextProvider: FC<SpaceProviderProps> = ({ children }) => {
       canCreateSubspaces: canCreateSubspaces,
       canCreateTemplates,
       canCreate,
-      communityReadAccess: communityPrivileges.includes(AuthorizationPrivilege.Read),
+      communityReadAccess:
+        communityPrivileges.includes(AuthorizationPrivilege.Read) &&
+        communityPrivileges.includes(AuthorizationPrivilege.ReadUsers),
       canReadCollaboration: collaborationPrivileges.includes(AuthorizationPrivilege.Read),
       canReadPosts: contextPrivileges.includes(AuthorizationPrivilege.Read),
       contextPrivileges,


### PR DESCRIPTION
- Fix for #7529
- Instead of what's done here #7532 I think we need to check for `Community > RoleSet > Authorization > READ_USERS` privilege. 
- The rest of the queries worked as they were


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Authorization**
	- Enhanced role set access control by adding a new check for read privileges
	- Refined community read access criteria to require both read and read users permissions

The changes improve system security by implementing more granular access control mechanisms for role sets and community resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->