### PR TITLE
Reveal the option for comments in post callout edit

### DIFF
--- a/src/domain/collaboration/callout/CalloutView/CalloutView.tsx
+++ b/src/domain/collaboration/callout/CalloutView/CalloutView.tsx
@@ -29,7 +29,7 @@ const CalloutView = ({ callout, ...props }: CalloutViewProps) => {
         </WhiteboardCollectionCalloutContainer>
       );
     case CalloutType.Post:
-      return <CommentsCallout callout={callout} disablePostResponses {...props} />;
+      return <CommentsCallout callout={callout} {...props} />;
     case CalloutType.LinkCollection:
       return <LinkCollectionCallout callout={callout} {...props} />;
     case CalloutType.Whiteboard:


### PR DESCRIPTION
Fixing only the visibility of 'Accept new responses' for Comments Callout. The options from the ticket remain as is for now.
https://github.com/alkem-io/client-web/issues/8219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled post responses in the CommentsCallout component for callouts of type "Post". Users can now interact with post responses as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->