### PR TITLE
Add missing package for win

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,9 @@
       "engines": {
         "node": ">=20.9.0",
         "npm": ">=10"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-win32-x64-msvc": "^4.40.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -191,6 +191,9 @@
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^2.0.3"
   },
+  "optionalDependencies": {
+    "@rollup/rollup-win32-x64-msvc": "^4.40.0"
+  },
   "engines": {
     "node": ">=20.9.0",
     "npm": ">=10"


### PR DESCRIPTION
I'm having troubles running the clinent without installing this package. 
@techsmyth do you have similar issue running `npm run` after `npm i`? - fixed by deleting pacakge-lock.json
@ccanos, can you double-check this is not causing issues on linux?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added an optional dependency to improve compatibility on certain Windows systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->