### PR TITLE
Remove redundant space information from Innovation hubs cards

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -5603,13 +5603,6 @@ export const AccountInformationDocument = gql`
               ...VisualUri
             }
           }
-          spaceVisibilityFilter
-          spaceListFilter {
-            id
-            about {
-              ...SpaceAboutLight
-            }
-          }
           subdomain
         }
       }
@@ -5617,7 +5610,6 @@ export const AccountInformationDocument = gql`
   }
   ${VisualUriFragmentDoc}
   ${AccountItemProfileFragmentDoc}
-  ${SpaceAboutLightFragmentDoc}
 `;
 
 /**
@@ -11337,13 +11329,6 @@ export const AccountResourcesInfoDocument = gql`
               ...VisualUri
             }
           }
-          spaceVisibilityFilter
-          spaceListFilter {
-            id
-            about {
-              ...SpaceAboutLight
-            }
-          }
           subdomain
         }
       }
@@ -11351,7 +11336,6 @@ export const AccountResourcesInfoDocument = gql`
   }
   ${AccountResourceProfileFragmentDoc}
   ${VisualUriFragmentDoc}
-  ${SpaceAboutLightFragmentDoc}
 `;
 
 /**

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -9001,7 +9001,6 @@ export type AccountInformationQuery = {
           innovationHubs: Array<{
             __typename?: 'InnovationHub';
             id: string;
-            spaceVisibilityFilter?: SpaceVisibility | undefined;
             subdomain: string;
             profile: {
               __typename?: 'Profile';
@@ -9012,36 +9011,6 @@ export type AccountInformationQuery = {
               banner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
               avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
             };
-            spaceListFilter?:
-              | Array<{
-                  __typename?: 'Space';
-                  id: string;
-                  about: {
-                    __typename?: 'SpaceAbout';
-                    id: string;
-                    isContentPublic: boolean;
-                    profile: {
-                      __typename?: 'Profile';
-                      id: string;
-                      displayName: string;
-                      url: string;
-                      tagline?: string | undefined;
-                      description?: string | undefined;
-                      tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-                      avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-                      cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-                    };
-                    membership: {
-                      __typename?: 'SpaceAboutMembership';
-                      myMembershipStatus?: CommunityMembershipStatus | undefined;
-                      myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-                      communityID: string;
-                      roleSetID: string;
-                    };
-                    guidelines: { __typename?: 'CommunityGuidelines'; id: string };
-                  };
-                }>
-              | undefined;
           }>;
         }
       | undefined;
@@ -16427,7 +16396,6 @@ export type AccountResourcesInfoQuery = {
           innovationHubs: Array<{
             __typename?: 'InnovationHub';
             id: string;
-            spaceVisibilityFilter?: SpaceVisibility | undefined;
             subdomain: string;
             profile: {
               __typename?: 'Profile';
@@ -16437,36 +16405,6 @@ export type AccountResourcesInfoQuery = {
               banner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
               avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
             };
-            spaceListFilter?:
-              | Array<{
-                  __typename?: 'Space';
-                  id: string;
-                  about: {
-                    __typename?: 'SpaceAbout';
-                    id: string;
-                    isContentPublic: boolean;
-                    profile: {
-                      __typename?: 'Profile';
-                      id: string;
-                      displayName: string;
-                      url: string;
-                      tagline?: string | undefined;
-                      description?: string | undefined;
-                      tagset?: { __typename?: 'Tagset'; id: string; tags: Array<string> } | undefined;
-                      avatar?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-                      cardBanner?: { __typename?: 'Visual'; id: string; uri: string; name: string } | undefined;
-                    };
-                    membership: {
-                      __typename?: 'SpaceAboutMembership';
-                      myMembershipStatus?: CommunityMembershipStatus | undefined;
-                      myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-                      communityID: string;
-                      roleSetID: string;
-                    };
-                    guidelines: { __typename?: 'CommunityGuidelines'; id: string };
-                  };
-                }>
-              | undefined;
           }>;
         }
       | undefined;

--- a/src/domain/account/queries/AccountInformation.graphql
+++ b/src/domain/account/queries/AccountInformation.graphql
@@ -75,13 +75,6 @@ query AccountInformation($accountId: UUID!) {
             ...VisualUri
           }
         }
-        spaceVisibilityFilter
-        spaceListFilter {
-          id
-          about {
-            ...SpaceAboutLight
-          }
-        }
         subdomain
       }
     }

--- a/src/domain/community/contributor/Account/AccountResourcesView.tsx
+++ b/src/domain/community/contributor/Account/AccountResourcesView.tsx
@@ -4,7 +4,7 @@ import PageContentBlockHeader from '@/core/ui/content/PageContentBlockHeader';
 import PageContentBlockGrid from '@/core/ui/content/PageContentBlockGrid';
 import ScrollableCardsLayoutContainer from '@/core/ui/card/cardsLayout/ScrollableCardsLayoutContainer';
 import SpaceTile from '@/domain/space/components/cards/SpaceTile';
-import { SpaceLevel, SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
+import { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import { BlockTitle } from '@/core/ui/typography';
 import Gutters from '@/core/ui/grid/Gutters';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +17,6 @@ import { Button } from '@mui/material';
 import { Actions } from '@/core/ui/actions/Actions';
 import { ExpandMore } from '@mui/icons-material';
 import { SpaceAboutLightModel } from '@/domain/space/about/model/spaceAboutLight.model';
-import { SpaceAboutMinimalUrlModel } from '@/domain/space/about/model/spaceAboutMinimal.model';
 import { useScreenSize } from '@/core/ui/grid/constants';
 
 const VISIBLE_SPACE_LIMIT = 6;
@@ -58,11 +57,6 @@ export interface AccountResourcesProps {
     profile: AccountProfile & {
       banner?: { uri: string };
     };
-    spaceVisibilityFilter?: SpaceVisibility;
-    spaceListFilter?: {
-      id: string;
-      about: SpaceAboutMinimalUrlModel;
-    }[];
     subdomain: string;
   }[];
 }
@@ -145,9 +139,7 @@ export const AccountResourcesView = ({ accountResources, title }: AccountResourc
             <Gutters>
               <BlockTitle>{t('pages.admin.generic.sections.account.customHomepages')}</BlockTitle>
               <Gutters disablePadding>
-                {accountResources?.innovationHubs?.map(hub => (
-                  <InnovationHubCardHorizontal key={hub.id} {...hub} />
-                ))}
+                {accountResources?.innovationHubs?.map(hub => <InnovationHubCardHorizontal key={hub.id} {...hub} />)}
               </Gutters>
             </Gutters>
           </GridItem>

--- a/src/domain/community/contributor/Account/ContributorAccountView.tsx
+++ b/src/domain/community/contributor/Account/ContributorAccountView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import PageContentColumn from '@/core/ui/content/PageContentColumn';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
@@ -18,7 +18,6 @@ import {
   LicenseEntitlement,
   LicenseEntitlementType,
   SpaceLevel,
-  SpaceVisibility,
 } from '@/core/apollo/generated/graphql-schema';
 import MenuItemWithIcon from '@/core/ui/menu/MenuItemWithIcon';
 import { DeleteOutline, SettingsOutlined } from '@mui/icons-material';
@@ -43,7 +42,6 @@ import RoundedIcon from '@/core/ui/icon/RoundedIcon';
 import { Button, IconButton } from '@mui/material';
 import useNavigate from '@/core/routing/useNavigate';
 import { Identifiable } from '@/core/utils/Identifiable';
-import { SpaceAboutMinimalUrlModel } from '@/domain/space/about/model/spaceAboutMinimal.model';
 
 const enum Entities {
   Space = 'Space',
@@ -107,11 +105,6 @@ export interface AccountTabResourcesProps {
     profile: AccountProfile & {
       banner?: { uri: string };
     };
-    spaceVisibilityFilter?: SpaceVisibility;
-    spaceListFilter?: {
-      id: string;
-      about: SpaceAboutMinimalUrlModel;
-    }[];
     subdomain: string;
   }[];
 }

--- a/src/domain/community/contributor/useAccountResources/AccountResourcesInfo.graphql
+++ b/src/domain/community/contributor/useAccountResources/AccountResourcesInfo.graphql
@@ -43,13 +43,6 @@ query AccountResourcesInfo($accountId: UUID!) {
             ...VisualUri
           }
         }
-        spaceVisibilityFilter
-        spaceListFilter {
-          id
-          about {
-            ...SpaceAboutLight
-          }
-        }
         subdomain
       }
     }

--- a/src/domain/innovationHub/InnovationHubCardHorizontal/InnovationHubCardHorizontal.tsx
+++ b/src/domain/innovationHub/InnovationHubCardHorizontal/InnovationHubCardHorizontal.tsx
@@ -2,11 +2,9 @@ import { Box, Skeleton } from '@mui/material';
 import BadgeCardView from '@/core/ui/list/BadgeCardView';
 import SpaceAvatar from '@/domain/space/components/SpaceAvatar';
 import RouterLink from '@/core/ui/link/RouterLink';
-import { Caption, BlockTitle } from '@/core/ui/typography';
+import { BlockTitle } from '@/core/ui/typography';
 import OneLineMarkdown from '@/core/ui/markdown/OneLineMarkdown';
-import { SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
 import { gutters } from '@/core/ui/grid/utils';
-import { useTranslation } from 'react-i18next';
 import { buildInnovationHubUrl } from '@/main/routing/urlBuilders';
 import ActionsMenu from '@/core/ui/card/ActionsMenu';
 import { AvatarSize } from '@/core/ui/avatar/Avatar';
@@ -38,32 +36,7 @@ export interface InnovationHubCardHorizontalProps extends InnovationHubSpacesPro
 }
 
 type InnovationHubSpacesProps = {
-  spaceVisibilityFilter?: SpaceVisibility;
-  spaceListFilter?: {
-    id: string;
-    about?: {
-      profile: {
-        displayName: string;
-      };
-    };
-  }[];
   actions?: React.ReactNode;
-};
-
-const InnovationHubSpaces = ({ spaceVisibilityFilter, spaceListFilter }: InnovationHubSpacesProps) => {
-  const { t } = useTranslation();
-  if (spaceVisibilityFilter) {
-    return <Caption>{t(`common.enums.space-visibility.${spaceVisibilityFilter}` as const)}</Caption>;
-  }
-  if (spaceListFilter && spaceListFilter.length) {
-    const spaceList = spaceListFilter.map(space => space.about?.profile.displayName).join(', ');
-    return (
-      <Caption maxWidth={gutters(7)} noWrap textOverflow="ellipsis" overflow="hidden" title={spaceList}>
-        {spaceList}
-      </Caption>
-    );
-  }
-  return null;
 };
 
 const InnovationHubCardHorizontal = ({
@@ -71,7 +44,6 @@ const InnovationHubCardHorizontal = ({
   subdomain,
   actions = undefined,
   size = 'medium',
-  ...spaces
 }: InnovationHubCardHorizontalProps) => {
   return (
     <BadgeCardView
@@ -87,7 +59,6 @@ const InnovationHubCardHorizontal = ({
           <BlockTitle>{displayName}</BlockTitle>
           <OneLineMarkdown>{description ?? ''}</OneLineMarkdown>
         </Box>
-        <InnovationHubSpaces {...spaces} />
       </Box>
     </BadgeCardView>
   );


### PR DESCRIPTION
Remove the spaces in the inno hub horizontal card in:
- account (org/user);
- My resources - user/org profile;
The redundant data was removed from the queries as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed unused properties and components related to space visibility and space list filters from account and innovation hub views.
  - Simplified the structure of innovation hub cards by eliminating space-related display and props.
- **Chores**
  - Cleaned up imports and interfaces to remove references to deprecated space-related fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->