### PR TITLE
fix admin subspace id

### DIFF
--- a/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
+++ b/src/domain/journey/opportunity/pages/AdminOpportunityCommunityPage.tsx
@@ -9,13 +9,13 @@ import { SettingsSection } from '@/domain/platform/admin/layout/EntitySettingsLa
 import { SettingsPageProps } from '@/domain/platform/admin/layout/EntitySettingsLayout/types';
 import SubspaceSettingsLayout from '@/domain/platform/admin/subspace/SubspaceSettingsLayout';
 import CommunityVirtualContributors from '@/domain/community/community/CommunityAdmin/CommunityVirtualContributors';
-import { useSpace } from '@/domain/journey/space/SpaceContext/useSpace';
 import { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import { useSubSpace } from '../../subspace/hooks/useSubSpace';
+import useUrlResolver from '@/main/routing/urlResolver/useUrlResolver';
 
 const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../' }) => {
+  const { spaceId, parentSpaceId } = useUrlResolver();
   const { loading: isLoadingChallenge, roleSetId } = useSubSpace();
-  const { spaceId } = useSpace();
 
   const {
     users,
@@ -36,10 +36,16 @@ const AdminOpportunityCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '.
     onRemoveVirtualContributor,
     getAvailableUsers,
     getAvailableOrganizations,
-    getAvailableVirtualContributors,
     getAvailableVirtualContributorsInLibrary,
     loading,
   } = useCommunityAdmin({ spaceId, roleSetId, spaceLevel: SpaceLevel.L2 });
+
+  // get the VC filtered on the parent
+  const { getAvailableVirtualContributors } = useCommunityAdmin({
+    roleSetId,
+    spaceId: parentSpaceId,
+    spaceLevel: SpaceLevel.L2,
+  });
 
   if (!spaceId || isLoadingChallenge) {
     return null;

--- a/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
+++ b/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
@@ -58,12 +58,13 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
     onRemoveVirtualContributor,
     getAvailableUsers,
     getAvailableOrganizations,
-    getAvailableVirtualContributors,
     getAvailableVirtualContributorsInLibrary,
     loading,
     inviteExternalUser,
     inviteExistingUser,
   } = useCommunityAdmin({ roleSetId, spaceId, spaceLevel });
+
+  const { getAvailableVirtualContributors } = useCommunityAdmin({ roleSetId, spaceId: parentSpaceId, spaceLevel });
 
   const currentApplicationsUserIds = useMemo(
     () =>

--- a/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
+++ b/src/domain/journey/subspace/pages/AdminSubspaceCommunityPage.tsx
@@ -64,6 +64,7 @@ const AdminSubspaceCommunityPage: FC<SettingsPageProps> = ({ routePrefix = '../'
     inviteExistingUser,
   } = useCommunityAdmin({ roleSetId, spaceId, spaceLevel });
 
+  // get the VC filtered on the parent
   const { getAvailableVirtualContributors } = useCommunityAdmin({ roleSetId, spaceId: parentSpaceId, spaceLevel });
 
   const currentApplicationsUserIds = useMemo(


### PR DESCRIPTION
- pass the parent space ID for filtering available VCs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Modified the logic for retrieving available virtual contributors by deriving space details from a new source.
	- Both Opportunity and Subspace community pages now filter contributor lists based on parent space information, ensuring a more consistent and accurate display.
	- These improvements enhance the overall administrative experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->