### PR TITLE
don't query archived spaces

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -3523,6 +3523,7 @@ export type SubscriptionKeySpecifier = (
   | 'activityCreated'
   | 'calloutPostCreated'
   | 'forumDiscussionUpdated'
+  | 'inAppNotificationReceived'
   | 'profileVerifiedCredential'
   | 'roomEvents'
   | 'subspaceCreated'
@@ -3533,6 +3534,7 @@ export type SubscriptionFieldPolicy = {
   activityCreated?: FieldPolicy<any> | FieldReadFunction<any>;
   calloutPostCreated?: FieldPolicy<any> | FieldReadFunction<any>;
   forumDiscussionUpdated?: FieldPolicy<any> | FieldReadFunction<any>;
+  inAppNotificationReceived?: FieldPolicy<any> | FieldReadFunction<any>;
   profileVerifiedCredential?: FieldPolicy<any> | FieldReadFunction<any>;
   roomEvents?: FieldPolicy<any> | FieldReadFunction<any>;
   subspaceCreated?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -17552,7 +17552,7 @@ export type UpdateSpacePlatformSettingsMutationOptions = Apollo.BaseMutationOpti
 >;
 export const AdminSpacesListDocument = gql`
   query adminSpacesList {
-    spaces(filter: { visibilities: [ARCHIVED, ACTIVE, DEMO] }) {
+    spaces(filter: { visibilities: [ACTIVE, DEMO] }) {
       ...AdminSpace
     }
   }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -6180,6 +6180,8 @@ export type Subscription = {
   calloutPostCreated: CalloutPostCreated;
   /** Receive updates on Discussions */
   forumDiscussionUpdated: Discussion;
+  /** New in-app notification received for the currently authenticated user. */
+  inAppNotificationReceived: InAppNotification;
   /** Received on verified credentials change */
   profileVerifiedCredential: ProfileCredentialVerified;
   /** Receive Room event */

--- a/src/domain/platform/admin/space/AdminSpaceListPage/adminSpacesList.graphql
+++ b/src/domain/platform/admin/space/AdminSpaceListPage/adminSpacesList.graphql
@@ -1,5 +1,5 @@
 query adminSpacesList {
-  spaces(filter: { visibilities: [ARCHIVED, ACTIVE, DEMO] }) {
+  spaces(filter: { visibilities: [ACTIVE, DEMO] }) {
     ...AdminSpace
   }
 }


### PR DESCRIPTION
- fixes #7838
- don't query ARCHIVED for adminSpacesList
- ARCHIVED spaces don't get their policies reset so they are WAAAAY outdated...
- if we want to do something with them, we'll use gql
- coordinated the approach with Neil, he's onboard