### PR TITLE
Allow opening of links from docs iframe

### DIFF
--- a/src/domain/documentation/DocumentationPage.tsx
+++ b/src/domain/documentation/DocumentationPage.tsx
@@ -93,7 +93,7 @@ const DocumentationPage = () => {
               <iframe
                 src={src}
                 ref={iframeRef}
-                sandbox="allow-scripts allow-same-origin"
+                sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
                 title={t('pages.documentation.title')}
                 style={{ width: '100%', height: DEFAULT_HEIGHT, border: 'none' }}
               />


### PR DESCRIPTION
Fixes: https://github.com/alkem-io/documentation/issues/28

Flags were added to the sandbox attribute of Docs' iframe to allow the opening of links.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox#allow-popups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The documentation view now supports interactive popups, allowing a more dynamic and engaging content experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->