### PR TITLE
CCF tooltips and disabled icons

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -784,7 +784,8 @@
               "label": "Default Whiteboard:",
               "explanation": "Edit the default whiteboard."
             }
-          }
+          },
+          "tooltipDisabled": "Please create a new post if you want a different collection option."
         }
       },
       "notification": {

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -791,7 +791,8 @@
       "notification": {
         "label": "Notify the community.",
         "description": "Members of this community will receive a notification if enabled in their notification settings."
-      }
+      },
+      "disabledSubmitTooltip": "Please make sure all titles are filled in."
     },
     "edit": {
       "dialogTitle": "Edit $t(common.post)"

--- a/src/core/ui/forms/radioButtons/RadioButtonsGroup.tsx
+++ b/src/core/ui/forms/radioButtons/RadioButtonsGroup.tsx
@@ -67,7 +67,7 @@ const RadioButtonsGroup = <Value,>({
                     height={gutters(2)}
                     bgcolor={value === optionValue ? 'background.paper' : undefined}
                   >
-                    <Icon color="primary" />
+                    <Icon color={(readOnly || disabled) && value !== optionValue ? 'disabled' : 'primary'} />
                   </Box>
                 </SwapColors>
               )}

--- a/src/domain/collaboration/callout/CalloutDialogs/CreateCalloutDialog.tsx
+++ b/src/domain/collaboration/callout/CalloutDialogs/CreateCalloutDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, DialogActions, DialogContent, Checkbox, FormControlLabel, Tooltip } from '@mui/material';
+import { Button, DialogActions, DialogContent, Checkbox, FormControlLabel, Tooltip, Box } from '@mui/material';
 import { useTemplateContentLazyQuery } from '@/core/apollo/generated/apollo-hooks';
 import {
   CreateCalloutContributionInput,
@@ -201,22 +201,26 @@ const CreateCalloutDialog = ({
               </Tooltip>
             </Gutters>
           )}
-          <Button
-            variant="text"
-            onClick={() => handlePublishCallout(CalloutVisibility.Draft)}
-            loading={publishingCallout}
-            disabled={!isValid}
-          >
-            {t('buttons.saveDraft')}
-          </Button>
-          <Button
-            variant="contained"
-            onClick={() => handlePublishCallout()}
-            loading={publishingCallout}
-            disabled={!isValid}
-          >
-            {t('buttons.post')}
-          </Button>
+          <Tooltip title={isValid ? undefined : t('callout.create.disabledSubmitTooltip')}>
+            <Box>
+              <Button
+                variant="text"
+                onClick={() => handlePublishCallout(CalloutVisibility.Draft)}
+                loading={publishingCallout}
+                disabled={!isValid}
+              >
+                {t('buttons.saveDraft')}
+              </Button>
+              <Button
+                variant="contained"
+                onClick={() => handlePublishCallout()}
+                loading={publishingCallout}
+                disabled={!isValid}
+              >
+                {t('buttons.post')}
+              </Button>
+            </Box>
+          </Tooltip>
         </DialogActions>
       </DialogWithGrid>
       <ImportTemplatesDialog

--- a/src/domain/collaboration/callout/CalloutForm/CalloutFormContributionSettings.tsx
+++ b/src/domain/collaboration/callout/CalloutForm/CalloutFormContributionSettings.tsx
@@ -109,19 +109,25 @@ const CalloutFormContributionSettings = ({ calloutRestrictions }: CalloutFormCon
                 icon: AttachFileOutlinedIcon,
                 value: CalloutContributionType.Link,
                 label: t('callout.create.contributionSettings.contributionTypes.link.title'),
-                tooltip: t('callout.create.contributionSettings.contributionTypes.link.tooltip'),
+                tooltip: calloutRestrictions?.readOnlyAllowedTypes
+                  ? t('callout.create.contributionSettings.contributionTypes.tooltipDisabled')
+                  : t('callout.create.contributionSettings.contributionTypes.link.tooltip'),
               },
               {
                 icon: calloutIcons[CalloutType.PostCollection],
                 value: CalloutContributionType.Post,
                 label: t('callout.create.contributionSettings.contributionTypes.post.title'),
-                tooltip: t('callout.create.contributionSettings.contributionTypes.post.tooltip'),
+                tooltip: calloutRestrictions?.readOnlyAllowedTypes
+                  ? t('callout.create.contributionSettings.contributionTypes.tooltipDisabled')
+                  : t('callout.create.contributionSettings.contributionTypes.post.tooltip'),
               },
               {
                 icon: calloutIcons[CalloutType.Whiteboard],
                 value: CalloutContributionType.Whiteboard,
                 label: t('callout.create.contributionSettings.contributionTypes.whiteboard.title'),
-                tooltip: t('callout.create.contributionSettings.contributionTypes.whiteboard.tooltip'),
+                tooltip: calloutRestrictions?.readOnlyAllowedTypes
+                  ? t('callout.create.contributionSettings.contributionTypes.tooltipDisabled')
+                  : t('callout.create.contributionSettings.contributionTypes.whiteboard.tooltip'),
                 disabled: calloutRestrictions?.disableWhiteboards,
               },
             ]}

