### PR TITLE
improve the knowledge base space page loading

### DIFF
--- a/src/domain/space/layout/tabbedLayout/Tabs/SpaceKnowledgeBase/SpaceKnowledgeBasePage.tsx
+++ b/src/domain/space/layout/tabbedLayout/Tabs/SpaceKnowledgeBase/SpaceKnowledgeBasePage.tsx
@@ -1,18 +1,18 @@
 import { useTranslation } from 'react-i18next';
 import PageContent from '@/core/ui/content/PageContent';
 import { ContributeCreationBlock } from '@/domain/space/components/ContributeCreationBlock';
-import MembershipBackdrop from '@/domain/shared/components/Backdrops/MembershipBackdrop';
 import { EntityPageSection } from '@/domain/shared/layout/EntityPageSection';
-import CalloutsGroupView from '../../../../../collaboration/calloutsSet/CalloutsInContext/CalloutsGroupView';
-import CalloutCreationDialog from '../../../../../collaboration/callout/creationDialog/CalloutCreationDialog';
-import { useCalloutCreationWithPreviewImages } from '../../../../../collaboration/calloutsSet/useCalloutCreation/useCalloutCreationWithPreviewImages';
+import CalloutsGroupView from '@/domain/collaboration/calloutsSet/CalloutsInContext/CalloutsGroupView';
+import CalloutCreationDialog from '@/domain/collaboration/callout/creationDialog/CalloutCreationDialog';
+import { useCalloutCreationWithPreviewImages } from '@/domain/collaboration/calloutsSet/useCalloutCreation/useCalloutCreationWithPreviewImages';
 import InfoColumn from '@/core/ui/content/InfoColumn';
 import ContentColumn from '@/core/ui/content/ContentColumn';
-import CalloutsList from '../../../../../collaboration/callout/calloutsList/CalloutsList';
+import CalloutsList from '@/domain/collaboration/callout/calloutsList/CalloutsList';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
 import SpacePageLayout from '@/domain/space/layout/tabbedLayout/layout/SpacePageLayout';
 import useCalloutsSet from '@/domain/collaboration/calloutsSet/useCalloutsSet/useCalloutsSet';
 import useSpaceTabProvider from '../../SpaceTabProvider';
+import Loading from '@/core/ui/loading/Loading';
 
 type KnowledgeBasePageProps = {
   calloutsFlowState: EntityPageSection;
@@ -46,37 +46,37 @@ const SpaceKnowledgeBasePage = ({ calloutsFlowState }: KnowledgeBasePageProps) =
   return (
     <SpacePageLayout journeyPath={journeyPath} currentSection={calloutsFlowState}>
       <>
-        <MembershipBackdrop show={loading} blockName={t('common.space')}>
-          <PageContent>
-            <InfoColumn>
-              <ContributeCreationBlock
-                canCreate={canCreateCallout}
-                handleCreate={handleCreate}
-                tabDescription={tabDescription}
-              />
-              <PageContentBlock>
-                <CalloutsList
-                  callouts={callouts}
-                  emptyListCaption={t('pages.generic.sections.subEntities.empty-list', {
-                    entities: t('common.callouts'),
-                  })}
-                />
-              </PageContentBlock>
-            </InfoColumn>
-
-            <ContentColumn>
-              <CalloutsGroupView
-                calloutsSetId={calloutsSetId}
-                createInFlowState={flowStateForNewCallouts?.displayName}
+        <PageContent>
+          <InfoColumn>
+            <ContributeCreationBlock
+              canCreate={canCreateCallout}
+              handleCreate={handleCreate}
+              tabDescription={tabDescription}
+            />
+            <PageContentBlock>
+              <CalloutsList
                 callouts={callouts}
-                canCreateCallout={canCreateCallout}
                 loading={loading}
-                onSortOrderUpdate={onCalloutsSortOrderUpdate}
-                onCalloutUpdate={refetchCallout}
+                emptyListCaption={t('pages.generic.sections.subEntities.empty-list', {
+                  entities: t('common.callouts'),
+                })}
               />
-            </ContentColumn>
-          </PageContent>
-        </MembershipBackdrop>
+            </PageContentBlock>
+          </InfoColumn>
+
+          <ContentColumn>
+            {loading && <Loading />}
+            <CalloutsGroupView
+              calloutsSetId={calloutsSetId}
+              createInFlowState={flowStateForNewCallouts?.displayName}
+              callouts={callouts}
+              canCreateCallout={canCreateCallout}
+              loading={loading}
+              onSortOrderUpdate={onCalloutsSortOrderUpdate}
+              onCalloutUpdate={refetchCallout}
+            />
+          </ContentColumn>
+        </PageContent>
         <CalloutCreationDialog
           open={isCalloutCreationDialogOpen}
           onClose={handleCreateCalloutClosed}


### PR DESCRIPTION
Making it similar to Subspaces tab - only loading on top of the callouts. The other components handle well the lack/refresh of data and there's no blocking anymore.