### PR TITLE
Excalidraw throttling of events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.82.2",
+  "version": "0.82.2.ex-perf",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/client-web",
-      "version": "0.82.2",
+      "version": "0.82.2.ex-perf",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/excalidraw": "0.17.1-alkemio-8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.82.2",
+  "version": "0.82.2.ex-perf",
   "description": "Alkemio client, enabling users to interact with Challenges hosted on the Alkemio platform.",
   "repository": {
     "type": "git",

--- a/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
@@ -19,6 +19,7 @@ import {
   CURSOR_SYNC_TIMEOUT,
   EVENT,
   IDLE_THRESHOLD,
+  SCENE_SYNC_TIMEOUT,
   SYNC_FULL_SCENE_INTERVAL_MS,
   WS_SCENE_EVENT_TYPES,
 } from './excalidrawAppConstants';
@@ -416,15 +417,22 @@ class Collab {
     this.portal.broadcastIdleChange(userState, this.state.username);
   };
 
-  public syncScene = async (elements: readonly OrderedExcalidrawElement[], files: BinaryFilesWithUrl) => {
-    const { hashElementsVersion } = await this.excalidrawUtils;
-    const newVersion = hashElementsVersion(elements);
+  private throttledSyncScene = throttle(
+    async (elements: readonly OrderedExcalidrawElement[], files: BinaryFilesWithUrl) => {
+      const { hashElementsVersion } = await this.excalidrawUtils;
+      const newVersion = hashElementsVersion(elements);
 
-    if (newVersion !== this.lastBroadcastedOrReceivedSceneVersion) {
-      this.portal.broadcastScene(WS_SCENE_EVENT_TYPES.SCENE_UPDATE, elements, files, { syncAll: false });
-      this.lastBroadcastedOrReceivedSceneVersion = newVersion;
-      this.queueBroadcastAllElements();
-    }
+      if (newVersion !== this.lastBroadcastedOrReceivedSceneVersion) {
+        this.portal.broadcastScene(WS_SCENE_EVENT_TYPES.SCENE_UPDATE, elements, files, { syncAll: false });
+        this.lastBroadcastedOrReceivedSceneVersion = newVersion;
+        this.queueBroadcastAllElements();
+      }
+    },
+    SCENE_SYNC_TIMEOUT
+  );
+
+  public syncScene = async (elements: readonly OrderedExcalidrawElement[], files: BinaryFilesWithUrl) => {
+    this.throttledSyncScene(elements, files);
   };
 
   private queueBroadcastAllElements = throttle(async () => {

--- a/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
@@ -130,7 +130,7 @@ class Collab {
   private handleCloseConnection = () => {
     this.setCollaborators([]);
     this.onCloseConnection();
-    this.portal.socketInitialized = false;
+    this.portal.sceneInitilized = false;
     this.onSceneInitChange(false);
   };
 
@@ -184,8 +184,7 @@ class Collab {
           },
           {
             'scene-init': async (payload: { elements: readonly ExcalidrawElement[]; files: BinaryFilesWithUrl }) => {
-              if (!this.portal.socketInitialized) {
-                this.portal.socketInitialized = true;
+              if (!this.portal.sceneInitilized) {
                 await this.handleRemoteSceneUpdate(
                   await this.reconcileElementsAndLoadFiles(payload.elements, payload.files),
                   {
@@ -198,6 +197,7 @@ class Collab {
                   await this.portal.broadcastScene(WS_SCENE_EVENT_TYPES.SCENE_UPDATE, [], convertedFilesWithUrl);
                 }
                 this.excalidrawAPI.zoomToFit();
+                this.portal.sceneInitilized = true;
                 this.onSceneInitChange(true);
               }
             },
@@ -214,22 +214,25 @@ class Collab {
 
               if (isInvalidResponsePayload(data)) {
                 return;
-              } else if (isMouseLocationPayload(data)) {
-                const { pointer, button, username, selectedElementIds } = data.payload;
-                const socketId: SocketUpdateDataSource['MOUSE_LOCATION']['payload']['socketId'] = data.payload.socketId;
-
+              }
+              // do not handled mouse location until socket is initialized - this may improve loading times
+              if (isMouseLocationPayload(data) && this.portal.sceneInitilized) {
+                const { pointer, button, username, selectedElementIds, socketId } = data.payload;
                 this.updateCollaborator(socketId, {
                   pointer,
                   button,
                   selectedElementIds,
                   username,
                 });
-              } else if (isSceneUpdatePayload(data)) {
+                return;
+              }
+              if (isSceneUpdatePayload(data)) {
                 const remoteElements = data.payload.elements as RemoteExcalidrawElement[];
                 const remoteFiles = data.payload.files;
                 await this.handleRemoteSceneUpdate(
                   await this.reconcileElementsAndLoadFiles(remoteElements, remoteFiles)
                 );
+                return;
               }
             },
             'collaborator-mode': event => {

--- a/src/domain/common/whiteboard/excalidraw/collab/Portal.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Portal.ts
@@ -43,7 +43,7 @@ class Portal {
   getSceneElements: () => readonly ExcalidrawElement[];
   getFiles: () => Promise<BinaryFilesWithUrl>;
   socket: Socket | null = null;
-  socketInitialized: boolean = false; // we don't want the socket to emit any updates until it is fully initialized
+  sceneInitilized: boolean = false; // we don't want the socket to emit any updates until it is fully initialized
   roomId: string | null = null;
   broadcastedElementVersions: Map<string, number> = new Map();
   broadcastedFiles: Set<string> = new Set();
@@ -131,12 +131,12 @@ class Portal {
     this.socket.close();
     this.socket = null;
     this.roomId = null;
-    this.socketInitialized = false;
+    this.sceneInitilized = false;
     this.broadcastedElementVersions = new Map();
   }
 
   isOpen() {
-    return !!(this.socketInitialized && this.socket && this.roomId);
+    return !!(this.sceneInitilized && this.socket && this.roomId);
   }
 
   private _broadcastSocketData(data: SocketUpdateData, { volatile = false }: BroadcastOptions = {}) {

--- a/src/domain/common/whiteboard/excalidraw/collab/excalidrawAppConstants.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/excalidrawAppConstants.ts
@@ -41,7 +41,11 @@ export const SAVE_TO_LOCAL_STORAGE_TIMEOUT = 300;
 export const FILE_UPLOAD_TIMEOUT = 300;
 export const LOAD_IMAGES_TIMEOUT = 500;
 export const SYNC_BROWSER_TABS_TIMEOUT = 50;
-export const CURSOR_SYNC_TIMEOUT = 33; // ~30fps
+
+export const SYNC_FULL_SCENE_INTERVAL_MS = 10000;
+export const CURSOR_SYNC_TIMEOUT = 100; // 10fps - no default
+export const SCENE_SYNC_TIMEOUT = 10; // 5ms is the default behaviour
+
 export const DELETED_ELEMENT_TIMEOUT = 24 * 60 * 60 * 1000; // 1 day
 
 // 1 year (https://stackoverflow.com/a/25201898/927631)

--- a/src/domain/common/whiteboard/excalidraw/collab/excalidrawAppConstants.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/excalidrawAppConstants.ts
@@ -40,7 +40,6 @@ export const ACTIVE_THRESHOLD = 3_000;
 export const SAVE_TO_LOCAL_STORAGE_TIMEOUT = 300;
 export const FILE_UPLOAD_TIMEOUT = 300;
 export const LOAD_IMAGES_TIMEOUT = 500;
-export const SYNC_FULL_SCENE_INTERVAL_MS = 5000;
 export const SYNC_BROWSER_TABS_TIMEOUT = 50;
 export const CURSOR_SYNC_TIMEOUT = 33; // ~30fps
 export const DELETED_ELEMENT_TIMEOUT = 24 * 60 * 60 * 1000; // 1 day


### PR DESCRIPTION
### The emission of the following events is throttled, meaning the client sends fewer events, thus less data
- mouse location events throttled to 10 times per second (30 previously)
- element mutation events throttled to 100 times per second (200 previously)


- client will not handle mouse location events until the scene is fully initialized

## todo
- fix version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the client package version to a new release variant.
  - Adjusted timing for full scene and cursor updates to refine synchronization frequency.

- **Refactor**
  - Enhanced real-time collaboration on the whiteboard by shifting focus to scene initialization.
  - Implemented throttled scene synchronization for more efficient and stable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->