### PR TITLE
Fix L2 Admin settings breadcrumbs

### DIFF
--- a/src/domain/spaceAdmin/layout/SpaceAdminLayoutSubspace.tsx
+++ b/src/domain/spaceAdmin/layout/SpaceAdminLayoutSubspace.tsx
@@ -29,7 +29,7 @@ const SubspaceSettingsLayout: FC<SubspaceSettingsLayoutProps> = props => {
 
   // TODO: this should ideally come from the SpaceContext
   const journeyPath: JourneyPath =
-    spaceLevel === SpaceLevel.L1 ? [levelZeroSpaceId, spaceId] : [spaceId, parentSpaceId!, spaceId];
+    spaceLevel === SpaceLevel.L1 ? [levelZeroSpaceId, spaceId] : [levelZeroSpaceId, parentSpaceId!, spaceId];
 
   const tabs = spaceLevel === SpaceLevel.L1 ? spaceAdminTabsL1 : spaceAdminTabsL2;
 


### PR DESCRIPTION
the L0 was displayed as the current subspace