### PR TITLE
Fix the privacy display of subspaces in the left navigation (Space dash and Subspaces)

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -1412,6 +1412,11 @@ export type GeoKeySpecifier = ('endpoint' | GeoKeySpecifier)[];
 export type GeoFieldPolicy = {
   endpoint?: FieldPolicy<any> | FieldReadFunction<any>;
 };
+export type GeoLocationKeySpecifier = ('latitude' | 'longitude' | GeoLocationKeySpecifier)[];
+export type GeoLocationFieldPolicy = {
+  latitude?: FieldPolicy<any> | FieldReadFunction<any>;
+  longitude?: FieldPolicy<any> | FieldReadFunction<any>;
+};
 export type GroupableKeySpecifier = ('groups' | GroupableKeySpecifier)[];
 export type GroupableFieldPolicy = {
   groups?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -1867,6 +1872,7 @@ export type LocationKeySpecifier = (
   | 'city'
   | 'country'
   | 'createdDate'
+  | 'geoLocation'
   | 'id'
   | 'postalCode'
   | 'stateOrProvince'
@@ -1879,6 +1885,7 @@ export type LocationFieldPolicy = {
   city?: FieldPolicy<any> | FieldReadFunction<any>;
   country?: FieldPolicy<any> | FieldReadFunction<any>;
   createdDate?: FieldPolicy<any> | FieldReadFunction<any>;
+  geoLocation?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   postalCode?: FieldPolicy<any> | FieldReadFunction<any>;
   stateOrProvince?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -2143,6 +2150,7 @@ export type MutationKeySpecifier = (
   | 'adminCommunicationUpdateRoomState'
   | 'adminSearchIngestFromScratch'
   | 'adminUpdateContributorAvatars'
+  | 'adminUpdateGeoLocationData'
   | 'adminUserAccountDelete'
   | 'adminWingbackCreateTestCustomer'
   | 'adminWingbackGetCustomerEntitlements'
@@ -2314,6 +2322,7 @@ export type MutationFieldPolicy = {
   adminCommunicationUpdateRoomState?: FieldPolicy<any> | FieldReadFunction<any>;
   adminSearchIngestFromScratch?: FieldPolicy<any> | FieldReadFunction<any>;
   adminUpdateContributorAvatars?: FieldPolicy<any> | FieldReadFunction<any>;
+  adminUpdateGeoLocationData?: FieldPolicy<any> | FieldReadFunction<any>;
   adminUserAccountDelete?: FieldPolicy<any> | FieldReadFunction<any>;
   adminWingbackCreateTestCustomer?: FieldPolicy<any> | FieldReadFunction<any>;
   adminWingbackGetCustomerEntitlements?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -4652,6 +4661,10 @@ export type StrictTypedTypePolicies = {
   Geo?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | GeoKeySpecifier | (() => undefined | GeoKeySpecifier);
     fields?: GeoFieldPolicy;
+  };
+  GeoLocation?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | GeoLocationKeySpecifier | (() => undefined | GeoLocationKeySpecifier);
+    fields?: GeoLocationFieldPolicy;
   };
   Groupable?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | GroupableKeySpecifier | (() => undefined | GroupableKeySpecifier);

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -16297,11 +16297,13 @@ export const SpaceDashboardNavigationSubspacesDocument = gql`
         }
         about {
           ...SpaceAboutCardBanner
+          isContentPublic
         }
         subspaces {
           id
           about {
             ...SpaceAboutCardAvatar
+            isContentPublic
             membership {
               myMembershipStatus
             }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -1410,7 +1410,7 @@ export type CommunityGuidelines = {
   createdDate: Scalars['DateTime']['output'];
   /** The ID of the entity */
   id: Scalars['UUID']['output'];
-  /** The details of the guidelilnes */
+  /** The details of the guidelines */
   profile: Profile;
   /** The date at which the entity was last updated. */
   updatedDate: Scalars['DateTime']['output'];
@@ -1960,6 +1960,8 @@ export type CreateReferenceOnProfileInput = {
 };
 
 export type CreateSpaceAboutInput = {
+  /** The CommunityGuidelines for the Space */
+  guidelines?: InputMaybe<CreateCommunityGuidelinesInput>;
   profileData: CreateProfileInput;
   when?: InputMaybe<Scalars['Markdown']['input']>;
   who?: InputMaybe<Scalars['Markdown']['input']>;
@@ -2496,6 +2498,14 @@ export type Geo = {
   __typename?: 'Geo';
   /** Endpoint where geo information is consumed from. */
   endpoint: Scalars['String']['output'];
+};
+
+export type GeoLocation = {
+  __typename?: 'GeoLocation';
+  /** The Latitude for this Location, derived from (City, Country) if those are set. */
+  latitude?: Maybe<Scalars['Float']['output']>;
+  /** The Longitude for this Location, derived from (City, Country) if those are set. */
+  longitude?: Maybe<Scalars['Float']['output']>;
 };
 
 export type GrantAuthorizationCredentialInput = {
@@ -3090,6 +3100,8 @@ export type Location = {
   country?: Maybe<Scalars['String']['output']>;
   /** The date at which the entity was created. */
   createdDate: Scalars['DateTime']['output'];
+  /** The GeoLocation for this Location, derived from (City, Country) if those are set. */
+  geoLocation: GeoLocation;
   /** The ID of the entity */
   id: Scalars['UUID']['output'];
   postalCode?: Maybe<Scalars['String']['output']>;
@@ -3698,6 +3710,8 @@ export type Mutation = {
   adminSearchIngestFromScratch: Scalars['String']['output'];
   /** Update the Avatar on the Profile with the spedified profileID to be stored as a Document. */
   adminUpdateContributorAvatars: Profile;
+  /** Updates the GeoLocation data where required on the platform. */
+  adminUpdateGeoLocationData: Scalars['Boolean']['output'];
   /** Remove the Kratos account associated with the specified User. Note: the Users profile on the platform is not deleted. */
   adminUserAccountDelete: User;
   /** Create a test customer on wingback. */
@@ -20737,6 +20751,7 @@ export type SpaceDashboardNavigationSubspacesQuery = {
             | undefined;
           about: {
             __typename?: 'SpaceAbout';
+            isContentPublic: boolean;
             id: string;
             profile: {
               __typename?: 'Profile';
@@ -20755,6 +20770,7 @@ export type SpaceDashboardNavigationSubspacesQuery = {
             id: string;
             about: {
               __typename?: 'SpaceAbout';
+              isContentPublic: boolean;
               id: string;
               membership: {
                 __typename?: 'SpaceAboutMembership';

--- a/src/core/ui/list/LinksList.tsx
+++ b/src/core/ui/list/LinksList.tsx
@@ -1,6 +1,5 @@
-import { MouseEvent } from 'react';
 import Avatar from '@/core/ui/avatar/Avatar';
-import { Box, Collapse, List, ListItem, Skeleton, Tooltip, IconButton, TooltipProps } from '@mui/material';
+import { Box, Collapse, List, ListItem, Skeleton, Tooltip, TooltipProps } from '@mui/material';
 import { times } from 'lodash';
 import { ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -34,7 +33,6 @@ const listItemStyles = {
   alignItems: 'center',
 } as const;
 
-// TODO: optimize the component render logic. There's a duplicated code for the ListItem.
 /**
  * LinksList
  *
@@ -49,74 +47,44 @@ const listItemStyles = {
  */
 const LinksList = ({ items = [], emptyListCaption, loading = false }: LinksListProps) => {
   const { t } = useTranslation();
-  const preventDefault = (e: MouseEvent<HTMLButtonElement>) => e.preventDefault();
   const tooltipPlacement: TooltipProps['placement'] = 'right';
 
   const [isExpanded, setIsExpanded] = useState(false);
 
   const handleExpand = () => setIsExpanded(!isExpanded);
 
+  // Helper to render a single link item
+  const renderListItem = (item: Item) => (
+    <ListItem
+      key={item.id}
+      component={RouterLink}
+      to={item.uri}
+      sx={{ paddingX: 0, marginTop: gutters(1), ...listItemStyles }}
+    >
+      <Avatar variant="rounded" alt="subspace avatar" src={item.cardBanner} aria-label="Subspace avatar" />
+
+      <BlockSectionTitle minWidth={0} noWrap>
+        {item.title}
+      </BlockSectionTitle>
+      {item.isPrivate && (
+        <Tooltip
+          title={<Caption>{t('components.dashboardNavigation.privateSubspace')}</Caption>}
+          placement={tooltipPlacement}
+          arrow
+        >
+          <LockOutlined sx={{ ml: 'auto', color: theme => theme.palette.neutral.light }} />
+        </Tooltip>
+      )}
+    </ListItem>
+  );
+
   return (
     <List sx={{ p: 0 }}>
       {loading && times(3, i => <ListItem key={i} component={Skeleton} sx={listItemStyles} />)}
       {!loading && items.length === 0 && emptyListCaption && <CaptionSmall>{emptyListCaption}</CaptionSmall>}
-      {!loading &&
-        items.length > 0 &&
-        items.slice(0, COLLAPSED_LIST_ITEM_LIMIT).map(item => (
-          <ListItem
-            key={item.id}
-            component={RouterLink}
-            to={item.uri}
-            sx={{ paddingX: 0, marginTop: gutters(1), ...listItemStyles }}
-          >
-            <Avatar variant="rounded" alt="subspace avatar" src={item.cardBanner} aria-label="Subspace avatar" />
-
-            <BlockSectionTitle minWidth={0} noWrap>
-              {item.title}
-            </BlockSectionTitle>
-            {item.isPrivate && (
-              <Tooltip
-                title={<Caption>{t('components.dashboardNavigation.privateSubspace')}</Caption>}
-                placement={tooltipPlacement}
-                arrow
-                sx={{ ml: 'auto' }}
-              >
-                <IconButton disableRipple onClick={preventDefault} aria-label={t('common.lock')}>
-                  <LockOutlined />
-                </IconButton>
-              </Tooltip>
-            )}
-          </ListItem>
-        ))}
+      {!loading && items.length > 0 && items.slice(0, COLLAPSED_LIST_ITEM_LIMIT).map(renderListItem)}
       {!loading && items.length > COLLAPSED_LIST_ITEM_LIMIT && (
-        <Collapse in={isExpanded}>
-          {items.slice(COLLAPSED_LIST_ITEM_LIMIT).map(item => (
-            <ListItem
-              key={item.id}
-              component={RouterLink}
-              to={item.uri}
-              sx={{ paddingX: 0, marginTop: gutters(1), ...listItemStyles }}
-            >
-              <Avatar variant="rounded" alt="subspace avatar" src={item.cardBanner} aria-label="Subspace avatar" />
-
-              <BlockSectionTitle minWidth={0} noWrap>
-                {item.title}
-              </BlockSectionTitle>
-              {item.isPrivate && (
-                <Tooltip
-                  title={<Caption>{t('components.dashboardNavigation.privateSubspace')}</Caption>}
-                  placement={tooltipPlacement}
-                  arrow
-                  sx={{ ml: 'auto' }}
-                >
-                  <IconButton disableRipple onClick={preventDefault} aria-label={t('common.lock')}>
-                    <LockOutlined />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </ListItem>
-          ))}
-        </Collapse>
+        <Collapse in={isExpanded}>{items.slice(COLLAPSED_LIST_ITEM_LIMIT).map(renderListItem)}</Collapse>
       )}
       <Box
         flexGrow={1}

--- a/src/core/ui/list/LinksList.tsx
+++ b/src/core/ui/list/LinksList.tsx
@@ -1,7 +1,11 @@
+import { MouseEvent } from 'react';
 import Avatar from '@/core/ui/avatar/Avatar';
-import { Box, Collapse, List, ListItem, Skeleton } from '@mui/material';
+import { Box, Collapse, List, ListItem, Skeleton, Tooltip, IconButton, TooltipProps } from '@mui/material';
 import { times } from 'lodash';
 import { ReactNode, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LockOutlined } from '@mui/icons-material';
+import { Caption } from '../typography';
 import CardExpandButton from '../card/CardExpandButton';
 import { gutters } from '../grid/utils';
 import RouterLink from '../link/RouterLink';
@@ -13,6 +17,7 @@ interface Item {
   icon: ReactNode;
   uri: string;
   cardBanner?: string;
+  isPrivate?: boolean;
 }
 
 export interface LinksListProps {
@@ -29,7 +34,24 @@ const listItemStyles = {
   alignItems: 'center',
 } as const;
 
+// TODO: optimize the component render logic. There's a duplicated code for the ListItem.
+/**
+ * LinksList
+ *
+ * Renders a vertical list of link items with optional loading state and empty caption.
+ * Displays up to a fixed number of items and allows expansion for more.
+ * Adds a lock icon tooltip for items marked as private to indicate restricted access.
+ *
+ * Props:
+ * @param {Item[]} props.items - Array of link items. Each item defines id, title, uri, optional icon, banner, and isPrivate flag.
+ * @param {string} [props.emptyListCaption] - Caption to display when there are no items.
+ * @param {boolean} [props.loading=false] - If true, shows skeleton loaders instead of list items.
+ */
 const LinksList = ({ items = [], emptyListCaption, loading = false }: LinksListProps) => {
+  const { t } = useTranslation();
+  const preventDefault = (e: MouseEvent<HTMLButtonElement>) => e.preventDefault();
+  const tooltipPlacement: TooltipProps['placement'] = 'right';
+
   const [isExpanded, setIsExpanded] = useState(false);
 
   const handleExpand = () => setIsExpanded(!isExpanded);
@@ -45,13 +67,25 @@ const LinksList = ({ items = [], emptyListCaption, loading = false }: LinksListP
             key={item.id}
             component={RouterLink}
             to={item.uri}
-            sx={{ ...listItemStyles, marginTop: gutters(0.5) }}
+            sx={{ paddingX: 0, marginTop: gutters(1), ...listItemStyles }}
           >
             <Avatar variant="rounded" alt="subspace avatar" src={item.cardBanner} aria-label="Subspace avatar" />
 
             <BlockSectionTitle minWidth={0} noWrap>
               {item.title}
             </BlockSectionTitle>
+            {item.isPrivate && (
+              <Tooltip
+                title={<Caption>{t('components.dashboardNavigation.privateSubspace')}</Caption>}
+                placement={tooltipPlacement}
+                arrow
+                sx={{ ml: 'auto' }}
+              >
+                <IconButton disableRipple onClick={preventDefault} aria-label={t('common.lock')}>
+                  <LockOutlined />
+                </IconButton>
+              </Tooltip>
+            )}
           </ListItem>
         ))}
       {!loading && items.length > COLLAPSED_LIST_ITEM_LIMIT && (
@@ -61,13 +95,25 @@ const LinksList = ({ items = [], emptyListCaption, loading = false }: LinksListP
               key={item.id}
               component={RouterLink}
               to={item.uri}
-              sx={{ ...listItemStyles, marginTop: gutters(0.5) }}
+              sx={{ paddingX: 0, marginTop: gutters(1), ...listItemStyles }}
             >
               <Avatar variant="rounded" alt="subspace avatar" src={item.cardBanner} aria-label="Subspace avatar" />
 
               <BlockSectionTitle minWidth={0} noWrap>
                 {item.title}
               </BlockSectionTitle>
+              {item.isPrivate && (
+                <Tooltip
+                  title={<Caption>{t('components.dashboardNavigation.privateSubspace')}</Caption>}
+                  placement={tooltipPlacement}
+                  arrow
+                  sx={{ ml: 'auto' }}
+                >
+                  <IconButton disableRipple onClick={preventDefault} aria-label={t('common.lock')}>
+                    <LockOutlined />
+                  </IconButton>
+                </Tooltip>
+              )}
             </ListItem>
           ))}
         </Collapse>

--- a/src/domain/space/components/spaceDashboardNavigation/SpaceDashboardNavigation.graphql
+++ b/src/domain/space/components/spaceDashboardNavigation/SpaceDashboardNavigation.graphql
@@ -8,11 +8,13 @@ query SpaceDashboardNavigationSubspaces($spaceId: UUID!) {
       }
       about {
         ...SpaceAboutCardBanner
+        isContentPublic
       }
       subspaces {
         id
         about {
           ...SpaceAboutCardAvatar
+          isContentPublic
           membership {
             myMembershipStatus
           }

--- a/src/domain/space/components/spaceDashboardNavigation/useSpaceDashboardNavigation.ts
+++ b/src/domain/space/components/spaceDashboardNavigation/useSpaceDashboardNavigation.ts
@@ -3,7 +3,6 @@ import {
   useSpacePrivilegesQuery,
 } from '@/core/apollo/generated/apollo-hooks';
 import {
-  Authorization,
   AuthorizationPrivilege,
   CommunityMembershipStatus,
   MyMembershipsRoleSetFragment,
@@ -37,30 +36,24 @@ export interface DashboardNavigationItem {
   children?: DashboardNavigationItem[];
 }
 
-const getDashboardNavigationItemProps = (
-  space: {
-    id: string;
-    about: SpaceAboutLightModel;
-    roleSet?: MyMembershipsRoleSetFragment;
-    authorization?: {
-      myPrivileges?: AuthorizationPrivilege[];
-    };
-  },
-  disabled?: boolean
-): DashboardNavigationItem => {
+const getDashboardNavigationItemProps = (space: {
+  id: string;
+  about: SpaceAboutLightModel;
+  roleSet?: MyMembershipsRoleSetFragment;
+  authorization?: {
+    myPrivileges?: AuthorizationPrivilege[];
+  };
+}): DashboardNavigationItem => {
   return {
     id: space.id,
     url: space.about.profile.url,
     displayName: space.about.profile.displayName,
     avatar: space.about.profile.avatar,
-    private: disabled,
+    private: !space.about.isContentPublic,
     member: space.about.membership?.myMembershipStatus === CommunityMembershipStatus.Member,
     canCreateSubspace: space.authorization?.myPrivileges?.includes(AuthorizationPrivilege.CreateSubspace),
   };
 };
-
-const isReadable = ({ authorization }: { authorization?: Partial<Authorization> }) =>
-  authorization?.myPrivileges?.includes(AuthorizationPrivilege.Read);
 
 const useSpaceDashboardNavigation = ({
   spaceId,
@@ -97,7 +90,7 @@ const useSpaceDashboardNavigation = ({
       ...getDashboardNavigationItemProps(space),
       children: space.subspaces.map(subspace => {
         return {
-          ...getDashboardNavigationItemProps(subspace, !isReadable(subspace)),
+          ...getDashboardNavigationItemProps(subspace),
         };
       }),
     };

--- a/src/domain/space/components/subspaces/SubspaceView.tsx
+++ b/src/domain/space/components/subspaces/SubspaceView.tsx
@@ -79,6 +79,7 @@ const SubspaceView = <ChildEntity extends BaseChildEntity>({
           icon: childEntitiesIcon,
           uri: entity.about.profile.url,
           cardBanner: entity.about.profile?.cardBanner?.uri || defaultVisualUrls.AVATAR,
+          isPrivate: !entity.about.isContentPublic,
         }))
         .filter(ss => ss.title.toLowerCase().includes(filter.toLowerCase())),
     [childEntities, filter, childEntitiesIcon]


### PR DESCRIPTION
Also adjusted the styles of the List component in the Subspaces dash, to be similar to the one from the Space dash.

![image](https://github.com/user-attachments/assets/66770eac-b8e6-48e1-8062-d66d011ea868)
![image](https://github.com/user-attachments/assets/8979cfb2-45a9-455a-8048-5c6c572d02f9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Items in lists now display a lock icon with a tooltip when marked as private, indicating restricted access.
  - Tooltip text for the lock icon is localized for different languages.

- **Chores**
  - Streamlined logic for determining item privacy and removed unused code for readability checks.
  - Updated GraphQL queries to include content privacy status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->