### PR TITLE
extended community permissions to distinghuish between users + orgs add

### DIFF
--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -922,6 +922,7 @@ export enum AuthorizationPrivilege {
   ReadUserSettings = 'READ_USER_SETTINGS',
   RolesetEntryRoleApply = 'ROLESET_ENTRY_ROLE_APPLY',
   RolesetEntryRoleAssign = 'ROLESET_ENTRY_ROLE_ASSIGN',
+  RolesetEntryRoleAssignOrganization = 'ROLESET_ENTRY_ROLE_ASSIGN_ORGANIZATION',
   RolesetEntryRoleInvite = 'ROLESET_ENTRY_ROLE_INVITE',
   RolesetEntryRoleInviteAccept = 'ROLESET_ENTRY_ROLE_INVITE_ACCEPT',
   RolesetEntryRoleJoin = 'ROLESET_ENTRY_ROLE_JOIN',

--- a/src/domain/community/inviteContributors/virtualContributors/InviteVCsDialog.tsx
+++ b/src/domain/community/inviteContributors/virtualContributors/InviteVCsDialog.tsx
@@ -131,7 +131,7 @@ const InviteVCsDialog = ({ open, onClose }: InviteContributorsDialogProps) => {
 
   const showOnAccount = (filteredOnAccount ?? onAccount).length > 0 && !loading;
   const availableActions =
-    (permissions?.canAddMembers || permissions?.canAddVirtualContributorsFromAccount) && !actionButtonDisabled;
+    (permissions?.canAddUsers || permissions?.canAddVirtualContributorsFromAccount) && !actionButtonDisabled;
 
   const renderActions = () => (
     <>

--- a/src/domain/community/inviteContributors/virtualContributors/InviteVCsDialog.tsx
+++ b/src/domain/community/inviteContributors/virtualContributors/InviteVCsDialog.tsx
@@ -131,7 +131,8 @@ const InviteVCsDialog = ({ open, onClose }: InviteContributorsDialogProps) => {
 
   const showOnAccount = (filteredOnAccount ?? onAccount).length > 0 && !loading;
   const availableActions =
-    (permissions?.canAddUsers || permissions?.canAddVirtualContributorsFromAccount) && !actionButtonDisabled;
+    (permissions?.canAddVirtualContributors || permissions?.canAddVirtualContributorsFromAccount) &&
+    !actionButtonDisabled;
 
   const renderActions = () => (
     <>

--- a/src/domain/spaceAdmin/SpaceAdminCommunity/SpaceAdminCommunityPage.tsx
+++ b/src/domain/spaceAdmin/SpaceAdminCommunity/SpaceAdminCommunityPage.tsx
@@ -138,7 +138,7 @@ const SpaceAdminCommunityPage = ({
   );
   const addVirtualContributorsEnabled =
     spaceVirtualContributorEntitlementEnabled &&
-    (permissions.canAddVirtualContributorsFromAccount || permissions.canAddMembers);
+    (permissions.canAddVirtualContributorsFromAccount || permissions.canAddVirtualContributors);
 
   const currentCommunityGuidelines = useRef<CommunityGuidelines>();
   const [communityGuidelinesTemplatesDialogOpen, setCommunityGuidelinesTemplatesDialogOpen] = useState(false);
@@ -290,7 +290,7 @@ const SpaceAdminCommunityPage = ({
               users={users}
               onUserLeadChange={onUserLeadChange}
               onUserAuthorizationChange={onUserAuthorizationChange}
-              canAddMembers={permissions.canAddMembers}
+              canAddUsers={permissions.canAddUsers}
               onAddMember={onAddUser}
               onRemoveMember={onRemoveUser}
               fetchAvailableUsers={getAvailableUsers}
@@ -305,7 +305,7 @@ const SpaceAdminCommunityPage = ({
             <CommunityOrganizations
               organizations={organizations}
               onOrganizationLeadChange={onOrganizationLeadChange}
-              canAddMembers={permissions.canAddMembers}
+              canAddOrganizations={permissions.canAddOrganizations}
               onAddMember={onAddOrganization}
               onRemoveMember={onRemoveOrganization}
               fetchAvailableOrganizations={getAvailableOrganizations}

--- a/src/domain/spaceAdmin/SpaceAdminCommunity/components/CommunityOrganizations.tsx
+++ b/src/domain/spaceAdmin/SpaceAdminCommunity/components/CommunityOrganizations.tsx
@@ -50,7 +50,7 @@ const initialState: GridInitialState = {
 interface CommunityOrganizationsProps {
   organizations: OrganizationDetailsFragmentWithRoles[] | undefined;
   onOrganizationLeadChange: (organizationId, newValue) => Promise<unknown> | void;
-  canAddMembers: boolean;
+  canAddOrganizations: boolean;
   onAddMember: (organizationId) => Promise<unknown> | undefined;
   fetchAvailableOrganizations: CommunityAddMembersDialogProps['fetchAvailableEntities'];
   onRemoveMember: (organizationId) => Promise<unknown> | void;
@@ -68,7 +68,7 @@ interface CommunityOrganizationsProps {
 const CommunityOrganizations = ({
   organizations = [],
   onOrganizationLeadChange,
-  canAddMembers,
+  canAddOrganizations,
   onAddMember,
   fetchAvailableOrganizations,
   onRemoveMember,
@@ -143,7 +143,7 @@ const CommunityOrganizations = ({
     <>
       <Box display="flex" justifyContent="space-between">
         <BlockTitle>{t('community.memberOrganizations', { count: organizations.length })}</BlockTitle>
-        {canAddMembers && (
+        {canAddOrganizations && (
           <Button variant="contained" startIcon={<AddIcon />} onClick={() => setAddingNewOrganization(true)}>
             {t('common.add')}
           </Button>

--- a/src/domain/spaceAdmin/SpaceAdminCommunity/components/CommunityUsers.tsx
+++ b/src/domain/spaceAdmin/SpaceAdminCommunity/components/CommunityUsers.tsx
@@ -47,7 +47,7 @@ interface CommunityUsersProps {
   onUserLeadChange: (userId: string, newValue: boolean) => Promise<unknown> | void;
   onUserAuthorizationChange?: (userId: string, newValue: boolean) => Promise<unknown> | void;
   onRemoveMember: (userId: string) => Promise<unknown> | void;
-  canAddMembers: boolean;
+  canAddUsers: boolean;
   onAddMember: (memberId: string) => Promise<unknown> | undefined;
   fetchAvailableUsers: CommunityAddMembersDialogProps['fetchAvailableEntities'];
   memberRoleDefinition?: {
@@ -66,7 +66,7 @@ const CommunityUsers = ({
   onUserLeadChange,
   onUserAuthorizationChange,
   onRemoveMember,
-  canAddMembers,
+  canAddUsers,
   onAddMember,
   fetchAvailableUsers,
   memberRoleDefinition,
@@ -141,7 +141,7 @@ const CommunityUsers = ({
     <>
       <Box display="flex" justifyContent="space-between">
         <BlockTitle>{t('community.memberUsers', { count: users.length })}</BlockTitle>
-        {canAddMembers && (
+        {canAddUsers && (
           <Button variant="contained" startIcon={<AddIcon />} onClick={() => setAddingNewUser(true)}>
             {t('common.add')}
           </Button>

--- a/src/domain/spaceAdmin/SpaceAdminCommunity/hooks/useCommunityAdmin.ts
+++ b/src/domain/spaceAdmin/SpaceAdminCommunity/hooks/useCommunityAdmin.ts
@@ -72,7 +72,9 @@ export interface useCommunityAdminProvided {
     onDeletePlatformInvitation: (invitationId: string) => Promise<unknown>;
   };
   permissions: {
-    canAddMembers: boolean;
+    canAddUsers: boolean;
+    canAddOrganizations: boolean;
+    canAddVirtualContributors: boolean;
     canAddVirtualContributorsFromAccount: boolean;
   };
   loading: boolean;
@@ -198,7 +200,13 @@ const useCommunityAdmin = ({ roleSetId }: useCommunityAdminParams): useCommunity
     inviteContributorsOnRoleSet({ roleSetId, ...inviteData });
 
   const permissions = {
-    canAddMembers: authorizationPrivileges.some(priv => priv === AuthorizationPrivilege.RolesetEntryRoleAssign),
+    canAddUsers: authorizationPrivileges.some(priv => priv === AuthorizationPrivilege.RolesetEntryRoleAssign),
+    canAddOrganizations:
+      authorizationPrivileges.some(priv => priv === AuthorizationPrivilege.RolesetEntryRoleAssignOrganization) &&
+      authorizationPrivileges.some(priv => priv === AuthorizationPrivilege.Grant),
+    canAddVirtualContributors: authorizationPrivileges.some(
+      priv => priv === AuthorizationPrivilege.RolesetEntryRoleAssign
+    ),
     // the following privilege allows Admins of a space without CommunityAddMember privilege, to
     // be able to add VC from the account; CommunityAddMember overrides this privilege as it's not granted to PAs
     canAddVirtualContributorsFromAccount: authorizationPrivileges.some(


### PR DESCRIPTION
added permission field for adding orgs that checks new assign orgs as members together with grant privilege


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - More granular controls for adding users, organizations, and virtual contributors are now available, allowing for more specific permission management in community and space administration pages.

- **Refactor**
  - Updated permission checks and button visibility to use new, more specific permission flags throughout community and space administration interfaces.
  - Renamed related properties and props for clarity, improving the consistency of permission-related options in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->