### PR TITLE
Fix - not the current but the one before that causes wrong requests w…

### DIFF
--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardPage.tsx
@@ -13,7 +13,6 @@ import { buildUpdatesUrl } from '@/main/routing/urlBuilders';
 import useUrlResolver from '@/main/routing/urlResolver/useUrlResolver';
 import { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import { useBackToStaticPath } from '@/core/routing/useBackToPath';
-import useAboutRedirect from '@/core/routing/useAboutRedirect';
 
 const SpaceDashboardPage = ({
   dialog,
@@ -22,9 +21,8 @@ const SpaceDashboardPage = ({
 
   const backToDashboard = useBackToStaticPath(`${currentPath.pathname}/dashboard` ?? '');
 
-  const { spaceId, collaborationId, journeyPath, calendarEventId, loading } = useUrlResolver();
-
-  useAboutRedirect({ spaceId, currentSection: EntityPageSection.Dashboard, skip: loading || !spaceId });
+  // using the spaceId from here leads to side effects - updating requests with old spaceId
+  const { journeyPath, calendarEventId } = useUrlResolver();
 
   return (
     <SpacePageLayout journeyPath={journeyPath} currentSection={EntityPageSection.Dashboard}>
@@ -32,8 +30,8 @@ const SpaceDashboardPage = ({
         {({ callouts, dashboardNavigation, about, ...entities }, state) => (
           <>
             <SpaceDashboardView
-              spaceId={spaceId}
-              collaborationId={collaborationId}
+              spaceId={entities.space?.id}
+              collaborationId={entities.space?.collaboration?.id}
               calloutsSetId={entities.space?.collaboration?.calloutsSet?.id}
               what={entities.space?.about.profile.description}
               dashboardNavigation={dashboardNavigation}
@@ -67,7 +65,7 @@ const SpaceDashboardPage = ({
               <CalendarDialog
                 open={dialog === 'calendar'}
                 onClose={backToDashboard}
-                journeyId={spaceId}
+                journeyId={entities.space?.id}
                 parentSpaceId={undefined}
                 parentPath={entities.space?.about.profile.url ?? ''}
                 calendarEventId={calendarEventId}
@@ -75,7 +73,7 @@ const SpaceDashboardPage = ({
             )}
             <SpaceAboutDialog
               open={dialog === 'about'}
-              spaceId={spaceId}
+              spaceId={entities.space?.id}
               spaceLevel={SpaceLevel.L0}
               about={about}
               sendMessageToCommunityLeads={entities.sendMessageToCommunityLeads}

--- a/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
+++ b/src/domain/journey/space/SpaceDashboard/SpaceDashboardView.tsx
@@ -37,6 +37,7 @@ import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DashboardNavigationItem } from '../spaceDashboardNavigation/useSpaceDashboardNavigation';
 import SpaceWelcomeDialog from './SpaceWelcomeDialog';
+import useAboutRedirect from '@/core/routing/useAboutRedirect';
 
 type SpaceDashboardViewProps = {
   spaceId: string | undefined;
@@ -111,6 +112,8 @@ const SpaceDashboardView = ({
     setOpenWelcome(false);
     removeSpaceWelcomeCache();
   };
+
+  useAboutRedirect({ spaceId, currentSection: EntityPageSection.Dashboard, skip: !spaceId });
 
   useEffect(() => {
     // on mount of a space, check the LS and show the try dialog if present


### PR DESCRIPTION
Fixes:

- timeline error when navigating back and forth from private to public communities;
- improves the About redirect logic - now if you navigate from private subspace to a space, it doesn't trigger the about dialog;

Note that the usage of the URLReslover, leads to side-effects - rendering components and making requests with not the current but with the previous spaceId.