### PR TITLE
7562 - Fix organizations missing avatar in subspace about page contributors dialog

### DIFF
--- a/src/domain/community/community/utils/useOrganizationCardProps.ts
+++ b/src/domain/community/community/utils/useOrganizationCardProps.ts
@@ -9,7 +9,7 @@ type OrganizationCardData = {
   id: string;
   profile: {
     displayName: string;
-    visual?: { uri: string };
+    avatar?: { uri: string };
     location?: { city?: string; country?: string };
     url?: string;
   };
@@ -20,7 +20,7 @@ type OrganizationCardData = {
 export const toOrganizationCardProps = (org: OrganizationCardData): OrganizationCardProps & Identifiable => ({
   id: org.id,
   name: org.profile.displayName,
-  avatar: org.profile.visual?.uri,
+  avatar: org.profile.avatar?.uri,
   city: org.profile.location?.city,
   country: org.profile.location?.country,
   associatesCount: getMetricCount(org.metrics ?? [], MetricType.Associate),


### PR DESCRIPTION
### Fix organizations missing avatar in subspace about page contributors dialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the organization card to consistently display avatars using a refined naming approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->