### PR TITLE
Client 7999 fix updates activity

### DIFF
--- a/src/domain/shared/layout/EntityPageSection.ts
+++ b/src/domain/shared/layout/EntityPageSection.ts
@@ -9,9 +9,8 @@ export enum EntityPageSection {
   Contribute = 'contribute',
   KnowledgeBase = 'knowledge-base',
   Subspaces = 'subspaces',
-  Subsubspaces = 'subsubspaces',
-  Agreements = 'agreements',
   Profile = 'profile',
   Share = 'share',
   Search = 'search',
+  Updates = 'updates',
 }

--- a/src/domain/space/components/subspaces/SubspaceDialogs.tsx
+++ b/src/domain/space/components/subspaces/SubspaceDialogs.tsx
@@ -15,7 +15,7 @@ import { GRID_COLUMNS_MOBILE } from '@/core/ui/grid/constants';
 import { Theme, useMediaQuery } from '@mui/material';
 import { DashboardNavigationItem } from '@/domain/space/components/spaceDashboardNavigation/useSpaceDashboardNavigation';
 import CommunityUpdatesDialog from '@/domain/community/community/CommunityUpdatesDialog/CommunityUpdatesDialog';
-import { buildUpdatesUrlLegacy } from '@/main/routing/urlBuilders';
+import { buildUpdatesUrl } from '@/main/routing/urlBuilders';
 
 export interface SubspaceDialogsProps {
   dialogOpen: SubspaceDialog | undefined;
@@ -89,7 +89,7 @@ const SubspaceDialogs = ({
         open={dialogOpen === SubspaceDialog.Updates}
         onClose={handleClose}
         communityId={communityId}
-        shareUrl={buildUpdatesUrlLegacy(journeyUrl ?? '')}
+        shareUrl={buildUpdatesUrl(journeyUrl ?? '')}
         loading={false}
       />
       <InnovationFlowSettingsDialog

--- a/src/domain/space/layout/flowLayout/SubspaceHomePage.tsx
+++ b/src/domain/space/layout/flowLayout/SubspaceHomePage.tsx
@@ -35,7 +35,7 @@ import { useConsumeAction } from './SubspacePageLayout';
 import { useColumns } from '@/core/ui/grid/GridContext';
 import CreateJourney from '../../components/subspaces/SubspaceCreationDialog/CreateJourney';
 import DashboardUpdatesSection from '@/domain/shared/components/DashboardSections/DashboardUpdatesSection';
-import { buildUpdatesUrlLegacy } from '@/main/routing/urlBuilders';
+import { buildUpdatesUrl } from '@/main/routing/urlBuilders';
 import { useSubspacePageQuery } from '@/core/apollo/generated/apollo-hooks';
 import useInnovationFlowStates from '@/domain/collaboration/InnovationFlow/InnovationFlowStates/useInnovationFlowStates';
 import useRoleSetManager from '@/domain/access/RoleSetManager/useRoleSetManager';
@@ -205,10 +205,7 @@ const SubspaceHomePage = ({ dialog }: { dialog?: SubspaceDialog }) => {
               onCreateSubspace={openCreateSubspace}
               onCurrentItemNotFound={dashboardNavigation.refetch}
             />
-            <DashboardUpdatesSection
-              communityId={communityId}
-              shareUrl={buildUpdatesUrlLegacy(about?.profile?.url ?? '')}
-            />
+            <DashboardUpdatesSection communityId={communityId} shareUrl={buildUpdatesUrl(about?.profile?.url ?? '')} />
           </>
         }
       >

--- a/src/domain/space/routing/SpaceRoute.tsx
+++ b/src/domain/space/routing/SpaceRoute.tsx
@@ -51,6 +51,10 @@ const LegacyRoutesRedirects = (spaceNameId: string) => (
       path={EntityPageSection.Contribute}
       element={<Navigate to={`/${spaceNameId}/?${TabbedLayoutParams.Section}=1`} replace />}
     />
+    <Route
+      path={EntityPageSection.Updates}
+      element={<Navigate to={`/${spaceNameId}/?${TabbedLayoutParams.Section}=1&dialog=updates`} replace />}
+    />
     <Route path="explore/*" element={<Redirect to={routes.Contribute} />} />
   </>
 );

--- a/src/main/routing/urlBuilders.ts
+++ b/src/main/routing/urlBuilders.ts
@@ -29,10 +29,6 @@ export const buildNewOrganizationUrl = () => {
 };
 
 export const buildUpdatesUrl = (journeyLocation: string) => {
-  return `${journeyLocation}?dialog=updates`;
-};
-
-export const buildUpdatesUrlLegacy = (journeyLocation: string) => {
   return `${journeyLocation}/updates`;
 };
 


### PR DESCRIPTION
New Legacy Space Route redirect was added - Updates;
Now we have the legacy `buildUpdatesUrl` which works for all space levels. 
We either use this common one or the L0 specific  `buildSpaceSectionUrl`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an "Updates" section accessible via dedicated navigation for streamlined content discovery.

- **Refactor**
  - Enhanced administrative settings to use refined space level indicators instead of binary flags, improving configuration consistency.
  - Updated navigation links for collaboration templates to dynamically adjust based on the current space context.

- **Chore**
  - Upgraded to a new package version, incorporating various internal improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->