### PR TITLE
Send Sentry error on onCloseConnection of a whiteboard

### DIFF
--- a/src/core/apollo/graphqlLinks/httpLink.ts
+++ b/src/core/apollo/graphqlLinks/httpLink.ts
@@ -50,7 +50,7 @@ export const httpLink = (graphQLEndpoint: string, enableWebSockets: boolean) => 
         uploadLink
       );
     } catch (error) {
-      logWarn(error as Error, { category: TagCategoryValues.WS });
+      logWarn(error as Error, { category: TagCategoryValues.WS, label: 'Failed to create ws link' });
     }
   }
   return uploadLink;

--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
@@ -47,6 +47,7 @@ export interface WhiteboardDetails {
     preview?: {
       id: string;
     } & PreviewImageDimensions;
+    url?: string;
   };
   createdBy?: {
     id: string;

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
@@ -28,6 +28,7 @@ import useWhiteboardDefaults from './useWhiteboardDefaults';
 import Loading from '@/core/ui/loading/Loading';
 import { Identifiable } from '@/core/utils/Identifiable';
 import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
+import { TagCategoryValues, error as logError } from '@/core/logging/sentry/log';
 
 const FILE_IMPORT_ENABLED = true;
 const SAVE_FILE_TO_DISK = true;
@@ -73,7 +74,7 @@ const useActorWhiteboardStyles = makeStyles(theme => ({
 }));
 
 export interface WhiteboardWhiteboardEntities {
-  whiteboard: Identifiable | undefined;
+  whiteboard: (Identifiable & { profile?: { url?: string } }) | undefined;
   filesManager: WhiteboardFilesManager;
   lastSavedDate: Date | undefined;
 }
@@ -165,6 +166,12 @@ const CollaborativeExcalidrawWrapper = ({
       if (isOnline) {
         setupReconnectTimeout();
       }
+      // event if it's duplicated by the httpLink and Portal handlers, let's log this closeConnection one
+      // with additional info here #7492
+      logError('WB Connection Closed', {
+        category: TagCategoryValues.WHITEBOARD,
+        label: `WB ID: ${whiteboard?.id}; URL: ${whiteboard?.profile?.url}; Online: ${isOnline}`,
+      });
     },
     onInitialize: collabApi => {
       combinedCollabApiRef.current = collabApi;


### PR DESCRIPTION
The Goal:
- get an explicit error with 'more' details when reconnection on WB is needed;

The implementation:
- New Sentry error log in the Excalidraw wrapper onCloseConnection. The WB URL, id, and online status are sent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error logging for WebSocket link creation.
  - Expanded whiteboard entity structure to include optional profile metadata.

- **Bug Fixes**
  - Added more context to error messages.
  - Improved tracking of collaborative whiteboard connection events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->