### PR TITLE
Removes classification details from callout details query

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -2125,6 +2125,7 @@ export type MigrateEmbeddingsFieldPolicy = {
   success?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type MutationKeySpecifier = (
+  | 'addIframeAllowedURL'
   | 'addReactionToMessageInRoom'
   | 'adminCommunicationEnsureAccessToCommunications'
   | 'adminCommunicationRemoveOrphanedRoom'
@@ -2217,6 +2218,7 @@ export type MutationKeySpecifier = (
   | 'refreshAllBodiesOfKnowledge'
   | 'refreshVirtualContributorBodyOfKnowledge'
   | 'removeCommunityGuidelinesContent'
+  | 'removeIframeAllowedURL'
   | 'removeMessageOnRoom'
   | 'removePlatformRoleFromUser'
   | 'removeReactionToMessageInRoom'
@@ -2292,6 +2294,7 @@ export type MutationKeySpecifier = (
   | MutationKeySpecifier
 )[];
 export type MutationFieldPolicy = {
+  addIframeAllowedURL?: FieldPolicy<any> | FieldReadFunction<any>;
   addReactionToMessageInRoom?: FieldPolicy<any> | FieldReadFunction<any>;
   adminCommunicationEnsureAccessToCommunications?: FieldPolicy<any> | FieldReadFunction<any>;
   adminCommunicationRemoveOrphanedRoom?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2384,6 +2387,7 @@ export type MutationFieldPolicy = {
   refreshAllBodiesOfKnowledge?: FieldPolicy<any> | FieldReadFunction<any>;
   refreshVirtualContributorBodyOfKnowledge?: FieldPolicy<any> | FieldReadFunction<any>;
   removeCommunityGuidelinesContent?: FieldPolicy<any> | FieldReadFunction<any>;
+  removeIframeAllowedURL?: FieldPolicy<any> | FieldReadFunction<any>;
   removeMessageOnRoom?: FieldPolicy<any> | FieldReadFunction<any>;
   removePlatformRoleFromUser?: FieldPolicy<any> | FieldReadFunction<any>;
   removeReactionToMessageInRoom?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -7177,16 +7177,14 @@ export function refetchCalloutsOnCalloutsSetUsingClassificationQuery(
 }
 
 export const CalloutDetailsDocument = gql`
-  query CalloutDetails($calloutId: UUID!, $withClassification: Boolean = true) {
+  query CalloutDetails($calloutId: UUID!) {
     lookup {
       callout(ID: $calloutId) {
         ...CalloutDetails
-        ...ClassificationDetails @include(if: $withClassification)
       }
     }
   }
   ${CalloutDetailsFragmentDoc}
-  ${ClassificationDetailsFragmentDoc}
 `;
 
 /**
@@ -7202,7 +7200,6 @@ export const CalloutDetailsDocument = gql`
  * const { data, loading, error } = useCalloutDetailsQuery({
  *   variables: {
  *      calloutId: // value for 'calloutId'
- *      withClassification: // value for 'withClassification'
  *   },
  * });
  */

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -3596,6 +3596,8 @@ export type MoveCalloutContributionInput = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  /** Adds an Iframe Allowed URL to the Platform Settings */
+  addIframeAllowedURL: Array<Scalars['String']>;
   /** Add a reaction to a message from the specified Room. */
   addReactionToMessageInRoom: Reaction;
   /** Ensure all community members are registered for communications. */
@@ -3780,6 +3782,8 @@ export type Mutation = {
   refreshVirtualContributorBodyOfKnowledge: Scalars['Boolean'];
   /** Empties the CommunityGuidelines. */
   removeCommunityGuidelinesContent: CommunityGuidelines;
+  /** Removes an Iframe Allowed URL from the Platform Settings */
+  removeIframeAllowedURL: Array<Scalars['String']>;
   /** Removes a message. */
   removeMessageOnRoom: Scalars['MessageID'];
   /** Removes a User from a Role on the Platform. */
@@ -3924,6 +3928,10 @@ export type Mutation = {
   uploadFileOnStorageBucket: Scalars['String'];
   /** Uploads and sets an image for the specified Visual. */
   uploadImageOnVisual: Visual;
+};
+
+export type MutationAddIframeAllowedUrlArgs = {
+  whitelistedURL: Scalars['String'];
 };
 
 export type MutationAddReactionToMessageInRoomArgs = {
@@ -4252,6 +4260,10 @@ export type MutationRefreshVirtualContributorBodyOfKnowledgeArgs = {
 
 export type MutationRemoveCommunityGuidelinesContentArgs = {
   communityGuidelinesData: RemoveCommunityGuidelinesContentInput;
+};
+
+export type MutationRemoveIframeAllowedUrlArgs = {
+  whitelistedURL: Scalars['String'];
 };
 
 export type MutationRemoveMessageOnRoomArgs = {
@@ -12420,7 +12432,6 @@ export type CalloutFragment = {
 
 export type CalloutDetailsQueryVariables = Exact<{
   calloutId: Scalars['UUID'];
-  withClassification?: InputMaybe<Scalars['Boolean']>;
 }>;
 
 export type CalloutDetailsQuery = {
@@ -12716,22 +12727,6 @@ export type CalloutDetailsQuery = {
             | undefined;
           authorization?:
             | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
-            | undefined;
-          classification?:
-            | {
-                __typename?: 'Classification';
-                id: string;
-                flowState?:
-                  | {
-                      __typename?: 'Tagset';
-                      id: string;
-                      name: string;
-                      tags: Array<string>;
-                      allowedValues: Array<string>;
-                      type: TagsetType;
-                    }
-                  | undefined;
-              }
             | undefined;
         }
       | undefined;

--- a/src/domain/collaboration/callout/CalloutDetailsContainer.tsx
+++ b/src/domain/collaboration/callout/CalloutDetailsContainer.tsx
@@ -24,7 +24,6 @@ const CalloutDetailsContainer = ({ callout, children }: CalloutDetailsContainerP
   const { data, loading } = useCalloutDetailsQuery({
     variables: {
       calloutId: callout.id,
-      withClassification: callout.classificationTagsets.length > 0,
     },
     skip: !inView,
   });

--- a/src/domain/collaboration/calloutsSet/useCalloutsSet/CalloutsSetQueries.graphql
+++ b/src/domain/collaboration/calloutsSet/useCalloutsSet/CalloutsSetQueries.graphql
@@ -38,23 +38,15 @@ fragment Callout on Callout {
   visibility
 }
 
-query CalloutDetails($calloutId: UUID!, $withClassification: Boolean = true) {
+query CalloutDetails($calloutId: UUID!) {
   lookup {
     callout(ID: $calloutId) {
       ...CalloutDetails
-      ...ClassificationDetails @include(if: $withClassification)
     }
   }
 }
 
-fragment ClassificationDetails on Callout {
-  classification {
-    id
-    flowState: tagset(tagsetName: FLOW_STATE) {
-      ...TagsetDetails
-    }
-  }
-}
+
 
 fragment CalloutDetails on Callout {
   id

--- a/src/domain/collaboration/calloutsSet/useCalloutsSet/useCalloutsSet.ts
+++ b/src/domain/collaboration/calloutsSet/useCalloutsSet/useCalloutsSet.ts
@@ -130,7 +130,6 @@ const useCalloutsSet = ({
     getCalloutDetails({
       variables: {
         calloutId,
-        withClassification: withClassificationDetails,
       },
     });
   };

--- a/src/domain/community/virtualContributor/knowledgeBase/useKnowledgeBase.tsx
+++ b/src/domain/community/virtualContributor/knowledgeBase/useKnowledgeBase.tsx
@@ -109,6 +109,7 @@ const useKnowledgeBase = ({ id }: useKnowledgeBaseParams): useKnowledgeBaseProvi
   } = useCalloutsSet({
     calloutsSetId,
     classificationTagsets: [],
+    includeClassification: false,
   });
 
   return {


### PR DESCRIPTION
The classification details are no longer needed in the
CalloutDetails query. This change removes the associated
fragments and logic to simplify the query and improve
performance by reducing the amount of data fetched. Also,
adds mutations for iframe allowed urls.
