### PR TITLE
Fix can't create WB template without touching it (twice).

### DIFF
--- a/src/domain/templates/components/Forms/WhiteboardTemplateForm.tsx
+++ b/src/domain/templates/components/Forms/WhiteboardTemplateForm.tsx
@@ -28,7 +28,7 @@ interface WhiteboardTemplateFormProps {
 
 const validator = {
   whiteboard: yup.object().shape({
-    content: yup.string().required(),
+    content: yup.string(),
   }),
 };
 


### PR DESCRIPTION
Suggested by Evgeni and approved by Simone - the WB content is no longer required to create a template.