### PR TITLE
Vidua non-verified identity flow handling

### DIFF
--- a/src/core/auth/authentication/components/Kratos/messages.tsx
+++ b/src/core/auth/authentication/components/Kratos/messages.tsx
@@ -18,7 +18,7 @@ const messages: Record<string, string> = {
   '1070009': 'verification-flow-continue',
   '4000007': 'login-flow-account-exists',
   '4000006': 'invalid-credentials',
-  '4000002': 'email-claim-missing',
+  '4000002': 'claim-missing',
   '1040009': 'pick-password',
 };
 

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2958,7 +2958,7 @@
       "verification-flow-continue": "Continue",
       "login-flow-account-exists": "This email is already associated with an account. If you previously signed up via LinkedIn, GitHub, or Microsoft, please use that login method. Otherwise, reset your password.",
       "invalid-credentials": "The email address or password you inserted is invalid. Please check your credentials and try again. Are you trying to sign up instead? You can do so by clicking the link above.",
-      "email-claim-missing": "You haven't verified your Vidua identity. Please verify your identity and try again or try another sign up method.",
+      "claim-missing": "You haven't verified your Vidua identity. Please verify your identity and try again or try another sign up method.",
       "pick-password": "Pick a password for your account"
     },
     "fields": {


### PR DESCRIPTION
- handles the case where the user has a `Vidua` account but it is not verified
- returns to the login page and provides error to the user with meaningful message (handled only for Vidua OIDC login). 
- needs extra translations
- the error code `4000002` is returned whenever any claim is missing, so I had to filter out based on the text (as in the first login the `accepted_terms` is also missing)
- deployed on Acceptance

![image](https://github.com/user-attachments/assets/23ce91c1-360b-41f9-bd82-8130d802ee5d)


