### PR TITLE
Fix L2 invite restriction

### DIFF
--- a/src/domain/community/contributor/RoleSetContributorsBlockWide/RoleSetContributorsBlockWide.tsx
+++ b/src/domain/community/contributor/RoleSetContributorsBlockWide/RoleSetContributorsBlockWide.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Actions } from '@/core/ui/actions/Actions';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import RoleSetContributorsBlockWideContent from './RoleSetContributorsBlockWideContent';
-import { RoleSetContributorType } from '@/core/apollo/generated/graphql-schema';
+import { RoleSetContributorType, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import AltToggle from '@/core/ui/forms/AltToggle/AltToggle';
 import MultipleSelect from '@/core/ui/search/MultipleSelect';
 import { useScreenSize } from '@/core/ui/grid/constants';
@@ -26,6 +26,7 @@ const grayedOutUsersImgSrc = '/contributors/users-grayed.png';
 type RoleSetContributorTypesBlockWideProps = {
   users: ContributorCardSquareProps[] | undefined;
   organizations: ContributorCardSquareProps[] | undefined;
+  level?: SpaceLevel;
   hasInvitePrivilege: boolean;
   isDialogView?: boolean;
   isLoading?: boolean;
@@ -47,6 +48,7 @@ const RoleSetContributorTypesBlockWide = ({
   users,
   showUsers,
   organizations,
+  level = SpaceLevel.L0,
   hasInvitePrivilege,
   isDialogView = false,
   isLoading = false,
@@ -93,6 +95,7 @@ const RoleSetContributorTypesBlockWide = ({
             <InviteContributorsWizard
               contributorType={RoleSetContributorType.User}
               filterContributors={filterInviteeContributors}
+              onlyFromParentCommunity={level === SpaceLevel.L2}
             />
           </Box>
         )}

--- a/src/domain/space/components/ContributorsToggleDialog.tsx
+++ b/src/domain/space/components/ContributorsToggleDialog.tsx
@@ -33,7 +33,7 @@ export interface ContributorsToggleDialogProps {
  */
 const ContributorsToggleDialog = ({ open = false, onClose }: ContributorsToggleDialogProps) => {
   const { isAuthenticated } = useCurrentUserContext();
-  const { spaceId } = useUrlResolver();
+  const { spaceId, spaceLevel } = useUrlResolver();
   const { t } = useTranslation();
 
   const { data: subspaceData, loading } = useSubspaceCommunityAndRoleSetIdQuery({
@@ -108,6 +108,7 @@ const ContributorsToggleDialog = ({ open = false, onClose }: ContributorsToggleD
               showUsers
               users={users}
               organizations={organizations}
+              level={spaceLevel}
               hasInvitePrivilege={hasInvitePrivilege}
               isLoading={loading}
               isDialogView


### PR DESCRIPTION
The restriction to invite from parent community only for L2 was not applied in the subspace community dialog.