### PR TITLE
Adds no-cache headers to prevent caching

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,8 +4,71 @@ import { defineConfig } from 'vite';
 import svgrPlugin from 'vite-plugin-svgr';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
+/**
+ * Vite configuration for the Alkemio client-web project.
+ *
+ * - Integrates React, TypeScript path resolution, and SVGR plugins.
+ * - Adds a custom plugin (`no-cache-index`) to prevent caching of `index.html` and `/home` routes in the dev server by setting aggressive no-cache headers.
+ * - Sets up path aliasing for `@` to `./src`.
+ * - Configures the dev server to run on `localhost:3001`.
+ * - Customizes build output directory, sourcemaps, and Rollup output filenames.
+ * - Optimizes dependencies for Emotion and MUI Tooltip.
+ *
+ * @module vite.config
+ */
 export default defineConfig({
-  plugins: [react(), viteTsconfigPaths(), svgrPlugin()],
+  plugins: [
+    react(),
+    viteTsconfigPaths(),
+    svgrPlugin(),
+    // Plugin to prevent index.html caching in dev server
+    {
+      /**
+       * Vite plugin server configuration hook to disable caching for specific routes.
+       *
+       * Adds middleware to the dev server that intercepts requests to '/', '/home', and any URL ending with '/home'.
+       * For these routes, it overrides the response methods to set aggressive no-cache headers, ensuring that
+       * browsers and proxies do not cache the responses.
+       *
+       * @param {import('vite').ViteDevServer} server - The Vite development server instance.
+       */
+      name: 'no-cache-index',      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url === '/' || req.url === '/home' || req.url?.endsWith('/home')) {
+            // Intercept the response to remove caching headers
+            const originalSend = res.send;
+            const originalEnd = res.end;
+            const originalWrite = res.write;
+
+            // Override response methods to set headers just before sending
+            res.send = function(chunk) {
+              setNoCacheHeaders(res);
+              return originalSend.call(this, chunk);
+            };
+
+            res.end = function(chunk) {
+              setNoCacheHeaders(res);
+              return originalEnd.call(this, chunk);
+            };
+
+            res.write = function(chunk) {
+              setNoCacheHeaders(res);
+              return originalWrite.call(this, chunk);
+            };
+
+            function setNoCacheHeaders(response) {
+
+              // Set comprehensive no-cache headers - most aggressive approach
+              response.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0');
+              response.setHeader('Pragma', 'no-cache');
+              response.setHeader('Expires', '0');
+            }
+          }
+          next();
+        });
+      }
+    }
+  ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -32,7 +32,8 @@ export default defineConfig({
        *
        * @param {import('vite').ViteDevServer} server - The Vite development server instance.
        */
-      name: 'no-cache-index',      configureServer(server) {
+      name: 'no-cache-index',
+      configureServer(server) {
         server.middlewares.use((req, res, next) => {
           if (req.url === '/' || req.url === '/home' || req.url?.endsWith('/home')) {
             // Intercept the response to remove caching headers


### PR DESCRIPTION
Prevents caching of `index.html` and `/home` routes in the dev
server by setting aggressive no-cache headers. This ensures that
browsers and proxies always fetch the latest version of the application
during development.

With those changes I get consistent results:

```
valentin@valentin-precision-3260:~/work/repos/alkemio/client-web$ curl -I https://dev-alkem.io/home
HTTP/2 200 
accept-ranges: bytes
access-control-allow-credentials: true
cache-control: no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0
content-type: text/html
cross-origin-resource-policy: same-site
date: Wed, 28 May 2025 08:03:36 GMT
etag: "6836b0ac-cf8"
expires: 0
last-modified: Wed, 28 May 2025 06:43:56 GMT
pragma: no-cache
server: nginx/1.27.5
vary: Origin
content-length: 3320

valentin@valentin-precision-3260:~/work/repos/alkemio/client-web$ curl -I https://alkem.io/home
HTTP/2 200 
accept-ranges: bytes
access-control-allow-credentials: true
content-type: text/html
cross-origin-resource-policy: same-site
date: Wed, 28 May 2025 08:05:34 GMT
etag: "682ed435-cf8"
last-modified: Thu, 22 May 2025 07:37:25 GMT
server: nginx/1.27.5
vary: Origin
content-length: 3320

valentin@valentin-precision-3260:~/work/repos/alkemio/client-web$ curl -I http://localhost:3000/home
HTTP/1.1 200 OK
Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0
Content-Type: text/html
Date: Wed, 28 May 2025 08:06:29 GMT
Etag: W/"d97-fzElRnMHIF76S/3ZJTfh90UVXTk"
Expires: 0
Pragma: no-cache
Vary: Origin
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved cache control for the home page and root routes during development to ensure users always see the latest content.
- **Documentation**
  - Enhanced configuration documentation with a detailed summary comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->