### PR TITLE
hard reload after version mismatch to bypass Safari's cache

### DIFF
--- a/src/main/versionHandling.tsx
+++ b/src/main/versionHandling.tsx
@@ -52,7 +52,8 @@ export const VersionHandling = () => {
               color: 'white',
             }}
             onClick={() => {
-              window.location.reload();
+              // using window to avoid redundant re-rendering
+              window.location.replace(window.location.pathname + window.location.search);
             }}
           >
             {t('pages.error.buttons.reload')}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the page refresh mechanism by updating the reload button to use a more efficient navigation method, resulting in a smoother user experience when refreshing the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->