### PR TITLE
Fix text not overflowing on PageBanner

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1959,8 +1959,8 @@
     "innovationLibrary": {
       "shortName": "$t(common.library)",
       "fullName": "Template Library",
-      "title": "Template Library on Alkemio is here to guide your way to impact",
-      "subtitle": "Open the template packs below to explore all the Whiteboard templates, post templates and innovation flows you can use. If you want to know more <click>click here</click>.",
+      "title": "Alkemio's Template Library",
+      "subtitle": "Get your (Sub)Space running with these ready-to-use tools. <click>Learn more</click>.",
       "useTemplateButton": "Access this template from your Space to use it.",
       "innovationPacks": {
         "headerTitle": "$t(common.innovation-packs)",

--- a/src/main/topLevelPages/pageBannerCard/PageBannerCard.tsx
+++ b/src/main/topLevelPages/pageBannerCard/PageBannerCard.tsx
@@ -20,14 +20,10 @@ const PageBannerCard = ({ title, subtitle, iconComponent: Icon, ...props }: Prop
     <PageBannerCardWrapper {...props}>
       <Gutters disablePadding gap={gutters(0.5)}>
         <BadgeCardView visual={Icon && <Icon color="primary" fontSize="large" />} minHeight={gutters(2)}>
-          <PageTitle color="primary" noWrap>
-            {title}
-          </PageTitle>
+          <PageTitle color="primary">{title}</PageTitle>
         </BadgeCardView>
 
-        <Text color="primary" noWrap>
-          {subtitle}
-        </Text>
+        <Text color="primary">{subtitle}</Text>
       </Gutters>
     </PageBannerCardWrapper>
   );


### PR DESCRIPTION
- Changed text of the forum page to something smaller: #8470 ]
- Removed noWrap - validated new behavior with Simone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the title and subtitle text in the innovation library section for clearer messaging.
  * Improved readability by allowing the page banner title and subtitle to wrap onto multiple lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->