### PR TITLE
Ignore rabbit review on certain branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,6 @@
 language: en
 early_access: false
+ignored_branch: "develop_translations"
 reviews:
   high_level_summary: true
   sequence_diagrams: true


### PR DESCRIPTION
Ignore rabbit review on translation branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a configuration option to exclude a branch used for translations from the review process. This update streamlines branch handling without impacting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->