### PR TITLE
MD styles

### DIFF
--- a/src/core/ui/markdown/WrapperMarkdown.tsx
+++ b/src/core/ui/markdown/WrapperMarkdown.tsx
@@ -10,7 +10,7 @@ import { useConfig } from '@/domain/platform/config/useConfig';
 
 const allowedNodeTypes = ['iframe'] as const;
 
-export const MARKDOWN_CLASS_NAME = 'markdown'; // global styles applied
+const MARKDOWN_CLASS_NAME = 'markdown'; // global styles applied
 
 export interface WrapperMarkdownProps extends ReactMarkdownOptions, Partial<MarkdownOptions> {
   // Do not remove. Even if it's not used directly, React adds a className
@@ -41,10 +41,9 @@ export const WrapperMarkdown = ({
     >
       <Box
         sx={{ li: { marginY: caption ? 0 : 1 }, display: plain ? 'inline' : undefined, ...sx }}
-        className={className}
+        className={`${MARKDOWN_CLASS_NAME} ${className || ''}`.trim()}
       >
         <ReactMarkdown
-          // @ts-ignore
           components={components}
           remarkPlugins={[
             gfm,

--- a/src/core/ui/markdown/components/MarkdownComponent.tsx
+++ b/src/core/ui/markdown/components/MarkdownComponent.tsx
@@ -1,13 +1,16 @@
-import { ElementType, ReactNode } from 'react';
+import { ElementType, ComponentProps } from 'react';
 import { Caption, CardText, Text } from '@/core/ui/typography';
 import { gutters } from '@/core/ui/grid/utils';
 import { useMarkdownOptions } from '../MarkdownOptionsContext';
 import { SxProps } from '@mui/material';
+import type { Element } from 'hast';
 
-interface MarkdownComponentProps {
+interface MarkdownComponentProps extends ComponentProps<'div'> {
   overrideDisableParagraphPadding?: boolean;
   sx?: SxProps;
-  node?: ReactNode;
+  node?: Element;
+  // Add index signature to handle ExtraProps from react-markdown
+  [key: string]: unknown;
 }
 
 const createMarkdownComponent =

--- a/src/core/ui/markdown/components/MarkdownHeading.tsx
+++ b/src/core/ui/markdown/components/MarkdownHeading.tsx
@@ -1,28 +1,12 @@
-import { ReactNode } from 'react';
-import { Typography } from '@mui/material';
-
-type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
-
-const HTML_HEADING_LEVEL_MAX = 6;
-
-const PLATFORM_HEADING_LEVEL_MAX = 4;
+import { Typography, TypographyVariant } from '@mui/material';
+import type { Element } from 'hast';
 
 interface HeadingProps {
-  level: number;
-  node?: ReactNode;
-  [key: string]: unknown;
+  node?: Element;
 }
 
-const MarkdownHeading = ({ level, node, ...props }: HeadingProps) => {
-  const markdownHeadingLevel = level + PLATFORM_HEADING_LEVEL_MAX;
-
-  if (markdownHeadingLevel <= HTML_HEADING_LEVEL_MAX) {
-    const variant = `h${markdownHeadingLevel as HeadingLevel}` as const;
-
-    return <Typography variant={variant} {...props} />;
-  } else {
-    return <div role="heading" aria-level={markdownHeadingLevel} {...props} />;
-  }
+const MarkdownHeading = ({ node, ...props }: HeadingProps) => {
+  return <Typography variant={(node?.tagName ?? 'h1') as TypographyVariant} {...props} />;
 };
 
 export default MarkdownHeading;

--- a/src/core/ui/markdown/components/MarkdownList.tsx
+++ b/src/core/ui/markdown/components/MarkdownList.tsx
@@ -1,9 +1,9 @@
 import { Box, SxProps } from '@mui/material';
-import { ReactNode } from 'react';
+import type { Element } from 'hast';
 
 interface ReactMarkdownProps {
   sx?: SxProps;
-  node?: ReactNode;
+  node?: Element;
 }
 
 const createMarkdownList =

--- a/src/core/ui/markdown/components/MarkdownListItem.tsx
+++ b/src/core/ui/markdown/components/MarkdownListItem.tsx
@@ -1,15 +1,15 @@
 import createMarkdownComponent from './MarkdownComponent';
 import { SxProps } from '@mui/material';
-import { ReactNode } from 'react';
+import type { Element } from 'hast';
 
 const Base = createMarkdownComponent('li');
 
 interface ReactMarkdownProps {
   sx?: SxProps;
-  node?: ReactNode;
+  node?: Element;
 }
 
-const MarkdownListItem = (props: ReactMarkdownProps): ReactNode => {
+const MarkdownListItem = (props: ReactMarkdownProps) => {
   // not sure when and what adds the `ordered` property but it results in
   //
   // hook.js:608 Warning: Received `true` for a non-boolean attribute `ordered`.

--- a/src/core/ui/markdown/components/MarkdownMedia.tsx
+++ b/src/core/ui/markdown/components/MarkdownMedia.tsx
@@ -1,11 +1,10 @@
 import { ElementType } from 'react';
 import { Box } from '@mui/material';
 import { useMarkdownOptions } from '../MarkdownOptionsContext';
+import type { Element } from 'hast';
 
 interface ReactMarkdownProps {
-  node?: {
-    tagName?: ElementType;
-  };
+  node?: Element;
 }
 
 const MarkdownMedia = ({ node, ...props }: ReactMarkdownProps) => {

--- a/src/core/ui/markdown/components/MarkdownParagraph.tsx
+++ b/src/core/ui/markdown/components/MarkdownParagraph.tsx
@@ -1,13 +1,13 @@
 import { useMarkdownOptions } from '../MarkdownOptionsContext';
 import createMarkdownComponent from './MarkdownComponent';
 import { SxProps } from '@mui/material';
-import { ReactNode } from 'react';
+import type { Element } from 'hast';
 
 const Base = createMarkdownComponent('p');
 
 interface ReactMarkdownProps {
   sx?: SxProps;
-  node?: ReactNode;
+  node?: Element;
 }
 
 const MarkdownParagraph = (props: ReactMarkdownProps) => {

--- a/src/core/ui/typography/themeTypographyOptions.ts
+++ b/src/core/ui/typography/themeTypographyOptions.ts
@@ -4,6 +4,7 @@ import { rem } from './utils';
 
 export const fontFamilyMontserrat = '"Montserrat", sans-serif';
 export const fontFamilySourceSans = '"Source Sans Pro", sans-serif';
+export const fontFamilyVerdana = '"Verdana", "Arial", sans-serif';
 
 const fontWeightRegular = 400;
 const fontWeightMedium = 500;

--- a/src/domain/collaboration/callout/CalloutView/CalloutViewLayout.tsx
+++ b/src/domain/collaboration/callout/CalloutView/CalloutViewLayout.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 import { AuthorizationPrivilege } from '@/core/apollo/generated/graphql-schema';
-import WrapperMarkdown, { MARKDOWN_CLASS_NAME } from '@/core/ui/markdown/WrapperMarkdown';
+import WrapperMarkdown from '@/core/ui/markdown/WrapperMarkdown';
 import { BlockTitle } from '@/core/ui/typography';
 import { Ribbon } from '@/core/ui/card/Ribbon';
 import References from '@/domain/shared/components/References/References';
@@ -72,7 +72,7 @@ const CalloutViewLayout = ({
           overflowY: expanded ? 'auto' : 'visible',
         }}
       >
-        <Box className={MARKDOWN_CLASS_NAME}>
+        <Box sx={theme => ({ padding: theme.spacing(0, 2, 1) })}>
           <WrapperMarkdown caption>{callout.framing.profile.description ?? ''}</WrapperMarkdown>
         </Box>
         {!skipReferences && !!callout.framing.profile.references?.length && (

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -10,7 +10,7 @@ import { Error404 } from '@/core/pages/Errors/Error404';
 import ScrollToTop from '@/core/routing/ScrollToTop';
 import { GlobalStateProvider } from '@/core/state/GlobalStateProvider';
 import RootThemeProvider from '@/core/ui/themes/RootThemeProvider';
-import { fontFamilySourceSans, subHeading } from '@/core/ui/typography/themeTypographyOptions';
+import { fontFamilySourceSans, fontFamilyVerdana, subHeading } from '@/core/ui/typography/themeTypographyOptions';
 import { PendingMembershipsDialogProvider } from '@/domain/community/pendingMembership/PendingMembershipsDialogContext';
 import { UserProvider } from '@/domain/community/userCurrent/CurrentUserProvider/CurrentUserProvider';
 import { ConfigProvider } from '@/domain/platform/config/ConfigProvider';
@@ -28,6 +28,7 @@ import { InAppNotificationsProvider } from './main/inAppNotifications/InAppNotif
 import { InAppNotificationSubscriber } from './main/inAppNotifications/inAppNotificationSubscriber';
 import { InAppNotificationsDialog } from './main/inAppNotifications/InAppNotificationsDialog';
 import { VersionHandling } from './main/versionHandling';
+import { rem } from '@/core/ui/typography/utils';
 
 // MARKDOWN_CLASS_NAME used in the styles below
 const globalStyles = (theme: Theme) => ({
@@ -63,10 +64,31 @@ const globalStyles = (theme: Theme) => ({
   '[aria-role="heading"]': subHeading,
   '.markdown': {
     wordWrap: 'break-word',
-    padding: theme.spacing(0, 2, 1),
   },
   '.markdown > pre': {
     whiteSpace: 'pre-wrap',
+  },
+  '.tiptap p, .markdown p': {
+    fontFamily: fontFamilyVerdana,
+    fontSize: rem(12),
+  },
+  '.tiptap h1, .markdown h1': {
+    fontFamily: fontFamilyVerdana,
+    fontWeight: 'bold',
+    fontSize: rem(14),
+    lineHeight: rem(20),
+  },
+  '.tiptap h2, .markdown h2': {
+    fontFamily: fontFamilyVerdana,
+    fontWeight: 'bold',
+    fontSize: rem(13),
+    lineHeight: rem(20),
+  },
+  '.tiptap h3, .markdown h3': {
+    fontFamily: fontFamilyVerdana,
+    fontWeight: 'bold',
+    fontSize: rem(12),
+    lineHeight: rem(20),
   },
   '.excalidraw-modal-container': {
     zIndex: `${theme.zIndex.modal + 1} !important`,


### PR DESCRIPTION
There was a regression in the MD styling due to the update of react-markdown. Back then, many types were removed from the lib, and I applied patches that were breaking.

With this PR:
- The typing around the WrapperMarkdown is fixed.
- The header logic was simplified.
- The required styling was applied.

Note that the styles were applied directly to the global styling using the tiptap and markdown HTML classes.
Although a bit primal and dependent on these strings, this is a simple approach, easy to understand, and maintain.

<img width="1529" height="797" alt="Screenshot 2025-07-11 124304" src="https://github.com/user-attachments/assets/135aa4ed-9d45-419d-8e3e-af49f82e8e6f" />

<img width="1855" height="925" alt="image" src="https://github.com/user-attachments/assets/214c1e87-094b-4e01-abb3-ab4a04cb3cd2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated global typography for markdown and tiptap content, introducing Verdana-based font styling and consistent font sizes for paragraphs and headings.
  * Improved application of markdown-related CSS classes and inline styles for better layout and appearance.
* **New Features**
  * Added a new Verdana font family option to typography settings.
* **Refactor**
  * Enhanced flexibility and type safety for markdown-related components by updating prop types and simplifying component logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->