### PR TITLE
Choose a community option for VC creation with existing knowledge

### DIFF
--- a/src/main/routing/urlBuilders.ts
+++ b/src/main/routing/urlBuilders.ts
@@ -65,11 +65,3 @@ export const getAccountLink = (profileUrl?: string) => {
 };
 
 export const buildWelcomeSpaceUrl = () => '/welcome-space';
-
-export const getSpaceUrlFromSubSpace = (subSpaceUrl: string) => {
-  const url = new URL(subSpaceUrl, window.location.origin);
-  const urlSegments = url.pathname.split('/challenges');
-
-  url.pathname = urlSegments[0];
-  return url.href;
-};

--- a/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useVirtualContributorWizard.tsx
+++ b/src/main/topLevelPages/myDashboard/newVirtualContributorWizard/useVirtualContributorWizard.tsx
@@ -39,7 +39,6 @@ import CreateExternalAIDialog, { ExternalVcFormValues } from './CreateExternalAI
 import { VisualWithAltText } from '@/core/ui/upload/FormikVisualUpload/FormikVisualUpload';
 import { useVirtualContributorWizardProvided, UserAccountProps } from './virtualContributorProps';
 import { StorageConfigContextProvider } from '@/domain/storage/StorageBucket/StorageConfigContext';
-import { getSpaceUrlFromSubSpace } from '@/main/routing/urlBuilders';
 import ChooseCommunity from './ChooseCommunity';
 import TryVcInfo from './TryVC/TryVcInfo';
 import { SpaceAboutMinimalUrlModel } from '@/domain/space/about/model/spaceAboutMinimal.model';
@@ -444,9 +443,9 @@ const useVirtualContributorWizard = (): useVirtualContributorWizardProvided => {
       return;
     }
 
-    await uploadAvatar(avatar, createdVCData?.profile?.avatar?.id);
-
     setCreatedVc(createdVCData);
+
+    await uploadAvatar(avatar, createdVCData?.profile?.avatar?.id);
 
     if (hasDocuments) {
       const createdLinkCollection = createdVCData.knowledgeBase?.calloutsSet?.callouts?.find(
@@ -455,9 +454,7 @@ const useVirtualContributorWizard = (): useVirtualContributorWizardProvided => {
       await addDocumentLinksToCallout(documents, createdLinkCollection?.id);
     }
 
-    // Refresh explicitly the ingestion after callouts creation
     refreshIngestion(createdVCData.id);
-
     setChooseCommunityStep();
   };
 
@@ -512,24 +509,12 @@ const useVirtualContributorWizard = (): useVirtualContributorWizardProvided => {
         return;
       }
 
+      setCreatedVc(createdVC);
+
       await uploadAvatar(avatar, createdVC?.profile?.avatar?.id);
 
-      // Refresh explicitly the ingestion
       refreshIngestion(createdVC.id);
-
-      const addToCommunity = await addVCToCommunity({
-        virtualContributorId: createdVC?.id,
-        parentRoleSetIds: selectedKnowledge.parentRoleSetIds,
-        spaceId: selectedKnowledge.id,
-      });
-
-      if (addToCommunity) {
-        addVCCreationCache(createdVC?.id);
-        await navigateToTryYourVC(getSpaceUrlFromSubSpace(selectedKnowledge.url ?? ''), undefined);
-      } else {
-        notifyErrorOnAddToCommunity();
-        handleCloseWizard();
-      }
+      setChooseCommunityStep();
     }
   };
 


### PR DESCRIPTION
Similar to the Written Knowledge step, provide the option to **choose a community** after **VC creation with existing knowledge**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the Virtual Contributor Wizard for a more efficient onboarding experience. Avatar uploads now occur immediately upon creating a new contributor profile, and the community selection step has been streamlined to offer a clearer, more intuitive workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->