### PR TITLE
Do not allow references without name in calloutForm and a few tweaks more

### DIFF
--- a/src/core/ui/actions/DeleteButton.tsx
+++ b/src/core/ui/actions/DeleteButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LoadingButton, LoadingButtonProps } from '@mui/lab';
 import { ButtonTypeMap } from '@mui/material/Button/Button';
 import { useTranslation } from 'react-i18next';
-import DeleteOutlinedIcon from '@mui/icons-material/Delete';
+import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 
 const DeleteButton = <D extends React.ElementType = ButtonTypeMap['defaultComponent'], P = {}>({
   loading,

--- a/src/domain/collaboration/callout/edit/editDialog/CalloutEditDialog.tsx
+++ b/src/domain/collaboration/callout/edit/editDialog/CalloutEditDialog.tsx
@@ -7,7 +7,8 @@ import calloutIcons from '@/domain/collaboration/callout/utils/calloutIcons';
 import { DEFAULT_TAGSET } from '@/domain/common/tags/tagset.constants';
 import { EmptyWhiteboardString } from '@/domain/common/whiteboard/EmptyWhiteboard';
 import { StorageConfigContextProvider } from '@/domain/storage/StorageBucket/StorageConfigContext';
-import { LoadingButton } from '@mui/lab';
+import SaveButton from '@/core/ui/actions/SaveButton';
+import DeleteButton from '@/core/ui/actions/DeleteButton';
 import { DialogActions, DialogContent } from '@mui/material';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -119,25 +120,9 @@ const CalloutEditDialog = ({
             />
           </StorageConfigContextProvider>
         </DialogContent>
-        <DialogActions sx={{ justifyContent: 'space-between' }}>
-          <LoadingButton
-            loading={loading}
-            disabled={loading}
-            variant="outlined"
-            onClick={() => onDelete(callout)}
-            aria-label={t('buttons.delete')}
-          >
-            {t('buttons.delete')}
-          </LoadingButton>
-          <LoadingButton
-            loading={loading}
-            disabled={!valid || loading}
-            variant="contained"
-            onClick={handleSave}
-            aria-label={t('buttons.save')}
-          >
-            {t('buttons.save')}
-          </LoadingButton>
+        <DialogActions>
+          <DeleteButton loading={loading} disabled={loading} onClick={() => onDelete(callout)} />
+          <SaveButton loading={loading} disabled={!valid || loading} onClick={handleSave} />
         </DialogActions>
         <ConfirmationDialog
           actions={{

--- a/src/domain/platform/admin/components/Common/ReferenceSegment.tsx
+++ b/src/domain/platform/admin/components/Common/ReferenceSegment.tsx
@@ -17,7 +17,8 @@ import Gutters from '@/core/ui/grid/Gutters';
 import useCurrentBreakpoint from '@/core/ui/utils/useCurrentBreakpoint';
 import FormikFileInput from '@/core/ui/forms/FormikFileInput/FormikFileInput';
 import { MessageWithPayload } from '@/domain/shared/i18n/ValidationMessageTranslation';
-import { MID_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@/core/ui/forms/field-length.constants';
+import { MARKDOWN_TEXT_LENGTH, MID_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@/core/ui/forms/field-length.constants';
+import MarkdownValidator from '@/core/ui/forms/MarkdownInput/MarkdownValidator';
 
 export interface ReferenceSegmentProps extends BoxProps {
   fieldName?: string;
@@ -36,8 +37,10 @@ export const referenceSegmentValidationObject = yup.object().shape({
   name: yup
     .string()
     .min(3, MessageWithPayload('forms.validations.minLength'))
-    .max(SMALL_TEXT_LENGTH, MessageWithPayload('forms.validations.maxLength')),
-  uri: yup.string().max(MID_TEXT_LENGTH, MessageWithPayload('forms.validations.maxLength')),
+    .max(SMALL_TEXT_LENGTH, MessageWithPayload('forms.validations.maxLength'))
+    .required('forms.validations.required'),
+  uri: yup.string().max(MID_TEXT_LENGTH, MessageWithPayload('forms.validations.maxLength')).url(),
+  description: MarkdownValidator(MARKDOWN_TEXT_LENGTH), // It's not markdown in the client but it's a TEXT column in the DB
 });
 export const referenceSegmentSchema = yup.array().of(referenceSegmentValidationObject);
 

--- a/src/domain/templates/components/Forms/CalloutTemplateForm.tsx
+++ b/src/domain/templates/components/Forms/CalloutTemplateForm.tsx
@@ -14,7 +14,7 @@ import { RadioButtonOption } from '@/core/ui/forms/radioButtons/RadioButtonsGrou
 import FormikInputField from '@/core/ui/forms/FormikInputField/FormikInputField';
 import { Box } from '@mui/material';
 import { gutters } from '@/core/ui/grid/utils';
-import { TagsetField } from '@/domain/platform/admin/components/Common/TagsetSegment';
+import { TagsetField, tagsetsSegmentSchema } from '@/domain/platform/admin/components/Common/TagsetSegment';
 import FormikRadioButtonsGroup from '@/core/ui/forms/radioButtons/FormikRadioButtonsGroup';
 import FormikWhiteboardPreview from '@/domain/collaboration/whiteboard/WhiteboardPreview/FormikWhiteboardPreview';
 import EmptyWhiteboard from '@/domain/common/whiteboard/EmptyWhiteboard';
@@ -24,6 +24,7 @@ import {
   mapTemplateProfileToUpdateProfile,
 } from './common/mappings';
 import { Caption } from '@/core/ui/typography';
+import { referenceSegmentSchema } from '@/domain/platform/admin/components/Common/ReferenceSegment';
 
 export interface CalloutTemplateFormSubmittedValues extends TemplateFormProfileSubmittedValues {
   callout?: {
@@ -73,18 +74,8 @@ const validator = {
         profile: yup.object().shape({
           displayName: displayNameValidator.required(),
           description: MarkdownValidator(MARKDOWN_TEXT_LENGTH).required(),
-          references: yup.array().of(
-            yup.object().shape({
-              name: yup.string().required(),
-              description: MarkdownValidator(MARKDOWN_TEXT_LENGTH),
-              uri: yup.string().url(),
-            })
-          ),
-          tagsets: yup.array().of(
-            yup.object().shape({
-              tags: yup.array().of(yup.string().required()).required(),
-            })
-          ),
+          references: referenceSegmentSchema,
+          tagsets: tagsetsSegmentSchema,
         }),
         whiteboard: yup.object().when('type', {
           is: (type: CalloutType) => type === CalloutType.Whiteboard,


### PR DESCRIPTION
- The actual fix, use the same reference yup validator for the callout templates form, as the validator for the callout form and everywhere else
- Added description validation to the reference validator
- change the Delete icon, it was the wrong one
- usage of Delete button and Save button, in the callout form recently added during the refactor