### PR TITLE
Resolver scroll fixes

### DIFF
--- a/src/core/ui/dialog/DialogWithGrid.tsx
+++ b/src/core/ui/dialog/DialogWithGrid.tsx
@@ -71,6 +71,7 @@ const DialogWithGrid = ({
 
   return (
     <MuiDialog
+      disableScrollLock
       PaperComponent={DialogContainer}
       PaperProps={{ columns, centeredVertically, fullScreen } as PaperProps}
       onClose={onClose}

--- a/src/core/ui/dialog/DialogWithGrid.tsx
+++ b/src/core/ui/dialog/DialogWithGrid.tsx
@@ -56,6 +56,7 @@ export interface DialogWithGridProps extends MuiDialogProps {
   columns?: GridItemProps['columns'];
   fullHeight?: boolean;
   centeredVertically?: boolean;
+  disableScrollLock?: boolean;
 }
 
 const DialogWithGrid = ({
@@ -71,7 +72,6 @@ const DialogWithGrid = ({
 
   return (
     <MuiDialog
-      disableScrollLock
       PaperComponent={DialogContainer}
       PaperProps={{ columns, centeredVertically, fullScreen } as PaperProps}
       onClose={onClose}

--- a/src/domain/collaboration/CalloutPage/CalloutPage.tsx
+++ b/src/domain/collaboration/CalloutPage/CalloutPage.tsx
@@ -10,7 +10,6 @@ import { DialogContent } from '@mui/material';
 import Loading from '@/core/ui/loading/Loading';
 import { isApolloForbiddenError, isApolloNotFoundError } from '@/core/apollo/hooks/useApolloErrorHandler';
 import { Error404 } from '@/core/pages/Errors/Error404';
-import useBackToPath from '@/core/routing/useBackToPath';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import { Text } from '@/core/ui/typography';
 import { useTranslation } from 'react-i18next';
@@ -20,6 +19,7 @@ import useSpacePermissionsAndEntitlements from '@/domain/space/hooks/useSpacePer
 import { useScreenSize } from '@/core/ui/grid/constants';
 import TopLevelLayout from '@/main/ui/layout/TopLevelLayout';
 import { Identifiable } from '@/core/utils/Identifiable';
+import useNavigate from '@/core/routing/useNavigate';
 
 type CalloutLocation = {
   parentPagePath: string;
@@ -52,6 +52,8 @@ const CalloutPage = ({ parentRoute, renderPage, disableCalloutsClassification, c
   const locationState = (useLocation().state ?? {}) as LocationStateCachedCallout;
 
   const { t } = useTranslation();
+
+  const navigate = useNavigate();
 
   const {
     data: calloutData,
@@ -97,8 +99,6 @@ const CalloutPage = ({ parentRoute, renderPage, disableCalloutsClassification, c
     return result;
   }, [callout, locationState, calloutsCanBeSavedAsTemplate]);
 
-  const backOrElse = useBackToPath();
-
   const { isSmallScreen } = useScreenSize();
 
   const calloutFlowState = typedCalloutDetails?.classification?.flowState?.tags[0];
@@ -136,7 +136,10 @@ const CalloutPage = ({ parentRoute, renderPage, disableCalloutsClassification, c
   const parentPagePath = typeof parentRoute === 'function' ? parentRoute(calloutPosition) : parentRoute;
 
   const handleClose = () => {
-    backOrElse(parentPagePath);
+    navigate(parentPagePath, {
+      state: { keepScroll: true },
+      replace: true,
+    });
   };
 
   const handleDeleteWithClose = async (callout: Identifiable) => {
@@ -165,7 +168,7 @@ const CalloutPage = ({ parentRoute, renderPage, disableCalloutsClassification, c
   return (
     <>
       {renderPage(calloutPosition)}
-      <DialogWithGrid open columns={12} onClose={handleClose} fullScreen={isSmallScreen} fullHeight>
+      <DialogWithGrid open columns={12} onClose={handleClose} fullScreen={isSmallScreen} fullHeight disableScrollLock>
         <DialogContent
           dividers
           sx={{

--- a/src/domain/collaboration/callout/CalloutForm/ContributionSettingsDialog/ContributionsSettings.tsx
+++ b/src/domain/collaboration/callout/CalloutForm/ContributionSettingsDialog/ContributionsSettings.tsx
@@ -22,8 +22,12 @@ const ContributionsSettings = forwardRef<
   const [field, , meta] = useField<CalloutFormSubmittedValues['settings']>('settings');
 
   const [formState, setFormState] = useState<FieldsState>({
-    membersCanRespond: field.value.contribution.canAddContributions === CalloutAllowedContributors.Members,
-    adminCanRespond: field.value.contribution.canAddContributions !== CalloutAllowedContributors.None,
+    membersCanRespond:
+      field.value.contribution.enabled &&
+      field.value.contribution.canAddContributions === CalloutAllowedContributors.Members,
+    adminCanRespond:
+      field.value.contribution.enabled &&
+      field.value.contribution.canAddContributions !== CalloutAllowedContributors.None,
     commentsOnEachResponse: field.value.contribution.commentsEnabled,
   });
 

--- a/src/domain/collaboration/callout/routing/CalloutRoute.tsx
+++ b/src/domain/collaboration/callout/routing/CalloutRoute.tsx
@@ -10,7 +10,7 @@ export interface CalloutRouteProps {
 const CalloutRoute = ({ parentPagePath }: CalloutRouteProps) => {
   return (
     <Routes>
-      <Route path={`posts/:${nameOfUrl.postNameId}/*`} element={<PostRoute parentPagePath={parentPagePath} />} />
+      <Route path={`posts/:${nameOfUrl.postNameId}/*`} element={<PostRoute />} />
       <Route
         path={`whiteboards/:${nameOfUrl.whiteboardNameId}/*`}
         element={<WhiteboardRoute parentPagePath={parentPagePath} />}

--- a/src/domain/collaboration/post/views/PostLayout.tsx
+++ b/src/domain/collaboration/post/views/PostLayout.tsx
@@ -11,7 +11,7 @@ export interface PostLayoutProps {
 }
 
 export const PostLayout = ({ currentSection, onClose, children }: PropsWithChildren<PostLayoutProps>) => (
-  <DialogWithGrid open={!!currentSection} columns={12} onClose={onClose}>
+  <DialogWithGrid open={!!currentSection} columns={12} onClose={onClose} disableScrollLock>
     <DialogHeader onClose={onClose} actions={<PostTabs currentTab={currentSection} />} />
     <DialogContent>{children}</DialogContent>
   </DialogWithGrid>

--- a/src/domain/collaboration/post/views/PostRoute.tsx
+++ b/src/domain/collaboration/post/views/PostRoute.tsx
@@ -1,18 +1,13 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
 import PostDashboardPage from '../pages/PostDashboardPage';
 import PostSettingsPage from '../pages/PostSettingsPage';
 import PostSharePage from '../pages/PostSharePage';
 import { PostDialogSection } from './PostDialogSection';
 import useUrlResolver from '@/main/routing/urlResolver/useUrlResolver';
-import useBackToPath from '@/core/routing/useBackToPath';
 
-export interface PostRouteProps {
-  parentPagePath: string;
-}
-
-const PostRoute = ({ parentPagePath }: PostRouteProps) => {
-  const backToExplore = useBackToPath();
-  const onClose = () => backToExplore(parentPagePath);
+const PostRoute = () => {
+  const navigate = useNavigate();
+  const onClose = () => navigate('../', { replace: true });
 
   const { postId, calloutsSetId, calloutId } = useUrlResolver();
 

--- a/src/domain/collaboration/post/views/PostRoute.tsx
+++ b/src/domain/collaboration/post/views/PostRoute.tsx
@@ -1,13 +1,17 @@
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import PostDashboardPage from '../pages/PostDashboardPage';
 import PostSettingsPage from '../pages/PostSettingsPage';
 import PostSharePage from '../pages/PostSharePage';
 import { PostDialogSection } from './PostDialogSection';
 import useUrlResolver from '@/main/routing/urlResolver/useUrlResolver';
+import useNavigate from '@/core/routing/useNavigate';
 
 const PostRoute = () => {
   const navigate = useNavigate();
-  const onClose = () => navigate('../', { replace: true });
+
+  const onClose = () => {
+    navigate('../', { state: { keepScroll: true }, replace: true });
+  };
 
   const { postId, calloutsSetId, calloutId } = useUrlResolver();
 

--- a/src/main/routing/urlResolver/UrlResolverProvider.tsx
+++ b/src/main/routing/urlResolver/UrlResolverProvider.tsx
@@ -202,9 +202,7 @@ const UrlResolverProvider = ({ children }: { children: ReactNode }) => {
     return () => {
       window.removeEventListener('popstate', handleUrlChange);
       // Restore original pushState
-      if (window.history.pushState === window.history.pushState) {
-        window.history.pushState = originalPushState;
-      }
+      window.history.pushState = originalPushState;
     };
   }, []);
 

--- a/src/main/routing/urlResolver/UrlResolverProvider.tsx
+++ b/src/main/routing/urlResolver/UrlResolverProvider.tsx
@@ -105,9 +105,18 @@ const selectUrlParams = <T extends {}, R extends {}>(
 
 const UrlResolverContext = createContext<UrlResolverContextValue>(emptyResult);
 
+/**
+ * The UrlResolverProvider monitors URL changes and resolves them to entities in the system.
+ * It has been enhanced to prevent redundant updates and re-renders when navigating between
+ * pages that use the same base entity (like a space and its callouts/posts).
+ */
 const UrlResolverProvider = ({ children }: { children: ReactNode }) => {
   // Using a state to force a re-render of the children when the url changes
   const [currentUrl, setCurrentUrl] = useState<string>('');
+
+  // Keep a stable ref of the last processed URL to avoid duplicate updates
+  const lastProcessedUrlRef = useRef<string>('');
+
   /**
    * Default Apollo's cache behavior will store the result of the URL resolver queries based on the Id of the space returned
    * And will fill the gaps of missing Ids when the user navigates to a different URL
@@ -140,49 +149,66 @@ const UrlResolverProvider = ({ children }: { children: ReactNode }) => {
   }
 
   useEffect(() => {
-    // strip parts of the URL that go below the resolved wentity
+    // strip parts of the URL that go below the resolved entity
     const maskedUrlParts = [
       // Remove anything after /settings, because it's the settings url of the same entity, no need to resolve it:
       /\/settings(?:\/[a-zA-Z0-9-]+)?\/?$/,
       // Remove tabs from the URL as well
       `/${TabbedLayoutParams.Section}(?:/[a-zA-Z0-9-]+)?/?$`,
     ];
-    const handleUrlChange = () => {
-      let nextUrl = window.location.origin + window.location.pathname;
 
+    // Process URL to get a standardized version for comparison
+    const processUrl = (url: string): string => {
       // Remove trailing slash because /:spaceNameId and /:spaceNameId/ are the same url
-      if (nextUrl.endsWith('/')) {
-        nextUrl = nextUrl.slice(0, -1);
+      if (url.endsWith('/')) {
+        url = url.slice(0, -1);
       }
 
-      // TODO: We need to rework the Urls of the templates anyway. See #8061
-      // For now just don't do anything, if the url is /innovation-packs/:innovationPackNameId/settings/:templateNameId let it pass to the urlResolver
-      // Remove anything after /settings, because it's the settings url of the same entity, no need to resolve it:
-      if (!/\/innovation-packs\/[a-zA-Z0-9-]+\/settings\/[a-zA-Z0-9-]+/.test(nextUrl)) {
+      // Apply URL masks
+      if (!/\/innovation-packs\/[a-zA-Z0-9-]+\/settings\/[a-zA-Z0-9-]+/.test(url)) {
         for (const mask of maskedUrlParts) {
-          nextUrl = nextUrl.replace(mask, '');
+          url = url.replace(mask, '');
         }
       }
 
-      if (nextUrl !== currentUrl) {
-        setCurrentUrl(nextUrl); // Update the query URL state
-      }
+      return url;
     };
+
+    const handleUrlChange = () => {
+      // Get the normalized URL
+      let nextUrl = processUrl(window.location.origin + window.location.pathname);
+
+      // Skip update if URL hasn't changed from the last processed URL
+      if (nextUrl === lastProcessedUrlRef.current) {
+        return;
+      }
+
+      // Update the last processed URL and trigger URL resolution
+      lastProcessedUrlRef.current = nextUrl;
+      setCurrentUrl(nextUrl);
+    };
+
+    // Set up event listeners
     window.addEventListener('popstate', handleUrlChange);
-    var pushState = window.history.pushState;
+    const originalPushState = window.history.pushState;
     window.history.pushState = function (...args) {
-      pushState.apply(window.history, args);
+      originalPushState.apply(window.history, args);
       handleUrlChange();
     };
 
+    // Initial URL resolution
     handleUrlChange();
 
     return () => {
       window.removeEventListener('popstate', handleUrlChange);
+      // Restore original pushState
+      if (window.history.pushState === window.history.pushState) {
+        window.history.pushState = originalPushState;
+      }
     };
   }, []);
 
-  // create cache for the resolver value
+  // Create cache for the resolver value
   const valueRef = useRef<UrlResolverContextValue>(emptyResult);
   const value = useMemo<UrlResolverContextValue>(() => {
     // start generating the context value on successfull request


### PR DESCRIPTION
In this PR:

- Optimize a bit the URLResolver where we were doing many repeating setCurrentUrl and then refetch and rerenders.
- Closing a Collaboration post was closing also the Callout, now closes only itself. 
- The scroll position is now kept on a SubSpace level.

Todo (maybe not part of this PR):
- Keep the scroll position on space L0. I couldn't make it work, the tabs are not working perfectly rerendering on every post/callout open/close, losing the scroll and even the tab - if you open a post the first tab is loaded below.


Regression of all callout open/close flows should be done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to control scroll locking behavior in dialogs, allowing certain dialogs to disable scroll lock when open.

* **Refactor**
  * Simplified navigation logic in post and callout dialogs for a more consistent user experience.
  * Streamlined component APIs by removing unnecessary props and interfaces.

* **Bug Fixes**
  * Improved URL handling to prevent unnecessary updates and re-renders when navigating between similar URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->