### PR TITLE
fix - callouts moved in order when changing flowState name

### DIFF
--- a/src/domain/collaboration/InnovationFlow/InnovationFlowDialogs/useInnovationFlowSettings.tsx
+++ b/src/domain/collaboration/InnovationFlow/InnovationFlowDialogs/useInnovationFlowSettings.tsx
@@ -225,6 +225,11 @@ const useInnovationFlowSettings = ({ collaborationId, skip }: useInnovationFlowS
         stateUpdatedData: newState,
       },
     });
+    await Promise.all(
+      callouts
+        .filter(callout => callout.flowState?.currentState === oldState.displayName)
+        .map((callout, index) => handleUpdateCalloutFlowState(callout.id, newState.displayName, index))
+    );
     refetch({ collaborationId: collaborationId! });
   };
 


### PR DESCRIPTION
Extracted from another PR, thanks @ccanos 