### PR TITLE
Excalidraw loadFiles behaviour improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.81.2",
+  "version": "0.81.2.excalidraw",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/client-web",
-      "version": "0.81.2",
+      "version": "0.81.2.excalidraw",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/excalidraw": "0.17.1-alkemio-8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.81.2",
+  "version": "0.81.2.excalidraw",
   "description": "Alkemio client, enabling users to interact with Challenges hosted on the Alkemio platform.",
   "repository": {
     "type": "git",

--- a/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
@@ -319,15 +319,18 @@ class Collab {
       restoredRemoteElements as RemoteExcalidrawElement[],
       appState
     );
+    // Avoid broadcasting to the rest of the collaborators the scene
+    // we just received!
+    // Note: this needs to be set before updating the scene as it
+    // synchronously calls render.
+    this.lastBroadcastedOrReceivedSceneVersion = hashElementsVersion(reconciledElements);
 
     // Download the files that this instance is missing:
     return this.filesManager.loadFiles({ files: remoteFiles }).then(() => {
-      // Avoid broadcasting to the rest of the collaborators the scene
-      // we just received!
-      // Note: this needs to be set before updating the scene as it
-      // synchronously calls render.
-      this.lastBroadcastedOrReceivedSceneVersion = hashElementsVersion(reconciledElements);
-
+      // once the files are loaded, we need to update the scene again to render them
+      // instead of updating the scene twice, which is already expensive, we
+      // return the elements once the files have been loaded
+      // that way we render the elements and images at the same time
       return reconciledElements;
     });
   };

--- a/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
@@ -321,15 +321,15 @@ class Collab {
     );
 
     // Download the files that this instance is missing:
