### PR TITLE
Fix the recovery 404

### DIFF
--- a/src/core/auth/authentication/components/Kratos/constants.ts
+++ b/src/core/auth/authentication/components/Kratos/constants.ts
@@ -2,7 +2,6 @@ import { UiNodeAttributes } from '@ory/kratos-client';
 
 export const KRATOS_INPUT_NAME_CSRF = 'csrf_token';
 export const KRATOS_TRAIT_NAME_FIRST_NAME = 'traits.name.first';
-export const KRATOS_TRAIT_NAME_ACCEPTED_TERMS = 'traits.accepted_terms';
 
 export const KRATOS_REQUIRED_FIELDS: readonly string[] = [
   'traits.email',

--- a/src/core/auth/authentication/constants/authentication.constants.ts
+++ b/src/core/auth/authentication/constants/authentication.constants.ts
@@ -1,12 +1,5 @@
 /**
  * @deprecated
- * Before getting to _AUTH_REGISTER_PATH the user must accept the Platform Terms which is done on AUTH_SIGN_UP_PATH,
- * so please use AUTH_SIGN_UP_PATH for buttons/links that take a user to the registration flow.
- */
-export const _AUTH_REGISTER_PATH = '/registration';
-
-/**
- * @deprecated
  * Use buildLoginUrl() helper
  */
 export const _AUTH_LOGIN_PATH = '/login';

--- a/src/core/auth/authentication/routing/useRedirectToIdentityDomain.ts
+++ b/src/core/auth/authentication/routing/useRedirectToIdentityDomain.ts
@@ -1,6 +1,7 @@
 import { useLayoutEffect } from 'react';
 import { useConfig } from '@/domain/platform/config/useConfig';
 
+// TODO: we should not allow space names starting with these values
 const IdentityLocations = [
   '/login',
   '/logout',
@@ -11,6 +12,7 @@ const IdentityLocations = [
   '/required',
   '/settings',
   '/error',
+  '/ory',
 ];
 
 const useRedirectToIdentityDomain = () => {


### PR DESCRIPTION
Add ory to IdentityLocations, preventing 404 when trying to access `/ory/kratos/public/self-service/recovery/browser`.

In addition, two unused constants were removed.

Looking into the `useRedirectToIdentityDomain` we should make sure space names are not starting with any of the IdentityLocations (left a TODO).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal constants related to authentication and registration.
  - Expanded the set of path prefixes that trigger redirection to the identity domain. 

No user-facing changes are expected from this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->