### PR TITLE
Richer Hosted Spaces tooltip with correct metrics

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -5593,6 +5593,10 @@ export const AccountInformationDocument = gql`
             id
             myPrivileges
           }
+          license {
+            id
+            availableEntitlements
+          }
           about {
             id
             profile {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -9242,6 +9242,11 @@ export type AccountInformationQuery = {
             authorization?:
               | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
               | undefined;
+            license: {
+              __typename?: 'License';
+              id: string;
+              availableEntitlements?: Array<LicenseEntitlementType> | undefined;
+            };
             about: {
               __typename?: 'SpaceAbout';
               id: string;

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -399,6 +399,11 @@
       "not-verified": ""
     },
     "enums": {
+      "licenseEntitlementType": {
+        "SPACE_FREE": "Free",
+        "SPACE_PLUS": "Plus",
+        "SPACE_PREMIUM": "Premium"
+      },
       "innovationFlowState": {
         "new": "New",
         "beingRefined": "Being Refined",
@@ -1903,7 +1908,7 @@
             "hostedSpaces": "Hosted Spaces",
             "virtualContributors": "Virtual Contributors",
             "innovationPacks": "$t(common.innovation-packs)",
-            "usageNotice": "You have created {{usage}} out of your {{limit}} available {{type}} in your account.",
+            "usageNotice": "From the available $t(common.spaces) in your account, you have created:\n{{freeUsage}} out of {{freeLimit}} Free $t(common.spaces)\n{{plusUsage}} out of {{plusLimit}} Plus $t(common.spaces)\n{{premiumUsage}} out of {{premiumLimit}} Premium $t(common.spaces)",
             "limitNotice": "Contact the Alkemio team to increase the limits on your account",
             "notAvailable": "Not available",
             "notAvailableNotice": "Contact the Alkemio team to enable this feature on your account",

--- a/src/core/ui/list/BadgeCardView.tsx
+++ b/src/core/ui/list/BadgeCardView.tsx
@@ -61,5 +61,6 @@ const BadgeCardView = forwardRef(
     );
   }
 );
+BadgeCardView.displayName = 'BadgeCardView';
 
 export default BadgeCardView;

--- a/src/core/ui/typography/TextWithTooltip.tsx
+++ b/src/core/ui/typography/TextWithTooltip.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 const TextWithTooltip = ({ text, tooltip }: { text: string; tooltip: string }) => {
   return (
-    <Tooltip arrow title={<Caption>{tooltip}</Caption>} placement="top">
+    <Tooltip arrow title={<Caption sx={{ whiteSpace: 'pre-line' }}>{tooltip}</Caption>} placement="top">
       <Text>{text}</Text>
     </Tooltip>
   );

--- a/src/domain/account/queries/AccountInformation.graphql
+++ b/src/domain/account/queries/AccountInformation.graphql
@@ -26,6 +26,10 @@ query AccountInformation($accountId: UUID!) {
           id
           myPrivileges
         }
+        license {
+          id
+          availableEntitlements
+        }
         about {
           id
           profile {

--- a/src/domain/community/contributor/Account/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/Account/ContributorAccountView.tsx
@@ -84,6 +84,9 @@ export interface AccountTabResourcesProps {
         tagline?: string;
       };
     };
+    license: {
+      availableEntitlements?: LicenseEntitlementType[];
+    };
   }[];
   virtualContributors: {
     id: string;
@@ -217,12 +220,15 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
 
   const enableWingbackAccountCreation = !loading && !externalSubscriptionID;
 
-  // Temporarily we're ordering the priority in this way: Display usage/limit from FREE / PLUS / PREMIUM
-  const { limit: hostedSpaceLimit = 0, usage: hostedSpaceUsage = 0 } =
-    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpaceFree) ??
-    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpacePlus) ??
+  const { limit: spaceFreeLimit = 0, usage: spaceFreeUsage = 0 } =
+    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpaceFree) ?? {};
+  const { limit: spacePlusLimit = 0, usage: spacePlusUsage = 0 } =
+    myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpacePlus) ?? {};
+  const { limit: spacePremiumLimit = 0, usage: spacePremiumUsage = 0 } =
     myAccountEntitlementDetails.find(entitlement => entitlement.type === LicenseEntitlementType.AccountSpacePremium) ??
     {};
+  const hostedSpaceLimit = spaceFreeLimit + spacePlusLimit + spacePremiumLimit;
+  const hostedSpaceUsage = spaceFreeUsage + spacePlusUsage + spacePremiumUsage;
 
   const { limit: vcLimit = 0, usage: vcUsage = 0 } =
     myAccountEntitlementDetails.find(
@@ -500,9 +506,12 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
             limit={hostedSpaceLimit}
             isAvailable={canCreateSpace}
             tooltip={t('pages.admin.generic.sections.account.usageNotice', {
-              type: t('pages.admin.generic.sections.account.hostedSpaces'),
-              usage: hostedSpaceUsage,
-              limit: hostedSpaceLimit,
+              freeUsage: spaceFreeUsage,
+              freeLimit: spaceFreeLimit,
+              plusUsage: spacePlusUsage,
+              plusLimit: spacePlusLimit,
+              premiumUsage: spacePremiumUsage,
+              premiumLimit: spacePremiumLimit,
             })}
           />
           <Gutters disablePadding disableGap justifyContent="space-between" fullHeight>
@@ -512,7 +521,7 @@ export const ContributorAccountView = ({ accountHostName, account, loading }: Co
                 account?.spaces.map(space => (
                   <JourneyCardHorizontal
                     key={space.id}
-                    space={{ about: space.about, level: space.level }}
+                    space={{ about: space.about, level: space.level, license: space.license }}
                     size="medium"
                     deepness={0}
                     seamless

--- a/src/domain/space/components/cards/JourneyCardHorizontal.tsx
+++ b/src/domain/space/components/cards/JourneyCardHorizontal.tsx
@@ -15,7 +15,7 @@ import { Caption } from '@/core/ui/typography';
 import withElevationOnHover from '@/domain/shared/components/withElevationOnHover';
 import RouterLink, { RouterLinkProps } from '@/core/ui/link/RouterLink';
 import BlockTitleWithIcon from '@/core/ui/content/BlockTitleWithIcon';
-import { RoleName, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
+import { LicenseEntitlementType, RoleName, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import { useTranslation } from 'react-i18next';
 import { intersection } from 'lodash';
 import FlexSpacer from '@/core/ui/utils/FlexSpacer';
@@ -24,6 +24,7 @@ import ActionsMenu from '@/core/ui/card/ActionsMenu';
 import { AvatarSize } from '@/core/ui/avatar/Avatar';
 import { spaceIconByLevel } from '@/domain/space/icons/SpaceIconByLevel';
 import { SpaceAboutLightModel } from '@/domain/space/about/model/spaceAboutLight.model';
+import { getSpaceSubscriptionLevel } from '@/domain/space/license/utils';
 
 export const JourneyCardHorizontalSkeleton = () => (
   <ElevatedPaper sx={{ padding: gutters() }}>
@@ -45,6 +46,9 @@ export interface JourneyCardHorizontalProps {
       };
     };
     level: SpaceLevel;
+    license?: {
+      availableEntitlements?: LicenseEntitlementType[];
+    };
   };
   deepness?: number;
   seamless?: boolean;
@@ -79,6 +83,8 @@ const JourneyCardHorizontal = ({
 
   const [communityRole] = intersection(VISIBLE_COMMUNITY_ROLES, space.community?.roleSet?.myRoles);
 
+  const spaceSubscriptionLevel = getSpaceSubscriptionLevel(space.license?.availableEntitlements ?? []);
+
   const mergedSx: PaperProps['sx'] = {
     padding: gutters(),
     marginLeft: gutters(deepness * 2),
@@ -102,6 +108,14 @@ const JourneyCardHorizontal = ({
           sx={{ height: gutters(1.5) }}
         >
           <FlexSpacer />
+
+          {spaceSubscriptionLevel && (
+            <Chip
+              variant="filled"
+              color="default"
+              label={t(`common.enums.licenseEntitlementType.${spaceSubscriptionLevel}` as const)}
+            />
+          )}
           {communityRole && (
             <Chip
               variant="filled"

--- a/src/domain/space/license/utils.ts
+++ b/src/domain/space/license/utils.ts
@@ -1,0 +1,31 @@
+import { LicenseEntitlementType } from '@/core/apollo/generated/graphql-schema';
+
+type SpaceEntitlementType =
+  | LicenseEntitlementType.SpaceFree
+  | LicenseEntitlementType.SpacePlus
+  | LicenseEntitlementType.SpacePremium;
+
+export const getSpaceSubscriptionLevel = (
+  availableEntitlements: LicenseEntitlementType[]
+): SpaceEntitlementType | undefined => {
+  if (availableEntitlements.length === 0) {
+    return undefined;
+  }
+
+  const targetTypes = [
+    LicenseEntitlementType.SpacePremium,
+    LicenseEntitlementType.SpacePlus,
+    LicenseEntitlementType.SpaceFree,
+  ];
+  const customOrder = [
+    LicenseEntitlementType.SpacePremium,
+    LicenseEntitlementType.SpacePlus,
+    LicenseEntitlementType.SpaceFree,
+  ];
+  // Filter and sort
+  const [firstSortedType] = availableEntitlements
+    .filter(item => targetTypes.includes(item))
+    .sort((a, b) => customOrder.indexOf(a) - customOrder.indexOf(b));
+
+  return firstSortedType as SpaceEntitlementType;
+};


### PR DESCRIPTION
- Metrics in the top-right corner correctly show the sum of all available Space-related Account entitlements
- Added chip showing the Space current subscription type: free, plus, premium
- Creation button stays enabled until all Space-related Account entitlements are used up
> Important :bangbang: Even though the Account has available Plus and Premium Account entitlements, new Spaces will be created with the Free subscription - A manual step to upgrade the Space is required. After the manual step, the metrics will be calculated correctly.
