### PR TITLE
Handle properly Edit Whiteboard Framing

### DIFF
--- a/src/core/apollo/utils/removeFromCache.ts
+++ b/src/core/apollo/utils/removeFromCache.ts
@@ -1,4 +1,5 @@
-import { ApolloCache, FetchResult } from '@apollo/client';
+import { ApolloCache, FetchResult, useApolloClient } from '@apollo/client';
+import { useCallback } from 'react';
 
 /***
  * A **MutationUpdaterFn** function that removes an object from Apollo cache, using the return result of a mutation.
@@ -53,3 +54,21 @@ export function evictFromCache<T = { [key: string]: unknown }>(cache: ApolloCach
   cache.evict({ id: normalizedId });
   cache.gc();
 }
+
+export const useApolloCache = () => {
+  const apolloClient = useApolloClient();
+
+  const handleEvictFromCache = useCallback(
+    (id: string | undefined, typeName: string) => {
+      if (!id) {
+        return;
+      }
+      evictFromCache(apolloClient.cache, id, typeName);
+    },
+    [apolloClient]
+  );
+
+  return {
+    evictFromCache: handleEvictFromCache,
+  };
+};

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -729,7 +729,8 @@
         },
         "whiteboard": {
           "title": "Whiteboard",
-          "tooltip": "Add a whiteboard to this post"
+          "tooltip": "Add a whiteboard to this post",
+          "onlyRealTimeEditorAvailable": "To edit this whiteboard now, please use the whiteboard editor closing this dialog and opening the whiteboard directly clicking on the preview."
         }
       },
       "contributionSettings": {

--- a/src/domain/collaboration/callout/CalloutDialogs/EditCalloutDialog.tsx
+++ b/src/domain/collaboration/callout/CalloutDialogs/EditCalloutDialog.tsx
@@ -170,6 +170,7 @@ const EditCalloutDialog = ({ open = false, onClose, calloutId, calloutRestrictio
                   readOnlyAllowedTypes: true,
                   temporaryLocation: false,
                   readOnlyContributions: true,
+                  onlyRealTimeWhiteboardFraming: true,
                 }}
               />
             </StorageConfigContextProvider>

--- a/src/domain/collaboration/callout/CalloutForm/CalloutFormFramingSettings.tsx
+++ b/src/domain/collaboration/callout/CalloutForm/CalloutFormFramingSettings.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import BlockIcon from '@mui/icons-material/Block';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
 import PageContentBlockHeader from '@/core/ui/content/PageContentBlockHeader';
@@ -12,9 +11,11 @@ import FormikWhiteboardPreview from '../../whiteboard/WhiteboardPreview/FormikWh
 import { useField, useFormikContext } from 'formik';
 import { CalloutFormSubmittedValues } from './CalloutFormModel';
 import { EmptyWhiteboardString } from '@/domain/common/whiteboard/EmptyWhiteboard';
-import type { FormikWhiteboardPreviewRef } from '../../whiteboard/WhiteboardPreview/FormikWhiteboardPreview';
 import { useScreenSize } from '@/core/ui/grid/constants';
 import { CalloutRestrictions } from '../../callout/CalloutRestrictionsTypes';
+import { Tooltip } from '@mui/material';
+import EditButton from '@/core/ui/actions/EditButton';
+import { useMemo } from 'react';
 
 interface CalloutFormFramingSettingsProps {
   calloutRestrictions?: CalloutRestrictions;
@@ -25,7 +26,6 @@ const CalloutFormFramingSettings = ({ calloutRestrictions }: CalloutFormFramingS
   const { isMediumSmallScreen } = useScreenSize();
 
   const [{ value: framing }] = useField<CalloutFormSubmittedValues['framing']>('framing');
-  const whiteboardPreviewRef = useRef<FormikWhiteboardPreviewRef>(null);
   const { setFieldValue } = useFormikContext<CalloutFormSubmittedValues>();
 
   const handleFramingTypeChange = (newType: CalloutFramingType) => {
@@ -67,6 +67,21 @@ const CalloutFormFramingSettings = ({ calloutRestrictions }: CalloutFormFramingS
     />
   );
 
+  const editButton = useMemo(() => {
+    if (!calloutRestrictions?.onlyRealTimeWhiteboardFraming) {
+      return undefined; // Use the FormikWhiteboardPreview's default edit button
+    } else {
+      // TODO: Maybe in the future, open the real-time whiteboard editor from here
+      return (
+        <Tooltip title={t('callout.create.framingSettings.whiteboard.onlyRealTimeEditorAvailable')}>
+          <span>
+            <EditButton disabled />
+          </span>
+        </Tooltip>
+      );
+    }
+  }, [calloutRestrictions?.onlyRealTimeWhiteboardFraming]);
+
   return (
     <>
       <PageContentBlock sx={{ marginTop: gutters(-1) }}>
@@ -80,11 +95,10 @@ const CalloutFormFramingSettings = ({ calloutRestrictions }: CalloutFormFramingS
       {framing.whiteboard && framing.type === CalloutFramingType.Whiteboard && (
         <PageContentBlock disablePadding>
           <FormikWhiteboardPreview
-            ref={whiteboardPreviewRef}
             name="framing.whiteboard.content"
             previewImagesName="framing.whiteboard.previewImages"
             canEdit
-            onChangeContent={() => whiteboardPreviewRef.current?.closeEditDialog()}
+            editButton={editButton}
             onDeleteContent={() => handleFramingTypeChange(CalloutFramingType.None)}
             maxHeight={gutters(12)}
             dialogProps={{ title: t('components.callout-creation.whiteboard.editDialogTitle') }}

--- a/src/domain/collaboration/callout/CalloutRestrictionsTypes.ts
+++ b/src/domain/collaboration/callout/CalloutRestrictionsTypes.ts
@@ -21,4 +21,8 @@ export interface CalloutRestrictions {
    * These cannot be edited when editing the callout, and cannot be used when creating/editing a callout template
    */
   readOnlyContributions?: boolean;
