### PR TITLE
Change switch in Subspaces form to add or skip callouts of the template

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -862,6 +862,9 @@
         "placeholder": "",
         "tooltip": "Tags"
       },
+      "addCallouts": {
+        "title": "Add default template's collaboration tools:"
+      },
       "addTutorialCallouts": {
         "title": "Add tutorials collaboration tools"
       },

--- a/src/domain/space/components/subspaces/CreateSubspaceForm.tsx
+++ b/src/domain/space/components/subspaces/CreateSubspaceForm.tsx
@@ -26,7 +26,13 @@ const FormikEffect = FormikEffectFactory<CreateSubspaceFormValues>();
 
 type CreateSubspaceFormValues = Pick<
   SpaceFormValues,
-  'displayName' | 'tagline' | 'description' | 'tags' | 'addTutorialCallouts' | 'collaborationTemplateId' | 'visuals'
+  | 'displayName'
+  | 'tagline'
+  | 'description'
+  | 'tags'
+  | 'addCallouts' /* | 'addTutorialCallouts'*/
+  | 'collaborationTemplateId'
+  | 'visuals'
 >;
 
 interface CreateSubspaceFormProps extends SpaceCreationForm {}
@@ -47,7 +53,8 @@ export const CreateSubspaceForm = ({
       tagline: value.tagline,
       description: value.description,
       tags: value.tags,
-      addTutorialCallouts: value.addTutorialCallouts,
+      addCallouts: value.addCallouts,
+      // addTutorialCallouts: value.addTutorialCallouts,
       collaborationTemplateId: value.collaborationTemplateId,
       visuals: value.visuals,
     });
@@ -57,7 +64,8 @@ export const CreateSubspaceForm = ({
     tagline: '',
     description: '',
     tags: [],
-    addTutorialCallouts: false,
+    addCallouts: true,
+    // addTutorialCallouts: false,
     collaborationTemplateId: undefined,
     visuals: {
       avatar: { file: undefined, altText: '' },
@@ -135,8 +143,8 @@ export const CreateSubspaceForm = ({
             </PageContentBlock>
             <SubspaceTemplateSelector name="collaborationTemplateId" disablePadding />
             <FormikRadiosSwitch
-              name="addTutorialCallouts"
-              label="Tutorials:"
+              name="addCallouts"
+              label={t('context.L1.addCallouts.title')}
               options={[
                 { label: 'On', value: true },
                 { label: 'Off', value: false },

--- a/src/domain/space/components/subspaces/SubspaceCreationDialog/CreateSubspace.tsx
+++ b/src/domain/space/components/subspaces/SubspaceCreationDialog/CreateSubspace.tsx
@@ -36,7 +36,8 @@ export const CreateSubspace = ({ isVisible = false, onClose, parentSpaceId = '' 
           },
           why: value.why,
         },
-        addTutorialCallouts: value.addTutorialCallouts,
+        // addTutorialCallouts: value.addTutorialCallouts,
+        addCallouts: value.addCallouts,
         collaborationTemplateId: value.collaborationTemplateId,
       });
 

--- a/src/domain/space/components/subspaces/SubspaceCreationDialog/SubspaceCreationDialog.tsx
+++ b/src/domain/space/components/subspaces/SubspaceCreationDialog/SubspaceCreationDialog.tsx
@@ -29,7 +29,8 @@ export const SubspaceCreationDialog: FC<SubspaceCreationDialogProps> = ({
     displayName: '',
     tagline: '',
     tags: [],
-    addTutorialCallouts: false,
+    // addTutorialCallouts: false,
+    addCallouts: true,
     collaborationTemplateId: undefined,
     visuals: {
       avatar: { file: undefined, altText: '' },

--- a/src/domain/space/components/subspaces/SubspaceCreationDialog/SubspaceCreationForm.ts
+++ b/src/domain/space/components/subspaces/SubspaceCreationDialog/SubspaceCreationForm.ts
@@ -9,7 +9,8 @@ export interface SpaceFormValues {
   why?: string;
   tags: string[];
   description?: string;
-  addTutorialCallouts: boolean;
+  // addTutorialCallouts: boolean;
+  addCallouts: boolean;
   collaborationTemplateId?: string;
   visuals: {
     avatar: VisualUpload;

--- a/src/domain/space/hooks/useSubspaceCreation/useSubspaceCreation.ts
+++ b/src/domain/space/hooks/useSubspaceCreation/useSubspaceCreation.ts
@@ -38,7 +38,8 @@ interface SubspaceCreationInput {
     };
     why?: string;
   };
-  addTutorialCallouts: boolean;
+  // addTutorialCallouts: boolean;
+  addCallouts: boolean;
   collaborationTemplateId?: string;
 }
 
@@ -109,8 +110,8 @@ export const useSubspaceCreation = (mutationOptions: CreateSubspaceMutationOptio
               },
             },
             collaborationData: {
-              addTutorialCallouts: value.addTutorialCallouts,
-              addCallouts: true, // Always add Callouts from the template
+              // addTutorialCallouts: value.addTutorialCallouts,
+              addCallouts: value.addCallouts,
               collaborationTemplateID: value.collaborationTemplateId,
               calloutsSetData: {},
             },

--- a/src/domain/space/layout/tabbedLayout/Tabs/SpaceSubspacesPage.tsx
+++ b/src/domain/space/layout/tabbedLayout/Tabs/SpaceSubspacesPage.tsx
@@ -54,7 +54,8 @@ const SpaceSubspacesPage = () => {
           },
           why: value.why,
         },
-        addTutorialCallouts: value.addTutorialCallouts,
+        // addTutorialCallouts: value.addTutorialCallouts,
+        addCallouts: value.addCallouts,
         collaborationTemplateId: value.collaborationTemplateId,
       });
 

--- a/src/domain/spaceAdmin/SpaceAdminSubspaces/SpaceAdminSubspacesPage.tsx
+++ b/src/domain/spaceAdmin/SpaceAdminSubspaces/SpaceAdminSubspacesPage.tsx
@@ -128,7 +128,8 @@ const SpaceAdminSubspacesPage: FC<SpaceAdminSubspacesPageProps> = ({
           },
           why: value.why ?? '',
         },
-        addTutorialCallouts: value.addTutorialCallouts,
+        // addTutorialCallouts: value.addTutorialCallouts,
+        addCallouts: value.addCallouts,
         collaborationTemplateId: value.collaborationTemplateId,
       });
 


### PR DESCRIPTION
There's no Subspace tutorials in the server
There's only space tutorials:
![image](https://github.com/user-attachments/assets/bf014f06-25ac-4bbe-9844-79c3376986e8)

So this switch makes no sense:
![image](https://github.com/user-attachments/assets/4f136347-ebb2-4449-b50f-a0380b36529f)

I have changed it to:
![image](https://github.com/user-attachments/assets/1da4dfac-c33c-4e86-ab85-2e7a3ae4bbd5)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated subspace creation form to use a new "Add default template's collaboration tools" option, replacing the previous tutorial callouts field.
  - The new option is enabled by default and features a dynamically translated label.

- **Bug Fixes**
  - Ensured consistent handling of the new collaboration tools option throughout the subspace creation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->