### PR TITLE
Bulk mark as read notifications

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -2125,6 +2125,7 @@ export type MigrateEmbeddingsFieldPolicy = {
   success?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type MutationKeySpecifier = (
+  | 'addIframeAllowedURL'
   | 'addReactionToMessageInRoom'
   | 'adminCommunicationEnsureAccessToCommunications'
   | 'adminCommunicationRemoveOrphanedRoom'
@@ -2212,11 +2213,14 @@ export type MutationKeySpecifier = (
   | 'inviteUserToPlatformAndRoleSet'
   | 'joinRoleSet'
   | 'licenseResetOnAccount'
+  | 'markNotificationsAsRead'
+  | 'markNotificationsAsUnread'
   | 'messageUser'
   | 'moveContributionToCallout'
   | 'refreshAllBodiesOfKnowledge'
   | 'refreshVirtualContributorBodyOfKnowledge'
   | 'removeCommunityGuidelinesContent'
+  | 'removeIframeAllowedURL'
   | 'removeMessageOnRoom'
   | 'removePlatformRoleFromUser'
   | 'removeReactionToMessageInRoom'
@@ -2292,6 +2296,7 @@ export type MutationKeySpecifier = (
   | MutationKeySpecifier
 )[];
 export type MutationFieldPolicy = {
+  addIframeAllowedURL?: FieldPolicy<any> | FieldReadFunction<any>;
   addReactionToMessageInRoom?: FieldPolicy<any> | FieldReadFunction<any>;
   adminCommunicationEnsureAccessToCommunications?: FieldPolicy<any> | FieldReadFunction<any>;
   adminCommunicationRemoveOrphanedRoom?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2379,11 +2384,14 @@ export type MutationFieldPolicy = {
   inviteUserToPlatformAndRoleSet?: FieldPolicy<any> | FieldReadFunction<any>;
   joinRoleSet?: FieldPolicy<any> | FieldReadFunction<any>;
   licenseResetOnAccount?: FieldPolicy<any> | FieldReadFunction<any>;
+  markNotificationsAsRead?: FieldPolicy<any> | FieldReadFunction<any>;
+  markNotificationsAsUnread?: FieldPolicy<any> | FieldReadFunction<any>;
   messageUser?: FieldPolicy<any> | FieldReadFunction<any>;
   moveContributionToCallout?: FieldPolicy<any> | FieldReadFunction<any>;
   refreshAllBodiesOfKnowledge?: FieldPolicy<any> | FieldReadFunction<any>;
   refreshVirtualContributorBodyOfKnowledge?: FieldPolicy<any> | FieldReadFunction<any>;
   removeCommunityGuidelinesContent?: FieldPolicy<any> | FieldReadFunction<any>;
+  removeIframeAllowedURL?: FieldPolicy<any> | FieldReadFunction<any>;
   removeMessageOnRoom?: FieldPolicy<any> | FieldReadFunction<any>;
   removePlatformRoleFromUser?: FieldPolicy<any> | FieldReadFunction<any>;
   removeReactionToMessageInRoom?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -20583,6 +20583,52 @@ export type UpdateNotificationStateMutationOptions = Apollo.BaseMutationOptions<
   SchemaTypes.UpdateNotificationStateMutation,
   SchemaTypes.UpdateNotificationStateMutationVariables
 >;
+export const MarkNotificationsAsReadDocument = gql`
+  mutation MarkNotificationsAsRead($notificationIds: [String!]!) {
+    markNotificationsAsRead(notificationIds: $notificationIds)
+  }
+`;
+export type MarkNotificationsAsReadMutationFn = Apollo.MutationFunction<
+  SchemaTypes.MarkNotificationsAsReadMutation,
+  SchemaTypes.MarkNotificationsAsReadMutationVariables
+>;
+
+/**
+ * __useMarkNotificationsAsReadMutation__
+ *
+ * To run a mutation, you first call `useMarkNotificationsAsReadMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useMarkNotificationsAsReadMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [markNotificationsAsReadMutation, { data, loading, error }] = useMarkNotificationsAsReadMutation({
+ *   variables: {
+ *      notificationIds: // value for 'notificationIds'
+ *   },
+ * });
+ */
+export function useMarkNotificationsAsReadMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    SchemaTypes.MarkNotificationsAsReadMutation,
+    SchemaTypes.MarkNotificationsAsReadMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    SchemaTypes.MarkNotificationsAsReadMutation,
+    SchemaTypes.MarkNotificationsAsReadMutationVariables
+  >(MarkNotificationsAsReadDocument, options);
+}
+
+export type MarkNotificationsAsReadMutationHookResult = ReturnType<typeof useMarkNotificationsAsReadMutation>;
+export type MarkNotificationsAsReadMutationResult = Apollo.MutationResult<SchemaTypes.MarkNotificationsAsReadMutation>;
+export type MarkNotificationsAsReadMutationOptions = Apollo.BaseMutationOptions<
+  SchemaTypes.MarkNotificationsAsReadMutation,
+  SchemaTypes.MarkNotificationsAsReadMutationVariables
+>;
 export const UrlResolverDocument = gql`
   query UrlResolver($url: String!) {
     urlResolver(url: $url) {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -3600,6 +3600,8 @@ export type MoveCalloutContributionInput = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  /** Adds an Iframe Allowed URL to the Platform Settings */
+  addIframeAllowedURL: Array<Scalars['String']>;
   /** Add a reaction to a message from the specified Room. */
   addReactionToMessageInRoom: Reaction;
   /** Ensure all community members are registered for communications. */
@@ -3774,6 +3776,10 @@ export type Mutation = {
   joinRoleSet: RoleSet;
   /** Reset the License with Entitlements on the specified Account. */
   licenseResetOnAccount: Account;
+  /** Mark multiple notifications as read. */
+  markNotificationsAsRead: Scalars['Boolean'];
+  /** Mark multiple notifications as unread. */
+  markNotificationsAsUnread: Scalars['Boolean'];
   /** Sends a message on the specified User`s behalf and returns the room id */
   messageUser: Scalars['String'];
   /** Moves the specified Contribution to another Callout. */
@@ -3784,6 +3790,8 @@ export type Mutation = {
   refreshVirtualContributorBodyOfKnowledge: Scalars['Boolean'];
   /** Empties the CommunityGuidelines. */
   removeCommunityGuidelinesContent: CommunityGuidelines;
+  /** Removes an Iframe Allowed URL from the Platform Settings */
+  removeIframeAllowedURL: Array<Scalars['String']>;
   /** Removes a message. */
   removeMessageOnRoom: Scalars['MessageID'];
   /** Removes a User from a Role on the Platform. */
@@ -3928,6 +3936,10 @@ export type Mutation = {
   uploadFileOnStorageBucket: Scalars['String'];
   /** Uploads and sets an image for the specified Visual. */
   uploadImageOnVisual: Visual;
+};
+
+export type MutationAddIframeAllowedUrlArgs = {
+  whitelistedURL: Scalars['String'];
 };
 
 export type MutationAddReactionToMessageInRoomArgs = {
@@ -4242,6 +4254,14 @@ export type MutationLicenseResetOnAccountArgs = {
   resetData: AccountLicenseResetInput;
 };
 
+export type MutationMarkNotificationsAsReadArgs = {
+  notificationIds: Array<Scalars['String']>;
+};
+
+export type MutationMarkNotificationsAsUnreadArgs = {
+  notificationIds: Array<Scalars['String']>;
+};
+
 export type MutationMessageUserArgs = {
   messageData: UserSendMessageInput;
 };
@@ -4256,6 +4276,10 @@ export type MutationRefreshVirtualContributorBodyOfKnowledgeArgs = {
 
 export type MutationRemoveCommunityGuidelinesContentArgs = {
   communityGuidelinesData: RemoveCommunityGuidelinesContentInput;
+};
+
+export type MutationRemoveIframeAllowedUrlArgs = {
+  whitelistedURL: Scalars['String'];
 };
 
 export type MutationRemoveMessageOnRoomArgs = {
@@ -27344,6 +27368,12 @@ export type UpdateNotificationStateMutation = {
   __typename?: 'Mutation';
   updateNotificationState: InAppNotificationState;
 };
+
+export type MarkNotificationsAsReadMutationVariables = Exact<{
+  notificationIds: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+export type MarkNotificationsAsReadMutation = { __typename?: 'Mutation'; markNotificationsAsRead: boolean };
 
 type InAppNotificationAllTypes_InAppNotificationCalloutPublished_Fragment = {
   __typename?: 'InAppNotificationCalloutPublished';

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1724,7 +1724,8 @@
           "description": "The {{memberType}} {{memberName}} has joined {{spaceName}}, of which you are an admin."
         }
       },
-      "emptyInbox": "No pending notifications"
+      "emptyInbox": "No pending notifications",
+      "markAllAsRead": "Mark all as read"
     },
     "spaceWelcomeDialog": {
       "title": "\uD83C\uDF89 Your Space is Ready!",

--- a/src/main/inAppNotifications/InAppNotificationsContext.tsx
+++ b/src/main/inAppNotifications/InAppNotificationsContext.tsx
@@ -8,7 +8,13 @@ interface InAppNotificationsContextProps {
   setIsOpen: (isOpen: boolean) => void;
 }
 
-const InAppNotifications = createContext<InAppNotificationsContextProps | undefined>(undefined);
+const defaultState: InAppNotificationsContextProps = {
+  isEnabled: false,
+  isOpen: false,
+  setIsOpen: () => {},
+};
+
+const InAppNotifications = createContext<InAppNotificationsContextProps>(defaultState);
 
 export const InAppNotificationsProvider = ({ children }: { children: ReactNode }) => {
   const { userModel, platformRoles } = useCurrentUserContext();

--- a/src/main/inAppNotifications/InAppNotificationsDialog.tsx
+++ b/src/main/inAppNotifications/InAppNotificationsDialog.tsx
@@ -1,18 +1,31 @@
-import { DialogContent } from '@mui/material';
+import { DialogContent, IconButton, Tooltip } from '@mui/material';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
 import { useTranslation } from 'react-i18next';
 import DialogWithGrid from '@/core/ui/dialog/DialogWithGrid';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import { useInAppNotificationsContext } from './InAppNotificationsContext';
 import { InAppNotificationsList } from './InAppNotificationsList';
+import { useInAppNotifications } from '@/main/inAppNotifications/useInAppNotifications';
+import DraftsOutlinedIcon from '@mui/icons-material/DraftsOutlined';
 
 export const InAppNotificationsDialog = () => {
   const { t } = useTranslation();
   const { isOpen, setIsOpen } = useInAppNotificationsContext();
+  const { markNotificationsAsRead } = useInAppNotifications();
 
   return (
     <DialogWithGrid open={isOpen} columns={8} onClose={() => setIsOpen(false)}>
-      <DialogHeader icon={<NotificationsNoneOutlinedIcon />} onClose={() => setIsOpen(false)}>
+      <DialogHeader
+        icon={<NotificationsNoneOutlinedIcon />}
+        onClose={() => setIsOpen(false)}
+        actions={
+          <Tooltip title={t('components.inAppNotifications.markAllAsRead')} placement="top">
+            <IconButton onClick={() => markNotificationsAsRead()}>
+              <DraftsOutlinedIcon />
+            </IconButton>
+          </Tooltip>
+        }
+      >
         {t('common.notifications')}
       </DialogHeader>
       <DialogContent sx={{ padding: 0 }}>{isOpen && <InAppNotificationsList />}</DialogContent>

--- a/src/main/inAppNotifications/graphql/InAppNotifications.graphql
+++ b/src/main/inAppNotifications/graphql/InAppNotifications.graphql
@@ -23,3 +23,7 @@ mutation UpdateNotificationState ($ID: UUID!, $state: InAppNotificationState!) {
      state: $state,
   })
 }
+
+mutation MarkNotificationsAsRead ($notificationIds: [String!]!) {
+  markNotificationsAsRead(notificationIds: $notificationIds)
+}

--- a/src/main/inAppNotifications/useInAppNotifications.ts
+++ b/src/main/inAppNotifications/useInAppNotifications.ts
@@ -133,8 +133,10 @@ export const useInAppNotifications = () => {
         ID: id,
         state: status,
       },
-      update: cache => {
-        updateNotificationsCache(cache, [id], status);
+      update: (cache, data) => {
+        if (data?.data?.updateNotificationState === status) {
+          updateNotificationsCache(cache, [id], status);
+        }
       },
     });
   };
@@ -150,8 +152,10 @@ export const useInAppNotifications = () => {
       variables: {
         notificationIds: ids,
       },
-      update: cache => {
-        updateNotificationsCache(cache, ids, InAppNotificationState.Read);
+      update: (cache, data) => {
+        if (data?.data?.markNotificationsAsRead) {
+          updateNotificationsCache(cache, ids, InAppNotificationState.Read);
+        }
       },
     });
   };

--- a/src/main/inAppNotifications/useInAppNotifications.ts
+++ b/src/main/inAppNotifications/useInAppNotifications.ts
@@ -11,6 +11,7 @@ import {
   refetchInAppNotificationsQuery,
   useInAppNotificationsQuery,
   useUpdateNotificationStateMutation,
+  useMarkNotificationsAsReadMutation,
 } from '@/core/apollo/generated/apollo-hooks';
 import { useInAppNotificationsContext } from './InAppNotificationsContext';
 
@@ -91,6 +92,7 @@ export const useInAppNotifications = () => {
   const { isEnabled } = useInAppNotificationsContext();
 
   const [updateState] = useUpdateNotificationStateMutation();
+  const [markAsRead] = useMarkNotificationsAsReadMutation();
 
   const { data, loading } = useInAppNotificationsQuery({
     skip: !isEnabled,
@@ -111,5 +113,20 @@ export const useInAppNotifications = () => {
     });
   };
 
-  return { items, isLoading: loading, updateNotificationState };
+  const markNotificationsAsRead = async () => {
+    const ids = items.filter(item => item.state === InAppNotificationState.Unread).map(item => item.id);
+
+    if (ids.length === 0) {
+      return;
+    }
+
+    await markAsRead({
+      variables: {
+        notificationIds: ids,
+      },
+      refetchQueries: [refetchInAppNotificationsQuery()],
+    });
+  };
+
+  return { items, isLoading: loading, updateNotificationState, markNotificationsAsRead };
 };


### PR DESCRIPTION
Straightforward implementation -> icon, hook, mutation. I had to define a default state as the context was complaining.
The server code is already in develop branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Mark all as read" button to the in-app notifications dialog, allowing users to mark all unread notifications as read with a single click.

- **Bug Fixes**
  - Improved reliability of the notifications context to prevent issues when accessing notification state.

- **Localization**
  - Added English translation for the "Mark all as read" action in notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->