+  /**
+   * Disables the editing of the callouts framing whiteboard, because it can only be edited in real-time when they are created.
+   */
+  onlyRealTimeWhiteboardFraming?: boolean;
 }

--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
@@ -29,6 +29,7 @@ import mergeWhiteboard from '../utils/mergeWhiteboard';
 import whiteboardSchema from '../validation/whiteboardSchema';
 import WhiteboardDialogFooter from './WhiteboardDialogFooter';
 import WhiteboardDisplayName from './WhiteboardDisplayName';
+import { useApolloCache } from '@/core/apollo/utils/removeFromCache';
 
 export interface WhiteboardDetails {
   id: string;
@@ -97,6 +98,7 @@ type RelevantExcalidrawState = Pick<ExportedDataState, 'appState' | 'elements' |
 const WhiteboardDialog = ({ entities, actions, options, state, lastSuccessfulSavedDate }: WhiteboardDialogProps) => {
   const { t } = useTranslation();
   const notify = useNotification();
+  const { evictFromCache } = useApolloCache();
   const { whiteboard } = entities;
 
   const [excalidrawAPI, setExcalidrawAPI] = useState<ExcalidrawImperativeAPI | null>(null);
@@ -193,6 +195,8 @@ const WhiteboardDialog = ({ entities, actions, options, state, lastSuccessfulSav
         });
       }
     }
+    // After editing the whiteboard in real time mode, we need to evict the cache in case we have a cached version, on CalloutForm for example.
+    evictFromCache(whiteboard?.id, 'Whiteboard');
     actions.onCancel();
   }, [editModeEnabled, collabApiRef, whiteboard, getWhiteboardState, prepareWhiteboardForUpdate, actions]);
 

--- a/src/domain/collaboration/whiteboard/WhiteboardPreview/FormikWhiteboardPreview.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardPreview/FormikWhiteboardPreview.tsx
@@ -1,6 +1,6 @@
 import { Box, BoxProps, IconButton, Skeleton, styled } from '@mui/material';
 import { useField } from 'formik';
-import { MouseEventHandler, useMemo, useState, forwardRef, useImperativeHandle } from 'react';
+import { MouseEventHandler, useMemo, useState, forwardRef, useImperativeHandle, ReactNode } from 'react';
 import ExcalidrawWrapper from '@/domain/common/whiteboard/excalidraw/ExcalidrawWrapper';
 import SingleUserWhiteboardDialog from '../WhiteboardDialog/SingleUserWhiteboardDialog';
 import { BlockTitle } from '@/core/ui/typography';
@@ -23,6 +23,7 @@ interface FormikWhiteboardPreviewProps extends BoxProps {
   name: string; // Formik fieldName of the Whiteboard content
   previewImagesName?: string; // Formik fieldName of the preview images. Will only be set if this argument is passed
   canEdit: boolean;
+  editButton?: ReactNode; // Optional custom edit button.
   onChangeContent?: (content: string, previewImages?: WhiteboardPreviewImage[]) => void;
   onDeleteContent?: () => void; // Optionally show Delete button
   loading?: boolean;
@@ -42,6 +43,7 @@ const FormikWhiteboardPreview = forwardRef<FormikWhiteboardPreviewRef, FormikWhi
       name = 'content',
       previewImagesName,
       canEdit,
+      editButton,
       onChangeContent,
       onDeleteContent,
       loading,
@@ -134,7 +136,7 @@ const FormikWhiteboardPreview = forwardRef<FormikWhiteboardPreviewRef, FormikWhi
             {canEdit ? (
               <>
                 <StyledBoxOverWhiteboard right={theme => theme.spacing(2.5)} bottom={theme => theme.spacing(2.5)}>
-                  <EditButton variant="contained" onClick={handleClickEditButton} />
+                  {editButton ? editButton : <EditButton variant="contained" onClick={handleClickEditButton} />}
                 </StyledBoxOverWhiteboard>
                 <SingleUserWhiteboardDialog
                   entities={{


### PR DESCRIPTION
- Evict cache after editing a wb in realtime
- Add the disabled Edit button to override the default behavior when editing a callout