### PR TITLE
Fix #8060 Urls of the templates are not opening the template dialog

### DIFF
--- a/src/main/routing/urlResolver/UrlResolverProvider.tsx
+++ b/src/main/routing/urlResolver/UrlResolverProvider.tsx
@@ -145,8 +145,14 @@ const UrlResolverProvider = ({ children }: { children: ReactNode }) => {
       if (nextUrl.endsWith('/')) {
         nextUrl = nextUrl.slice(0, -1);
       }
-      // Remove anything after /settings, because it's the settings url of the same entity, no need to resolve it:
-      nextUrl = nextUrl.replace(/\/settings(?:\/[a-zA-Z0-9-]+)?\/?$/, '');
+
+      if (/\/innovation-packs\/[a-zA-Z0-9-]+\/settings\/[a-zA-Z0-9-]+/.test(nextUrl)) {
+        // TODO: We need to rework the Urls of the templates anyway. See #8061
+        // For now just don't do anything, if the url is /innovation-packs/:innovationPackNameId/settings/:templateNameId let it pass to the urlResolver
+      } else {
+        // Remove anything after /settings, because it's the settings url of the same entity, no need to resolve it:
+        nextUrl = nextUrl.replace(/\/settings(?:\/[a-zA-Z0-9-]+)?\/?$/, '');
+      }
 
       if (nextUrl !== currentUrl) {
         setCurrentUrl(nextUrl); // Update the query URL state


### PR DESCRIPTION
This same commit is also being applied to the release/17 branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL handling to ensure that innovation pack settings URLs are preserved and not truncated during navigation. Other URLs will continue to have the `/settings` segment removed as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->