### PR TITLE
Copy changes

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -163,7 +163,7 @@
     "select": "Select",
     "change-field": "Change {{field}}",
     "send": "Send",
-    "contact-leads": "Contact the {{contact}}(s)",
+    "contactLeads": "Contact the {{contact}}",
     "moveUp": "Move up",
     "moveDown": "Move down",
     "moveToTop": "Move to top",

--- a/src/domain/space/components/ContributeCreationBlock.tsx
+++ b/src/domain/space/components/ContributeCreationBlock.tsx
@@ -24,7 +24,7 @@ export const ContributeCreationBlock = ({ tabDescription, canCreate, handleCreat
       {canCreate && (
         <Actions justifyContent="end">
           <Button variant="contained" startIcon={<AddOutlinedIcon />} onClick={handleCreate}>
-            {t('common.create')}
+            {t('common.post')}
           </Button>
         </Actions>
       )}

--- a/src/domain/space/layout/tabbedLayout/Tabs/SpaceCommunityPage/SpaceCommunityPage.tsx
+++ b/src/domain/space/layout/tabbedLayout/Tabs/SpaceCommunityPage/SpaceCommunityPage.tsx
@@ -140,7 +140,7 @@ const SpaceCommunityPage = () => {
           leadOrganizations={leadOrganizations}
         />
         <ContactLeadsButton onClick={openContactLeadsDialog}>
-          {t('buttons.contact-leads', { contact: t('community.host') })}
+          {t('buttons.contactLeads', { contact: t('community.leads') })}
         </ContactLeadsButton>
         {hasInvitePrivilege && (
           <InviteContributorsWizard


### PR DESCRIPTION
Changes requested by @DonnaDuiker 
Note that we tend to stick to camelCase instead of kebab-case. 
Also, note that I removed the '(s)' as even if there's one Lead, 'Contact the Leads' sounds better to me.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button labels for improved clarity and consistency in text.
  * Adjusted translation keys and values for better naming conventions and more accurate messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->