### PR TITLE
Fix the APM console error

### DIFF
--- a/src/core/analytics/apm/context/ApmProvider.tsx
+++ b/src/core/analytics/apm/context/ApmProvider.tsx
@@ -20,7 +20,9 @@ export const ApmProvider = ({ children }: PropsWithChildren) => {
 
   const initFn = useApmInit(user);
 
-  useEffect(() => setApm(initFn), [initFn]);
+  useEffect(() => {
+    setApm(initFn);
+  }, [initFn]);
 
   const value = useMemo(() => ({ apm, setUser }), [apm]);
 

--- a/src/core/analytics/apm/useApmInit.ts
+++ b/src/core/analytics/apm/useApmInit.ts
@@ -45,9 +45,11 @@ export const useApmInit = (user: CurrentUserModel | undefined) => {
   const rumEnabled = apmConfig?.rumEnabled ?? false;
   const endpoint = apmConfig?.endpoint;
   const environment = locations?.environment;
+  // prevent console errors in dev mode
+  const isInitAllowed = import.meta.env.MODE === 'production';
 
   return useCallback(() => {
-    if (!endpoint || !environment) {
+    if (!endpoint || !environment || !isInitAllowed) {
       return undefined;
     }
 


### PR DESCRIPTION
In case of non-prod env, don't initialize APM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented APM initialization in non-production environments to avoid console errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->