### PR TITLE
WB template - can't save with empty content

### DIFF
--- a/src/domain/templates/components/Forms/WhiteboardTemplateForm.tsx
+++ b/src/domain/templates/components/Forms/WhiteboardTemplateForm.tsx
@@ -28,7 +28,7 @@ interface WhiteboardTemplateFormProps {
 
 const validator = {
   whiteboard: yup.object().shape({
-    content: yup.string(),
+    content: yup.string().required(),
   }),
 };
 
@@ -38,7 +38,7 @@ const WhiteboardTemplateForm = ({ template, onSubmit, actions }: WhiteboardTempl
   const initialValues: WhiteboardTemplateFormSubmittedValues = {
     profile: mapTemplateProfileToUpdateProfile(template?.profile),
     whiteboard: {
-      content: template?.whiteboard?.content ?? JSON.stringify(EmptyWhiteboard),
+      content: template?.whiteboard?.content || JSON.stringify(EmptyWhiteboard),
     },
   };
 


### PR DESCRIPTION
Make sure there's always WB content. Even if the content is defined but empty, assign an EmptyWhiteboard instead.