--- a/src/domain/collaboration/callout/CalloutForm/CalloutFormContributionSettings.tsx
+++ b/src/domain/collaboration/callout/CalloutForm/CalloutFormContributionSettings.tsx
@@ -69,6 +69,8 @@ const CalloutFormContributionSettings = ({ calloutRestrictions }: CalloutFormCon
     return result;
   }, [allowedTypesField.value]);
 
+  const disabledTooltip = t('callout.create.contributionSettings.contributionTypes.tooltipDisabled');
+
   return (
     <PageContentBlockCollapsible
       header={<PageContentBlockHeader title={t('callout.create.contributionSettings.title')} />}
@@ -110,7 +112,7 @@ const CalloutFormContributionSettings = ({ calloutRestrictions }: CalloutFormCon
                 value: CalloutContributionType.Link,
                 label: t('callout.create.contributionSettings.contributionTypes.link.title'),
                 tooltip: calloutRestrictions?.readOnlyAllowedTypes
-                  ? t('callout.create.contributionSettings.contributionTypes.tooltipDisabled')
+                  ? disabledTooltip
                   : t('callout.create.contributionSettings.contributionTypes.link.tooltip'),
               },
               {
@@ -118,7 +120,7 @@ const CalloutFormContributionSettings = ({ calloutRestrictions }: CalloutFormCon
                 value: CalloutContributionType.Post,
                 label: t('callout.create.contributionSettings.contributionTypes.post.title'),
                 tooltip: calloutRestrictions?.readOnlyAllowedTypes
-                  ? t('callout.create.contributionSettings.contributionTypes.tooltipDisabled')
+                  ? disabledTooltip
                   : t('callout.create.contributionSettings.contributionTypes.post.tooltip'),
               },
               {
@@ -126,7 +128,7 @@ const CalloutFormContributionSettings = ({ calloutRestrictions }: CalloutFormCon
                 value: CalloutContributionType.Whiteboard,
                 label: t('callout.create.contributionSettings.contributionTypes.whiteboard.title'),
                 tooltip: calloutRestrictions?.readOnlyAllowedTypes
-                  ? t('callout.create.contributionSettings.contributionTypes.tooltipDisabled')
+                  ? disabledTooltip
                   : t('callout.create.contributionSettings.contributionTypes.whiteboard.tooltip'),
                 disabled: calloutRestrictions?.disableWhiteboards,
               },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual tooltips to guide users when certain options or submission buttons are disabled in the callout creation interface.
  * Tooltips now provide specific reasons and instructions when contribution types are restricted or form fields are incomplete.

* **Style**
  * Updated icon colors in radio button groups to better reflect disabled or read-only states for unselected options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->