### PR TITLE
More routing refresh fixes

### DIFF
--- a/src/domain/community/pendingMembership/PendingMembershipsDialog.tsx
+++ b/src/domain/community/pendingMembership/PendingMembershipsDialog.tsx
@@ -59,6 +59,11 @@ const PendingMembershipsDialog = () => {
     invitation => invitation.invitation.contributorType !== RoleSetContributorType.Virtual
   );
 
+  const handleSpaceCardClick = (spaceUrl: string) => {
+    closeDialog();
+    navigate(spaceUrl);
+  };
+
   const onInvitationAccept = () => {
     if (openDialog?.spaceUri) {
       navigate(openDialog?.spaceUri);
@@ -133,6 +138,7 @@ const PendingMembershipsDialog = () => {
                           tags={hydratedApplication.space.about.profile.tagset?.tags ?? []}
                           banner={hydratedApplication.space.about.profile.cardBanner}
                           spaceUri={hydratedApplication.space.about.profile.url}
+                          onClick={() => handleSpaceCardClick(hydratedApplication.space.about.profile.url)}
                         >
                           <SpaceCardTagline>{hydratedApplication.space.about.profile.tagline ?? ''}</SpaceCardTagline>
                         </SpaceCardBase>

--- a/src/domain/space/about/SpaceAboutDialog.tsx
+++ b/src/domain/space/about/SpaceAboutDialog.tsx
@@ -192,7 +192,15 @@ const SpaceAboutDialog = ({
                 />
               </PageContentBlock>
               <Gutters disablePadding display="flex" flexDirection="column" alignItems="center" width="100%">
-                <ApplicationButtonContainer spaceId={space.id} parentSpaceId={parentSpaceId}>
+                <ApplicationButtonContainer
+                  spaceId={space.id}
+                  parentSpaceId={parentSpaceId}
+                  onJoin={() => {
+                    if (aboutProfile?.url) {
+                      navigate(aboutProfile.url);
+                    }
+                  }}
+                >
                   {(applicationButtonProps, loading) => {
                     if (loading || applicationButtonProps.isMember) {
                       return null;

--- a/src/domain/space/layout/SpacePageLayout.tsx
+++ b/src/domain/space/layout/SpacePageLayout.tsx
@@ -22,6 +22,7 @@ import PageBannerWatermark from '@/main/ui/platformNavigation/PageBannerWatermar
 // keep the logic around sections in one place - SpaceRoutes
 export const SpacePageLayout = () => {
   const { spaceId, spaceHierarchyPath, spaceLevel } = useUrlResolver();
+
   const sectionIndex = useSectionIndex({ spaceId, spaceLevel });
 
   const { isSmallScreen } = useScreenSize();

--- a/src/domain/space/layout/tabbedLayout/Tabs/SpaceTabs.tsx
+++ b/src/domain/space/layout/tabbedLayout/Tabs/SpaceTabs.tsx
@@ -60,9 +60,12 @@ const SpaceTabs = ({ currentTab, mobile, actions, onMenuOpen }: SpacePageTabsPro
 
   const { pathname } = useLocation();
 
-  const { space, permissions } = useSpace();
+  const { space, permissions, loading } = useSpace();
   const { id: spaceId, about } = space;
-  const { tabs, showSettings } = useSpaceTabs({ spaceId: permissions.canRead ? spaceId : undefined });
+  const { tabs, showSettings } = useSpaceTabs({
+    skip: !permissions.canRead || loading,
+    spaceId: permissions.canRead ? spaceId : undefined,
+  });
 
   const spaceUrl = about.profile.url;
   const { share, shareDialog } = useShare({ url: spaceUrl, entityTypeName: 'space' });

--- a/src/domain/space/layout/useSectionIndex.tsx
+++ b/src/domain/space/layout/useSectionIndex.tsx
@@ -2,11 +2,17 @@ import { useSearchParams } from 'react-router-dom';
 import useSpaceTabs from './tabbedLayout/layout/useSpaceTabs';
 import { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import { TabbedLayoutParams } from '@/main/routing/urlBuilders';
+import { useSpace } from '../context/useSpace';
 
 export const useSectionIndex = ({ spaceId, spaceLevel }: { spaceId?: string; spaceLevel?: SpaceLevel }) => {
   const [searchParams] = useSearchParams();
 
-  const { defaultTabIndex } = useSpaceTabs({ spaceId: spaceId, skip: !spaceId || spaceLevel !== SpaceLevel.L0 });
+  const { permissions } = useSpace();
+
+  const { defaultTabIndex } = useSpaceTabs({
+    spaceId: spaceId,
+    skip: !spaceId || spaceLevel !== SpaceLevel.L0 || !permissions.canRead,
+  });
 
   let sectionIndex = searchParams.get(TabbedLayoutParams.Section);
   if (!sectionIndex) {

--- a/src/domain/space/routing/SpaceRoutes.tsx
+++ b/src/domain/space/routing/SpaceRoutes.tsx
@@ -105,15 +105,17 @@ const SpaceRoutes = () => {
             />
             <Route path={`${EntityPageSection.Settings}/*`} element={<SpaceAdminL0Route />} />
             <Route path={`/:dialog?/:${nameOfUrl.calendarEventNameId}?`} element={<SpaceDashboardPage />} />
-            <Route
-              path={`/challenges/:${nameOfUrl.subspaceNameId}/*`}
-              element={
-                <SubspaceContextProvider>
-                  <SubspaceRoutes />
-                </SubspaceContextProvider>
-              }
-            />
           </Route>
+          {/* subspaces have their own protections */}
+          <Route
+            path={`/challenges/:${nameOfUrl.subspaceNameId}/*`}
+            element={
+              <SubspaceContextProvider>
+                <SubspaceRoutes />
+              </SubspaceContextProvider>
+            }
+          />
+
           <Route path="*" element={<LegacyRoutesRedirects />} />
         </Route>
       </Routes>

--- a/src/domain/space/routing/SubspaceRoutes.tsx
+++ b/src/domain/space/routing/SubspaceRoutes.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { Route, Routes } from 'react-router';
 import { Outlet, Navigate } from 'react-router-dom';
 import { Error404 } from '@/core/pages/Errors/Error404';
@@ -36,19 +36,10 @@ const InnovationFlowStateContextProvider = ({ children }) => {
 
 const SubspaceRoute = ({ level = SpaceLevel.L1 }: { level?: SpaceLevel }) => {
   const { subspace, permissions, loading } = useSubSpace();
-
-  const { canRead, spaceId } = useMemo(
-    () => ({
-      canRead: permissions.canRead,
-      spaceId: subspace.id,
-    }),
-    [subspace, permissions]
-  );
-
   if (loading) {
     return <Loading />;
   }
-  if (spaceId && !loading && !canRead) {
+  if (subspace.id && !loading && !permissions.canRead) {
     return (
       <Routes>
         <Route path={EntityPageSection.About} element={<SubspaceAboutPage />} />
@@ -58,7 +49,7 @@ const SubspaceRoute = ({ level = SpaceLevel.L1 }: { level?: SpaceLevel }) => {
   }
 
   return (
-    <StorageConfigContextProvider locationType="space" spaceId={spaceId}>
+    <StorageConfigContextProvider locationType="space" spaceId={subspace.id}>
       <InnovationFlowStateContextProvider>
         <Routes>
           {/* subspace settings page doesn't need any subpsace layout - it uses the level 0 space page banner */}


### PR DESCRIPTION
Fixes:
- https://github.com/alkem-io/client-web/issues/8121
- https://github.com/alkem-io/client-web/issues/7980
- https://github.com/alkem-io/client-web/issues/8163
- https://github.com/alkem-io/client-web/issues/8109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - You can now click on a space card in the pending memberships dialog to close the dialog and navigate directly to the selected space.
  - The join button in the space about dialog now navigates you to the relevant profile page after joining, if available.

- **Bug Fixes**
  - Improved stability of URL resolution, ensuring the last known state is maintained during loading transitions.

- **Refactor**
  - Enhanced permission checks to prevent unnecessary data fetching and tab loading when access is restricted or data is still loading.
  - Simplified internal logic for subspace route handling and permission evaluation.
  - Adjusted route structure for subspaces to clarify protection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->