### PR TITLE
Remove the subspaces' default callouts and tutorials radio options 

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -862,9 +862,6 @@
         "placeholder": "",
         "tooltip": "Tags"
       },
-      "addCallouts": {
-        "title": "Add default template's collaboration tools:"
-      },
       "addTutorialCallouts": {
         "title": "Add tutorials collaboration tools"
       },

--- a/src/domain/space/components/subspaces/CreateSubspaceForm.tsx
+++ b/src/domain/space/components/subspaces/CreateSubspaceForm.tsx
@@ -13,7 +13,6 @@ import {
   SpaceFormValues,
 } from '@/domain/space/components/subspaces/SubspaceCreationDialog/SubspaceCreationForm';
 import MarkdownValidator from '@/core/ui/forms/MarkdownInput/MarkdownValidator';
-import { FormikRadiosSwitch } from '@/core/ui/forms/FormikRadiosSwitch';
 import SubspaceTemplateSelector from '@/domain/templates/components/TemplateSelectors/SubspaceTemplateSelector';
 import Gutters from '@/core/ui/grid/Gutters';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
@@ -134,16 +133,17 @@ export const CreateSubspaceForm = ({
               <FormikVisualUpload name="visuals.cardBanner" visualType={VisualType.Card} flex={1} />
             </PageContentBlock>
             <SubspaceTemplateSelector name="collaborationTemplateId" disablePadding />
-            <FormikRadiosSwitch
-              name="addTutorialCallouts"
-              label="Tutorials:"
-              options={[
-                { label: 'On', value: true },
-                { label: 'Off', value: false },
-              ]}
-              row
-              disablePadding
-            />
+            {/* TEMPORARY DISABLE AS THERE ARE NO SUBSPACE TUTORIALS */}
+            {/*<FormikRadiosSwitch*/}
+            {/*  name="addTutorialCallouts"*/}
+            {/*  label="Tutorials:"*/}
+            {/*  options={[*/}
+            {/*    { label: 'On', value: true },*/}
+            {/*    { label: 'Off', value: false },*/}
+            {/*  ]}*/}
+            {/*  row*/}
+            {/*  disablePadding*/}
+            {/*/>*/}
           </Gutters>
         </Form>
       )}

--- a/src/domain/space/components/subspaces/CreateSubspaceForm.tsx
+++ b/src/domain/space/components/subspaces/CreateSubspaceForm.tsx
@@ -26,13 +26,7 @@ const FormikEffect = FormikEffectFactory<CreateSubspaceFormValues>();
 
 type CreateSubspaceFormValues = Pick<
   SpaceFormValues,
-  | 'displayName'
-  | 'tagline'
-  | 'description'
-  | 'tags'
-  | 'addCallouts' /* | 'addTutorialCallouts'*/
-  | 'collaborationTemplateId'
-  | 'visuals'
+  'displayName' | 'tagline' | 'description' | 'tags' | 'addTutorialCallouts' | 'collaborationTemplateId' | 'visuals'
 >;
 
 interface CreateSubspaceFormProps extends SpaceCreationForm {}
@@ -53,8 +47,7 @@ export const CreateSubspaceForm = ({
       tagline: value.tagline,
       description: value.description,
       tags: value.tags,
-      addCallouts: value.addCallouts,
-      // addTutorialCallouts: value.addTutorialCallouts,
+      addTutorialCallouts: value.addTutorialCallouts,
       collaborationTemplateId: value.collaborationTemplateId,
       visuals: value.visuals,
     });
