### PR TITLE
Excalidraw collaboration to generate less data

### DIFF
--- a/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash';
+import { cloneDeep, throttle } from 'lodash';
 import type {
   Collaborator,
   ExcalidrawImperativeAPI,
@@ -33,6 +33,8 @@ import {
 } from '@alkemio/excalidraw/dist/excalidraw/data/reconcile';
 import type { Mutable } from '@alkemio/excalidraw/dist/excalidraw/utility-types';
 import { lazyImportWithErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
+import { detectChanges } from './detect.changes';
+import { mergeElements } from '@/domain/common/whiteboard/excalidraw/collab/merge.elements';
 
 type CollabState = {
   errorMessage: string;
@@ -81,6 +83,7 @@ class Collab {
   private onCollaboratorModeChange: (event: CollaboratorModeEvent) => void;
   private onSceneInitChange: (initialized: boolean) => void;
   private excalidrawUtils: Promise<ExcalidrawUtils>;
+  private prevElements: ReadonlyArray<OrderedExcalidrawElement>;
 
   constructor(props: CollabProps) {
     this.state = {
@@ -101,6 +104,7 @@ class Collab {
     this.onCollaboratorModeChange = props.onCollaboratorModeChange;
     this.onSceneInitChange = props.onSceneInitChange;
     this.excalidrawUtils = lazyImportWithErrorHandler<ExcalidrawUtils>(() => import('@alkemio/excalidraw'));
+    this.prevElements = [];
   }
 
   init() {
@@ -227,9 +231,9 @@ class Collab {
               } else if (isSceneUpdatePayload(data)) {
                 const remoteElements = data.payload.elements as RemoteExcalidrawElement[];
                 const remoteFiles = data.payload.files;
-                await this.handleRemoteSceneUpdate(
-                  await this.reconcileElementsAndLoadFiles(remoteElements, remoteFiles)
-                );
+                const result = await this.reconcileElementsAndLoadFiles(remoteElements, remoteFiles);
+                console.log(result.find(x => x.id === 'mcUDKzKv24UsBCLkYTqQd'));
+                await this.handleRemoteSceneUpdate(result);
               }
             },
             'collaborator-mode': event => {
@@ -312,7 +316,10 @@ class Collab {
 
     const { restoreElements, hashElementsVersion, reconcileElements } = await this.excalidrawUtils;
 
-    const restoredRemoteElements = restoreElements(remoteElements, null);
+    const mergedRemoteElements = cloneDeep(remoteElements);
+    mergeElements(mergedRemoteElements, localElements);
+
+    const restoredRemoteElements = restoreElements(mergedRemoteElements, null);
 
     const reconciledElements = reconcileElements(
       localElements,
@@ -455,9 +462,19 @@ class Collab {
     const newVersion = hashElementsVersion(elements);
 
     if (newVersion !== this.lastBroadcastedOrReceivedSceneVersion) {
-      this.portal.broadcastScene(WS_SCENE_EVENT_TYPES.SCENE_UPDATE, elements, files, { syncAll: false });
+      const elementDeltas = detectChanges(this.prevElements, elements);
+      // console.log(detectChanges(this.prevElements as never, elements as never));
+
+      this.portal.broadcastScene(
+        WS_SCENE_EVENT_TYPES.SCENE_UPDATE,
+        elementDeltas as OrderedExcalidrawElement[],
+        files,
+        { syncAll: false }
+      );
       this.lastBroadcastedOrReceivedSceneVersion = newVersion;
-      this.queueBroadcastAllElements();
+      // this.queueBroadcastAllElements();
+
+      this.prevElements = cloneDeep(elements);
     }
   };
 

--- a/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
@@ -232,7 +232,6 @@ class Collab {
                 const remoteElements = data.payload.elements as RemoteExcalidrawElement[];
                 const remoteFiles = data.payload.files;
                 const result = await this.reconcileElementsAndLoadFiles(remoteElements, remoteFiles);
-                console.log(result.find(x => x.id === 'mcUDKzKv24UsBCLkYTqQd'));
                 await this.handleRemoteSceneUpdate(result);
               }
             },
@@ -315,11 +314,9 @@ class Collab {
     const appState = this.excalidrawAPI.getAppState();
 
     const { restoreElements, hashElementsVersion, reconcileElements } = await this.excalidrawUtils;
+    mergeElements(remoteElements, localElements);
 
-    const mergedRemoteElements = cloneDeep(remoteElements);
-    mergeElements(mergedRemoteElements, localElements);
-
-    const restoredRemoteElements = restoreElements(mergedRemoteElements, null);
+    const restoredRemoteElements = restoreElements(remoteElements, null);
 
     const reconciledElements = reconcileElements(
       localElements,
@@ -472,7 +469,7 @@ class Collab {
         { syncAll: false }
       );
       this.lastBroadcastedOrReceivedSceneVersion = newVersion;
-      // this.queueBroadcastAllElements();
+      this.queueBroadcastAllElements();
 
       this.prevElements = cloneDeep(elements);
     }

--- a/src/domain/common/whiteboard/excalidraw/collab/detect.changes.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/detect.changes.ts
@@ -1,0 +1,94 @@
+import { isEqual } from 'lodash';
+import {
+  ExcalidrawElement,
+  ExcalidrawLinearElement,
+  type OrderedExcalidrawElement,
+} from '@alkemio/excalidraw/dist/excalidraw/element/types';
+
+export type ExcalidrawElementDelta = Partial<ExcalidrawElement> & {
+  _brand: 'delta';
+};
+
+/**
+ * Detects the changes between two arrays of ExcalidrawElements, and returns the deltas
+ * @return Array<ExcalidrawElementDelta> An array of the deltas between each of the elements in the array
+ * @param oldArrInput
+ * @param newArrInput
+ */
+export const detectChanges = (
+  oldArrInput: ReadonlyArray<OrderedExcalidrawElement>,
+  newArrInput: ReadonlyArray<OrderedExcalidrawElement>
+): Array<ExcalidrawElementDelta> => {
+  const oldLen = oldArrInput.length;
+  const newLen = newArrInput.length;
+  // if both are empty, no changes
+  if (oldLen === 0 && newLen === 0) {
+    return [];
+  }
+  // if oldArr is empty, all new are inserted
+  if (oldLen === 0) {
+    return newArrInput as Array<ExcalidrawElementDelta>;
+  }
+  // if new is empty, all elements of oldArr are deleted
+  if (newLen === 0) {
+    // return only the ID and mark it as deleted to conserve data
+    return oldArrInput.map(item => ({
+      id: item.id,
+      isDeleted: true,
+      // used internally
+      updated: item.updated,
+    })) as Array<ExcalidrawElementDelta>;
+  }
+
+  const deltas: Array<Partial<ExcalidrawElement>> = [];
+
+  const oldElementMap = new Map(oldArrInput.map(item => [item.id, item]));
+  for (const newItem of newArrInput) {
+    const oldItem = oldElementMap.get(newItem.id);
+    // if the new item is not in the old array, it is inserted
+    if (!oldItem) {
+      deltas.push(newItem);
+      continue;
+    }
+    // a match is found - the element is updated or deleted
+    // if both are deleted - ignore, since deleted elements cannot be updated
+    if (oldItem.isDeleted && newItem.isDeleted) {
+      continue;
+    }
+    // if the new item is deleted, it is considered deleted
+    if (newItem.isDeleted) {
+      deltas.push({ id: newItem.id, isDeleted: true, updated: newItem.updated });
+      continue;
+    }
+    // a match is found and the item is not deleted
+    // search what has been updated
+    const updatedFields: Partial<ExcalidrawElement> = { id: newItem.id };
+    let isUpdated = false;
+    // compare every field of the new item against every field of the old item
+    for (const key in newItem) {
+      const typedKey = key as keyof ExcalidrawElement;
+      if (
+        (typeof newItem[typedKey] === 'object' && isEqual(newItem[typedKey], oldItem[typedKey])) ||
+        newItem[typedKey] === oldItem[typedKey]
+      ) {
+        continue;
+      }
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      updatedFields[typedKey] = newItem[typedKey];
+      isUpdated = true;
+    }
+
+    if (isUpdated) {
+      deltas.push({
+        ...updatedFields,
+        // the fields below are used internally
+        type: newItem.type,
+        points: (newItem as ExcalidrawLinearElement)?.points,
+        width: newItem.width,
+        height: newItem.height,
+      });
+    }
+  }
+  return deltas as Array<ExcalidrawElementDelta>;
+};

--- a/src/domain/common/whiteboard/excalidraw/collab/merge.elements.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/merge.elements.ts
@@ -6,10 +6,10 @@ export const mergeElements = (
   toBeUsed: ReadonlyArray<ExcalidrawElement>
 ) => {
   const toBeUsedMap = new Map<string, ExcalidrawElement>(toBeUsed.map(x => [x.id, x]));
-
-  return toBeMergedWith.map(x => mergeWith(x, toBeUsedMap.get(x.id), mergeFn));
+  return toBeMergedWith.map(x => mergeWith(x, toBeUsedMap.get(x.id), preferDestinationFields));
 };
 
-const mergeFn: MergeWithCustomizer = (destValue: unknown, srcValue: unknown) => {
-  return destValue !== undefined ? destValue : srcValue;
+const preferDestinationFields: MergeWithCustomizer = (destValue: unknown, srcValue: unknown) => {
+  // if the destination value is defined, prefer it instead of the source value
+  return destValue === undefined ? srcValue : destValue;
 };

--- a/src/domain/common/whiteboard/excalidraw/collab/merge.elements.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/merge.elements.ts
@@ -1,0 +1,15 @@
+import { ExcalidrawElement } from '@alkemio/excalidraw/dist/excalidraw/element/types';
+import { MergeWithCustomizer, mergeWith } from 'lodash';
+
+export const mergeElements = (
+  toBeMergedWith: ReadonlyArray<ExcalidrawElement>,
+  toBeUsed: ReadonlyArray<ExcalidrawElement>
+) => {
+  const toBeUsedMap = new Map<string, ExcalidrawElement>(toBeUsed.map(x => [x.id, x]));
+
+  return toBeMergedWith.map(x => mergeWith(x, toBeUsedMap.get(x.id), mergeFn));
+};
+
+const mergeFn: MergeWithCustomizer = (destValue: unknown, srcValue: unknown) => {
+  return destValue !== undefined ? destValue : srcValue;
+};


### PR DESCRIPTION
_We don't want these changes at the moment._

>  :warning: Disclaimer: This method will use slightly more CPU.

Before | After
---|---
![image](https://github.com/user-attachments/assets/6c4916af-9d0c-44ec-ad10-ca13f756b144)|![image](https://github.com/user-attachments/assets/289619f1-491a-4179-a34c-236c553393b5)

The running time of the reconciliation before (236.4ms) vs after (572ms)  has a 2.62x times increase, which is a lot but still represents a small amount of the overall running time (6.7%) vs 2.6% before.

## Benchmark
30 seconds each round

messages|total traffic (MB) |
---|---
4910 | 59.65
4907 | 59.26 
4965 | 59.65

**Average 59.52 MB**

---
### After
messages|total traffic (MB) |
---|---
5364 | 26.45
5350 | 26.33
5355 | 26.35

**Average ~26.38 MB**

> Dunno about the more messages the seconds time ...

## Todo
- server changes