### PR TITLE
Creation Confirm dialog - handling create of a post (call for posts)

### DIFF
--- a/src/domain/collaboration/post/PostCreationDialog/PostCreationDialog.tsx
+++ b/src/domain/collaboration/post/PostCreationDialog/PostCreationDialog.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Dialog from '@mui/material/Dialog';
 import { Box, Button, DialogActions, DialogContent } from '@mui/material';
 import PostForm, { PostFormOutput } from '../PostForm/PostForm';
 import { CalloutType, CreatePostInput } from '@/core/apollo/generated/graphql-schema';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import calloutIcons from '@/domain/collaboration/callout/utils/calloutIcons';
+import ConfirmationDialog from '@/core/ui/dialogs/ConfirmationDialog';
+import DialogWithGrid from '@/core/ui/dialog/DialogWithGrid';
 
 export type PostCreationType = Partial<CreatePostInput>;
 export type PostCreationOutput = CreatePostInput;
@@ -36,11 +37,16 @@ const PostCreationDialog = ({
   const [post, setPost] = useState<PostCreationType>({});
   const [isFormValid, setIsFormValid] = useState(false);
   const CalloutIcon = calloutIcons[CalloutType.PostCollection];
+  const [closeConfirmDialogOpen, setCloseConfirmDialogOpen] = useState(false);
 
   const handleClose = () => {
     setPost({});
     onClose();
   };
+
+  const onCloseClick = useCallback(() => {
+    setCloseConfirmDialogOpen(true);
+  }, []);
 
   const handleCreate = async () => {
     await onCreate({
@@ -67,7 +73,7 @@ const PostCreationDialog = ({
   const renderButtons = () => {
     return (
       <>
-        <Button onClick={handleClose}>{t('buttons.cancel')}</Button>
+        <Button onClick={onCloseClick}>{t('buttons.cancel')}</Button>
         <Button onClick={handleCreate} variant="contained" disabled={!isFormValid || creating}>
           {t('buttons.create')}
         </Button>
@@ -76,13 +82,12 @@ const PostCreationDialog = ({
   };
 
   return (
-    <Dialog open={open} maxWidth="md" fullWidth aria-labelledby="post-creation-title">
-      <DialogHeader onClose={handleClose}>
-        <Box display="flex" alignItems="center">
-          <CalloutIcon sx={{ marginRight: 1 }} />
-          {t('components.post-creation.title', { calloutDisplayName: calloutDisplayName })}
-        </Box>
-      </DialogHeader>
+    <DialogWithGrid open={open} columns={8} aria-labelledby="post-creation-title">
+      <DialogHeader
+        icon={<CalloutIcon sx={{ marginRight: 1 }} />}
+        title={t('components.post-creation.title', { calloutDisplayName: calloutDisplayName })}
+        onClose={onCloseClick}
+      />
       <DialogContent>
         <Box marginBottom={2} marginTop={2}>
           <PostForm
@@ -95,9 +100,26 @@ const PostCreationDialog = ({
             disableRichMedia={disableRichMedia}
           />
         </Box>
+        <ConfirmationDialog
+          actions={{
+            onConfirm: () => {
+              setCloseConfirmDialogOpen(false);
+              handleClose();
+            },
+            onCancel: () => setCloseConfirmDialogOpen(false),
+          }}
+          options={{
+            show: closeConfirmDialogOpen,
+          }}
+          entities={{
+            titleId: 'post-edit.closeConfirm.title',
+            contentId: 'post-edit.closeConfirm.description',
+            confirmButtonTextId: 'buttons.yes-close',
+          }}
+        />
       </DialogContent>
       <DialogActions>{renderButtons()}</DialogActions>
-    </Dialog>
+    </DialogWithGrid>
   );
 };
 


### PR DESCRIPTION
The dialog for creating responses to the call for posts has now confirmation on close.
Additionally, the usage of the Dialog and it's header was updated as it was using the deprecated styles. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a confirmation step when closing the post creation dialog to prevent accidental loss of progress.
  - Updated the dialog layout and header presentation for a more consistent and clear user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->