### PR TITLE
Subspace Creation flow updates - add/remove template, additional info.

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -981,6 +981,9 @@
         "invalidUrl": "The url is not recognized as a Space URL.",
         "spaceNotFoundError": "Space not found",
         "selectAnother": "Update Collaboration from another Space"
+      },
+      "preview": {
+        "info": "Also included: About information & Settings"
       }
     },
     "communityGuidelinesTemplates": {

--- a/src/domain/space/components/subspaces/CreateSubspaceForm.tsx
+++ b/src/domain/space/components/subspaces/CreateSubspaceForm.tsx
@@ -55,7 +55,7 @@ export const CreateSubspaceForm = ({
       tags: value.tags,
       addTutorialCallouts: false,
       addCallouts: Boolean(value.spaceTemplateId) ? value.addCallouts : true,
-      spaceTemplateId: value.spaceTemplateId,
+      spaceTemplateId: value.spaceTemplateId || undefined, // in case of empty string
       visuals: value.visuals,
     });
 
@@ -106,6 +106,7 @@ export const CreateSubspaceForm = ({
       {() => (
         <Form noValidate>
           <FormikEffect onChange={handleChanged} onStatusChange={onValidChanged} />
+          <SubspaceTemplateSelector name="spaceTemplateId" disablePadding sx={{ paddingBottom: gutters() }} />
           <FormikInputField
             name="displayName"
             title={t(`context.${level}.displayName.title`)}
@@ -141,7 +142,6 @@ export const CreateSubspaceForm = ({
               <FormikVisualUpload name="visuals.avatar" visualType={VisualType.Avatar} flex={1} />
               <FormikVisualUpload name="visuals.cardBanner" visualType={VisualType.Card} flex={1} />
             </PageContentBlock>
-            <SubspaceTemplateSelector name="spaceTemplateId" disablePadding />
             {/* Temporarily hidden until we have more options to choose from */}
             {/* Show options only if a template is selected */}
             {/*{Boolean(spaceTemplateId) && (*/}

--- a/src/domain/templates/components/Previews/TemplateContentSpacePreview.tsx
+++ b/src/domain/templates/components/Previews/TemplateContentSpacePreview.tsx
@@ -5,6 +5,8 @@ import Loading from '@/core/ui/loading/Loading';
 import InnovationFlowChips from '@/domain/collaboration/InnovationFlow/InnovationFlowVisualizers/InnovationFlowChips';
 import InnovationFlowCalloutsPreview from '../../../collaboration/InnovationFlow/InnovationFlowCalloutsPreview';
 import { TemplateContentSpaceModel } from '../../contentSpace/model/TemplateContentSpaceModel';
+import { Caption } from '@/core/ui/typography';
+import { useTranslation } from 'react-i18next';
 
 interface TemplateContentSpacePreviewProps {
   loading?: boolean;
@@ -14,6 +16,7 @@ interface TemplateContentSpacePreviewProps {
 }
 
 const TemplateContentSpacePreview = ({ template, loading }: TemplateContentSpacePreviewProps) => {
+  const { t } = useTranslation();
   const [selectedState, setSelectedState] = useState<string | undefined>(undefined);
   const collaboration = template?.contentSpace?.collaboration;
   const templateStates = collaboration?.innovationFlow?.states ?? [];
@@ -37,21 +40,24 @@ const TemplateContentSpacePreview = ({ template, loading }: TemplateContentSpace
   }, [selectedState, templateStates]);
 
   return (
-    <PageContentBlock>
-      {loading && (
-        <Box textAlign="center">
-          <Loading />
-        </Box>
-      )}
-      {!loading && (
-        <InnovationFlowChips
-          states={templateStates}
-          selectedState={selectedState}
-          onSelectState={state => setSelectedState(state.displayName)}
-        />
-      )}
-      <InnovationFlowCalloutsPreview callouts={callouts} selectedState={selectedState} loading={loading} />
-    </PageContentBlock>
+    <>
+      <PageContentBlock>
+        {loading && (
+          <Box textAlign="center">
+            <Loading />
+          </Box>
+        )}
+        {!loading && (
+          <InnovationFlowChips
+            states={templateStates}
+            selectedState={selectedState}
+            onSelectState={state => setSelectedState(state.displayName)}
+          />
+        )}
+        <InnovationFlowCalloutsPreview callouts={callouts} selectedState={selectedState} loading={loading} />
+      </PageContentBlock>
+      <Caption>{t('templateLibrary.spaceTemplates.preview.info')}</Caption>
+    </>
   );
 };
 

--- a/src/domain/templates/components/TemplateSelectors/SubspaceTemplateSelector.tsx
+++ b/src/domain/templates/components/TemplateSelectors/SubspaceTemplateSelector.tsx
@@ -44,7 +44,7 @@ export const SubspaceTemplateSelector: FC<SubspaceTemplateSelectorProps> = ({ na
 
   const templateName = useMemo(() => {
     return templateData?.lookup.template?.profile.displayName ?? defaultTemplateName;
-  }, [templateData, defaultSpaceTemplatesData, t]);
+  }, [templateData, defaultTemplateName, t]);
 
   const handleSelectTemplate = async ({ id: templateId }: Identifiable): Promise<void> => {
     helpers.setValue(templateId);

--- a/src/domain/templates/components/TemplateSelectors/SubspaceTemplateSelector.tsx
+++ b/src/domain/templates/components/TemplateSelectors/SubspaceTemplateSelector.tsx
@@ -1,8 +1,8 @@
-import { Box, Button, Skeleton } from '@mui/material';
+import { Box, Button, Chip, Skeleton } from '@mui/material';
 import { useField } from 'formik';
-import { FC, useMemo, useState } from 'react';
+import React, { FC, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BlockSectionTitle, Text } from '@/core/ui/typography';
+import { BlockSectionTitle, Caption } from '@/core/ui/typography';
 import ImportTemplatesDialog from '../Dialogs/ImportTemplateDialog/ImportTemplatesDialog';
 import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt';
 import { LibraryIcon } from '@/domain/templates/LibraryIcon';
@@ -34,26 +34,43 @@ export const SubspaceTemplateSelector: FC<SubspaceTemplateSelectorProps> = ({ na
     skip: !spaceId,
   });
 
-  const templateName = useMemo(() => {
-    const selectedTemplate = templateData?.lookup.template?.profile.displayName;
+  const defaultTemplateName = useMemo(() => {
     const defaultSpaceTemplate = defaultSpaceTemplatesData?.lookup.space?.templatesManager?.templateDefaults.find(
       templateDefault => templateDefault.type === TemplateDefaultType.SpaceSubspace
     )?.template?.profile.displayName;
-    const defaultPlatformTemplate = t(`context.${SpaceLevel.L1}.template.defaultTemplate`);
-    return selectedTemplate ?? defaultSpaceTemplate ?? defaultPlatformTemplate;
-  }, [templateId, templateData, defaultSpaceTemplatesData, t]);
+
+    return defaultSpaceTemplate ?? t(`context.${SpaceLevel.L1}.template.defaultTemplate`);
+  }, [defaultSpaceTemplatesData, t]);
+
+  const templateName = useMemo(() => {
+    return templateData?.lookup.template?.profile.displayName ?? defaultTemplateName;
+  }, [templateData, defaultSpaceTemplatesData, t]);
 
   const handleSelectTemplate = async ({ id: templateId }: Identifiable): Promise<void> => {
     helpers.setValue(templateId);
     setDialogOpen(false);
   };
 
+  const handleRemoveTemplate = (): void => {
+    helpers.setValue('');
+  };
+
   const loading = loadingSpace || loadingTemplate || loadingSpaceTemplate;
 
   return (
     <Gutters row alignItems="center" {...rest}>
-      <BlockSectionTitle>{t(`context.${SpaceLevel.L1}.template.title`)}</BlockSectionTitle>
-      {loading ? <Skeleton width="100%" /> : <Text>{templateName}</Text>}
+      {loading && <Skeleton width="100%" />}
+      {!loading && templateName !== defaultTemplateName && (
+        <>
+          <BlockSectionTitle>{t(`context.${SpaceLevel.L1}.template.title`)}</BlockSectionTitle>
+          <Chip
+            variant="filled"
+            color="primary"
+            label={<Caption variant="button">{templateName}</Caption>}
+            onDelete={handleRemoveTemplate}
+          />
+        </>
+      )}
       <Box sx={{ marginLeft: 'auto' }}>
         <Button
           onClick={() => setDialogOpen(true)}


### PR DESCRIPTION
Changes related to the SubSpace creation:

- The Change Template block moved on top;
- Don't show the default template.
- In case of selected custom Space Template - show it.
- Option to remove already selected (defaults back to the default tmpl).
- Additional text on the bottom of the template preview - 'Also included: About information & Settings'.

![image](https://github.com/user-attachments/assets/b70f8289-1392-4372-b3a1-6c3394e83093)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a translated caption to the template space preview, providing additional information about included content.
- **Enhancements**
  - Improved template selection in forms by moving the template selector to a more prominent position and updating its appearance with chips and captions.
  - Enhanced user experience by allowing easy removal of selected templates directly from the form.
- **Localization**
  - Added a new translation string for template library previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->