### PR TITLE
[VC BoK] No import from library button in create callout dialog

### DIFF
--- a/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
+++ b/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
@@ -229,15 +229,18 @@ const CalloutCreationDialog = ({
                 onSelect={handleSelectCalloutType}
                 availableCalloutTypes={availableCalloutTypes}
                 extraButtons={
-                  <Button
-                    size="large"
-                    startIcon={<TipsAndUpdatesOutlinedIcon />}
-                    variant="outlined"
-                    sx={{ textTransform: 'none', justifyContent: 'start' }}
-                    onClick={() => setImportCalloutDialogOpen(true)}
-                  >
-                    {t('components.calloutTypeSelect.callout-templates-library')}
-                  </Button>
+                  // Show the import button only if there are no provided callout types
+                  !availableCalloutTypes?.length && (
+                    <Button
+                      size="large"
+                      startIcon={<TipsAndUpdatesOutlinedIcon />}
+                      variant="outlined"
+                      sx={{ textTransform: 'none', justifyContent: 'start' }}
+                      onClick={() => setImportCalloutDialogOpen(true)}
+                    >
+                      {t('components.calloutTypeSelect.callout-templates-library')}
+                    </Button>
+                  )
                 }
               />
             </Gutters>


### PR DESCRIPTION
Minimal changes fix - if availableCalloutTypes prop is passed (KB), don't show the library option in the create callout dialog.