### PR TITLE
fix the host msg in about dialog

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -1798,6 +1798,7 @@ export const SpaceAboutDetailsFragmentDoc = gql`
           city
           country
         }
+        type
       }
     }
     profile {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -19971,6 +19971,7 @@ export type SpaceAboutDetailsQuery = {
                     id: string;
                     url: string;
                     displayName: string;
+                    type?: ProfileType | undefined;
                     avatar?:
                       | {
                           __typename?: 'Visual';
@@ -19993,6 +19994,7 @@ export type SpaceAboutDetailsQuery = {
                     id: string;
                     url: string;
                     displayName: string;
+                    type?: ProfileType | undefined;
                     avatar?:
                       | {
                           __typename?: 'Visual';
@@ -20015,6 +20017,7 @@ export type SpaceAboutDetailsQuery = {
                     id: string;
                     url: string;
                     displayName: string;
+                    type?: ProfileType | undefined;
                     avatar?:
                       | {
                           __typename?: 'Visual';
@@ -20197,6 +20200,7 @@ export type SpaceAboutFullQuery = {
                     id: string;
                     url: string;
                     displayName: string;
+                    type?: ProfileType | undefined;
                     avatar?:
                       | {
                           __typename?: 'Visual';
@@ -20219,6 +20223,7 @@ export type SpaceAboutFullQuery = {
                     id: string;
                     url: string;
                     displayName: string;
+                    type?: ProfileType | undefined;
                     avatar?:
                       | {
                           __typename?: 'Visual';
@@ -20241,6 +20246,7 @@ export type SpaceAboutFullQuery = {
                     id: string;
                     url: string;
                     displayName: string;
+                    type?: ProfileType | undefined;
                     avatar?:
                       | {
                           __typename?: 'Visual';
@@ -20427,6 +20433,7 @@ export type SpaceAboutDetailsFragment = {
           id: string;
           url: string;
           displayName: string;
+          type?: ProfileType | undefined;
           avatar?:
             | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
             | undefined;
@@ -20443,6 +20450,7 @@ export type SpaceAboutDetailsFragment = {
           id: string;
           url: string;
           displayName: string;
+          type?: ProfileType | undefined;
           avatar?:
             | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
             | undefined;
@@ -20459,6 +20467,7 @@ export type SpaceAboutDetailsFragment = {
           id: string;
           url: string;
           displayName: string;
+          type?: ProfileType | undefined;
           avatar?:
             | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
             | undefined;
@@ -21179,6 +21188,7 @@ export type UpdateSpaceMutation = {
               id: string;
               url: string;
               displayName: string;
+              type?: ProfileType | undefined;
               avatar?:
                 | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
                 | undefined;
@@ -21195,6 +21205,7 @@ export type UpdateSpaceMutation = {
               id: string;
               url: string;
               displayName: string;
+              type?: ProfileType | undefined;
               avatar?:
                 | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
                 | undefined;
@@ -21211,6 +21222,7 @@ export type UpdateSpaceMutation = {
               id: string;
               url: string;
               displayName: string;
+              type?: ProfileType | undefined;
               avatar?:
                 | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
                 | undefined;
@@ -21352,6 +21364,7 @@ export type SpaceInfoFragment = {
             id: string;
             url: string;
             displayName: string;
+            type?: ProfileType | undefined;
             avatar?:
               | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
               | undefined;
@@ -21368,6 +21381,7 @@ export type SpaceInfoFragment = {
             id: string;
             url: string;
             displayName: string;
+            type?: ProfileType | undefined;
             avatar?:
               | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
               | undefined;
@@ -21384,6 +21398,7 @@ export type SpaceInfoFragment = {
             id: string;
             url: string;
             displayName: string;
+            type?: ProfileType | undefined;
             avatar?:
               | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
               | undefined;
@@ -21970,6 +21985,7 @@ export type SpacePageQuery = {
                     id: string;
                     url: string;
                     displayName: string;
+                    type?: ProfileType | undefined;
                     description?: string | undefined;
                     avatar?:
                       | {
@@ -22003,6 +22019,7 @@ export type SpacePageQuery = {
                     id: string;
                     url: string;
                     displayName: string;
+                    type?: ProfileType | undefined;
                     description?: string | undefined;
                     avatar?:
                       | {
@@ -22036,6 +22053,7 @@ export type SpacePageQuery = {
                     id: string;
                     url: string;
                     displayName: string;
+                    type?: ProfileType | undefined;
                     description?: string | undefined;
                     avatar?:
                       | {
@@ -22250,6 +22268,7 @@ export type SpacePageFragment = {
             id: string;
             url: string;
             displayName: string;
+            type?: ProfileType | undefined;
             description?: string | undefined;
             avatar?:
               | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
@@ -22277,6 +22296,7 @@ export type SpacePageFragment = {
             id: string;
             url: string;
             displayName: string;
+            type?: ProfileType | undefined;
             description?: string | undefined;
             avatar?:
               | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
@@ -22304,6 +22324,7 @@ export type SpacePageFragment = {
             id: string;
             url: string;
             displayName: string;
+            type?: ProfileType | undefined;
             description?: string | undefined;
             avatar?:
               | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }

--- a/src/domain/community/community/EntityDashboardLeadsSection/EntityDashboardLeadsSection.tsx
+++ b/src/domain/community/community/EntityDashboardLeadsSection/EntityDashboardLeadsSection.tsx
@@ -9,6 +9,7 @@ import DashboardLeads from './DashboardLeads';
 import ContributorCardHorizontal, { ContributorCardHorizontalProps } from '@/core/ui/card/ContributorCardHorizontal';
 import useDirectMessageDialog from '@/domain/communication/messaging/DirectMessaging/useDirectMessageDialog';
 import { ContributorViewModel } from '../utils/ContributorViewModel';
+import { ProfileType } from '@/core/apollo/generated/graphql-schema';
 
 const OrganizationCardTransparent = (props: ContributorCardHorizontalProps) => <ContributorCardHorizontal {...props} />;
 
@@ -24,6 +25,8 @@ interface EntityDashboardLeadsProps {
   organizationsHeaderIcon?: ReactElement<SvgIconProps>;
   usersHeader?: string;
 }
+
+export const getMessageType = (type: ProfileType | undefined) => (type === ProfileType.User ? 'user' : 'organization');
 
 const EntityDashboardLeadsSection = ({
   usersHeader,
@@ -48,7 +51,7 @@ const EntityDashboardLeadsSection = ({
         profile: org.profile,
         seamless: true,
         onContact: () => {
-          sendMessage('organization', {
+          sendMessage(getMessageType(ProfileType.Organization), {
             id: org.id,
             avatarUri: org.profile.avatar?.uri,
             displayName: org.profile.displayName,
@@ -66,7 +69,7 @@ const EntityDashboardLeadsSection = ({
       profile: user.profile,
       seamless: true,
       onContact: () => {
-        sendMessage('user', {
+        sendMessage(getMessageType(ProfileType.User), {
           id: user.id,
           avatarUri: user.profile.avatar?.uri,
           displayName: user.profile.displayName,

--- a/src/domain/space/about/SpaceAboutDialog.tsx
+++ b/src/domain/space/about/SpaceAboutDialog.tsx
@@ -130,7 +130,7 @@ const SpaceAboutDialog = ({
             component={Link}
             onClick={() => {
               if (!isAuthenticated) {
-                window.location.href = buildSignUpUrl(window.location.pathname, window.location.search);
+                navigate(buildSignUpUrl(window.location.pathname, window.location.search));
                 return;
               }
 

--- a/src/domain/space/about/SpaceAboutDialog.tsx
+++ b/src/domain/space/about/SpaceAboutDialog.tsx
@@ -6,12 +6,14 @@ import { MouseEventHandler, useRef } from 'react';
 import { Caption, CaptionSmall } from '@/core/ui/typography';
 import PageContentColumn from '@/core/ui/content/PageContentColumn';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
-import EntityDashboardLeadsSection from '@/domain/community/community/EntityDashboardLeadsSection/EntityDashboardLeadsSection';
+import EntityDashboardLeadsSection, {
+  getMessageType,
+} from '@/domain/community/community/EntityDashboardLeadsSection/EntityDashboardLeadsSection';
 import { Trans, useTranslation } from 'react-i18next';
 import { Theme } from '@mui/material/styles';
 import PageContentBlockSeamless from '@/core/ui/content/PageContentBlockSeamless';
 import References from '@/domain/shared/components/References/References';
-import { CommunityMembershipStatus, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
+import { CommunityMembershipStatus, ProfileType, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import FlagCircleOutlinedIcon from '@mui/icons-material/FlagCircleOutlined';
@@ -27,9 +29,10 @@ import ApplicationButton from '@/domain/community/applicationButton/ApplicationB
 import ApplicationButtonContainer from '@/domain/access/ApplicationsAndInvitations/ApplicationButtonContainer';
 import RouterLink from '@/core/ui/link/RouterLink';
 import CommunityGuidelinesBlock from '@/domain/community/community/CommunityGuidelines/CommunityGuidelinesBlock';
-import { buildSettingsUrl } from '@/main/routing/urlBuilders';
+import { buildSettingsUrl, buildSignUpUrl } from '@/main/routing/urlBuilders';
 import useNavigate from '@/core/routing/useNavigate';
 import { SpaceDashboardSpaceDetails } from '../layout/tabbedLayout/Tabs/SpaceDashboard/SpaceDashboardView';
+import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
 
 export interface SpaceAboutDialogProps {
   open: boolean;
@@ -59,6 +62,7 @@ const SpaceAboutDialog = ({
 }: SpaceAboutDialogProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { isAuthenticated } = useCurrentUserContext();
 
   const isLevelZeroSpace = space.level === SpaceLevel.L0;
   const spaceLevel = space.level || SpaceLevel.L0;
@@ -106,29 +110,38 @@ const SpaceAboutDialog = ({
       return <Loading />;
     }
 
+    const providerType = provider.profile.type;
+    const isOrganization = providerType === ProfileType.Organization;
+
     return (
       <EntityDashboardLeadsSection
         organizationsHeader={t('pages.space.sections.dashboard.organization')}
+        usersHeader={t('pages.space.sections.dashboard.organization')}
         organizationsHeaderIcon={
           <Tooltip title={t('pages.space.sections.dashboard.hostTooltip')} arrow>
             <InfoOutlinedIcon color="primary" />
           </Tooltip>
         }
-        leadOrganizations={provider ? [provider] : undefined}
-        leadUsers={undefined}
+        leadOrganizations={isOrganization ? [provider] : undefined}
+        leadUsers={isOrganization ? undefined : [provider]}
       >
         {provider && (
           <Caption
             component={Link}
-            onClick={() =>
-              sendMessage('organization', {
+            onClick={() => {
+              if (!isAuthenticated) {
+                window.location.href = buildSignUpUrl(window.location.pathname, window.location.search);
+                return;
+              }
+
+              return sendMessage(getMessageType(providerType), {
                 id: provider.id,
                 displayName: provider.profile.displayName,
                 avatarUri: provider.profile.avatar?.uri,
                 country: provider.profile.location?.country,
                 city: provider.profile.location?.city,
-              })
-            }
+              });
+            }}
             sx={{ cursor: 'pointer' }}
           >
             <MailOutlineIcon color="primary" sx={{ verticalAlign: 'bottom', marginRight: gutters(0.5) }} />

--- a/src/domain/space/about/graphql/fragments/spaceAboutDetails.graphql
+++ b/src/domain/space/about/graphql/fragments/spaceAboutDetails.graphql
@@ -58,6 +58,7 @@ fragment SpaceAboutDetails on SpaceAbout {
         city
         country
       }
+      type
     }
   }
   profile {

--- a/src/domain/space/about/model/spaceAboutFull.model.ts
+++ b/src/domain/space/about/model/spaceAboutFull.model.ts
@@ -1,4 +1,4 @@
-import { AuthorizationPrivilege, TagsetType } from '@/core/apollo/generated/graphql-schema';
+import { AuthorizationPrivilege, ProfileType, TagsetType } from '@/core/apollo/generated/graphql-schema';
 
 export type ContributorModel = {
   id: string;
@@ -9,13 +9,14 @@ export type ContributorModel = {
     tagline?: string;
     description?: string;
     avatar?: {
-      id;
-      uri;
+      id: string;
+      uri: string;
     };
     location?: {
       city?: string;
       country?: string;
     };
+    type?: ProfileType;
   };
 };
 export type SpaceAboutFullModel = {


### PR DESCRIPTION
Fixes:

- [x] Set the correct type of contributor to the Host section. Fixes the msg sent from the hover card in the provider is user.
- [x] Send the message to user or organization based on the provider profile type (not always to ORG).
- [x] If the current user is not authenticated, on clicking to message the host - navigate to sign up. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentication check before allowing users to send direct messages to providers. Unauthenticated users are redirected to sign up.
  * Lead display logic now dynamically distinguishes between organizations and users when contacting providers.

* **Improvements**
  * Enhanced data models and GraphQL fragments to include provider profile type information for more accurate messaging and display.
  * Centralized logic for determining message recipient type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->