### PR TITLE
Bugfix: Lock icon is displayed for public space on Organization profile 

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -11363,6 +11363,7 @@ export const SpaceContributionDetailsDocument = gql`
             roleSetID
             communityID
           }
+          isContentPublic
         }
       }
     }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -17098,6 +17098,7 @@ export type SpaceContributionDetailsQuery = {
           about: {
             __typename?: 'SpaceAbout';
             id: string;
+            isContentPublic: boolean;
             profile: {
               __typename?: 'Profile';
               id: string;

--- a/src/domain/community/profile/useContributionProvider/useContributionQueries.graphql
+++ b/src/domain/community/profile/useContributionProvider/useContributionQueries.graphql
@@ -22,6 +22,7 @@ query SpaceContributionDetails($spaceId: UUID!) {
           roleSetID
           communityID
         }
+        isContentPublic
       }
     }
   }

--- a/src/domain/space/components/cards/SpaceTile.tsx
+++ b/src/domain/space/components/cards/SpaceTile.tsx
@@ -29,7 +29,7 @@ const SPACE_TITLE_CLASS_NAME = 'JourneyTitle';
 const ElevatedPaper = withElevationOnHover(Paper) as typeof Paper;
 
 const SpaceTile = ({ journey, columns = 3 }: SpaceTileProps) => {
-  const isPrivate = !journey?.about.isContentPublic;
+  const isPrivate = journey?.about.isContentPublic === false;
   return (
     <GridItem columns={columns}>
       <ElevatedPaper


### PR DESCRIPTION
see #8069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved privacy logic to only mark journeys as private when content is explicitly set as not public, preventing unintended privacy status due to missing or undefined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->