### PR TITLE
When creating discussion, url is not replaced in the history

### DIFF
--- a/src/domain/communication/discussion/views/NewDiscussionDialog.tsx
+++ b/src/domain/communication/discussion/views/NewDiscussionDialog.tsx
@@ -37,7 +37,7 @@ const NewDiscussionDialog = ({ open, onClose, forumId, categories }: NewDiscussi
     });
     onClose();
     if (data?.createDiscussion) {
-      navigate(data.createDiscussion.profile.url, { replace: true });
+      navigate(data.createDiscussion.profile.url, { replace: false });
     }
   };
 


### PR DESCRIPTION
When the URL is replaced the URL resolver could not pick up that the url has changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the navigation behavior after creating a discussion so that users can now use the browser’s back button to return to the previous page, providing a smoother and more intuitive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->