### PR TITLE
VC invite entitlements

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -10374,6 +10374,7 @@ export const CommunityProviderDetailsDocument = gql`
   query CommunityProviderDetails($spaceId: UUID!) {
     lookup {
       space(ID: $spaceId) {
+        id
         provider {
           ...RoleSetMemberOrganization
         }
@@ -10433,6 +10434,69 @@ export type CommunityProviderDetailsQueryResult = Apollo.QueryResult<
 >;
 export function refetchCommunityProviderDetailsQuery(variables: SchemaTypes.CommunityProviderDetailsQueryVariables) {
   return { query: CommunityProviderDetailsDocument, variables: variables };
+}
+
+export const SpaceEntitlementsDocument = gql`
+  query SpaceEntitlements($spaceId: UUID!) {
+    lookup {
+      space(ID: $spaceId) {
+        id
+        license {
+          id
+          availableEntitlements
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useSpaceEntitlementsQuery__
+ *
+ * To run a query within a React component, call `useSpaceEntitlementsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSpaceEntitlementsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSpaceEntitlementsQuery({
+ *   variables: {
+ *      spaceId: // value for 'spaceId'
+ *   },
+ * });
+ */
+export function useSpaceEntitlementsQuery(
+  baseOptions: Apollo.QueryHookOptions<SchemaTypes.SpaceEntitlementsQuery, SchemaTypes.SpaceEntitlementsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SchemaTypes.SpaceEntitlementsQuery, SchemaTypes.SpaceEntitlementsQueryVariables>(
+    SpaceEntitlementsDocument,
+    options
+  );
+}
+
+export function useSpaceEntitlementsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.SpaceEntitlementsQuery,
+    SchemaTypes.SpaceEntitlementsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SchemaTypes.SpaceEntitlementsQuery, SchemaTypes.SpaceEntitlementsQueryVariables>(
+    SpaceEntitlementsDocument,
+    options
+  );
+}
+
+export type SpaceEntitlementsQueryHookResult = ReturnType<typeof useSpaceEntitlementsQuery>;
+export type SpaceEntitlementsLazyQueryHookResult = ReturnType<typeof useSpaceEntitlementsLazyQuery>;
+export type SpaceEntitlementsQueryResult = Apollo.QueryResult<
+  SchemaTypes.SpaceEntitlementsQuery,
+  SchemaTypes.SpaceEntitlementsQueryVariables
+>;
+export function refetchSpaceEntitlementsQuery(variables: SchemaTypes.SpaceEntitlementsQueryVariables) {
+  return { query: SpaceEntitlementsDocument, variables: variables };
 }
 
 export const RoleSetApplicationFormDocument = gql`

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -14832,6 +14832,10 @@ export const SpaceCommunityPageDocument = gql`
           id
           myPrivileges
         }
+        license {
+          id
+          availableEntitlements
+        }
         about {
           ...SpaceAboutLight
         }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -19349,6 +19349,11 @@ export type SpaceCommunityPageQuery = {
           authorization?:
             | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
             | undefined;
+          license: {
+            __typename?: 'License';
+            id: string;
+            availableEntitlements?: Array<LicenseEntitlementType> | undefined;
+          };
           about: {
             __typename?: 'SpaceAbout';
             id: string;

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -16111,6 +16111,7 @@ export type CommunityProviderDetailsQuery = {
     space?:
       | {
           __typename?: 'Space';
+          id: string;
           provider:
             | {
                 __typename?: 'Organization';
@@ -16144,6 +16145,28 @@ export type CommunityProviderDetailsQuery = {
               }
             | { __typename?: 'User' }
             | { __typename?: 'VirtualContributor' };
+        }
+      | undefined;
+  };
+};
+
+export type SpaceEntitlementsQueryVariables = Exact<{
+  spaceId: Scalars['UUID'];
+}>;
+
+export type SpaceEntitlementsQuery = {
+  __typename?: 'Query';
+  lookup: {
+    __typename?: 'LookupQueryResults';
+    space?:
+      | {
+          __typename?: 'Space';
+          id: string;
+          license: {
+            __typename?: 'License';
+            id: string;
+            availableEntitlements?: Array<LicenseEntitlementType> | undefined;
+          };
         }
       | undefined;
   };

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -530,7 +530,8 @@
       "inviteExternalVC": "Invite External VC",
       "externalVCsInfo": "At the moment, only Alkemio Support can add an external Virtual Contributor to your Space. Please contact Support <click>here</click> if you wish to do so, we are happy to help!",
       "searchVC": "Find Virtual Contributor",
-      "inviteBtn": "Invite Virtual Contributor"
+      "inviteBtn": "Invite Virtual Contributor",
+      "permissionRequiredTooltip": "To use Virtual Contributors, please upgrade your license or contact the Alkemio team for assistance."
     },
     "application-form": {
       "title": "Application Form",

--- a/src/core/ui/button/ButtonWithTooltip.tsx
+++ b/src/core/ui/button/ButtonWithTooltip.tsx
@@ -5,14 +5,16 @@ import { ButtonTypeMap } from '@mui/material/Button/Button';
 import { Caption } from '../typography';
 
 interface ButtonWithTooltipProps {
-  tooltip: string;
+  tooltip?: string;
   iconButton?: boolean;
+  startIcon?: React.ReactNode;
   tooltipPlacement?: TooltipProps['placement'];
 }
 
 const ButtonWithTooltip = <D extends React.ElementType = ButtonTypeMap['defaultComponent'], P = {}>({
   tooltip,
   iconButton,
+  startIcon,
   tooltipPlacement,
   sx,
   children,
@@ -46,6 +48,14 @@ const ButtonWithTooltip = <D extends React.ElementType = ButtonTypeMap['defaultC
     '.MuiButton-startIcon': { margin: 0 },
   };
 
+  if (!tooltip) {
+    return (
+      <Button {...props} sx={buttonStyle} startIcon={(iconButton && children) || startIcon}>
+        {!iconButton && children}
+      </Button>
+    );
+  }
+
   return (
     <Tooltip
       arrow
@@ -54,7 +64,7 @@ const ButtonWithTooltip = <D extends React.ElementType = ButtonTypeMap['defaultC
       placement={tooltipPlacement}
     >
       <Box>
-        <Button aria-label={tooltip} {...props} sx={buttonStyle} startIcon={iconButton && children}>
+        <Button aria-label={tooltip} {...props} sx={buttonStyle} startIcon={(iconButton && children) || startIcon}>
           {!iconButton && children}
         </Button>
       </Box>

--- a/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
+++ b/src/domain/community/community/CommunityAdmin/CommunityVirtualContributors.tsx
@@ -1,5 +1,5 @@
 import AddIcon from '@mui/icons-material/Add';
-import { Box, Button, IconButton, Link, TextField } from '@mui/material';
+import { Box, IconButton, Link, TextField } from '@mui/material';
 import {
   GridColDef,
   GridFilterModel,
@@ -22,6 +22,7 @@ import { Identifiable } from '@/core/utils/Identifiable';
 import InviteVirtualContributorDialog from '@/domain/community/invitations/InviteVirtualContributorDialog';
 import { InviteContributorsData } from '@/domain/access/ApplicationsAndInvitations/useRoleSetApplicationsAndInvitations';
 import { ContributorViewProps } from '../EntityDashboardContributorsSection/Types';
+import ButtonWithTooltip from '@/core/ui/button/ButtonWithTooltip';
 
 type RenderParams = GridRenderCellParams<string, ContributorViewProps>;
 type GetterParams = GridValueGetterParams<string, ContributorViewProps>;
@@ -143,20 +144,27 @@ const CommunityVirtualContributors = ({
 
   const closeInvitationDialog = () => setIsInvitingExternal(false);
 
+  const renderInviteButton = (external: boolean = false) => (
+    <ButtonWithTooltip
+      tooltip={canAddVirtualContributors ? undefined : t('community.virtualContributors.permissionRequiredTooltip')}
+      tooltipPlacement="top"
+      variant="contained"
+      startIcon={<AddIcon />}
+      disabled={!canAddVirtualContributors}
+      onClick={() => openAvailableContributorsDialog(external)}
+    >
+      {external ? t('community.virtualContributors.inviteExternalVC') : t('common.add')}
+    </ButtonWithTooltip>
+  );
+
   return (
     <>
       <Box display="flex" justifyContent="space-between">
         <BlockTitle>{t('community.virtualContributors.blockTitle', { count: virtualContributors.length })}</BlockTitle>
-        {canAddVirtualContributors && (
-          <Actions>
-            <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog()}>
-              {t('common.add')}
-            </Button>
-            <Button variant="contained" startIcon={<AddIcon />} onClick={() => openAvailableContributorsDialog(true)}>
-              {t('community.virtualContributors.inviteExternalVC')}
-            </Button>
-          </Actions>
-        )}
+        <Actions>
+          {renderInviteButton()}
+          {renderInviteButton(true)}
+        </Actions>
       </Box>
       <TextField
         value={filterString}

--- a/src/domain/community/community/CommunityAdmin/SpaceEntitlements.graphql
+++ b/src/domain/community/community/CommunityAdmin/SpaceEntitlements.graphql
@@ -1,11 +1,12 @@
-query CommunityProviderDetails(
+query SpaceEntitlements(
   $spaceId: UUID!
 ) {
   lookup {
     space(ID: $spaceId) {
       id
-      provider {
-        ...RoleSetMemberOrganization
+      license {
+        id
+        availableEntitlements
       }
     }
   }

--- a/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
+++ b/src/domain/community/community/CommunityAdmin/useCommunityAdmin.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useCommunityProviderDetailsQuery } from '@/core/apollo/generated/apollo-hooks';
+import { useCommunityProviderDetailsQuery, useSpaceEntitlementsQuery } from '@/core/apollo/generated/apollo-hooks';
 import {
   RoleName,
   RoleSetContributorType,
@@ -39,6 +39,13 @@ const useCommunityAdmin = ({ roleSetId, spaceId, spaceLevel }: useCommunityAdmin
       spaceId: spaceId!,
     },
     skip: !spaceId || spaceLevel !== SpaceLevel.L0,
+  });
+
+  const { data: spaceData } = useSpaceEntitlementsQuery({
+    variables: {
+      spaceId: spaceId!,
+    },
+    skip: !spaceId,
   });
 
   const {
@@ -174,6 +181,7 @@ const useCommunityAdmin = ({ roleSetId, spaceId, spaceLevel }: useCommunityAdmin
     memberRoleDefinition,
     leadRoleDefinition,
     permissions,
+    spaceEntitlements: spaceData?.lookup.space?.license?.availableEntitlements ?? [],
     applications,
     invitations,
     platformInvitations,

--- a/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPageQueries.graphql
+++ b/src/domain/journey/space/SpaceCommunityPage/SpaceCommunityPageQueries.graphql
@@ -6,6 +6,10 @@ query SpaceCommunityPage($spaceId: UUID!, $includeCommunity: Boolean!) {
         id
         myPrivileges
       }
+      license {
+        id
+        availableEntitlements
+      }
       about {
         ...SpaceAboutLight
       }

--- a/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
+++ b/src/domain/journey/space/pages/AdminSpaceCommunityPage.tsx
@@ -26,7 +26,7 @@ import CommunityGuidelinesContainer, {
   CommunityGuidelines,
 } from '@/domain/community/community/CommunityGuidelines/CommunityGuidelinesContainer';
 import ImportTemplatesDialog from '@/domain/templates/components/Dialogs/ImportTemplateDialog/ImportTemplatesDialog';
-import { SpaceLevel, TemplateType } from '@/core/apollo/generated/graphql-schema';
+import { LicenseEntitlementType, SpaceLevel, TemplateType } from '@/core/apollo/generated/graphql-schema';
 import { LoadingButton } from '@mui/lab';
 import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt';
 import { useCreateTemplateMutation, useSpaceTemplatesManagerLazyQuery } from '@/core/apollo/generated/apollo-hooks';
@@ -48,6 +48,7 @@ const AdminSpaceCommunityPage = ({ routePrefix = '../' }: SettingsPageProps) => 
     memberRoleDefinition,
     leadRoleDefinition,
     permissions,
+    spaceEntitlements,
     onApplicationStateChange,
     onInvitationStateChange,
     onDeleteInvitation,
@@ -105,6 +106,10 @@ const AdminSpaceCommunityPage = ({ routePrefix = '../' }: SettingsPageProps) => 
       setSaveAsTemplateDialogOpen(false);
     }
   };
+
+  const canAddVirtualContributors =
+    spaceEntitlements.includes(LicenseEntitlementType.SpaceFlagVirtualContributorAccess) &&
+    (permissions.canAddVirtualContributorsFromAccount || permissions.canAddMembers);
 
   if (!spaceId || isLoadingSpace) {
     return null;
@@ -261,9 +266,7 @@ const AdminSpaceCommunityPage = ({ routePrefix = '../' }: SettingsPageProps) => 
             <PageContentBlock>
               <CommunityVirtualContributors
                 virtualContributors={virtualContributors}
-                canAddVirtualContributors={
-                  permissions.canAddVirtualContributorsFromAccount || permissions.canAddMembers
-                }
+                canAddVirtualContributors={canAddVirtualContributors}
                 onRemoveMember={onRemoveVirtualContributor}
                 spaceDisplayName={spaceAbout.profile.displayName}
                 fetchAvailableVirtualContributors={getAvailableVirtualContributorsInLibrary}


### PR DESCRIPTION
- No Invite block in space L0 -> community if space entitlements don't include the VC feature;
- Buttons with tooltips in Space (all levels) -> settings -> community; Tooltip if add/invite not enabled;
- The TooltipButton was extended to support optional tooltip and startIcon.

A SpaceEntitlements query was added. Needed in the SpaecSettings. Once cached by spaceId, this will be reused by the Apollo cache. Overall it's better to have more smaller size cached queries, rather than huge ones. (TBD)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a user-facing tooltip that explains licensing requirements when using virtual contributor features.
	- Licensing and entitlement data is now integrated to control the availability of virtual contributor invitation options.

- **Refactor**
	- Enhanced button elements for improved flexibility with optional tooltips and dynamic icon display.
	- Streamlined the invitation logic for virtual contributors, resulting in a more consistent and maintainable user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->