### PR TITLE
Fix startDate Datepicker not showing up empty when editing an event

### DIFF
--- a/src/domain/timeline/calendar/views/CalendarEventForm.tsx
+++ b/src/domain/timeline/calendar/views/CalendarEventForm.tsx
@@ -65,7 +65,7 @@ const CalendarEventForm = ({
 
   const dateNow = new Date();
 
-  const initialStartDate = useMemo(() => event?.startDate ?? dateNow, [event]);
+  const initialStartDate = useMemo(() => (event?.startDate ? new Date(event.startDate) : dateNow), [event]);
   const initialEndDate = useMemo(() => {
     if (!event?.startDate) {
       return dateNow;


### PR DESCRIPTION
I've detected a bug related to the date-picker package update. This fixes it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of event start dates in the calendar event form to ensure dates are consistently recognized and processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->