### PR TITLE
Change the translation on the SubSpaces page from spaces to subspaces

### DIFF
--- a/src/domain/space/components/subspaces/SubspaceView.tsx
+++ b/src/domain/space/components/subspaces/SubspaceView.tsx
@@ -113,7 +113,7 @@ const ChildJourneyView = <ChildEntity extends BaseChildEntity>({
           <PageContentBlockSeamless>
             <Caption textAlign="center">
               {t('pages.generic.sections.subEntities.empty', {
-                entities: t(`common.space-level.${level}`),
+                entities: t('common.space-level.L1'),
                 parentEntity: t(`common.space-level.${level}`),
               })}
             </Caption>
@@ -127,7 +127,7 @@ const ChildJourneyView = <ChildEntity extends BaseChildEntity>({
                 valueGetter={childEntityValueGetter}
                 tagsGetter={childEntityTagsGetter}
                 title={t('common.entitiesWithCount', {
-                  entityType: t(`common.space-level.${level}`),
+                  entityType: t('common.space-level.L1'),
                   count: childEntities.length,
                 })}
               >


### PR DESCRIPTION
- [x] Only the part of the story where the copy says Space was fixed.
The other requirements were already fixed or not relevant.

 
