### PR TITLE
Available plans - use the privileges and entitlements of the account, not of the active user

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -2200,9 +2200,9 @@ export type MutationKeySpecifier = (
   | 'cleanupCollections'
   | 'convertChallengeToSpace'
   | 'convertOpportunityToChallenge'
+  | 'convertVirtualContributorToUseKnowledgeBase'
   | 'createActor'
   | 'createActorGroup'
-  | 'createCallout'
   | 'createCalloutOnCalloutsSet'
   | 'createChatGuidanceRoom'
   | 'createContributionOnCallout'
@@ -2280,6 +2280,7 @@ export type MutationKeySpecifier = (
   | 'sendMessageToOrganization'
   | 'sendMessageToRoom'
   | 'sendMessageToUser'
+  | 'transferCallout'
   | 'transferInnovationHubToAccount'
   | 'transferInnovationPackToAccount'
   | 'transferSpaceToAccount'
@@ -2371,9 +2372,9 @@ export type MutationFieldPolicy = {
   cleanupCollections?: FieldPolicy<any> | FieldReadFunction<any>;
   convertChallengeToSpace?: FieldPolicy<any> | FieldReadFunction<any>;
   convertOpportunityToChallenge?: FieldPolicy<any> | FieldReadFunction<any>;
+  convertVirtualContributorToUseKnowledgeBase?: FieldPolicy<any> | FieldReadFunction<any>;
   createActor?: FieldPolicy<any> | FieldReadFunction<any>;
   createActorGroup?: FieldPolicy<any> | FieldReadFunction<any>;
-  createCallout?: FieldPolicy<any> | FieldReadFunction<any>;
   createCalloutOnCalloutsSet?: FieldPolicy<any> | FieldReadFunction<any>;
   createChatGuidanceRoom?: FieldPolicy<any> | FieldReadFunction<any>;
   createContributionOnCallout?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2451,6 +2452,7 @@ export type MutationFieldPolicy = {
   sendMessageToOrganization?: FieldPolicy<any> | FieldReadFunction<any>;
   sendMessageToRoom?: FieldPolicy<any> | FieldReadFunction<any>;
   sendMessageToUser?: FieldPolicy<any> | FieldReadFunction<any>;
+  transferCallout?: FieldPolicy<any> | FieldReadFunction<any>;
   transferInnovationHubToAccount?: FieldPolicy<any> | FieldReadFunction<any>;
   transferInnovationPackToAccount?: FieldPolicy<any> | FieldReadFunction<any>;
   transferSpaceToAccount?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2656,6 +2658,7 @@ export type PaginatedUsersFieldPolicy = {
 };
 export type PlatformKeySpecifier = (
   | 'authorization'
+  | 'chatGuidanceVirtualContributor'
   | 'configuration'
   | 'createdDate'
   | 'forum'
@@ -2674,6 +2677,7 @@ export type PlatformKeySpecifier = (
 )[];
 export type PlatformFieldPolicy = {
   authorization?: FieldPolicy<any> | FieldReadFunction<any>;
+  chatGuidanceVirtualContributor?: FieldPolicy<any> | FieldReadFunction<any>;
   configuration?: FieldPolicy<any> | FieldReadFunction<any>;
   createdDate?: FieldPolicy<any> | FieldReadFunction<any>;
   forum?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -12357,6 +12357,65 @@ export type UpdateOrganizationSettingsMutationOptions = Apollo.BaseMutationOptio
   SchemaTypes.UpdateOrganizationSettingsMutation,
   SchemaTypes.UpdateOrganizationSettingsMutationVariables
 >;
+export const PendingInvitationsCountDocument = gql`
+  query PendingInvitationsCount {
+    me {
+      communityInvitationsCount(states: ["invited"])
+    }
+  }
+`;
+
+/**
+ * __usePendingInvitationsCountQuery__
+ *
+ * To run a query within a React component, call `usePendingInvitationsCountQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePendingInvitationsCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePendingInvitationsCountQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function usePendingInvitationsCountQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    SchemaTypes.PendingInvitationsCountQuery,
+    SchemaTypes.PendingInvitationsCountQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SchemaTypes.PendingInvitationsCountQuery, SchemaTypes.PendingInvitationsCountQueryVariables>(
+    PendingInvitationsCountDocument,
+    options
+  );
+}
+
+export function usePendingInvitationsCountLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.PendingInvitationsCountQuery,
+    SchemaTypes.PendingInvitationsCountQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SchemaTypes.PendingInvitationsCountQuery,
+    SchemaTypes.PendingInvitationsCountQueryVariables
+  >(PendingInvitationsCountDocument, options);
+}
+
+export type PendingInvitationsCountQueryHookResult = ReturnType<typeof usePendingInvitationsCountQuery>;
+export type PendingInvitationsCountLazyQueryHookResult = ReturnType<typeof usePendingInvitationsCountLazyQuery>;
+export type PendingInvitationsCountQueryResult = Apollo.QueryResult<
+  SchemaTypes.PendingInvitationsCountQuery,
+  SchemaTypes.PendingInvitationsCountQueryVariables
+>;
+export function refetchPendingInvitationsCountQuery(variables?: SchemaTypes.PendingInvitationsCountQueryVariables) {
+  return { query: PendingInvitationsCountDocument, variables: variables };
+}
+
 export const PendingMembershipsSpaceDocument = gql`
   query PendingMembershipsSpace(
     $spaceId: UUID!
@@ -16366,21 +16425,18 @@ export function refetchPlansTableQuery(variables?: SchemaTypes.PlansTableQueryVa
   return { query: PlansTableDocument, variables: variables };
 }
 
-export const FreePlanAvailabilityDocument = gql`
-  query FreePlanAvailability {
-    me {
-      id
-      user {
+export const AccountPlanAvailabilityDocument = gql`
+  query AccountPlanAvailability($accountId: UUID!) {
+    lookup {
+      account(ID: $accountId) {
         id
-        account {
+        authorization {
           id
-          authorization {
-            id
-            myPrivileges
-          }
-          license {
-            availableEntitlements
-          }
+          myPrivileges
+        }
+        license {
+          id
+          availableEntitlements
         }
       }
     }
@@ -16388,54 +16444,55 @@ export const FreePlanAvailabilityDocument = gql`
 `;
 
 /**
- * __useFreePlanAvailabilityQuery__
+ * __useAccountPlanAvailabilityQuery__
  *
- * To run a query within a React component, call `useFreePlanAvailabilityQuery` and pass it any options that fit your needs.
- * When your component renders, `useFreePlanAvailabilityQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAccountPlanAvailabilityQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAccountPlanAvailabilityQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useFreePlanAvailabilityQuery({
+ * const { data, loading, error } = useAccountPlanAvailabilityQuery({
  *   variables: {
+ *      accountId: // value for 'accountId'
  *   },
  * });
  */
-export function useFreePlanAvailabilityQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    SchemaTypes.FreePlanAvailabilityQuery,
-    SchemaTypes.FreePlanAvailabilityQueryVariables
+export function useAccountPlanAvailabilityQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    SchemaTypes.AccountPlanAvailabilityQuery,
+    SchemaTypes.AccountPlanAvailabilityQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<SchemaTypes.FreePlanAvailabilityQuery, SchemaTypes.FreePlanAvailabilityQueryVariables>(
-    FreePlanAvailabilityDocument,
+  return Apollo.useQuery<SchemaTypes.AccountPlanAvailabilityQuery, SchemaTypes.AccountPlanAvailabilityQueryVariables>(
+    AccountPlanAvailabilityDocument,
     options
   );
 }
 
-export function useFreePlanAvailabilityLazyQuery(
+export function useAccountPlanAvailabilityLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    SchemaTypes.FreePlanAvailabilityQuery,
-    SchemaTypes.FreePlanAvailabilityQueryVariables
+    SchemaTypes.AccountPlanAvailabilityQuery,
+    SchemaTypes.AccountPlanAvailabilityQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<SchemaTypes.FreePlanAvailabilityQuery, SchemaTypes.FreePlanAvailabilityQueryVariables>(
-    FreePlanAvailabilityDocument,
-    options
-  );
+  return Apollo.useLazyQuery<
+    SchemaTypes.AccountPlanAvailabilityQuery,
+    SchemaTypes.AccountPlanAvailabilityQueryVariables
+  >(AccountPlanAvailabilityDocument, options);
 }
 
-export type FreePlanAvailabilityQueryHookResult = ReturnType<typeof useFreePlanAvailabilityQuery>;
-export type FreePlanAvailabilityLazyQueryHookResult = ReturnType<typeof useFreePlanAvailabilityLazyQuery>;
-export type FreePlanAvailabilityQueryResult = Apollo.QueryResult<
-  SchemaTypes.FreePlanAvailabilityQuery,
-  SchemaTypes.FreePlanAvailabilityQueryVariables
+export type AccountPlanAvailabilityQueryHookResult = ReturnType<typeof useAccountPlanAvailabilityQuery>;
+export type AccountPlanAvailabilityLazyQueryHookResult = ReturnType<typeof useAccountPlanAvailabilityLazyQuery>;
+export type AccountPlanAvailabilityQueryResult = Apollo.QueryResult<
+  SchemaTypes.AccountPlanAvailabilityQuery,
+  SchemaTypes.AccountPlanAvailabilityQueryVariables
 >;
-export function refetchFreePlanAvailabilityQuery(variables?: SchemaTypes.FreePlanAvailabilityQueryVariables) {
-  return { query: FreePlanAvailabilityDocument, variables: variables };
+export function refetchAccountPlanAvailabilityQuery(variables: SchemaTypes.AccountPlanAvailabilityQueryVariables) {
+  return { query: AccountPlanAvailabilityDocument, variables: variables };
 }
 
 export const ContactSupportLocationDocument = gql`
@@ -22859,65 +22916,6 @@ export type CampaignBlockCredentialsQueryResult = Apollo.QueryResult<
 >;
 export function refetchCampaignBlockCredentialsQuery(variables?: SchemaTypes.CampaignBlockCredentialsQueryVariables) {
   return { query: CampaignBlockCredentialsDocument, variables: variables };
-}
-
-export const PendingInvitationsCountDocument = gql`
-  query PendingInvitationsCount {
-    me {
-      communityInvitationsCount(states: ["invited"])
-    }
-  }
-`;
-
-/**
- * __usePendingInvitationsCountQuery__
- *
- * To run a query within a React component, call `usePendingInvitationsCountQuery` and pass it any options that fit your needs.
- * When your component renders, `usePendingInvitationsCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = usePendingInvitationsCountQuery({
- *   variables: {
- *   },
- * });
- */
-export function usePendingInvitationsCountQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    SchemaTypes.PendingInvitationsCountQuery,
-    SchemaTypes.PendingInvitationsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<SchemaTypes.PendingInvitationsCountQuery, SchemaTypes.PendingInvitationsCountQueryVariables>(
-    PendingInvitationsCountDocument,
-    options
-  );
-}
-
-export function usePendingInvitationsCountLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    SchemaTypes.PendingInvitationsCountQuery,
-    SchemaTypes.PendingInvitationsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    SchemaTypes.PendingInvitationsCountQuery,
-    SchemaTypes.PendingInvitationsCountQueryVariables
-  >(PendingInvitationsCountDocument, options);
-}
-
-export type PendingInvitationsCountQueryHookResult = ReturnType<typeof usePendingInvitationsCountQuery>;
-export type PendingInvitationsCountLazyQueryHookResult = ReturnType<typeof usePendingInvitationsCountLazyQuery>;
-export type PendingInvitationsCountQueryResult = Apollo.QueryResult<
-  SchemaTypes.PendingInvitationsCountQuery,
-  SchemaTypes.PendingInvitationsCountQueryVariables
->;
-export function refetchPendingInvitationsCountQuery(variables?: SchemaTypes.PendingInvitationsCountQueryVariables) {
-  return { query: PendingInvitationsCountDocument, variables: variables };
 }
 
 export const DashboardWithMembershipsDocument = gql`

--- a/src/domain/journey/space/createSpace/CreateSpaceDialog.tsx
+++ b/src/domain/journey/space/createSpace/CreateSpaceDialog.tsx
@@ -130,7 +130,7 @@ const CreateSpaceDialog = ({ withRedirectOnClose = true, onClose, account }: Cre
         category: TagCategoryValues.UI,
         label: 'SpaceCreationError',
       });
-      notify('No Available Plans. Please, contact support.', 'success');
+      notify('No Available Plans. Please, contact support.', 'warning');
       return;
     }
 

--- a/src/domain/journey/space/createSpace/PlansTable.graphql
+++ b/src/domain/journey/space/createSpace/PlansTable.graphql
@@ -19,20 +19,17 @@ query PlansTable {
   }
 }
 
-query FreePlanAvailability {
-  me {
-    id
-    user {
+query AccountPlanAvailability($accountId: UUID!) {
+  lookup {
+    account(ID: $accountId) {
       id
-      account {
+      authorization {
         id
-        authorization {
-          id
-          myPrivileges
-        }
-        license {
-          availableEntitlements
-        }
+        myPrivileges
+      }
+      license {
+        id
+        availableEntitlements
       }
     }
   }


### PR DESCRIPTION
In this PR we're detaching the dependency of the userContext in the useSpacePlans/available plans logic.

This fixes the issue where when creating a space on another account (org) the wrong entitlements are checked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The alert during space creation now displays a warning when no available plans are found, providing clearer guidance.
- **New Features**
  - Enhanced plan availability checks now leverage account data to ensure you receive more precise and reliable feedback during the space creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->