### PR TITLE
Reduce the LatestContributionsSpacesFlat request fields

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -22675,13 +22675,16 @@ export const LatestContributionsSpacesFlatDocument = gql`
         space {
           id
           about {
-            ...SpaceAboutLight
+            id
+            profile {
+              id
+              displayName
+            }
           }
         }
       }
     }
   }
-  ${SpaceAboutLightFragmentDoc}
 `;
 
 /**

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -29405,17 +29405,7 @@ export type LatestContributionsSpacesFlatQuery = {
         about: {
           __typename?: 'SpaceAbout';
           id: string;
-          profile: {
-            __typename?: 'Profile';
-            id: string;
-            displayName: string;
-            url: string;
-            tagline?: string | undefined;
-            description?: string | undefined;
-            tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-            avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-            cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-          };
+          profile: { __typename?: 'Profile'; id: string; displayName: string };
         };
       };
     }>;

--- a/src/main/topLevelPages/myDashboard/latestContributions/LatestContributionsSpacesFlat.graphql
+++ b/src/main/topLevelPages/myDashboard/latestContributions/LatestContributionsSpacesFlat.graphql
@@ -5,7 +5,11 @@ query LatestContributionsSpacesFlat {
       space {
         id
         about {
-          ...SpaceAboutLight
+          id
+          profile {
+            id
+            displayName
+          }
         }
       }
     }


### PR DESCRIPTION
As part of the About entity, we increased the amount of props requested with the LatestContributionsSpacesFlat query.
This is critical for the dashboards with many memberships and affects the overall platform stability.

The fix - 'revert' to the previous limited request props.