### PR TITLE
Fix the layout shift on Space Dashboard page

### DIFF
--- a/src/domain/space/layout/tabbedLayout/Tabs/SpaceDashboard/SpaceDashboardPage.tsx
+++ b/src/domain/space/layout/tabbedLayout/Tabs/SpaceDashboard/SpaceDashboardPage.tsx
@@ -73,15 +73,15 @@ const SpaceDashboardPage = () => {
 
   return (
     <>
-      <PageContent>
-        {!loading && (
-          <ApplicationButtonContainer spaceId={spaceId}>
-            {(applicationButtonProps, loading) => {
-              if (loading || applicationButtonProps.isMember) {
-                return null;
-              }
+      {!loading && (
+        <ApplicationButtonContainer spaceId={spaceId}>
+          {(applicationButtonProps, loading) => {
+            if (loading || applicationButtonProps.isMember) {
+              return null;
+            }
 
-              return (
+            return (
+              <PageContent gridContainerProps={{ paddingBottom: 0 }} sx={{ flexGrow: 0 }}>
                 <PageContentColumn columns={12}>
                   <ApplicationButton
                     {...applicationButtonProps}
@@ -92,11 +92,11 @@ const SpaceDashboardPage = () => {
                     spaceLevel={spaceLevel}
                   />
                 </PageContentColumn>
-              );
-            }}
-          </ApplicationButtonContainer>
-        )}
-      </PageContent>
+              </PageContent>
+            );
+          }}
+        </ApplicationButtonContainer>
+      )}
 
       <SpaceDashboardView
         space={space}


### PR DESCRIPTION
Due to some Application Button position changes, there was an odd offset on top of the content in the Space Dashboard.
The layout was altered to render as previously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to filter out existing members or contributors when inviting new contributors, ensuring only eligible users are shown in invite dialogs.
  - Introduced a new GraphQL query to fetch user and membership information for inviting users to a space.

- **Enhancements**
  - Improved flexibility in contributor selection by allowing external filter functions to be passed to selection components.
  - Updated privilege checks for virtual contributor wizard to use a broader "Read" privilege.

- **Removed**
  - Removed the "inspiration" button from the contribute creation block for a simplified interface.

- **Other**
  - Updated package version to 0.91.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->