### PR TITLE
Fix PROD issue with CallForPosts contributions failing to load 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.81.1",
+  "version": "0.81.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/client-web",
-      "version": "0.81.1",
+      "version": "0.81.2",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/excalidraw": "0.17.1-alkemio-8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.81.1",
+  "version": "0.81.2",
   "description": "Alkemio client, enabling users to interact with Challenges hosted on the Alkemio platform.",
   "repository": {
     "type": "git",

--- a/src/main/urlResolver/useUrlResolver.ts
+++ b/src/main/urlResolver/useUrlResolver.ts
@@ -234,7 +234,7 @@ const useUrlResolver = ({
   const calloutId = calloutData?.lookup.calloutsSet?.callouts?.[0].id;
   loading = loading || calloutDataLoading;
   if (throwIfNotFound && calloutNameId && calloutsSetId && !calloutDataLoading && !calloutId) {
-    throw new NotFoundError(`Callout '${calloutNameId}' not found in VC '${vcNameId}'`);
+    throw new NotFoundError(`Callout '${calloutNameId}' not found in calloutSet '${calloutsSetId}'`);
   }
 
   // Callout for posts and a post open
@@ -242,8 +242,9 @@ const useUrlResolver = ({
     variables: { calloutId: calloutId!, postNameId: postNameId! },
     skip: !calloutId || !postNameId,
   });
-  const contributionId = calloutPostData?.lookup.callout?.contributions[0]?.id;
-  const postId = calloutPostData?.lookup.callout?.contributions[0]?.post?.id;
+  const contribution = calloutPostData?.lookup.callout?.contributions.find(contribution => contribution.post);
+  const contributionId = contribution?.id;
+  const postId = contribution?.post?.id;
   loading = loading || calloutPostLoading;
   if (throwIfNotFound && calloutId && postNameId && !calloutPostLoading && !postId) {
     throw new NotFoundError(`Post '${postNameId}' in callout '${calloutNameId}' ${calloutId} not found`);


### PR DESCRIPTION
Simple hotfix to iterate over all contributions. Repro only on prod, probably bad data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the package version (0.81.1 → 0.81.2).
- **Bug Fixes**
	- Enhanced error messaging for clearer context.
	- Refined data handling to ensure more robust processing of related entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->