### PR TITLE
Routing fixes

### DIFF
--- a/src/domain/platform/admin/layout/EntitySettingsLayout/SettingsSection.ts
+++ b/src/domain/platform/admin/layout/EntitySettingsLayout/SettingsSection.ts
@@ -5,7 +5,6 @@ export enum SettingsSection {
   Communications = 'communications',
   Authorization = 'authorization',
   Subspaces = 'subspaces',
-  Subsubspaces = 'subsubspaces',
   Templates = 'templates',
   Storage = 'storage',
   SpaceSettings = 'space-settings',

--- a/src/domain/space/components/SubspacePageBanner/SubspacePageBanner.tsx
+++ b/src/domain/space/components/SubspacePageBanner/SubspacePageBanner.tsx
@@ -19,27 +19,28 @@ const SubspacePageBanner = () => {
   });
 
   const bannerVisual = useMemo(() => {
-    const spaceBanner = data?.lookup.level0Space?.about.profile.banner;
-    if (data?.lookup.level0Space?.about.profile.banner?.uri) {
+    const spaceBanner = data?.lookup.level0Space?.about?.profile.banner;
+    if (data?.lookup.level0Space?.about?.profile.banner?.uri) {
       return spaceBanner;
     }
     return {
       ...spaceBanner,
       uri: defaultVisualUrls[VisualType.Banner],
     };
-  }, [data]);
+  }, [data?.lookup.level0Space?.about?.profile.banner?.id]);
 
   if (spaceLevel === SpaceLevel.L0) {
     return null;
   }
+
   return (
     <PageBanner
       banner={bannerVisual}
       cardComponent={SpacePageBannerCard}
-      displayName={data?.lookup.space?.about.profile.displayName ?? ''}
-      tagline={data?.lookup.space?.about.profile.tagline ?? ''}
-      avatar={data?.lookup.space?.about.profile.avatar}
-      tags={data?.lookup.space?.about.profile.tagset?.tags}
+      displayName={data?.lookup.space?.about?.profile.displayName ?? ''}
+      tagline={data?.lookup.space?.about?.profile.tagline ?? ''}
+      avatar={data?.lookup.space?.about?.profile.avatar}
+      tags={data?.lookup.space?.about?.profile.tagset?.tags}
     />
   );
 };

--- a/src/domain/space/pages/SpaceCalloutPage.tsx
+++ b/src/domain/space/pages/SpaceCalloutPage.tsx
@@ -1,28 +1,10 @@
 import CalloutPage from '@/domain/collaboration/CalloutPage/CalloutPage';
-import SpaceSubspacesPage from '../layout/tabbedLayout/Tabs/SpaceSubspacesPage';
-import SpaceKnowledgeBasePage from '@/domain/space/layout/tabbedLayout/Tabs/SpaceKnowledgeBase/SpaceKnowledgeBasePage';
 import { SpaceCalloutDialogProps } from '@/domain/space/pages/SpaceCalloutDialogProps';
-import SpaceCommunityPage from '../layout/tabbedLayout/Tabs/SpaceCommunityPage/SpaceCommunityPage';
 import { useSpace } from '../context/useSpace';
-import SpaceDashboardPage from '@/domain/space/layout/tabbedLayout/Tabs/SpaceDashboard/SpaceDashboardPage';
 import { buildSpaceSectionUrl } from '@/main/routing/urlBuilders';
+import { SpaceTabbedPages } from '@/domain/space/routing/SpaceRoutes';
 
-const renderPage = (sectionIndex: number | undefined) => {
-  switch (sectionIndex) {
-    case 0:
-      return <SpaceDashboardPage />;
-    case 1:
-      return <SpaceCommunityPage />;
-    case 2:
-      return <SpaceSubspacesPage />;
-    case 3:
-    case 4:
-      return <SpaceKnowledgeBasePage sectionIndex={sectionIndex} />;
-    default: {
-      return undefined;
-    }
-  }
-};
+const renderPage = () => <SpaceTabbedPages />;
 
 const SpaceCalloutPage = (props: SpaceCalloutDialogProps) => {
   const { space } = useSpace();

--- a/src/domain/space/routing/SpaceRoutes.tsx
+++ b/src/domain/space/routing/SpaceRoutes.tsx
@@ -91,7 +91,7 @@ const SpaceTabbedPages = () => {
     if (defaultTabIndex && defaultTabIndex >= 0) {
       sectionIndex = defaultTabIndex.toString();
     } else {
-      sectionIndex = '1';
+      sectionIndex = '0'; // set default to dashboard
     }
   } else {
     sectionIndex = `${parseInt(sectionIndex) - 1}`;

--- a/src/domain/space/routing/SpaceRoutes.tsx
+++ b/src/domain/space/routing/SpaceRoutes.tsx
@@ -75,7 +75,7 @@ const SpaceProtectedRoutes = () => {
   return <Outlet />;
 };
 
-const SpaceTabbedPages = () => {
+export const SpaceTabbedPages = () => {
   const { spaceId, spaceLevel } = useUrlResolver();
   const [isTabsMenuOpen, setTabsMenuOpen] = useState(false);
   const { isSmallScreen } = useScreenSize();

--- a/src/domain/spaceAdmin/layout/SpaceAdminTabsL1.tsx
+++ b/src/domain/spaceAdmin/layout/SpaceAdminTabsL1.tsx
@@ -22,7 +22,7 @@ export const spaceAdminTabsL1: TabDefinition<SettingsSection>[] = [
     icon: ForumOutlinedIcon,
   },
   {
-    section: SettingsSection.Subsubspaces,
+    section: SettingsSection.Subspaces,
     route: 'opportunities',
     icon: FlagOutlinedIcon,
   },


### PR DESCRIPTION
- fix infinite loop in subspace settings (not only);
- console error with wrong tab section on L1 admin subspaces;
- the default Space tab was index 1 - community;
- the code for renderPage for callouts on the space level was duplicated and lacks the space tabs;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when displaying banners on subspace pages by handling missing profile information more gracefully.
	- Updated an admin tab to point to the correct settings section for easier navigation.
	- Set the default tab to the dashboard for a more intuitive starting view in space pages.
- **New Features**
	- Simplified space page navigation by consolidating multiple tab pages into a single tabbed component.
- **Chores**
	- Removed deprecated settings section to streamline admin options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->