### PR TITLE
Privacy settings for L2 enabled

### DIFF
--- a/src/domain/spaceAdmin/routing/SpaceAdminRouteL2.tsx
+++ b/src/domain/spaceAdmin/routing/SpaceAdminRouteL2.tsx
@@ -43,7 +43,7 @@ export const SpaceAdminL2Route = () => {
     level: subspace?.level,
     membershipsEnabled: false,
     subspacesEnabled: false,
-    privateSettingsEnabled: false,
+    privateSettingsEnabled: true,
     parentSpaceUrl: space.about.profile?.url, // Should be L1
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled private settings functionality on the Space Admin Settings page for subspace-level routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->