### PR TITLE
Fix - Space query sometimes triggered w the wrong ID 

### DIFF
--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardContainer.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardContainer.tsx
@@ -44,14 +44,12 @@ export interface SpaceContainerState {
 }
 
 export interface SpacePageContainerProps
-  extends ContainerChildProps<SpaceContainerEntities, SpaceContainerActions, SpaceContainerState> {
-  spaceId: string | undefined;
-}
+  extends ContainerChildProps<SpaceContainerEntities, SpaceContainerActions, SpaceContainerState> {}
 
 const NO_PRIVILEGES = [];
 
-export const SpaceDashboardContainer: FC<SpacePageContainerProps> = ({ spaceId, children }) => {
-  const { loading: loadingSpace, permissions: spacePermissions, isPrivate } = useSpace();
+export const SpaceDashboardContainer: FC<SpacePageContainerProps> = ({ children }) => {
+  const { loading: loadingSpace, permissions: spacePermissions, isPrivate, spaceId } = useSpace();
   const { user, isAuthenticated } = useUserContext();
 
   const { data: spaceData, loading: loadingSpaceQuery } = useSpacePageQuery({
@@ -61,7 +59,7 @@ export const SpaceDashboardContainer: FC<SpacePageContainerProps> = ({ spaceId, 
       authorizedReadAccessCommunity: spacePermissions.canReadCommunity,
     },
     errorPolicy: 'all',
-    skip: !spaceId,
+    skip: !spaceId || loadingSpace,
   });
 
   const space = spaceData?.lookup.space;

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
@@ -28,7 +28,7 @@ const SpaceDashboardPage = ({
 
   return (
     <SpacePageLayout journeyPath={journeyPath} currentSection={EntityPageSection.Dashboard}>
-      <SpaceDashboardContainer spaceId={spaceId}>
+      <SpaceDashboardContainer>
         {({ callouts, dashboardNavigation, about, ...entities }, state) => (
           <>
             <SpaceDashboardView


### PR DESCRIPTION
Passing the id to the container led to side-effects making calls with the last id.
Obtaining it directly in the container from the useSpace hook, prevents this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a real‐time save status indicator on whiteboards with intuitive tooltips.
  - Enabled interactive navigation on invitation and contributor cards.
  - Added dynamic pagination with a “Load More” option for dashboard spaces.

- **Style**
  - Updated layouts and design across whiteboard, post, and community pages.
  - Enhanced confirmation dialogs and user messages for clearer guidance.

- **Refactor**
  - Streamlined data handling and authorization checks for a smoother and more responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->