### PR TITLE
Fix global search on space page

### DIFF
--- a/src/main/routing/urlBuilders.ts
+++ b/src/main/routing/urlBuilders.ts
@@ -42,7 +42,7 @@ export const buildSpaceSectionUrl = (
   dialog: string | undefined = undefined
 ) => {
   let result = '';
-  const params = new URLSearchParams();
+  const params = new URLSearchParams(window.location.search);
 
   try {
     const url = new URL(spaceUrl); // Parse the URL and extract the pathname if it's absolute
@@ -56,6 +56,8 @@ export const buildSpaceSectionUrl = (
   }
   if (dialog) {
     params.set(URL_PARAM_DIALOG, dialog);
+  } else {
+    params.delete(URL_PARAM_DIALOG);
   }
 
   return `${result}?${params.toString()}`;


### PR DESCRIPTION
When you try to search and you are in a space dash (or other tab) the search dialog closes. 
This was due to a rerender of the tabs, the logic applying the tab param didn't take in consideration the existing URL query params.
The fix makes sure that when applying tab param, all the other params are preserved. It also adds deletion of the dialog param which was persistent - the calendar/updates couldn't be closed after the first change.