### PR TITLE
Fix organization block when references are too long #8362

### DIFF
--- a/src/domain/community/profile/views/OrganizationProfileView.tsx
+++ b/src/domain/community/profile/views/OrganizationProfileView.tsx
@@ -91,7 +91,7 @@ export const OrganizationProfileView = ({ entity }: OrganizationProfileViewProps
             )}
 
           {!isEmpty(links) && (
-            <Gutters fullHeight>
+            <Gutters fullHeight maxWidth="100%">
               <BlockSectionTitle>{t('components.profile.fields.links.title')}</BlockSectionTitle>
 
               <References

--- a/src/domain/shared/components/References/ReferenceView.tsx
+++ b/src/domain/shared/components/References/ReferenceView.tsx
@@ -48,6 +48,8 @@ const ReferenceDescription = ({ children }: ReferenceDescriptionProps) => {
 const ReferenceView = ({ reference, canEdit, onClickEdit }: ReferenceViewProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
+  const hasEditIcon = Boolean(onClickEdit) && canEdit;
+
   return (
     <Root>
       <BadgeCardView
@@ -58,15 +60,20 @@ const ReferenceView = ({ reference, canEdit, onClickEdit }: ReferenceViewProps) 
             {isFileAttachmentUrl(reference.uri) ? <AttachmentIcon /> : <ReferenceIcon />}
           </RoundedBadge>
         }
-        sx={{ flexGrow: 1, maxWidth: `calc(100% - ${gutters(2)(theme)})` }}
+        flexGrow={1}
+        overflow="hidden"
+        textOverflow="ellipsis"
+        maxWidth={hasEditIcon ? `calc(100% - ${gutters(2)(theme)})` : '100%'}
       >
         <Tooltip title={reference.uri} placement="top-start" disableInteractive>
-          <BlockSectionTitle>{reference.name}</BlockSectionTitle>
+          <BlockSectionTitle overflow="hidden" textOverflow="ellipsis">
+            {reference.name}
+          </BlockSectionTitle>
         </Tooltip>
         <ReferenceDescription>{reference.description}</ReferenceDescription>
       </BadgeCardView>
 
-      {canEdit && onClickEdit && (
+      {hasEditIcon && (
         <IconButton
           size="small"
           onClick={onClickEdit}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout and width constraints for the links section in organization profiles.
  * Enhanced text overflow handling and layout consistency in reference views, especially when edit options are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->