### PR TITLE
Improves caching strategy for SPA

### DIFF
--- a/.build/.nginx/nginx.conf
+++ b/.build/.nginx/nginx.conf
@@ -8,7 +8,7 @@ http {
         root  /usr/share/nginx/html;
         include /etc/nginx/mime.types;
 
-        # Prevent caching of index.html
+        # Prevent caching of index.html when accessed directly
         location = /index.html {
             add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
             add_header Pragma "no-cache";
@@ -16,9 +16,33 @@ http {
             try_files $uri =404;
         }
 
-        try_files $uri /index.html;
+        # Handle static assets with normal caching
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
+        }
+
+        # Handle API routes (if any) - pass through without index.html fallback
+        location /api/ {
+            try_files $uri =404;
+        }
+
+        # Handle all other routes (SPA routes) - serve index.html with no-cache headers
+        location / {
+            try_files $uri @index;
+        }
+
         location /appui {
-            try_files $uri /index.html;
+            try_files $uri @index;
+        }
+
+        # Named location to serve index.html with no-cache headers for SPA routes
+        location @index {
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+            try_files /index.html =404;
         }
     }
 }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -24,18 +24,28 @@ export default defineConfig({
     // Plugin to prevent index.html caching in dev server
     {
       /**
-       * Vite plugin server configuration hook to disable caching for specific routes.
+       * Vite plugin server configuration hook to disable caching for all SPA routes.
        *
-       * Adds middleware to the dev server that intercepts requests to '/', '/home', and any URL ending with '/home'.
-       * For these routes, it overrides the response methods to set aggressive no-cache headers, ensuring that
-       * browsers and proxies do not cache the responses.
+       * Adds middleware to the dev server that intercepts requests to all routes that serve index.html.
+       * This includes '/', '/index.html', and any URL that doesn't contain a file extension and doesn't
+       * start with '/api/' or '/@' (Vite internal routes). For these routes, it overrides the response
+       * methods to set aggressive no-cache headers, ensuring that browsers and proxies do not cache
+       * the index.html responses.
        *
        * @param {import('vite').ViteDevServer} server - The Vite development server instance.
        */
       name: 'no-cache-index',
       configureServer(server) {
         server.middlewares.use((req, res, next) => {
-          if (req.url === '/' || req.url === '/home' || req.url?.endsWith('/home')) {
+          // Check if this is an HTML request (SPA route) that will serve index.html
+          const isHtmlRoute = req.url && (
+            req.url === '/' ||
+            req.url === '/index.html' ||
+            req.url?.endsWith('/index.html') ||
+            (!req.url.includes('.') && !req.url.startsWith('/api/') && !req.url.startsWith('/@'))
+          );
+
+          if (isHtmlRoute) {
             // Intercept the response to remove caching headers
             const originalSend = res.send;
             const originalEnd = res.end;
@@ -58,11 +68,25 @@ export default defineConfig({
             };
 
             function setNoCacheHeaders(response) {
+              // Remove caching headers
+              response.removeHeader('Last-Modified');
+              response.removeHeader('ETag');
+              response.removeHeader('etag');
+              response.removeHeader('If-Modified-Since');
+              response.removeHeader('If-None-Match');
 
               // Set comprehensive no-cache headers - most aggressive approach
-              response.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0');
+              response.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0, s-maxage=0, private');
               response.setHeader('Pragma', 'no-cache');
-              response.setHeader('Expires', '0');
+              response.setHeader('Expires', 'Thu, 01 Jan 1970 00:00:00 GMT');
+              response.setHeader('Surrogate-Control', 'no-store');
+              response.setHeader('X-Accel-Expires', '0');
+              response.setHeader('Vary', '*');
+              response.setHeader('Content-Type', 'text/html; charset=utf-8');
+
+              // Additional anti-cache headers
+              response.setHeader('X-Cache-Control', 'no-cache');
+              response.setHeader('X-Powered-By', 'Vite-NoCache-' + Date.now());
             }
           }
           next();


### PR DESCRIPTION
Enhances caching for Single Page Applications (SPAs) by implementing a more comprehensive no-cache strategy for `index.html` and other routes that serve it.
This change addresses issues with browsers and proxies caching outdated versions of the application.

The updated Nginx configuration includes rules for serving static assets with long-term caching, API routes without index.html fallback, and other routes (SPA routes) serving `index.html` with no-cache headers via a named location.

The Vite plugin is updated to aggressively prevent caching of `index.html` during development by setting more comprehensive no-cache headers. It now intercepts requests based on the route to apply the no-cache headers, excluding API and Vite internal routes.
