### PR TITLE
Filter templates by name, tags and description

### DIFF
--- a/src/domain/templates/components/Dialogs/ImportTemplateDialog/ImportTemplatesDialogGallery.tsx
+++ b/src/domain/templates/components/Dialogs/ImportTemplateDialog/ImportTemplatesDialogGallery.tsx
@@ -26,10 +26,22 @@ const ImportTemplatesDialogGallery = ({
   const { t } = useTranslation();
   const [filter, setFilter] = useState<string>('');
 
-  const filterTemplatesCallback = (template: AnyTemplateWithInnovationPack) => {
-    const lowerCaseFilter = filter.toLowerCase();
+  const matchesFilter = (value: string | undefined, filter: string): boolean => {
+    if (!value) {
+      return false;
+    }
 
-    return template?.template?.profile?.displayName.toLowerCase().includes(lowerCaseFilter);
+    return value.toLowerCase().includes(filter.toLowerCase());
+  };
+
+  const filterTemplatesCallback = (template: AnyTemplateWithInnovationPack) => {
+    const fieldsToFilter = [
+      template?.template?.profile?.displayName,
+      template?.template?.profile?.description,
+      ...(template?.template?.profile?.defaultTagset?.tags || []),
+    ];
+
+    return fieldsToFilter.some(field => matchesFilter(field, filter));
   };
 
   const filteredTemplates = useMemo(


### PR DESCRIPTION
Add tags and description together with the displayName to the search for templates. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved template filtering in the import dialog to search across display name, description, and tags for more accurate and flexible results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->