### PR TITLE
Fix - wrong spaceId passed when updating subspace settings.

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -17274,10 +17274,6 @@ export const SpaceDashboardNavigationChallengesDocument = gql`
     lookup {
       space(ID: $spaceId) {
         id
-        authorization {
-          id
-          myPrivileges
-        }
         profile {
           ...SpaceDashboardNavigationProfile
         }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -21529,9 +21529,6 @@ export type SpaceDashboardNavigationChallengesQuery = {
       | {
           __typename?: 'Space';
           id: string;
-          authorization?:
-            | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
-            | undefined;
           profile: {
             __typename?: 'Profile';
             id: string;

--- a/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsView.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsView.tsx
@@ -231,7 +231,7 @@ export const SpaceSettingsView = ({ spaceLevel }: SpaceSettingsViewProps) => {
         await updateSpaceSettings({
           variables: {
             settingsData: {
-              spaceID: spaceId,
+              spaceID: subspaceId,
               settings: settingsVariable,
             },
           },

--- a/src/domain/journey/space/spaceDashboardNavigation/SpaceDashboardNavigation.graphql
+++ b/src/domain/journey/space/spaceDashboardNavigation/SpaceDashboardNavigation.graphql
@@ -2,10 +2,6 @@ query SpaceDashboardNavigationChallenges($spaceId: UUID!) {
   lookup {
     space(ID: $spaceId) {
       id
-      authorization {
-        id
-        myPrivileges
-      }
       profile {
         ...SpaceDashboardNavigationProfile
       }


### PR DESCRIPTION
- Fixing server-4964;
- redundant authorization on the Space was removed from the DashboardNavigation query;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the settings update process for layered spaces, ensuring that changes in subspace configurations are now applied correctly.
  - Removed authorization details from the space query, streamlining the data returned for navigation challenges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->