### PR TITLE
Redirect from documentation to docs in case of internal SPA navigation

### DIFF
--- a/src/main/documentation/RedirectDocumentation.tsx
+++ b/src/main/documentation/RedirectDocumentation.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import useNavigate from '@/core/routing/useNavigate';
+
+const RedirectDocumentation = () => {
+  const { pathname, search } = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (pathname.startsWith('/documentation')) {
+      const newPath = pathname.replace('/documentation', '/docs');
+      navigate(`${newPath}${search}`, { replace: true }); // Perform a full-page reload
+    }
+  }, [pathname]);
+
+  return null; // Render nothing
+};
+
+export default RedirectDocumentation;

--- a/src/main/routing/TopLevelRoutePath.ts
+++ b/src/main/routing/TopLevelRoutePath.ts
@@ -15,6 +15,7 @@ export enum TopLevelRoutePath {
   Profile = 'profile',
   Restricted = 'restricted',
   Docs = 'docs',
+  Documentation = 'documentation',
   Contact = 'contact',
   _Landing = 'landing', // Legacy route that redirects to Welcome site
   _Identity = 'identity', // Legacy route that's not used anymore but is decided to be reserved

--- a/src/main/routing/TopLevelRoutes.tsx
+++ b/src/main/routing/TopLevelRoutes.tsx
@@ -21,6 +21,7 @@ import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErr
 import { UrlResolverProvider } from './urlResolver/UrlResolverProvider';
 
 const DocumentationPage = lazyWithGlobalErrorHandler(() => import('@/main/documentation/DocumentationPage'));
+const RedirectDocumentation = lazyWithGlobalErrorHandler(() => import('@/main/documentation/RedirectDocumentation'));
 const SpaceExplorerPage = lazyWithGlobalErrorHandler(
   () => import('@/main/topLevelPages/topLevelSpaces/SpaceExplorerPage')
 );
@@ -89,6 +90,14 @@ export const TopLevelRoutes = () => {
           element={
             <Suspense fallback={<Loading />}>
               <DocumentationPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path={`${TopLevelRoutePath.Documentation}/*`}
+          element={
+            <Suspense fallback={<Loading />}>
+              <RedirectDocumentation />
             </Suspense>
           }
         />


### PR DESCRIPTION
The `/documentation/*` path is handled on Trafik side where there's a redirect to the stand-alone documentation site.

However, if you try to navigate to a path to it in the client-web, the SPA navigation fails as there is no such route defined (not sure why it doesn't render 404, hm).

This PR fixes that, defining the documentation path and applying logic to redirect to the `/docs/*` where the documentation site is embedded. 

Expected / To reproduce:
- Paste a link to the documentation site (use /documentation/ path) in any block supporting links (description);
- click on it;
- it should redirect to the same link but with /docs/ instead of documentation/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Users visiting URLs starting with "/documentation" are now automatically redirected to the equivalent "/docs" path, ensuring a seamless navigation experience.
- **Chores**
	- Added internal support for recognizing "/documentation" as a valid top-level route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->