### PR TITLE
Fix the error on deletion of a post in call for posts callout.

### DIFF
--- a/src/domain/collaboration/post/pages/PostSettingsPage.tsx
+++ b/src/domain/collaboration/post/pages/PostSettingsPage.tsx
@@ -92,8 +92,11 @@ const PostSettingsPage = ({ postId, calloutId, calloutsSetId, onClose }: PostSet
       return;
     }
 
-    await postSettings.handleDelete(postSettings.post.id);
+    // close the dialog optimistically before deleting to prevent errors querying the post settings
+    // use the inClose directly as we don't want to show the confirmation dialog
     onClose();
+
+    await postSettings.handleDelete(postSettings.post.id);
   }, [postSettings, post, onClose]);
 
   const onCloseEdit = useCallback(() => {


### PR DESCRIPTION
On deletion, the modal is still behind, trying to load the data, resulting in errors. 
Closing the modal optimistically prevents it.