### PR TITLE
fix missing references and location on subspace about

### DIFF
--- a/src/domain/journey/subspace/forms/CreateSubspaceForm.tsx
+++ b/src/domain/journey/subspace/forms/CreateSubspaceForm.tsx
@@ -77,7 +77,7 @@ export const CreateSubspaceForm = ({
       .trim()
       .min(3, MessageWithPayload('forms.validations.minLength'))
       .max(SMALL_TEXT_LENGTH, MessageWithPayload('forms.validations.maxLength')),
-    background: MarkdownValidator(MARKDOWN_TEXT_LENGTH),
+    description: MarkdownValidator(MARKDOWN_TEXT_LENGTH),
     tags: yup.array().of(yup.string().min(2)).notRequired(),
     collaborationTemplateId: yup.string().nullable(),
   });

--- a/src/domain/space/about/SpaceAboutPageContainer.tsx
+++ b/src/domain/space/about/SpaceAboutPageContainer.tsx
@@ -158,6 +158,8 @@ const AboutPageContainer = ({ journeyId, children }: AboutPageContainerProps) =>
         tagline: nonMemberSpaceAboutProfile?.tagline ?? '',
         url: nonMemberSpaceAboutProfile?.url ?? '',
         visuals: nonMemberSpaceAboutProfile?.visuals ?? [],
+        location: nonMemberSpaceAboutProfile?.location,
+        references: nonMemberSpaceAboutProfile?.references ?? [],
       },
     };
   }, [nonMemberSpaceAboutProfile]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the about page to include additional profile details, such as location information.
	- Introduced a references section for profiles, ensuring a default display when no data is provided.
- **Bug Fixes**
	- Updated validation schema in the Create Subspace Form to focus on validating the description field instead of the background field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->