### PR TITLE
Fix search on 404 page

### DIFF
--- a/src/core/pages/Errors/Error404.tsx
+++ b/src/core/pages/Errors/Error404.tsx
@@ -106,7 +106,7 @@ export const Error404 = () => {
                 })}
               />
               <Tagline>{t('pages.four-ou-four.message')}</Tagline>
-              <StyledSearchBox />
+              <StyledSearchBox withRedirect />
               <UsefulLinks>
                 <StyledLink href="/" subtitle={t('pages.four-ou-four.links.home')}>
                   {t('common.home')}

--- a/src/main/ui/layout/topBar/SearchBar.tsx
+++ b/src/main/ui/layout/topBar/SearchBar.tsx
@@ -12,10 +12,12 @@ import { useLocation } from 'react-router-dom';
 const MINIMUM_TERM_LENGTH = 2;
 const getSearchTerms = (searchInput: string) => searchInput.trim();
 
-const SearchBar = forwardRef<typeof Box, BoxProps>((props, ref) => {
+const SearchBar = forwardRef<typeof Box, BoxProps & { withRedirect?: boolean }>((props, ref) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const query = useQueryParams();
+
   const getInitialValue = () => {
     const terms = query.get(SEARCH_TERMS_URL_PARAM);
     return terms ? terms.split(',').join(', ') : '';
@@ -41,11 +43,12 @@ const SearchBar = forwardRef<typeof Box, BoxProps>((props, ref) => {
     [setValue]
   );
 
-  const { pathname } = useLocation();
-
   const handleNavigateToSearchPage = useCallback(() => {
     const terms = getSearchTerms(value);
     const params = new URLSearchParams({ [SEARCH_TERMS_URL_PARAM]: terms });
+    if (props.withRedirect) {
+      window.location.href = `/?${params}`;
+    }
     navigate(`${pathname}?${params}`);
   }, [isTermValid, value, navigate]);
 

--- a/src/main/ui/layout/topBar/SearchBar.tsx
+++ b/src/main/ui/layout/topBar/SearchBar.tsx
@@ -48,9 +48,10 @@ const SearchBar = forwardRef<typeof Box, BoxProps & { withRedirect?: boolean }>(
     const params = new URLSearchParams({ [SEARCH_TERMS_URL_PARAM]: terms });
     if (props.withRedirect) {
       window.location.href = `/?${params}`;
+    } else {
+      navigate(`${pathname}?${params}`);
     }
-    navigate(`${pathname}?${params}`);
-  }, [isTermValid, value, navigate]);
+  }, [isTermValid, value, navigate, props.withRedirect]);
 
   return (
     <Box ref={ref} flexGrow={1} justifyContent="center" {...props}>


### PR DESCRIPTION
There's an issue with the router and how we render Error pages.

The fix is redirecting to the homepage if you search from the Error page. That reloads the Router and fixes the issue.
Just so you know, I had issues locally with localhost URLs. The cards weren't opening at all. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for redirecting to the search page from the 404 error page using the search box.
  - Search functionality now includes an option to perform a full page redirect when searching from specific locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->