### PR TITLE
Handle Errors on VC profile (page and invite dialog)

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -13427,6 +13427,78 @@ export function refetchVirtualContributorProfileQuery(variables: SchemaTypes.Vir
   return { query: VirtualContributorProfileDocument, variables: variables };
 }
 
+export const BodyOfKnowledgeProfileAuthorizationDocument = gql`
+  query BodyOfKnowledgeProfileAuthorization($spaceId: UUID!) {
+    lookup {
+      space(ID: $spaceId) {
+        id
+        authorization {
+          id
+          myPrivileges
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useBodyOfKnowledgeProfileAuthorizationQuery__
+ *
+ * To run a query within a React component, call `useBodyOfKnowledgeProfileAuthorizationQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBodyOfKnowledgeProfileAuthorizationQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBodyOfKnowledgeProfileAuthorizationQuery({
+ *   variables: {
+ *      spaceId: // value for 'spaceId'
+ *   },
+ * });
+ */
+export function useBodyOfKnowledgeProfileAuthorizationQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    SchemaTypes.BodyOfKnowledgeProfileAuthorizationQuery,
+    SchemaTypes.BodyOfKnowledgeProfileAuthorizationQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    SchemaTypes.BodyOfKnowledgeProfileAuthorizationQuery,
+    SchemaTypes.BodyOfKnowledgeProfileAuthorizationQueryVariables
+  >(BodyOfKnowledgeProfileAuthorizationDocument, options);
+}
+
+export function useBodyOfKnowledgeProfileAuthorizationLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.BodyOfKnowledgeProfileAuthorizationQuery,
+    SchemaTypes.BodyOfKnowledgeProfileAuthorizationQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SchemaTypes.BodyOfKnowledgeProfileAuthorizationQuery,
+    SchemaTypes.BodyOfKnowledgeProfileAuthorizationQueryVariables
+  >(BodyOfKnowledgeProfileAuthorizationDocument, options);
+}
+
+export type BodyOfKnowledgeProfileAuthorizationQueryHookResult = ReturnType<
+  typeof useBodyOfKnowledgeProfileAuthorizationQuery
+>;
+export type BodyOfKnowledgeProfileAuthorizationLazyQueryHookResult = ReturnType<
+  typeof useBodyOfKnowledgeProfileAuthorizationLazyQuery
+>;
+export type BodyOfKnowledgeProfileAuthorizationQueryResult = Apollo.QueryResult<
+  SchemaTypes.BodyOfKnowledgeProfileAuthorizationQuery,
+  SchemaTypes.BodyOfKnowledgeProfileAuthorizationQueryVariables
+>;
+export function refetchBodyOfKnowledgeProfileAuthorizationQuery(
+  variables: SchemaTypes.BodyOfKnowledgeProfileAuthorizationQueryVariables
+) {
+  return { query: BodyOfKnowledgeProfileAuthorizationDocument, variables: variables };
+}
+
 export const BodyOfKnowledgeProfileDocument = gql`
   query BodyOfKnowledgeProfile($spaceId: UUID!) {
     lookup {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -18350,6 +18350,26 @@ export type VirtualContributorProfileQuery = {
   };
 };
 
+export type BodyOfKnowledgeProfileAuthorizationQueryVariables = Exact<{
+  spaceId: Scalars['UUID'];
+}>;
+
+export type BodyOfKnowledgeProfileAuthorizationQuery = {
+  __typename?: 'Query';
+  lookup: {
+    __typename?: 'LookupQueryResults';
+    space?:
+      | {
+          __typename?: 'Space';
+          id: string;
+          authorization?:
+            | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        }
+      | undefined;
+  };
+};
+
 export type BodyOfKnowledgeProfileQueryVariables = Exact<{
   spaceId: Scalars['UUID'];
 }>;

--- a/src/domain/community/virtualContributor/VirtualContributor.graphql
+++ b/src/domain/community/virtualContributor/VirtualContributor.graphql
@@ -89,6 +89,18 @@ query VirtualContributorProfile($id: UUID!) {
   }
 }
 
+query BodyOfKnowledgeProfileAuthorization($spaceId: UUID!) {
+  lookup {
+    space(ID: $spaceId) {
+      id
+      authorization {
+        id
+        myPrivileges
+      }
+    }
+  }
+}
+
 query BodyOfKnowledgeProfile($spaceId: UUID!) {
   lookup {
     space(ID: $spaceId) {

--- a/src/domain/community/virtualContributor/vcProfilePage/VCProfilePageView.tsx
+++ b/src/domain/community/virtualContributor/vcProfilePage/VCProfilePageView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback } from 'react';
 
 import { groupBy } from 'lodash';
 import { Button, Tooltip } from '@mui/material';
@@ -19,7 +19,8 @@ import { gutters } from '@/core/ui/grid/utils';
 import useNavigate from '@/core/routing/useNavigate';
 import { KNOWLEDGE_BASE_PATH } from '@/main/routing/urlBuilders';
 import useKnowledgeBase from '../knowledgeBase/useKnowledgeBase';
-import { AiPersonaEngine, AiPersonaBodyOfKnowledgeType } from '@/core/apollo/generated/graphql-schema';
+import { AiPersonaEngine, AiPersonaBodyOfKnowledgeType, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
+import JourneyCardHorizontal from '@/domain/journey/common/JourneyCardHorizontal/JourneyCardHorizontal';
 
 const OTHER_LINK_GROUP = 'other';
 const SOCIAL_LINK_GROUP = 'social';
@@ -51,6 +52,8 @@ export const VCProfilePageView = ({ virtualContributor, ...rest }: VCProfilePage
       navigate(`${virtualContributor.profile.url}/${KNOWLEDGE_BASE_PATH}`);
     }
   }, [navigate, virtualContributor]);
+
+  const defaultProfile = { displayName: t('components.card.privacy.private', { entity: 'space' }), url: '' };
 
   const renderBokVisitButton = useCallback(
     () =>
@@ -132,7 +135,15 @@ export const VCProfilePageView = ({ virtualContributor, ...rest }: VCProfilePage
                 </Caption>
 
                 <Gutters disableGap disablePadding paddingTop={1}>
-                  <ContributorCardHorizontal profile={rest?.bokProfile} seamless />
+                  <JourneyCardHorizontal
+                    space={{ about: { profile: rest?.bokProfile || defaultProfile }, level: SpaceLevel.L0 }}
+                    size="small"
+                    deepness={0}
+                    seamless
+                    sx={{ display: 'inline-block', maxWidth: '100%', padding: 0 }}
+                    disableHoverState
+                    disableTagline
+                  />
                 </Gutters>
               </Gutters>
             </Gutters>


### PR DESCRIPTION
Fixes:
https://github.com/alkem-io/client-web/issues/7581
and
https://github.com/alkem-io/server/issues/4960

Before querying the details of the space we first check the authorization for Read privilege.
Ideally we should have this logic in a single place (not for this PR/fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Whiteboard interfaces now include a real‑time save status indicator with clearer auto‐save and error messaging.
  - Contributor profile pages have been refreshed with a new card layout and improved access controls.
  - Space profiles now display additional details such as location and references.
  - The subspace creation form now uses a “description” field for more intuitive input.
  - In‑app notifications have been streamlined for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->