### PR TITLE
Fix the time position on invite horizontal card

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -688,6 +688,7 @@
         }
       },
       "invitationTitle": "{{time}} {{user}} invited {{invitedEntity}} to <spaceicon /> {{space}}",
+      "invitationCardTitle": "{{user}} invited {{invitedEntity}} to <spaceicon /> {{space}}",
       "you": "you",
       "vc": "your Virtual Contributor"
     },

--- a/src/domain/community/invitations/InvitationCardHorizontal/InvitationCardHorizontal.tsx
+++ b/src/domain/community/invitations/InvitationCardHorizontal/InvitationCardHorizontal.tsx
@@ -1,11 +1,15 @@
 import { InvitationWithMeta } from '@/domain/community/pendingMembership/PendingMemberships';
 import SpaceAvatar from '@/domain/space/components/SpaceAvatar';
-import { BlockSectionTitle, CardText } from '@/core/ui/typography';
+import { BlockSectionTitle, CardText, Caption } from '@/core/ui/typography';
 import { gutters } from '@/core/ui/grid/utils';
 import WrapperMarkdown from '@/core/ui/markdown/WrapperMarkdown';
 import BadgeCardView from '@/core/ui/list/BadgeCardView';
 import DetailedActivityDescription from '@/domain/shared/components/ActivityDescription/DetailedActivityDescription';
 import LinkButton from '@/core/ui/button/LinkButton';
+import { formatTimeElapsed } from '@/domain/shared/utils/formatTimeElapsed';
+import { useTranslation } from 'react-i18next';
+import { Box } from '@mui/material';
+import Gutters from '@/core/ui/grid/Gutters';
 
 type InvitationCardHorizontalProps = {
   invitation: InvitationWithMeta | undefined;
@@ -17,6 +21,9 @@ const InvitationCardHorizontal = ({ invitation, onClick }: InvitationCardHorizon
     return null;
   }
 
+  const { t } = useTranslation();
+  const time = formatTimeElapsed(invitation.invitation.createdDate, t);
+
   return (
     <BadgeCardView
       component={LinkButton}
@@ -24,31 +31,37 @@ const InvitationCardHorizontal = ({ invitation, onClick }: InvitationCardHorizon
       onClick={onClick}
       outlined
     >
-      <BlockSectionTitle noWrap>
-        <DetailedActivityDescription
-          i18nKey="community.pendingMembership.invitationTitle"
-          spaceDisplayName={invitation.space.about.profile.displayName}
-          spaceUrl={invitation.space.about.profile.url}
-          spaceLevel={invitation.space.level}
-          createdDate={invitation.invitation.createdDate}
-          author={{ displayName: invitation.userDisplayName }}
-          type={invitation.invitation.contributorType}
-        />
-      </BlockSectionTitle>
-      <CardText
-        sx={{
-          img: {
-            maxHeight: gutters(1),
-          },
-        }}
-        noWrap
-      >
-        {invitation.invitation.welcomeMessage && (
-          <WrapperMarkdown card plain>
-            {invitation.invitation.welcomeMessage}
-          </WrapperMarkdown>
-        )}
-      </CardText>
+      <Gutters disablePadding row fullWidth>
+        <Box flex={1}>
+          <BlockSectionTitle>
+            <DetailedActivityDescription
+              i18nKey="community.pendingMembership.invitationCardTitle"
+              spaceDisplayName={invitation.space.about.profile.displayName}
+              spaceUrl={invitation.space.about.profile.url}
+              spaceLevel={invitation.space.level}
+              createdDate={invitation.invitation.createdDate}
+              author={{ displayName: invitation.userDisplayName }}
+              type={invitation.invitation.contributorType}
+            />
+          </BlockSectionTitle>
+          <CardText
+            sx={{
+              img: {
+                maxHeight: gutters(1),
+              },
+            }}
+          >
+            {invitation.invitation.welcomeMessage && (
+              <WrapperMarkdown card plain multiline>
+                {invitation.invitation.welcomeMessage}
+              </WrapperMarkdown>
+            )}
+          </CardText>
+        </Box>
+        <Box display="flex" alignItems="center">
+          <Caption>{time}</Caption>
+        </Box>
+      </Gutters>
     </BadgeCardView>
   );
 };


### PR DESCRIPTION
In addition, the entire text is now visible on smaller resolutions. 
The other views - full card, etc - were not altered. Only the described card.
The positioning of the card can be changed in the translations. 

![image](https://github.com/user-attachments/assets/65e40e52-30b9-48c6-b313-be15ca1643de)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible time caption showing how long ago the invitation was sent on the invitation card.

- **Improvements**
  - Enhanced invitation card layout for better readability.
  - Improved internationalization and text formatting support, including multiline welcome messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->