### PR TITLE
crowdin config

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,6 @@
 files:
-  - source: /develop/src/core/i18n/en/translation.en.json  # Path in Crowdin
-    translation: /develop/src/core/i18n/%two_letters_code%/translation.%two_letters_code%.json  # Path in Crowdin
+  - source: /src/core/i18n/en/translation.en.json  # Path in Crowdin
+    translation: /src/core/i18n/%two_letters_code%/translation.%two_letters_code%.json  # Path in Crowdin
     export_pattern: /src/core/i18n/%two_letters_code%/translation.%two_letters_code%.json  # Map to local project structure
 project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Crowdin configuration file paths to remove the `/develop` prefix from source and translation file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->