### PR TITLE
Callout Page layout updates

### DIFF
--- a/src/domain/collaboration/CalloutPage/CalloutPage.tsx
+++ b/src/domain/collaboration/CalloutPage/CalloutPage.tsx
@@ -165,7 +165,23 @@ const CalloutPage = ({ parentRoute, renderPage, disableCalloutsClassification, c
   return (
     <>
       {renderPage(calloutPosition)}
-      <DialogWithGrid open columns={12} onClose={handleClose} fullScreen={isSmallScreen}>
+      <DialogWithGrid
+        open
+        columns={12}
+        onClose={handleClose}
+        fullScreen={isSmallScreen}
+        sx={{
+          '.MuiDialog-paper': {
+            // copied from DialogWithGrid as it will be overridden here
+            maxWidth: '100vw',
+            margin: 0,
+            height: 'auto',
+            maxHeight: isSmallScreen ? '100vh' : '100%',
+
+            overflowY: 'auto',
+          },
+        }}
+      >
         <CalloutView
           callout={typedCalloutDetails}
           contributionsCount={typedCalloutDetails.activity}

--- a/src/domain/collaboration/CalloutPage/CalloutPage.tsx
+++ b/src/domain/collaboration/CalloutPage/CalloutPage.tsx
@@ -174,23 +174,34 @@ const CalloutPage = ({ parentRoute, renderPage, disableCalloutsClassification, c
           '.MuiDialog-paper': {
             // copied from DialogWithGrid as it will be overridden here
             maxWidth: '100vw',
-            margin: 0,
+            maxHeight: isSmallScreen ? '100vh' : '80vh',
             height: 'auto',
-            maxHeight: isSmallScreen ? '100vh' : '100%',
-
-            overflowY: 'auto',
+            minHeight: 'auto', // Allows dialog to be smaller when content is minimal
           },
         }}
       >
-        <CalloutView
-          callout={typedCalloutDetails}
-          contributionsCount={typedCalloutDetails.activity}
-          onVisibilityChange={changeCalloutVisibility}
-          onCalloutUpdate={refetchCalloutData}
-          onCalloutDelete={handleDeleteWithClose}
-          onCollapse={handleClose}
-          expanded
-        />
+        <DialogContent
+          dividers
+          sx={{
+            p: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            // Allow content to determine height, with max constraint
+            flexGrow: 1, // Take up available space
+            height: 'auto',
+            overflow: 'hidden', // Prevent dialog from scrolling
+          }}
+        >
+          <CalloutView
+            callout={typedCalloutDetails}
+            contributionsCount={typedCalloutDetails.activity}
+            onVisibilityChange={changeCalloutVisibility}
+            onCalloutUpdate={refetchCalloutData}
+            onCalloutDelete={handleDeleteWithClose}
+            onCollapse={handleClose}
+            expanded
+          />
+        </DialogContent>
       </DialogWithGrid>
       {children?.({ parentPagePath })}
     </>

--- a/src/domain/collaboration/callout/CalloutView/CommentsCalloutLayout.tsx
+++ b/src/domain/collaboration/callout/CalloutView/CommentsCalloutLayout.tsx
@@ -12,8 +12,6 @@ import CalloutClosedMarginal from '../calloutBlock/CalloutClosedMarginal';
 import { CalloutLayoutProps } from '../calloutBlock/CalloutLayoutTypes';
 import { gutters } from '@/core/ui/grid/utils';
 
-const DESCRIPTION_MAX_HEIGHT = 'calc(100vh - 400px)';
-
 const CommentsCalloutLayout = ({
   callout,
   children,
@@ -37,48 +35,69 @@ const CommentsCalloutLayout = ({
 
   const hasCalloutDetails = callout.authorName && callout.publishedAt;
 
-  // fixes comments not visible when description too long in modal/expanded
-  const expandedStyles = expanded ? { maxHeight: DESCRIPTION_MAX_HEIGHT, overflowY: 'auto' } : undefined;
-
   return (
-    <>
-      {callout.draft && (
-        <Ribbon>
-          <BlockTitle textAlign="center">{t('callout.draftNotice')}</BlockTitle>
-        </Ribbon>
-      )}
-      <CalloutHeader
-        callout={callout}
-        contributionsCount={contributionsCount}
-        expanded={expanded}
-        onExpand={onExpand}
-        onCollapse={onCollapse}
-        settingsOpen={settingsOpen}
-        onOpenSettings={onOpenSettings}
-        calloutActions={calloutActions}
-      />
-      {hasCalloutDetails && <BlockTitle noWrap>{callout.framing.profile.displayName}</BlockTitle>}
-      <Box className={MARKDOWN_CLASS_NAME}>
-        <WrapperMarkdown caption sx={expandedStyles}>
-          {callout.framing.profile.description ?? ''}
-        </WrapperMarkdown>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: expanded ? '100%' : 'auto',
+        position: 'relative',
+        overflow: expanded ? 'hidden' : 'visible',
+      }}
+    >
+      {/* header area - fixed at top */}
+      <Box sx={{ position: expanded ? 'sticky' : 'static', top: 0, zIndex: 10, background: 'white' }}>
+        {callout.draft && (
+          <Ribbon>
+            <BlockTitle textAlign="center">{t('callout.draftNotice')}</BlockTitle>
+          </Ribbon>
+        )}
+        <CalloutHeader
+          callout={callout}
+          contributionsCount={contributionsCount}
+          expanded={expanded}
+          onExpand={onExpand}
+          onCollapse={onCollapse}
+          settingsOpen={settingsOpen}
+          onOpenSettings={onOpenSettings}
+          calloutActions={calloutActions}
+        />
+        {hasCalloutDetails && <BlockTitle noWrap>{callout.framing.profile.displayName}</BlockTitle>}
       </Box>
-      {!skipReferences && !!callout.framing.profile.references?.length && (
-        <Box paddingX={gutters()} paddingBottom={gutters(0.5)}>
-          <References compact references={callout.framing.profile.references} />
+
+      {/* scrollable content region */}
+      <Box
+        sx={{
+          flex: expanded ? '1 1 auto' : '0 0 auto',
+          minHeight: 0,
+          maxHeight: expanded ? 'calc(100% - 120px)' : 'none',
+          overflowY: expanded ? 'auto' : 'visible',
+        }}
+      >
+        <Box className={MARKDOWN_CLASS_NAME}>
+          <WrapperMarkdown caption>{callout.framing.profile.description ?? ''}</WrapperMarkdown>
         </Box>
-      )}
-      {callout.framing.profile.tagset?.tags && callout.framing.profile.tagset?.tags.length > 0 ? (
-        <TagsComponent tags={callout.framing.profile.tagset?.tags} sx={{ paddingX: gutters() }} />
-      ) : undefined}
-      {expanded ? <Box sx={{ overflowY: 'auto' }}>{children}</Box> : children}
-      <CalloutClosedMarginal
-        messagesCount={callout.comments?.messages?.length ?? 0}
-        disabled={!callout.settings.framing.commentsEnabled}
-        contributionsCount={contributionsCount}
-        isMember={isMember}
-      />
-    </>
+        {!skipReferences && !!callout.framing.profile.references?.length && (
+          <Box paddingX={gutters()} paddingBottom={gutters(0.5)}>
+            <References compact references={callout.framing.profile.references} />
+          </Box>
+        )}
+        {callout.framing.profile.tagset?.tags && callout.framing.profile.tagset?.tags.length > 0 && (
+          <TagsComponent tags={callout.framing.profile.tagset?.tags} sx={{ paddingX: gutters() }} />
+        )}
+        {children}
+      </Box>
+
+      {/* footer area - fixed at bottom */}
+      <Box sx={{ position: expanded ? 'sticky' : 'static', bottom: 0, zIndex: 10, background: 'white' }}>
+        <CalloutClosedMarginal
+          messagesCount={callout.comments?.messages?.length ?? 0}
+          disabled={!callout.settings.framing.commentsEnabled}
+          contributionsCount={contributionsCount}
+          isMember={isMember}
+        />
+      </Box>
+    </Box>
   );
 };
 

--- a/src/domain/collaboration/callout/CalloutView/CommentsCalloutLayout.tsx
+++ b/src/domain/collaboration/callout/CalloutView/CommentsCalloutLayout.tsx
@@ -71,7 +71,7 @@ const CommentsCalloutLayout = ({
       {callout.framing.profile.tagset?.tags && callout.framing.profile.tagset?.tags.length > 0 ? (
         <TagsComponent tags={callout.framing.profile.tagset?.tags} sx={{ paddingX: gutters() }} />
       ) : undefined}
-      {children}
+      {expanded ? <Box sx={{ overflowY: 'auto' }}>{children}</Box> : children}
       <CalloutClosedMarginal
         messagesCount={callout.comments?.messages?.length ?? 0}
         disabled={!callout.settings.framing.commentsEnabled}


### PR DESCRIPTION
Currently, if you have too many assets in a callout, it fails to display them when previewed by the URL / in a dialog.

These changes make sure all the content is available but:
- breaks the scroll to last comment functionality when in dialog;
- in case of a long thread the entire scroll to the comments input is long;

