### PR TITLE
completely removed spaceIconByLevel 

### DIFF
--- a/src/domain/community/invitations/InvitationDialog.tsx
+++ b/src/domain/community/invitations/InvitationDialog.tsx
@@ -4,7 +4,7 @@ import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import Gutters from '@/core/ui/grid/Gutters';
 import { CheckOutlined, HdrStrongOutlined } from '@mui/icons-material';
 import SpaceCardBase from '@/domain/space/components/cards/SpaceCardBase';
-import { spaceIconByLevel } from '@/domain/space/icons/SpaceIconByLevel';
+import { spaceLevelIcon } from '@/domain/space/icons/SpaceIconByLevel';
 import SpaceCardTagline from '@/domain/space/components/cards/components/SpaceCardTagline';
 import { BlockSectionTitle, Caption, Text } from '@/core/ui/typography';
 import DetailedActivityDescription from '@/domain/shared/components/ActivityDescription/DetailedActivityDescription';
@@ -101,7 +101,7 @@ const InvitationDialog = ({
                     alignItems={isMobile ? 'center' : 'start'}
                   >
                     <SpaceCardBase
-                      iconComponent={spaceIconByLevel[invitation.space.level]}
+                      iconComponent={spaceLevelIcon[invitation.space.level]}
                       header={invitation.space.about.profile.displayName}
                       tags={invitation.space.about.profile.tagset?.tags ?? []}
                       banner={invitation.space.about.profile.cardBanner}

--- a/src/domain/community/invitations/SingleInvitationFull.tsx
+++ b/src/domain/community/invitations/SingleInvitationFull.tsx
@@ -16,7 +16,7 @@ import References from '@/domain/shared/components/References/References';
 import { gutters } from '@/core/ui/grid/utils';
 import FlexSpacer from '@/core/ui/utils/FlexSpacer';
 import { Actions } from '@/core/ui/actions/Actions';
-import { spaceIconByLevel } from '@/domain/space/icons/SpaceIconByLevel';
+import { spaceLevelIcon } from '@/domain/space/icons/SpaceIconByLevel';
 
 type SingleInvitationFullProps = {
   invitation: PendingInvitationItem | undefined;
@@ -87,7 +87,7 @@ const SingleInvitationFull = ({
                   alignItems={isMobile ? 'center' : 'start'}
                 >
                   <SpaceCardBase
-                    iconComponent={spaceIconByLevel[invitation.space.level]}
+                    iconComponent={spaceLevelIcon[invitation.space.level]}
                     header={invitation.space.about.profile.displayName}
                     tags={invitation.space.about.profile.tagset?.tags ?? []}
                     banner={invitation.space.about.profile.cardBanner}

--- a/src/domain/community/pendingMembership/PendingMembershipsDialog.tsx
+++ b/src/domain/community/pendingMembership/PendingMembershipsDialog.tsx
@@ -22,7 +22,7 @@ import BackButton from '@/core/ui/actions/BackButton';
 import useNavigate from '@/core/routing/useNavigate';
 import { PendingMembershipsDialogType, usePendingMembershipsDialog } from './PendingMembershipsDialogContext';
 import { defer } from 'lodash';
-import { spaceIconByLevel } from '@/domain/space/icons/SpaceIconByLevel';
+import { spaceLevelIcon } from '@/domain/space/icons/SpaceIconByLevel';
 
 const PendingMembershipsDialog = () => {
   const { t } = useTranslation();
@@ -128,7 +128,7 @@ const PendingMembershipsDialog = () => {
                     {({ application: hydratedApplication }) =>
                       hydratedApplication && (
                         <SpaceCardBase
-                          iconComponent={spaceIconByLevel[hydratedApplication.space.level]}
+                          iconComponent={spaceLevelIcon[hydratedApplication.space.level]}
                           header={hydratedApplication.space.about.profile.displayName}
                           tags={hydratedApplication.space.about.profile.tagset?.tags ?? []}
                           banner={hydratedApplication.space.about.profile.cardBanner}

--- a/src/domain/community/profile/views/ContributionDetailsCard.tsx
+++ b/src/domain/community/profile/views/ContributionDetailsCard.tsx
@@ -9,7 +9,7 @@ import SpaceCardTagline from '@/domain/space/components/cards/components/SpaceCa
 import CardRibbon from '@/core/ui/card/CardRibbon';
 import { SpaceLevel, SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
-import { spaceIconByLevel } from '@/domain/space/icons/SpaceIconByLevel';
+import { spaceLevelIcon } from '@/domain/space/icons/SpaceIconByLevel';
 
 interface ContributionDetailsCardProps extends Omit<SpaceCard2Props, 'iconComponent' | 'header'> {
   tagline: string;
@@ -61,7 +61,7 @@ const ContributionDetailsCard = ({
     <>
       <SpaceCardBase
         {...props}
-        iconComponent={spaceIconByLevel[level || SpaceLevel.L0]}
+        iconComponent={spaceLevelIcon[level || SpaceLevel.L0]}
         header={
           <BlockTitle component="div" sx={webkitLineClamp(2)}>
             {displayName}

--- a/src/domain/space/components/cards/SpaceCardHorizontal.tsx
+++ b/src/domain/space/components/cards/SpaceCardHorizontal.tsx
@@ -22,7 +22,7 @@ import FlexSpacer from '@/core/ui/utils/FlexSpacer';
 import SpaceAvatar from '../SpaceAvatar';
 import ActionsMenu from '@/core/ui/card/ActionsMenu';
 import { AvatarSize } from '@/core/ui/avatar/Avatar';
-import { spaceIconByLevel } from '@/domain/space/icons/SpaceIconByLevel';
+import { spaceLevelIcon } from '@/domain/space/icons/SpaceIconByLevel';
 import { SpaceAboutLightModel } from '@/domain/space/about/model/spaceAboutLight.model';
 import { getSpaceSubscriptionLevel } from '@/domain/space/license/utils';
 
@@ -77,7 +77,7 @@ const SpaceCardHorizontal = ({
   disableHoverState = false,
   disableTagline = false,
 }: SpaceCardHorizontalProps) => {
-  const Icon = space.level ? spaceIconByLevel[space.level] : undefined;
+  const Icon = space.level ? spaceLevelIcon[space.level] : undefined;
 
   const { t } = useTranslation();
 

--- a/src/domain/space/icons/SpaceIconByLevel.tsx
+++ b/src/domain/space/icons/SpaceIconByLevel.tsx
@@ -5,13 +5,6 @@ import { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import { ComponentType } from 'react';
 import { SvgIconProps } from '@mui/material';
 
-export const spaceIconByLevel = [
-  SpaceL0Icon,
-  SpaceL1Icon,
-  SpaceL2Icon,
-  undefined, // for Typescript to correctly assume you can get undefined as well
-] as const;
-
 const spaceIcon = {
   space: SpaceL0Icon,
   subspace: SpaceL1Icon,


### PR DESCRIPTION
Turns out `spaceIconByLevel` is irrelevant - we should be using `spaceLevelIcon` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal icon mapping for space levels across several components to use a new icon mapping.
- **Chores**
  - Removed an unused icon mapping, resulting in minor internal cleanup. 

No visible changes to user experience or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->