### PR TITLE
Disables caching for index.html

### DIFF
--- a/.build/.nginx/nginx.conf
+++ b/.build/.nginx/nginx.conf
@@ -7,6 +7,15 @@ http {
         listen 80;
         root  /usr/share/nginx/html;
         include /etc/nginx/mime.types;
+
+        # Prevent caching of index.html
+        location = /index.html {
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+            try_files $uri =404;
+        }
+
         try_files $uri /index.html;
         location /appui {
             try_files $uri /index.html;


### PR DESCRIPTION
Ensures that the index.html file is not cached by browsers or proxies.

This prevents users from seeing outdated versions of the application
after deployment.


I've updated the nginx configuration to prevent caching of index.html. Here's what I added:

1. **Specific location block for index.html**: Added a `location = /index.html` block that matches exactly the index.html file
2. **Cache-Control headers**: Added headers to ensure the file is never cached:
   - `no-store`: Prevents storing the response in any cache
   - `no-cache`: Forces revalidation with the server
   - `must-revalidate`: Ensures cached copies are revalidated
   - `proxy-revalidate`: Applies to proxy caches
   - `max-age=0`: Sets cache lifetime to 0 seconds
3. **Additional headers**: Added `Pragma: no-cache` and `Expires: 0` for compatibility with older browsers and proxies

This configuration ensures that whenever someone requests index.html (directly or through the fallback mechanism), it will always be served fresh from the server without any caching. This is particularly important for single-page applications where the index.html file might contain updated build hashes or configuration that needs to be current.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated server configuration to prevent caching of the main page, ensuring users always receive the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->