-    await this.filesManager.loadFiles({ files: remoteFiles });
+    return this.filesManager.loadFiles({ files: remoteFiles }).then(() => {
+      // Avoid broadcasting to the rest of the collaborators the scene
+      // we just received!
+      // Note: this needs to be set before updating the scene as it
+      // synchronously calls render.
+      this.lastBroadcastedOrReceivedSceneVersion = hashElementsVersion(reconciledElements);
 
-    // Avoid broadcasting to the rest of the collaborators the scene
-    // we just received!
-    // Note: this needs to be set before updating the scene as it
-    // synchronously calls render.
-    this.lastBroadcastedOrReceivedSceneVersion = hashElementsVersion(reconciledElements);
-
-    return reconciledElements;
+      return reconciledElements;
+    });
   };
 
   private handleRemoteSceneUpdate = async (

--- a/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
+++ b/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
@@ -203,36 +203,41 @@ const useWhiteboardFilesManager = ({
     const files = whiteboard.files;
 
     const pendingFileIds = Object.keys(files).filter(fileId => !files[fileId]?.dataURL);
+
+    if (!pendingFileIds.length) {
+      return;
+    }
+
     log('I need to download these files', pendingFileIds);
     const newFiles: BinaryFilesWithUrl = {};
 
     setDownloadingFiles(true);
 
-    try {
-      await Promise.all(
-        pendingFileIds.map(async fileId => {
-          const file = whiteboard!.files![fileId];
-          if (fileStore.current[fileId]?.dataURL) {
-            log(`No need to download ${fileId} already in the store`, fileStore.current[fileId]);
-            return;
-          }
-          if (file.url) {
-            log('DOWNLOADING ', file);
-            try {
-              const dataURL = await fetchFileToDataURL(file.url);
-              newFiles[fileId] = { ...file, dataURL } as BinaryFileDataWithUrl;
-              fileStoreAddFile(fileId, newFiles[fileId]);
-            } catch (e) {
-              error(`Error downloading file: ${file.url}`, { label: 'whiteboard-file-manager' });
-            }
-          } else {
-            error(`Cannot download: ${file.id}`, { label: 'whiteboard-file-manager' });
-          }
-        })
-      );
-    } finally {
-      setDownloadingFiles(false);
-    }
+    await Promise.allSettled(
+      pendingFileIds.map(async fileId => {
+        if (fileStore.current[fileId]?.dataURL) {
+          log(`No need to download ${fileId} already in the store`, fileStore.current[fileId]);
+          return;
+        }
+        const file = whiteboard!.files![fileId];
+        if (!file.url) {
+          error(`Cannot download: ${file.id}`, { label: 'whiteboard-file-manager' });
+          throw new Error(`Cannot download: ${file.id}`);
+        }
+
+        log('DOWNLOADING ', file);
+        try {
+          const dataURL = await fetchFileToDataURL(file.url);
+          newFiles[fileId] = { ...file, dataURL } as BinaryFileDataWithUrl;
+          fileStoreAddFile(fileId, newFiles[fileId]);
+        } catch (e) {
+          error(`Error downloading file: ${file.url}`, { label: 'whiteboard-file-manager' });
+          throw e;
+        }
+      })
+    );
+
+    setDownloadingFiles(false);
   };
 
   /**

--- a/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
+++ b/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
@@ -201,8 +201,8 @@ const useWhiteboardFilesManager = ({
     }
 
     const files = whiteboard.files;
-
-    const pendingFileIds = Object.keys(files).filter(fileId => !files[fileId]?.dataURL);
+    // leave only the incoming files that don't have a dataURL and are not in the fileStore
+    const pendingFileIds = Object.keys(files).filter(fileId => !files[fileId]?.dataURL && !fileStore.current[fileId]);
 
     if (!pendingFileIds.length) {
       return;

--- a/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
+++ b/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
@@ -209,7 +209,6 @@ const useWhiteboardFilesManager = ({
     }
 
     log('I need to download these files', pendingFileIds);
-    const newFiles: BinaryFilesWithUrl = {};
 
     setDownloadingFiles(true);
 
@@ -228,8 +227,8 @@ const useWhiteboardFilesManager = ({
         log('DOWNLOADING ', file);
         try {
           const dataURL = await fetchFileToDataURL(file.url);
-          newFiles[fileId] = { ...file, dataURL } as BinaryFileDataWithUrl;
-          fileStoreAddFile(fileId, newFiles[fileId]);
+          // try-catch will avoid putting the file in the store if fetching fails
+          fileStoreAddFile(fileId, { ...file, dataURL } as BinaryFileDataWithUrl);
         } catch (e) {
           error(`Error downloading file: ${file.url}`, { label: 'whiteboard-file-manager' });
           throw e;


### PR DESCRIPTION
## The scene
I've done two pairs of benchmark - before and after of resource usage and a breakdown of running times.
The benchmark is pretty simple but very effective - one browser was just receiving, the other was sending events.
The receiving side was profiled for 20 seconds each time under heavy usage of the sender (a lot of events generated per second).

## Running times profiling
|before|after|
|---|---|
![image](https://github.com/user-attachments/assets/389afb0e-e86e-4c9a-8f23-8fc7bd780114)|![image](https://github.com/user-attachments/assets/12cc13a1-da0b-4607-9fd8-f0b30db05406)

Looking at the `before` the reconciliation took `62.2%` (4486ms) of the total microtask time (11560ms).
The main issue I saw was that `loadFiles` took `99%` of the running time of the reconciliation (4452ms)
The profiling also highlighted the Excalidraw native `updateScene` takes half of the running time which is also a good candite for optimization. The only thing I can think of is calling it less but I suspect that will be hard to do - throttling the incoming events might be an improvement.

## The result
After a simple optimization of `loadFiles` I managed to take down it's running time down to 46ms - **97x!!!!** improvement; the total microtask time to 6803ms (41.2% improvement :arrow_upper_right:) and the reconciliation time **31x times!!!!** (144ms).



|---|before|after|improvement
|---|---|---|---
microtask|11560.4|6803.9|1.7x
reconcileElementsAndLoadFiles|4486.6|144.6|31x
loadFiles|4452.3|46.0|97x


---

## Resource profiling
|before|after|
|---|---|
![image](https://github.com/user-attachments/assets/0d41ad46-ff9f-4b71-95c7-5b6270951e83)|![image](https://github.com/user-attachments/assets/0a0a8b97-a4ce-4d8b-addd-ba1cc121d04d)
