### PR TITLE
Simplified code of ApplicationButton

### DIFF
--- a/src/domain/community/applicationButton/ApplicationButton.tsx
+++ b/src/domain/community/applicationButton/ApplicationButton.tsx
@@ -1,7 +1,6 @@
 import { Button as MuiButton, CircularProgress } from '@mui/material';
-import { forwardRef, Ref, useMemo, useState } from 'react';
+import { forwardRef, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import RouterLink from '@/core/ui/link/RouterLink';
 import { buildLoginUrl } from '@/main/routing/urlBuilders';
 import PreApplicationDialog from './PreApplicationDialog';
 import isApplicationPending from './isApplicationPending';
@@ -43,7 +42,7 @@ export interface ApplicationButtonProps {
   noAuthApplyButtonText?: string;
 }
 
-export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, ApplicationButtonProps>(
+export const ApplicationButton = forwardRef<HTMLButtonElement, ApplicationButtonProps>(
   (
     {
       isAuthenticated,
@@ -150,18 +149,12 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
 
     const renderApplicationButton = () => {
       if (loading) {
-        return <Button ref={ref as Ref<HTMLButtonElement>} disabled startIcon={<CircularProgress size={24} />} />;
+        return <Button ref={ref} disabled startIcon={<CircularProgress size={24} />} />;
       }
 
       if (!isAuthenticated) {
         return (
-          <Button
-            ref={ref as Ref<HTMLAnchorElement>}
-            variant="contained"
-            component={RouterLink}
-            to={buildLoginUrl(applyUrl)}
-            sx={{ '&:hover': { color: theme => theme.palette.common.white } }}
-          >
+          <Button ref={ref} variant="contained" onClick={() => navigate(buildLoginUrl(applyUrl))}>
             {noAuthApplyButtonText ?? t('components.application-button.apply-not-signed')}
           </Button>
         );
@@ -170,7 +163,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
       if (isMember) {
         return (
           <Button
-            ref={ref as Ref<HTMLButtonElement>}
+            ref={ref}
             variant="outlined"
             startIcon={<PersonOutlined />}
             disabled
@@ -189,7 +182,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
       if (canAcceptInvitation) {
         return (
           <Button
-            ref={ref as Ref<HTMLButtonElement>}
+            ref={ref}
             startIcon={extended ? <AddOutlined /> : undefined}
             onClick={handleClickAcceptInvitation}
             variant="contained"
@@ -203,7 +196,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
       if (canJoinCommunity) {
         return (
           <Button
-            ref={ref as Ref<HTMLButtonElement>}
+            ref={ref}
             startIcon={extended ? <AddOutlined /> : undefined}
             onClick={handleClickJoin}
             variant="contained"
@@ -216,7 +209,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
 
       if (isApplicationPending(applicationState)) {
         return (
-          <Button ref={ref as Ref<HTMLButtonElement>} disabled>
+          <Button ref={ref} disabled>
             {t('components.application-button.apply-pending')}
           </Button>
         );
@@ -226,7 +219,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
         const verb = extended ? t('components.application-button.applyTo') : t('buttons.apply');
         return (
           <Button
-            ref={ref as Ref<HTMLButtonElement>}
+            ref={ref}
             startIcon={extended ? <AddOutlined /> : undefined}
             onClick={handleClickApply}
             variant="contained"
@@ -241,7 +234,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
       if (isParentMember) {
         return (
           <Button
-            ref={ref as Ref<HTMLButtonElement>}
+            ref={ref}
             disabled
             variant="outlined"
             sx={{
@@ -258,7 +251,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
 
       if (isApplicationPending(parentApplicationState)) {
         return (
-          <Button ref={ref as Ref<HTMLButtonElement>} disabled>
+          <Button ref={ref} disabled>
             {t('components.application-button.parent-pending')}
           </Button>
         );
@@ -266,7 +259,7 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
 
       if (canJoinParentCommunity) {
         return (
-          <Button ref={ref as Ref<HTMLButtonElement>} onClick={handleClickJoinParent} variant={'contained'}>
+          <Button ref={ref} onClick={handleClickJoinParent} variant={'contained'}>
             {t('components.application-button.join')}
           </Button>
         );
@@ -274,14 +267,14 @@ export const ApplicationButton = forwardRef<HTMLButtonElement | HTMLAnchorElemen
 
       if (canApplyToParentCommunity) {
         return (
-          <Button ref={ref as Ref<HTMLButtonElement>} onClick={handleClickApplyParent} variant={'contained'}>
+          <Button ref={ref} onClick={handleClickApplyParent} variant={'contained'}>
             {t('buttons.apply')}
           </Button>
         );
       }
 
       return (
-        <Button ref={ref as Ref<HTMLButtonElement>} disabled variant={'contained'}>
+        <Button ref={ref} disabled variant={'contained'}>
           {t('components.application-button.apply-disabled')}
         </Button>
       );

--- a/src/domain/space/about/SpaceAboutDialog.tsx
+++ b/src/domain/space/about/SpaceAboutDialog.tsx
@@ -74,7 +74,7 @@ const SpaceAboutDialog = ({
   const { sendMessage, directMessageDialog } = useDirectMessageDialog({
     dialogTitle: t('send-message-dialog.direct-message-title'),
   });
-  const applicationButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+  const applicationButtonRef = useRef<HTMLButtonElement>(null);
 
   const aboutProfile = about?.profile;
   const communityGuidelinesId = about?.guidelines.id;


### PR DESCRIPTION
The bug was not reproducible anymore, but I saw that it was fixed with the custom CSS: 
`sx={{ '&:hover': { color: theme => theme.palette.common.white } }}`

I have removed that and simplified the code. The Application button could be a `Buttton` or a `RouterLink`, but now they are always `Button`s, and that simplifies the ref, it doesn't have to be a Ref<Button | Link>.

Note for testing: The problematic button was the "Sign in to apply", so only visible when not logged in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified navigation for unauthenticated users by replacing link-based navigation with a standard button and click handler.
	- Streamlined ref handling by narrowing supported element types to button elements only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->