### PR TITLE
Always redirect on space creation

### DIFF
--- a/src/domain/community/contributor/Account/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/Account/ContributorAccountView.tsx
@@ -534,7 +534,7 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
                 />
                 {createSpaceDialogOpen && (
                   <CreateSpaceDialog
-                    redirectOnComplete={false}
+                    withRedirectOnClose={false}
                     onClose={() => setCreateSpaceDialogOpen(false)}
                     account={{ id: account?.id, name: accountHostName }}
                   />

--- a/src/domain/journey/space/createSpace/CreateSpaceDialog.tsx
+++ b/src/domain/journey/space/createSpace/CreateSpaceDialog.tsx
@@ -49,11 +49,11 @@ type CreateSpaceDialogProps = {
         name: string | undefined;
       }
     | undefined;
-  redirectOnComplete?: boolean;
+  withRedirectOnClose?: boolean;
   onClose?: () => void;
 };
 
-const CreateSpaceDialog = ({ redirectOnComplete = true, onClose, account }: CreateSpaceDialogProps) => {
+const CreateSpaceDialog = ({ withRedirectOnClose = true, onClose, account }: CreateSpaceDialogProps) => {
   const redirectToHome = useBackToStaticPath(ROUTE_HOME);
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -86,7 +86,7 @@ const CreateSpaceDialog = ({ redirectOnComplete = true, onClose, account }: Crea
     setDialogOpen(false);
     setCreatingLoading(false);
     onClose?.();
-    redirectOnComplete && redirectToHome();
+    withRedirectOnClose && redirectToHome();
   };
 
   const tagsets = useMemo(() => {
@@ -170,20 +170,16 @@ const CreateSpaceDialog = ({ redirectOnComplete = true, onClose, account }: Crea
       });
       notify(t('pages.admin.space.notifications.space-created'), 'success');
 
-      if (redirectOnComplete) {
-        const { data: spaceUrlData } = await getSpaceUrl({
-          variables: {
-            spaceNameId: spaceID,
-          },
-        });
+      const { data: spaceUrlData } = await getSpaceUrl({
+        variables: {
+          spaceNameId: spaceID,
+        },
+      });
 
-        const spaceUrl = spaceUrlData?.space.profile.url;
-        if (spaceUrl) {
-          navigate(spaceUrl);
-          return;
-        }
-      } else {
-        handleClose();
+      const spaceUrl = spaceUrlData?.space.profile.url;
+      if (spaceUrl) {
+        navigate(spaceUrl);
+        return;
       }
     }
   });
@@ -271,7 +267,7 @@ const CreateSpaceDialog = ({ redirectOnComplete = true, onClose, account }: Crea
                         onClick={() => handleSubmit()}
                         disabled={Object.keys(errors).length > 0 || !hasAcceptedTerms || creatingLoading}
                       >
-                        {t('buttons.continue')}
+                        {t('buttons.create')}
                       </LoadingButton>
                     </Actions>
                   </DialogFooter>


### PR DESCRIPTION
Feature request as part of https://github.com/alkem-io/client-web/issues/7607 (see the comments)

- Always redirect on space creation (until now it was omitted on the account settings tab);
- Change Continue to Create copy for the Space creation button; 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the space creation dialog so that redirection now occurs upon closing the dialog, streamlining navigation.
  - Revised the action button label from "Continue" to "Create" for clearer user guidance during space creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->