@@ -64,8 +57,7 @@ export const CreateSubspaceForm = ({
     tagline: '',
     description: '',
     tags: [],
-    addCallouts: true,
-    // addTutorialCallouts: false,
+    addTutorialCallouts: false,
     collaborationTemplateId: undefined,
     visuals: {
       avatar: { file: undefined, altText: '' },
@@ -143,8 +135,8 @@ export const CreateSubspaceForm = ({
             </PageContentBlock>
             <SubspaceTemplateSelector name="collaborationTemplateId" disablePadding />
             <FormikRadiosSwitch
-              name="addCallouts"
-              label={t('context.L1.addCallouts.title')}
+              name="addTutorialCallouts"
+              label="Tutorials:"
               options={[
                 { label: 'On', value: true },
                 { label: 'Off', value: false },

--- a/src/domain/space/components/subspaces/SubspaceCreationDialog/CreateSubspace.tsx
+++ b/src/domain/space/components/subspaces/SubspaceCreationDialog/CreateSubspace.tsx
@@ -36,8 +36,7 @@ export const CreateSubspace = ({ isVisible = false, onClose, parentSpaceId = '' 
           },
           why: value.why,
         },
-        // addTutorialCallouts: value.addTutorialCallouts,
-        addCallouts: value.addCallouts,
+        addTutorialCallouts: value.addTutorialCallouts,
         collaborationTemplateId: value.collaborationTemplateId,
       });
 

--- a/src/domain/space/components/subspaces/SubspaceCreationDialog/SubspaceCreationDialog.tsx
+++ b/src/domain/space/components/subspaces/SubspaceCreationDialog/SubspaceCreationDialog.tsx
@@ -29,8 +29,7 @@ export const SubspaceCreationDialog: FC<SubspaceCreationDialogProps> = ({
     displayName: '',
     tagline: '',
     tags: [],
-    // addTutorialCallouts: false,
-    addCallouts: true,
+    addTutorialCallouts: false,
     collaborationTemplateId: undefined,
     visuals: {
       avatar: { file: undefined, altText: '' },

--- a/src/domain/space/components/subspaces/SubspaceCreationDialog/SubspaceCreationForm.ts
+++ b/src/domain/space/components/subspaces/SubspaceCreationDialog/SubspaceCreationForm.ts
@@ -9,8 +9,7 @@ export interface SpaceFormValues {
   why?: string;
   tags: string[];
   description?: string;
-  // addTutorialCallouts: boolean;
-  addCallouts: boolean;
+  addTutorialCallouts: boolean;
   collaborationTemplateId?: string;
   visuals: {
     avatar: VisualUpload;

--- a/src/domain/space/hooks/useSubspaceCreation/useSubspaceCreation.ts
+++ b/src/domain/space/hooks/useSubspaceCreation/useSubspaceCreation.ts
@@ -38,8 +38,7 @@ interface SubspaceCreationInput {
     };
     why?: string;
   };
-  // addTutorialCallouts: boolean;
-  addCallouts: boolean;
+  addTutorialCallouts: boolean;
   collaborationTemplateId?: string;
 }
 
@@ -110,8 +109,8 @@ export const useSubspaceCreation = (mutationOptions: CreateSubspaceMutationOptio
               },
             },
             collaborationData: {
-              // addTutorialCallouts: value.addTutorialCallouts,
-              addCallouts: value.addCallouts,
+              addTutorialCallouts: value.addTutorialCallouts,
+              addCallouts: true, // Always add Callouts from the template
               collaborationTemplateID: value.collaborationTemplateId,
               calloutsSetData: {},
             },

--- a/src/domain/space/layout/tabbedLayout/Tabs/SpaceSubspacesPage.tsx
+++ b/src/domain/space/layout/tabbedLayout/Tabs/SpaceSubspacesPage.tsx
@@ -54,8 +54,7 @@ const SpaceSubspacesPage = () => {
           },
           why: value.why,
         },
-        // addTutorialCallouts: value.addTutorialCallouts,
-        addCallouts: value.addCallouts,
+        addTutorialCallouts: value.addTutorialCallouts,
         collaborationTemplateId: value.collaborationTemplateId,
       });
 

--- a/src/domain/spaceAdmin/SpaceAdminSubspaces/SpaceAdminSubspacesPage.tsx
+++ b/src/domain/spaceAdmin/SpaceAdminSubspaces/SpaceAdminSubspacesPage.tsx
@@ -128,8 +128,7 @@ const SpaceAdminSubspacesPage: FC<SpaceAdminSubspacesPageProps> = ({
           },
           why: value.why ?? '',
         },
-        // addTutorialCallouts: value.addTutorialCallouts,
-        addCallouts: value.addCallouts,
+        addTutorialCallouts: value.addTutorialCallouts,
         collaborationTemplateId: value.collaborationTemplateId,
       });
 


### PR DESCRIPTION
As agrred with @techsmyth & @SimoneZaza , for now we're going to hide the tutorial option for SubSpaces. 
- revert the changes from https://github.com/alkem-io/client-web/pull/8257
- hide the tutorials radio;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated subspace creation forms and dialogs to use a more specific option for adding tutorial callouts, replacing the previous generic callouts option.

- **Bug Fixes**
  - Ensured that the correct callout options are passed during subspace creation, improving consistency across the interface.

- **Style**
  - Removed outdated references to generic callouts and updated interface text for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->