### PR TITLE
Fix the case where apply on subspace about level doesn't work.

### DIFF
--- a/src/domain/journey/subspace/context/SubspaceProvider.tsx
+++ b/src/domain/journey/subspace/context/SubspaceProvider.tsx
@@ -21,6 +21,7 @@ interface SubspaceContextProps {
     };
   };
   loading: boolean;
+  parentSpaceId: string | undefined;
   permissions: SubspacePermissions;
 }
 
@@ -55,6 +56,7 @@ const defaultValue: SubspaceContextProps = {
       },
     },
   },
+  parentSpaceId: undefined,
   permissions: {
     canUpdate: false,
     canCreate: false,
@@ -68,7 +70,7 @@ export const SubspaceContext = React.createContext<SubspaceContextProps>(default
 interface SubspaceProviderProps extends PropsWithChildren {}
 
 const SubspaceProvider: FC<SubspaceProviderProps> = ({ children }) => {
-  const { spaceId, loading: urlResolverLoading } = useUrlResolver();
+  const { spaceId, loading: urlResolverLoading, parentSpaceId } = useUrlResolver();
 
   const { data, loading } = useSpaceAboutDetailsQuery({
     variables: { spaceId: spaceId! },
@@ -135,6 +137,7 @@ const SubspaceProvider: FC<SubspaceProviderProps> = ({ children }) => {
 
   let state = {
     subspace,
+    parentSpaceId,
     permissions,
     loading: loading || urlResolverLoading,
   };

--- a/src/domain/space/about/SpaceAboutDialog.tsx
+++ b/src/domain/space/about/SpaceAboutDialog.tsx
@@ -34,6 +34,7 @@ import { SpaceDashboardSpaceDetails } from '../layout/TabbedSpaceL0/Tabs/SpaceDa
 export interface SpaceAboutDialogProps {
   open: boolean;
   space: SpaceDashboardSpaceDetails;
+  parentSpaceId?: string;
   loading?: boolean;
   virtualContributors?: VirtualContributorProps[];
   hasReadPrivilege?: boolean;
@@ -50,6 +51,7 @@ const gradient = (theme: Theme) =>
 const SpaceAboutDialog = ({
   open,
   space,
+  parentSpaceId,
   loading = false,
   onClose,
   hasReadPrivilege,
@@ -190,7 +192,7 @@ const SpaceAboutDialog = ({
                 />
               </PageContentBlock>
               <Box display="flex" justifyContent="center" width="100%">
-                <ApplicationButtonContainer journeyId={space.id}>
+                <ApplicationButtonContainer journeyId={space.id} parentSpaceId={parentSpaceId}>
                   {(applicationButtonProps, loading) => {
                     if (loading || applicationButtonProps.isMember) {
                       return null;

--- a/src/domain/space/about/SubspaceAboutPage.tsx
+++ b/src/domain/space/about/SubspaceAboutPage.tsx
@@ -7,7 +7,7 @@ import SubspaceContributorsDialogContent from '@/domain/community/community/enti
 import { SpaceDashboardSpaceDetails } from '../layout/TabbedSpaceL0/Tabs/SpaceDashboard/SpaceDashboardView';
 
 const SubspaceAboutPage = () => {
-  const { subspace, permissions, loading } = useSubSpace();
+  const { subspace, permissions, loading, parentSpaceId } = useSubSpace();
   const { about } = subspace;
 
   const [isContributorsDialogOpen, setIsContributorsDialogOpen] = useState(false);
@@ -25,6 +25,7 @@ const SubspaceAboutPage = () => {
       <SpaceAboutDialog
         open
         space={space}
+        parentSpaceId={parentSpaceId}
         loading={loading}
         onClose={backToParentPage}
         hasReadPrivilege={permissions.canRead}


### PR DESCRIPTION
ParentId was needed by the ApplicationContainer. Please, double-check the change in `useSubSpace` hook.