### PR TITLE
7673 [bug fix] Hide titles on empty tags, links, keywords and skills

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -1237,6 +1237,7 @@ export const OrganizationInfoFragmentDoc = gql`
         id
         name
         uri
+        description
       }
       location {
         ...fullLocation

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -7235,6 +7235,7 @@ export enum UrlType {
   ContributorsExplorer = 'CONTRIBUTORS_EXPLORER',
   Discussion = 'DISCUSSION',
   Documentation = 'DOCUMENTATION',
+  Flow = 'FLOW',
   Forum = 'FORUM',
   Home = 'HOME',
   InnovationHub = 'INNOVATION_HUB',
@@ -16720,7 +16721,9 @@ export type OrganizationInfoFragment = {
           type: TagsetType;
         }>
       | undefined;
-    references?: Array<{ __typename?: 'Reference'; id: string; name: string; uri: string }> | undefined;
+    references?:
+      | Array<{ __typename?: 'Reference'; id: string; name: string; uri: string; description?: string | undefined }>
+      | undefined;
     location?:
       | {
           __typename?: 'Location';
@@ -16777,7 +16780,15 @@ export type OrganizationInfoQuery = {
                   type: TagsetType;
                 }>
               | undefined;
-            references?: Array<{ __typename?: 'Reference'; id: string; name: string; uri: string }> | undefined;
+            references?:
+              | Array<{
+                  __typename?: 'Reference';
+                  id: string;
+                  name: string;
+                  uri: string;
+                  description?: string | undefined;
+                }>
+              | undefined;
             location?:
               | {
                   __typename?: 'Location';

--- a/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
+++ b/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
@@ -54,7 +54,11 @@ const useCommunityAdmin = ({ roleSetId, spaceId, spaceLevel }: useCommunityAdmin
   } = useRoleSetManager({
     roleSetId,
     relevantRoles: RELEVANT_ROLES.Community,
-    contributorTypes: [RoleSetContributorType.User, RoleSetContributorType.Organization],
+    contributorTypes: [
+      RoleSetContributorType.User,
+      RoleSetContributorType.Organization,
+      RoleSetContributorType.Virtual,
+    ],
     fetchContributors: true,
     fetchRoleDefinitions: true,
     onChange: () => refetchAvailableContributors(),

--- a/src/domain/community/contributor/organization/OrganizationPageContainer/OrganizationPageContainer.tsx
+++ b/src/domain/community/contributor/organization/OrganizationPageContainer/OrganizationPageContainer.tsx
@@ -24,6 +24,7 @@ export interface OrganizationContainerEntities {
     id: string;
     name: string;
     uri: string;
+    description?: string;
   }[];
   capabilities: string[];
   keywords: string[];

--- a/src/domain/community/contributor/organization/context/OrganizationInfoFragment.graphql
+++ b/src/domain/community/contributor/organization/context/OrganizationInfoFragment.graphql
@@ -31,6 +31,7 @@ fragment OrganizationInfo on Organization {
       id
       name
       uri
+      description
     }
     location {
       ...fullLocation

--- a/src/domain/community/profile/views/ProfileView/OrganizationProfileView.tsx
+++ b/src/domain/community/profile/views/ProfileView/OrganizationProfileView.tsx
@@ -1,4 +1,4 @@
-import { groupBy } from 'lodash';
+import { groupBy, isEmpty } from 'lodash';
 import { Box, CardContent, Grid, styled } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import ProfileDetail from '@/domain/community/profile/ProfileDetail/ProfileDetail';
@@ -50,11 +50,13 @@ const OTHER_LINK_GROUP = 'other';
 export const OrganizationProfileView = ({ entity }: OrganizationProfileViewProps) => {
   const { t } = useTranslation();
 
-  const links = useMemo(() => {
-    return groupBy(entity.references, reference =>
-      isSocialNetworkSupported(reference.name) ? SOCIAL_LINK_GROUP : OTHER_LINK_GROUP
-    );
-  }, [entity.references]);
+  const links = useMemo(
+    () =>
+      groupBy(entity.references, reference =>
+        isSocialNetworkSupported(reference.name) ? SOCIAL_LINK_GROUP : OTHER_LINK_GROUP
+      ),
+    [entity.references]
+  );
 
   const socialLinks = links[SOCIAL_LINK_GROUP]?.map(s => ({
     type: s.name as SocialNetworkEnum,
@@ -88,13 +90,15 @@ export const OrganizationProfileView = ({ entity }: OrganizationProfileViewProps
               ) : null
             )}
 
-          {Number(links[OTHER_LINK_GROUP].length) > 0 && (
+          {!isEmpty(links) && (
             <Gutters fullHeight>
               <BlockSectionTitle>{t('components.profile.fields.links.title')}</BlockSectionTitle>
+
               <References
                 references={links[OTHER_LINK_GROUP]}
                 noItemsView={<CardText color="neutral.main">{t('common.no-references')}</CardText>}
               />
+
               <SocialLinks items={socialLinks} />
             </Gutters>
           )}

--- a/src/domain/community/profile/views/ProfileView/OrganizationProfileView.tsx
+++ b/src/domain/community/profile/views/ProfileView/OrganizationProfileView.tsx
@@ -76,22 +76,28 @@ export const OrganizationProfileView = ({ entity }: OrganizationProfileViewProps
           <Gutters>
             <ProfileDetail title={t('components.profile.fields.bio.title')} value={entity.bio} />
           </Gutters>
+
           {entity.tagsets
             ?.filter(t => t.tags.length > 0)
-            .map((tagset, i) => (
-              <Gutters key={i}>
-                <BlockTitle>{tagset.name}</BlockTitle>
-                <TagsComponent tags={tagset.tags} count={5} />
-              </Gutters>
-            ))}
-          <Gutters fullHeight>
-            <BlockSectionTitle>{t('components.profile.fields.links.title')}</BlockSectionTitle>
-            <References
-              references={links[OTHER_LINK_GROUP]}
-              noItemsView={<CardText color="neutral.main">{t('common.no-references')}</CardText>}
-            />
-            <SocialLinks items={socialLinks} />
-          </Gutters>
+            .map((tagset, i) =>
+              tagset.tags.length > 0 ? (
+                <Gutters key={i}>
+                  <BlockTitle>{tagset.name}</BlockTitle>
+                  <TagsComponent tags={tagset.tags} count={5} />
+                </Gutters>
+              ) : null
+            )}
+
+          {Number(links[OTHER_LINK_GROUP].length) > 0 && (
+            <Gutters fullHeight>
+              <BlockSectionTitle>{t('components.profile.fields.links.title')}</BlockSectionTitle>
+              <References
+                references={links[OTHER_LINK_GROUP]}
+                noItemsView={<CardText color="neutral.main">{t('common.no-references')}</CardText>}
+              />
+              <SocialLinks items={socialLinks} />
+            </Gutters>
+          )}
         </Grid>
       </CardContent>
     </PageContentBlock>

--- a/src/domain/community/profile/views/ProfileView/UserProfileView.tsx
+++ b/src/domain/community/profile/views/ProfileView/UserProfileView.tsx
@@ -48,26 +48,35 @@ export const UserProfileView = ({ entities: { userMetadata } }: UserProfileViewP
         <ProfileDetail title={t('components.profile.fields.bio.title')} value={bio} aria-label="bio" />
       </Grid>
 
-      <Grid item>
-        <BlockSectionTitle>{t('components.profile.fields.keywords.title')}</BlockSectionTitle>
-        <TagsWithOffset tags={keywords} hideNoTagsMessage />
-      </Grid>
+      {keywords.length > 0 && (
+        <Grid item>
+          <BlockSectionTitle>{t('components.profile.fields.keywords.title')}</BlockSectionTitle>
+          <TagsWithOffset tags={keywords} />
+        </Grid>
+      )}
 
-      <Grid item>
-        <BlockSectionTitle>{t('components.profile.fields.skills.title')}</BlockSectionTitle>
-        <TagsWithOffset tags={skills} hideNoTagsMessage />
-      </Grid>
+      {skills.length > 0 && (
+        <Grid item>
+          <BlockSectionTitle>{t('components.profile.fields.skills.title')}</BlockSectionTitle>
+          <TagsWithOffset tags={skills} />
+        </Grid>
+      )}
 
-      <Grid item container direction="column">
-        <BlockSectionTitle mb={gutters()}>{t('components.profile.fields.links.title')}</BlockSectionTitle>
-        <References
-          references={links[OTHER_LINK_GROUP]}
-          noItemsView={<CardText color="neutral.main">{t('common.no-references')}</CardText>}
-        />
-      </Grid>
-      <Grid item display="flex" flexGrow={1} justifyContent="end">
-        <SocialLinks items={socialLinks} />
-      </Grid>
+      {Number(links[OTHER_LINK_GROUP].length) > 0 && (
+        <Grid item container direction="column">
+          <BlockSectionTitle mb={gutters()}>{t('components.profile.fields.links.title')}</BlockSectionTitle>
+          <References
+            references={links[OTHER_LINK_GROUP]}
+            noItemsView={<CardText color="neutral.main">{t('common.no-references')}</CardText>}
+          />
+        </Grid>
+      )}
+
+      {socialLinks.length > 0 && (
+        <Grid item display="flex" flexGrow={1} justifyContent="end">
+          <SocialLinks items={socialLinks} />
+        </Grid>
+      )}
     </PageContentBlock>
   );
 };

--- a/src/domain/journey/common/PageBanner/JourneyPageBannerCard/PageBannerCardWithVisual.tsx
+++ b/src/domain/journey/common/PageBanner/JourneyPageBannerCard/PageBannerCardWithVisual.tsx
@@ -56,7 +56,7 @@ const PageBannerCardWithVisual = ({
           </Caption>
 
           <RowContainer>
-            <TagsComponent tags={tags} color="primary" hideNoTagsMessage minHeight={gutters()} variant="filled" />
+            {tags.length > 0 && <TagsComponent tags={tags} color="primary" minHeight={gutters()} variant="filled" />}
           </RowContainer>
         </Box>
       </BadgeCardView>

--- a/src/domain/shared/components/References/References.tsx
+++ b/src/domain/shared/components/References/References.tsx
@@ -17,6 +17,10 @@ interface ReferencesProps {
 }
 
 const References: FC<ReferencesProps> = ({ references, onEdit, noItemsView, icon, compact }) => {
+  if (!references || references.length === 0) {
+    return null;
+  }
+
   if (compact) {
     if (references && references.length > 0) {
       return (

--- a/src/domain/shared/components/SocialLinks/SocialLinks.tsx
+++ b/src/domain/shared/components/SocialLinks/SocialLinks.tsx
@@ -61,6 +61,11 @@ export const SocialLinks: FC<SocialLinksProps> = ({ title, items, iconSize }) =>
         .sort((a, b) => SocialNetworksSortOrder[a.type] - SocialNetworksSortOrder[b.type]) || [],
     [items]
   );
+
+  if (!items || items.length === 0) {
+    return null;
+  }
+
   return (
     <Box>
       {title && (

--- a/src/domain/shared/components/SocialLinks/SocialLinks.tsx
+++ b/src/domain/shared/components/SocialLinks/SocialLinks.tsx
@@ -62,7 +62,7 @@ export const SocialLinks: FC<SocialLinksProps> = ({ title, items, iconSize }) =>
     [items]
   );
 
-  if (!items || items.length === 0) {
+  if (!filteredSortedItems.length) {
     return null;
   }
 

--- a/src/domain/shared/components/TagsComponent/TagsComponent.tsx
+++ b/src/domain/shared/components/TagsComponent/TagsComponent.tsx
@@ -42,9 +42,9 @@ const TagsComponent = ({
   variant = 'outlined',
   selectedVariant = 'filled',
   height,
-  hideNoTagsMessage,
   canShowAll = false,
   selectedIndexes = [],
+  hideNoTagsMessage = false,
   onClickTag,
   ...tagsContainerProps
 }: TagsComponentProps) => {


### PR DESCRIPTION
### 7673 [bug fix] Hide titles on empty tags, links, keywords and skills

* Remove the **Keywords*, **Capabilities**, **Links** and **Tags** in the User and Organization profiles when no data is present. This PR is extension to the previous one which removed the `No tags available` message was removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional `description` property for references in the organization component and GraphQL fragment.
  
- **Refactor**
  - Updated profile and banner views to conditionally display sections (tags, keywords, skills, links, social links) only when data is available.
  - Enhanced the tags display behavior by ensuring the "no tags" message is handled consistently.
  - Improved rendering logic in the References and SocialLinks components to prevent rendering when no data is available, resulting in a cleaner and more efficient interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->