### PR TITLE
Whiteboard error handling

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2510,7 +2510,7 @@
       "no-whiteboards": "No whiteboards have been created yet. Be the first to add one.",
       "locked-by": "{{user}} is currently editing this Whiteboard",
       "loadingScene": "Loading scene",
-      "room-not-saved": "The server failed to save the last changes. If the problem persists we suggest saving the whiteboard to disk to not loose your work.",
+      "room-not-saved": "We could not save the last changes. If the problem persists we suggest saving the whiteboard to disk to not loose your work.",
       "state-actions": {
         "save-as-template": "Save as template",
         "save-and-check-in": "Save & stop editing",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2510,6 +2510,7 @@
       "no-whiteboards": "No whiteboards have been created yet. Be the first to add one.",
       "locked-by": "{{user}} is currently editing this Whiteboard",
       "loadingScene": "Loading scene",
+      "room-not-saved": "The server failed to save the last changes. If the problem persists we suggest saving the whiteboard to disk to not loose your work.",
       "state-actions": {
         "save-as-template": "Save as template",
         "save-and-check-in": "Save & stop editing",

--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
@@ -105,7 +105,8 @@ const WhiteboardDialog = ({ entities, actions, options, state }: WhiteboardDialo
 
   const columns = useGlobalGridColumns();
 
-  const [lastSavedDate, setLastSavedDate] = useState<Date | undefined>(undefined);
+  const [lastSuccessfulSavedDate, setLastSuccessfulSavedDate] = useState<Date | undefined>(undefined);
+  const [lastSaveError, setLastSaveError] = useState<string | undefined>();
   const [isSceneInitialized, setSceneInitialized] = useState(false);
 
   const { data: lastSaved } = useWhiteboardLastUpdatedDateQuery({
@@ -114,8 +115,8 @@ const WhiteboardDialog = ({ entities, actions, options, state }: WhiteboardDialo
     fetchPolicy: 'network-only',
   });
 
-  if (!lastSavedDate && lastSaved?.lookup.whiteboard?.updatedDate) {
-    setLastSavedDate(new Date(lastSaved?.lookup.whiteboard?.updatedDate));
+  if (!lastSuccessfulSavedDate && lastSaved?.lookup.whiteboard?.updatedDate) {
+    setLastSuccessfulSavedDate(new Date(lastSaved?.lookup.whiteboard?.updatedDate));
   }
 
   const filesManager = useWhiteboardFilesManager({
@@ -261,7 +262,7 @@ const WhiteboardDialog = ({ entities, actions, options, state }: WhiteboardDialo
   return (
     <>
       <CollaborativeExcalidrawWrapper
-        entities={{ whiteboard, filesManager, lastSavedDate }}
+        entities={{ whiteboard, filesManager, lastSuccessfulSavedDate }}
         collabApiRef={collabApiRef}
         options={{
           UIOptions: {
@@ -274,8 +275,13 @@ const WhiteboardDialog = ({ entities, actions, options, state }: WhiteboardDialo
         }}
         actions={{
           onInitApi: setExcalidrawAPI,
-          onRemoteSave: () => {
-            setLastSavedDate(new Date());
+          onRemoteSave: (error?: string) => {
+            if (error) {
+              setLastSaveError(error);
+            } else {
+              setLastSuccessfulSavedDate(new Date());
+              setLastSaveError(undefined);
+            }
           },
           onSceneInitChange: setSceneInitialized,
         }}
@@ -318,7 +324,8 @@ const WhiteboardDialog = ({ entities, actions, options, state }: WhiteboardDialo
                 <WhiteboardDialogFooter
                   collaboratorMode={mode}
                   collaboratorModeReason={modeReason}
-                  lastSavedDate={lastSavedDate}
+                  lastSuccessfulSavedDate={lastSuccessfulSavedDate}
+                  lastSaveError={lastSaveError}
                   onDelete={() => setDeleteDialogOpen(true)}
                   canDelete={options.canDelete}
                   onRestart={restartCollaboration}

--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialogFooter.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialogFooter.tsx
@@ -248,12 +248,14 @@ const LastSavedCaption = ({ date }: { date: Date | undefined }) => {
 };
 
 const LastSaveError = ({ error }: { error: string | undefined }) => {
+  const { t } = useTranslation();
+
   if (!error) {
     return null;
   }
 
   return (
-    <Tooltip title={<Caption>The server failed to save your last changes</Caption>} placement="top">
+    <Tooltip title={<Caption>{t('pages.whiteboard.room-not-saved')}</Caption>} placement="top">
       <ErrorOutlineOutlinedIcon color="error" />
     </Tooltip>
   );

--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialogFooter.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialogFooter.tsx
@@ -1,6 +1,7 @@
-import { MouseEventHandler, useEffect, useState } from 'react';
+import React, { MouseEventHandler, useEffect, useState } from 'react';
 import { gutters } from '@/core/ui/grid/utils';
-import { Button, DialogContent } from '@mui/material';
+import { Button, DialogContent, Tooltip } from '@mui/material';
+import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined';
 import { Caption } from '@/core/ui/typography';
 import { DeleteOutline } from '@mui/icons-material';
 import { Actions } from '@/core/ui/actions/Actions';
@@ -27,7 +28,8 @@ import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import WrapperMarkdown from '@/core/ui/markdown/WrapperMarkdown';
 
 interface WhiteboardDialogFooterProps {
-  lastSavedDate: Date | undefined;
+  lastSuccessfulSavedDate: Date | undefined;
+  lastSaveError: string | undefined;
   canUpdateContent: boolean;
   onDelete: () => void;
   canDelete?: boolean;
@@ -55,7 +57,8 @@ enum ReadonlyReason {
 }
 
 const WhiteboardDialogFooter = ({
-  lastSavedDate,
+  lastSuccessfulSavedDate,
+  lastSaveError,
   canUpdateContent,
   onDelete,
   canDelete,
@@ -197,7 +200,12 @@ const WhiteboardDialogFooter = ({
             {t('pages.whiteboard.restartCollaboration')}
           </Button>
         )}
-        {!readonlyReason && <LastSavedCaption date={lastSavedDate} />}
+        {!readonlyReason && (
+          <>
+            <LastSavedCaption date={lastSuccessfulSavedDate} />
+            {LastSaveError && <LastSaveError error={lastSaveError} />}
+          </>
+        )}
         {directMessageDialog}
       </Actions>
       <DialogWithGrid open={isLearnWhyDialogOpen} onClose={() => setIsLearnWhyDialogOpen(false)}>
@@ -237,4 +245,16 @@ const LastSavedCaption = ({ date }: { date: Date | undefined }) => {
   }
 
   return <Caption>{t('common.last-saved', { datetime: formattedTime })}</Caption>;
+};
+
+const LastSaveError = ({ error }: { error: string | undefined }) => {
+  if (!error) {
+    return null;
+  }
+
+  return (
+    <Tooltip title={<Caption>The server failed to save your last changes</Caption>} placement="top">
+      <ErrorOutlineOutlinedIcon color="error" />
+    </Tooltip>
+  );
 };

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
@@ -58,13 +58,13 @@ const LoadingScene = React.memo(({ enabled }: { enabled: boolean }) => {
 export interface WhiteboardWhiteboardEntities {
   whiteboard: (Identifiable & { profile?: { url?: string } }) | undefined;
   filesManager: WhiteboardFilesManager;
-  lastSavedDate: Date | undefined;
+  lastSuccessfulSavedDate: Date | undefined;
 }
 
 export interface WhiteboardWhiteboardActions {
   onInitApi?: (excalidrawApi: ExcalidrawImperativeAPI) => void;
   onSceneInitChange?: (initialized: boolean) => void;
-  onRemoteSave?: () => void;
+  onRemoteSave?: (error?: string) => void;
 }
 
 export interface WhiteboardWhiteboardEvents {}
@@ -101,7 +101,7 @@ const CollaborativeExcalidrawWrapper = ({
 
   const [collaborationStoppedNoticeOpen, setCollaborationStoppedNoticeOpen] = useState(false);
 
-  const { whiteboard, filesManager, lastSavedDate } = entities;
+  const { whiteboard, filesManager, lastSuccessfulSavedDate } = entities;
   const whiteboardDefaults = useWhiteboardDefaults();
 
   const combinedCollabApiRef = useCombinedRefs<CollabAPI | null>(null, collabApiRef);
@@ -147,7 +147,7 @@ const CollaborativeExcalidrawWrapper = ({
   const [collabApi, initializeCollab, { connecting, collaborating, mode, modeReason }] = useCollab({
     username,
     filesManager,
-    onRemoteSave: () => actions.onRemoteSave?.(),
+    onRemoteSave: (error?: string) => actions.onRemoteSave?.(error),
     onCloseConnection: () => {
       setCollaborationStoppedNoticeOpen(true);
       setSceneInitialized(false);
@@ -259,10 +259,10 @@ const CollaborativeExcalidrawWrapper = ({
         <DialogContent>
           {isOnline && <WrapperMarkdown>{t('pages.whiteboard.whiteboardDisconnected.message')}</WrapperMarkdown>}
           {!isOnline && <WrapperMarkdown>{t('pages.whiteboard.whiteboardDisconnected.offline')}</WrapperMarkdown>}
-          {lastSavedDate && (
+          {lastSuccessfulSavedDate && (
             <Text>
               {t('pages.whiteboard.whiteboardDisconnected.lastSaved', {
-                lastSaved: formatTimeElapsed(lastSavedDate, t, 'long'),
+                lastSaved: formatTimeElapsed(lastSuccessfulSavedDate, t, 'long'),
               })}
             </Text>
           )}

--- a/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Collab.ts
@@ -44,7 +44,7 @@ type CollabState = {
 export interface CollabProps {
   excalidrawApi: ExcalidrawImperativeAPI;
   username: string;
-  onRemoteSave: () => void; // The client has received a room saved event
+  onRemoteSave: (error?: string) => void; // The client has received a room saved event
   filesManager: WhiteboardFilesManager;
   onCloseConnection: () => void;
   onCollaboratorModeChange: (event: CollaboratorModeEvent) => void;

--- a/src/domain/common/whiteboard/excalidraw/collab/Portal.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/Portal.ts
@@ -37,7 +37,7 @@ interface SocketEventHandlers {
 }
 
 class Portal {
-  onRemoteSave: () => void;
+  onRemoteSave: (error?: string) => void;
   onCloseConnection: () => void;
   onRoomUserChange: (clients: SocketId[]) => void;
   getSceneElements: () => readonly ExcalidrawElement[];
@@ -88,6 +88,7 @@ class Portal {
       });
 
       this.socket.on('room-saved', () => this.onRemoteSave());
+      this.socket.on('room-not-saved', ({ error }) => this.onRemoteSave(error));
 
       this.socket.on('collaborator-mode', eventHandlers['collaborator-mode']);
 

--- a/src/domain/common/whiteboard/excalidraw/collab/useCollab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/useCollab.ts
@@ -55,8 +55,8 @@ const useCollab = ({
     }
   };
 
-  const handleRemoteSave = () => {
-    onRemoteSave?.();
+  const handleRemoteSave = (error?: string) => {
+    onRemoteSave?.(error);
   };
 
   const handleSceneInitChange = (initialized: boolean) => {


### PR DESCRIPTION
The whiteboard will receive a message from the server that the save failed. This PR is handling the message.

If a message is "fail" received, the "last saved" timer won't change - showing the last actual save, and a small icon with a tooltip will appear showing that the save failed.
If a "success" message is received the timer will update and the icon will be hidden.

![image](https://github.com/user-attachments/assets/2dcc15b9-603a-4023-a255-5da08298c517)
