### PR TITLE
Fix Sign In, Sign Up buttons on forum and contributors

### DIFF
--- a/src/domain/communication/discussion/views/DiscussionView.tsx
+++ b/src/domain/communication/discussion/views/DiscussionView.tsx
@@ -38,7 +38,7 @@ export const DiscussionView = ({
 
   const { id, description, author, createdAt, comments, myPrivileges } = discussion;
 
-  const canPost = comments.myPrivileges?.includes(AuthorizationPrivilege.CreateMessage) ?? false;
+  const canPostMessages = comments.myPrivileges?.includes(AuthorizationPrivilege.CreateMessage) ?? false;
   const canDeleteDiscussion = myPrivileges?.includes(AuthorizationPrivilege.Delete) ?? false;
   const canUpdateDiscussion = myPrivileges?.includes(AuthorizationPrivilege.Update) ?? false;
   const canDeleteComment = (authorId?: string) =>
@@ -92,7 +92,7 @@ export const DiscussionView = ({
                   return (
                     <Gutters>
                       <MessagesThread
-                        canPostMessages
+                        canPostMessages={canPostMessages}
                         messages={filteredComments}
                         canDeleteMessage={canDeleteComment}
                         onDeleteMessage={onDeleteComment}
@@ -110,14 +110,14 @@ export const DiscussionView = ({
         <GridLegacy item container spacing={2}>
           <GridLegacy item xs={12}>
             <Box paddingY={2}>
-              {canPost && (
+              {canPostMessages && (
                 <PostMessageToCommentsForm
                   onPostComment={comment => postMessage?.(comment)}
                   title={t('components.post-comment.fields.description.title')}
                   placeholder={t('components.post-comment.fields.description.placeholder')}
                 />
               )}
-              {!canPost && (
+              {!canPostMessages && (
                 <Box paddingY={4} display="flex" justifyContent="center">
                   <Typography variant="h4">{t('components.discussion.cant-post')}</Typography>
                 </Box>

--- a/src/domain/communication/room/Comments/MessageWithRepliesView.tsx
+++ b/src/domain/communication/room/Comments/MessageWithRepliesView.tsx
@@ -13,10 +13,12 @@ const ChildMessageContainer = styled(Box)(({ theme }) => ({
 
 interface MessageWithRepliesViewProps extends MessageViewProps {
   reply?: ReactNode;
+  canReply?: boolean;
 }
 
 export const MessageWithRepliesView = ({
   reply,
+  canReply = true,
   children,
   ...props
 }: PropsWithChildren<MessageWithRepliesViewProps>) => {
@@ -29,11 +31,13 @@ export const MessageWithRepliesView = ({
   return (
     <MessageView
       actions={
-        !isReplyFormVisible && (
-          <ButtonBase component="li" onClick={() => setHasPressedReply(true)}>
-            <CardText>{t('buttons.reply')}</CardText>
-          </ButtonBase>
-        )
+        <>
+          {!isReplyFormVisible && canReply && (
+            <ButtonBase component="li" onClick={() => setHasPressedReply(true)}>
+              <CardText>{t('buttons.reply')}</CardText>
+            </ButtonBase>
+          )}
+        </>
       }
       {...props}
     >

--- a/src/domain/communication/room/Comments/MessageWithRepliesView.tsx
+++ b/src/domain/communication/room/Comments/MessageWithRepliesView.tsx
@@ -31,13 +31,12 @@ export const MessageWithRepliesView = ({
   return (
     <MessageView
       actions={
-        <>
-          {!isReplyFormVisible && canReply && (
-            <ButtonBase component="li" onClick={() => setHasPressedReply(true)}>
-              <CardText>{t('buttons.reply')}</CardText>
-            </ButtonBase>
-          )}
-        </>
+        !isReplyFormVisible &&
+        canReply && (
+          <ButtonBase component="li" onClick={() => setHasPressedReply(true)}>
+            <CardText>{t('buttons.reply')}</CardText>
+          </ButtonBase>
+        )
       }
       {...props}
     >

--- a/src/domain/communication/room/Comments/MessagesThread.tsx
+++ b/src/domain/communication/room/Comments/MessagesThread.tsx
@@ -47,6 +47,7 @@ const MessagesThread = ({
           message={message}
           canDelete={!message.deleted && canDeleteMessage(message.author?.id)}
           onDelete={onDeleteMessage}
+          canReply={canPostMessages}
           canAddReaction={canAddReaction && !message.deleted}
           addReaction={addReaction}
           removeReaction={removeReaction}

--- a/src/domain/shared/components/Backdrops/ImageBackdrop.tsx
+++ b/src/domain/shared/components/Backdrops/ImageBackdrop.tsx
@@ -1,9 +1,10 @@
-import { _AUTH_LOGIN_PATH, AUTH_SIGN_UP_PATH } from '@/core/auth/authentication/constants/authentication.constants';
 import useNavigate from '@/core/routing/useNavigate';
 import ImageFadeIn from '@/core/ui/image/ImageFadeIn';
+import { buildLoginUrl, buildSignUpUrl } from '@/main/routing/urlBuilders';
 import { Box, BoxProps, Button, styled, Typography, TypographyProps } from '@mui/material';
 import { FC, PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 const Root = styled(Box)(() => ({
   position: 'relative',
@@ -73,6 +74,9 @@ const ImageBackdrop: FC<ImageBackdropProps> = ({
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const loginUrl = buildLoginUrl(pathname);
+  const signUpUrl = buildSignUpUrl(pathname);
 
   return (
     <>
@@ -88,11 +92,11 @@ const ImageBackdrop: FC<ImageBackdropProps> = ({
             </Typography>
 
             <ButtonsWrapper>
-              <Button variant={'contained'} onClick={() => navigate(_AUTH_LOGIN_PATH, { replace: true })}>
+              <Button variant={'contained'} onClick={() => navigate(loginUrl, { replace: true })}>
                 {t('authentication.sign-in')}
               </Button>
 
-              <Button variant={'contained'} onClick={() => navigate(AUTH_SIGN_UP_PATH, { replace: true })}>
+              <Button variant={'contained'} onClick={() => navigate(signUpUrl, { replace: true })}>
                 {t('authentication.sign-up')}
               </Button>
             </ButtonsWrapper>

--- a/src/main/routing/urlBuilders.ts
+++ b/src/main/routing/urlBuilders.ts
@@ -30,7 +30,7 @@ export const buildLoginUrl = (returnUrl?: string) => {
 };
 
 export const buildSignUpUrl = (returnUrl?: string, params?: string) => {
-  return `${AUTH_SIGN_UP_PATH}${buildReturnUrlParam(returnUrl)}${params}`;
+  return `${AUTH_SIGN_UP_PATH}${buildReturnUrlParam(returnUrl)}${params ? params : ''}`;
 };
 
 export const buildNewOrganizationUrl = () => {


### PR DESCRIPTION
- Forum was working alright
- Fixed the Contributors page with the ImageBackdrop file changes
- That component is also used in a Public Space > Community tab. It was failing the same way before, fixed now

I detected a few other problems
- I could click on Reply to a message and try to send a message while not logged in, resulting in an error - Fixed with the changes in domain/communication files
- buildSignUp url was returning urls like `https://alkem.io/contributorsundefined` concatenating undefined when params was not defined.
- Behavior of the signup is not consistent - The localStorage is sometimes storing it, sometimes not. there's some a problem in `SignUpReturnUrl.ts` that I think I cannot fix in a bugsquashing session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for conditionally displaying the reply button in message threads based on user permissions.

- **Bug Fixes**
	- Improved URL generation for sign-up links to prevent unintended text from appearing in the URL.

- **Refactor**
	- Updated internal naming for message posting permissions to improve clarity.
	- Navigation buttons now use dynamically generated URLs based on the current location, enhancing context awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->