### PR TITLE
no notification on callout creation by default

### DIFF
--- a/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
+++ b/src/domain/collaboration/callout/creationDialog/CalloutCreationDialog.tsx
@@ -68,7 +68,7 @@ const CalloutCreationDialog = ({
   const [selectedCalloutType, setSelectedCalloutType] = useState<CalloutType>();
   const [isPublishDialogOpen, setIsConfirmPublishDialogOpen] = useState(false);
   const [isConfirmCloseDialogOpen, setIsConfirmCloseDialogOpen] = useState(false);
-  const [sendNotification, setSendNotification] = useState(true);
+  const [sendNotification, setSendNotification] = useState(false);
   const [importCalloutTemplateDialogOpen, setImportCalloutDialogOpen] = useState(false);
 
   useLayoutEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Changed the default setting so that notifications are now disabled by default when publishing a callout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->