### PR TITLE
fix the redirect after subspace deletion

### DIFF
--- a/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsPage.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsPage.tsx
@@ -19,11 +19,6 @@ const SpaceSettingsPage: FC<SettingsPageProps> = ({ routePrefix = '../' }) => {
         </SpaceSettingsLayout>
       );
     case SpaceLevel.L1:
-      return (
-        <SubspaceSettingsLayout currentTab={SettingsSection.SpaceSettings} tabRoutePrefix={routePrefix}>
-          {loading ? <Skeleton /> : <SpaceSettingsView spaceLevel={spaceLevel} />}
-        </SubspaceSettingsLayout>
-      );
     case SpaceLevel.L2:
       return (
         <SubspaceSettingsLayout currentTab={SettingsSection.SpaceSettings} tabRoutePrefix={routePrefix}>

--- a/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsView.tsx
+++ b/src/domain/journey/space/pages/SpaceSettings/SpaceSettingsView.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import useNavigate from '@/core/routing/useNavigate';
 import scrollToTop from '@/core/ui/utils/scrollToTop';
 import {
   refetchAdminSpaceSubspacesPageQuery,


### PR DESCRIPTION
fix the redirect after subspace deletion - the correct navigate usage for absolute URLs 