### PR TITLE
Fix the broken VC edit form

### DIFF
--- a/src/domain/common/reference/newReferenceName.ts
+++ b/src/domain/common/reference/newReferenceName.ts
@@ -1,4 +1,9 @@
 import type { TFunction } from 'i18next';
 
-export const newReferenceName = (t: TFunction, count: number) =>
-  t('components.referenceSegment.newReference', { count: count + 1 });
+export const newReferenceName = (t: TFunction, count: number) => {
+  if (count === 0) {
+    return t('components.referenceSegment.newReference');
+  }
+
+  return t('components.referenceSegment.newReference_plural', { count: count + 1 });
+};

--- a/src/domain/community/virtualContributor/vcProfilePage/VCProfilePageView.tsx
+++ b/src/domain/community/virtualContributor/vcProfilePage/VCProfilePageView.tsx
@@ -19,7 +19,6 @@ import { KNOWLEDGE_BASE_PATH } from '@/main/routing/urlBuilders';
 import useKnowledgeBase from '../knowledgeBase/useKnowledgeBase';
 import { AiPersonaEngine, AiPersonaBodyOfKnowledgeType, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import SpaceCardHorizontal from '@/domain/space/components/cards/SpaceCardHorizontal';
-import { ReferenceModelWithOptionalAuthorization } from '@/domain/common/reference/ReferenceModel';
 import { VirtualContributorModelFull } from '../model/VirtualContributorModelFull';
 import { SpaceBodyOfKnowledgeModel } from '../model/SpaceBodyOfKnowledgeModel';
 import { EMPTY_MODEL_CARD } from '../model/AiPersonaModelCardModel';
@@ -86,9 +85,6 @@ export const VCProfilePageView = ({ virtualContributor, ...rest }: VCProfilePage
     [hasReadAccess, t, onClickHandleKnowledgeBase]
   );
 
-  const otherLinkReference = links[OTHER_LINK_GROUP] ?? [];
-  const referencesWithAuth: ReferenceModelWithOptionalAuthorization[] = [...otherLinkReference];
-
   return (
     <PageContent>
       <PageContentColumn columns={4}>
@@ -112,7 +108,7 @@ export const VCProfilePageView = ({ virtualContributor, ...rest }: VCProfilePage
             </Gutters>
 
             <References
-              references={referencesWithAuth}
+              references={links[OTHER_LINK_GROUP]}
               noItemsView={<CardText color="neutral.main">{t('common.no-references')}</CardText>}
             />
           </Gutters>

--- a/src/domain/community/virtualContributorAdmin/vcSettingsPage/VirtualContributorForm.tsx
+++ b/src/domain/community/virtualContributorAdmin/vcSettingsPage/VirtualContributorForm.tsx
@@ -94,8 +94,12 @@ export const VirtualContributorForm = ({
   );
 
   const validationSchema = yup.object().shape({
-    name: nameSegmentSchema.fields?.displayName ?? yup.string(),
-    description: profileSegmentSchema.fields?.description ?? yup.string(),
+    profile: yup.object().shape({
+      displayName: nameSegmentSchema.fields?.displayName ?? yup.string().required(),
+      description: profileSegmentSchema.fields?.description ?? yup.string().required(),
+    }),
+    hostDisplayName: yup.string(),
+    subSpaceName: yup.string(),
   });
 
   // use keywords tagset (existing after creation of VC) as tags
@@ -168,13 +172,18 @@ export const VirtualContributorForm = ({
                   </GridItem>
                   <GridItem columns={isMobile ? cols : 8}>
                     <Gutters>
-                      <FormikInputField name="name" title={t('components.nameSegment.name')} />
+                      <FormikInputField name="profile.displayName" title={t('components.nameSegment.name')} />
                       <ProfileSegment />
                       {keywordsTagsetWrapped ? (
                         <TagsetSegment tagsets={keywordsTagsetWrapped} title={t('common.tags')} />
                       ) : null}
 
-                      <ProfileReferenceSegment fullWidth profileId={vcProfileId} references={references ?? []} />
+                      <ProfileReferenceSegment
+                        fullWidth
+                        fieldName="profile.references"
+                        profileId={vcProfileId}
+                        references={references ?? []}
+                      />
 
                       {hostDisplayName && <HostFields />}
                       <Actions marginTop={theme.spacing(2)} sx={{ justifyContent: 'end' }}>

--- a/src/domain/platform/admin/components/Common/ContextReferenceSegment.tsx
+++ b/src/domain/platform/admin/components/Common/ContextReferenceSegment.tsx
@@ -10,6 +10,9 @@ interface ContextReferenceSegmentProps extends ReferenceSegmentProps {
   profileId?: string;
 }
 
+/**
+ * @deprecated Use ProfileReferenceSegment instead. This component is kept for backward compatibility and will be removed in a future release.
+ */
 export const ContextReferenceSegment: FC<ContextReferenceSegmentProps> = ({
   fieldName,
   profileId,

--- a/src/domain/templates/components/Forms/common/mappings.ts
+++ b/src/domain/templates/components/Forms/common/mappings.ts
@@ -256,7 +256,7 @@ export const toCreateTemplateFromCollaborationMutationVariables = (
     throw new Error('Collaboration ID is required to create a template from a collaboration');
   }
 
-  const result: CreateTemplateFromCollaborationMutationVariables = {
+  return {
     collaborationId: values.collaborationId,
     templatesSetId: templatesSetId,
     profileData: {
@@ -270,7 +270,6 @@ export const toCreateTemplateFromCollaborationMutationVariables = (
     },
     tags: handleCreateTags(values),
   };
-  return result;
 };
 
 interface TemplateTagset {


### PR DESCRIPTION
The VC form was totally messed up. The latest profile object usage/changes are introducing regressions in forms.

The Reference creation was also fixed, not sure when/how it was working before. 

One component was spotted for deprication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified how reference links are passed to the References component for improved clarity.
  - Restructured the contributor settings form to group profile-related fields, updating validation and form inputs accordingly. 
  - Added optional fields for host and sub-space names in the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->