### PR TITLE
Fix the Subspace About Dialog discrepancies

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -749,9 +749,14 @@
         "description": "",
         "placeholder": ""
       },
-      "background": {
+      "description": {
         "title": "A description of the subspace that is visible on the subspace dashboard",
         "description": "",
+        "placeholder": ""
+      },
+      "background": {
+        "title": "Current Reality",
+        "description": "Give a brief impression of the current state of the Subspace. Think of the 'What, where, when and who'.",
         "placeholder": ""
       },
       "impact": {

--- a/src/domain/journey/subspace/forms/CreateSubspaceForm.tsx
+++ b/src/domain/journey/subspace/forms/CreateSubspaceForm.tsx
@@ -109,9 +109,9 @@ export const CreateSubspaceForm = ({
           />
           <FormikMarkdownField
             name="background"
-            title={t('context.subspace.background.title')}
+            title={t('context.subspace.description.title')}
             rows={5}
-            helperText={t('context.subspace.background.description')}
+            helperText={t('context.subspace.description.description')}
             disabled={isSubmitting}
             maxLength={MARKDOWN_TEXT_LENGTH}
             temporaryLocation


### PR DESCRIPTION
- [x] fixed the copy reused in the subspace creation flow, causing the issue with the wrong "Background" block (description);

- The second part of the bug - the community guidelines issue reusing the subspace description - is fixed as part of: https://github.com/alkem-io/server/pull/4925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced subspace interface with updated field labels for improved clarity on the dashboard, including a new “Current Reality” section to capture impressions.
  - Updated titles and helper texts in subspace creation forms to reflect these clearer label changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->