### PR TITLE
Add recursive flag to updateSpaceTemplate and a few tweaks more to the templates form

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -20539,8 +20539,11 @@ export const SpaceTemplateContentDocument = gql`
         settings {
           ...SpaceTemplateContent_Settings
         }
-        about {
-          ...SpaceTemplateContent_Subspaces
+        subspaces {
+          id
+          about {
+            ...SpaceTemplateContent_Subspaces
+          }
         }
       }
     }
@@ -21019,8 +21022,8 @@ export type UpdateCalloutTemplateMutationOptions = Apollo.BaseMutationOptions<
   SchemaTypes.UpdateCalloutTemplateMutationVariables
 >;
 export const UpdateTemplateFromSpaceDocument = gql`
-  mutation UpdateTemplateFromSpace($templateId: UUID!, $spaceId: UUID!) {
-    updateTemplateFromSpace(updateData: { templateID: $templateId, spaceID: $spaceId }) {
+  mutation UpdateTemplateFromSpace($templateId: UUID!, $spaceId: UUID!, $recursive: Boolean) {
+    updateTemplateFromSpace(updateData: { templateID: $templateId, spaceID: $spaceId, recursive: $recursive }) {
       id
     }
   }
@@ -21045,6 +21048,7 @@ export type UpdateTemplateFromSpaceMutationFn = Apollo.MutationFunction<
  *   variables: {
  *      templateId: // value for 'templateId'
  *      spaceId: // value for 'spaceId'
+ *      recursive: // value for 'recursive'
  *   },
  * });
  */

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -7327,6 +7327,8 @@ export type UpdateTemplateDefaultTemplateInput = {
 };
 
 export type UpdateTemplateFromSpaceInput = {
+  /** Whether to reproduce the hierarchy or just the space. */
+  recursive?: InputMaybe<Scalars['Boolean']['input']>;
   /** The Space whose content should be copied to this Template. */
   spaceID: Scalars['UUID']['input'];
   /** The ID of the Template. */
@@ -25505,7 +25507,6 @@ export type SpaceTemplateContentQuery = {
           about: {
             __typename?: 'SpaceAbout';
             id: string;
-            isContentPublic: boolean;
             profile: {
               __typename?: 'Profile';
               id: string;
@@ -25530,12 +25531,6 @@ export type SpaceTemplateContentQuery = {
                 name: string;
                 alternativeText?: string | undefined;
               }>;
-              avatar?:
-                | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
-                | undefined;
-              cardBanner?:
-                | { __typename?: 'Visual'; id: string; uri: string; name: string; alternativeText?: string | undefined }
-                | undefined;
             };
           };
           settings: {
@@ -25559,6 +25554,40 @@ export type SpaceTemplateContentQuery = {
               allowEventsFromSubspaces: boolean;
             };
           };
+          subspaces: Array<{
+            __typename?: 'Space';
+            id: string;
+            about: {
+              __typename?: 'SpaceAbout';
+              id: string;
+              isContentPublic: boolean;
+              profile: {
+                __typename?: 'Profile';
+                id: string;
+                displayName: string;
+                tagline?: string | undefined;
+                url: string;
+                avatar?:
+                  | {
+                      __typename?: 'Visual';
+                      id: string;
+                      uri: string;
+                      name: string;
+                      alternativeText?: string | undefined;
+                    }
+                  | undefined;
+                cardBanner?:
+                  | {
+                      __typename?: 'Visual';
+                      id: string;
+                      uri: string;
+                      name: string;
+                      alternativeText?: string | undefined;
+                    }
+                  | undefined;
+              };
+            };
+          }>;
         }
       | undefined;
   };
@@ -26377,6 +26406,7 @@ export type UpdateCalloutTemplateMutation = {
 export type UpdateTemplateFromSpaceMutationVariables = Exact<{
   templateId: Scalars['UUID']['input'];
   spaceId: Scalars['UUID']['input'];
+  recursive?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type UpdateTemplateFromSpaceMutation = {

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1115,6 +1115,9 @@
         "title": "Discard template",
         "description": "Are you sure you want to close this template? Unsaved changes will be lost."
       }
+    },
+    "notifications": {
+      "templateSaved": "Template saved successfully"
     }
   },
   "innovation-templates": {

--- a/src/domain/space/components/cards/SpaceTile.tsx
+++ b/src/domain/space/components/cards/SpaceTile.tsx
@@ -22,6 +22,7 @@ type SpaceTileProps = {
       }
     | undefined;
   columns?: number;
+  disableLink?: boolean;
 };
 
 export const RECENT_SPACE_CARD_ASPECT_RATIO = '175/100';
@@ -29,7 +30,7 @@ export const RECENT_SPACE_CARD_ASPECT_RATIO = '175/100';
 const SPACE_TITLE_CLASS_NAME = 'SpaceTitle';
 const ElevatedPaper = withElevationOnHover(Paper) as typeof Paper;
 
-const SpaceTile = ({ space, columns = 3 }: SpaceTileProps) => {
+const SpaceTile = ({ space, columns = 3, disableLink }: SpaceTileProps) => {
   const isPrivate = space?.about.isContentPublic === false;
 
   const getVisualUrl = () => {
@@ -43,8 +44,7 @@ const SpaceTile = ({ space, columns = 3 }: SpaceTileProps) => {
   return (
     <GridItem columns={columns}>
       <ElevatedPaper
-        component={RouterLink}
-        to={space?.about.profile.url ?? ''}
+        {...(disableLink ? undefined : { component: RouterLink, to: space?.about.profile.url ?? '' })}
         sx={{
           position: 'relative',
         }}

--- a/src/domain/spaceAdmin/SpaceAdminAccount/SpaceAdminAccountPage.tsx
+++ b/src/domain/spaceAdmin/SpaceAdminAccount/SpaceAdminAccountPage.tsx
@@ -1,5 +1,4 @@
 import {
-  refetchAdminSpacesListQuery,
   useDeleteSpaceMutation,
   useOrganizationAuthorizationLazyQuery,
   useSpaceAccountQuery,
@@ -117,8 +116,6 @@ const SpaceAdminAccountPage: FC<SpaceAdminAccountPageProps> = ({ spaceId, routeP
   }, [data]);
 
   const [deleteSpace] = useDeleteSpaceMutation({
-    refetchQueries: [refetchAdminSpacesListQuery()],
-    awaitRefetchQueries: true,
     onCompleted: () => {
       notify(t('pages.admin.space.notifications.space-removed'), 'success');
       navigate(ROUTE_HOME, { replace: true });

--- a/src/domain/templates/components/Dialogs/CreateEditTemplateDialog/CreateEditTemplateDialogBase.tsx
+++ b/src/domain/templates/components/Dialogs/CreateEditTemplateDialog/CreateEditTemplateDialogBase.tsx
@@ -45,8 +45,12 @@ const CreateEditTemplateDialogBase = ({
           actions: formik => (
             <DialogFooter>
               <DialogActions sx={{ marginLeft: 'auto' }}>
-                {editMode && onDelete && <DeleteButton onClick={onDelete} />}
-                {editMode && onCancel && <BackButton onClick={onCancel}>{t('buttons.cancel')}</BackButton>}
+                {editMode && onDelete && <DeleteButton onClick={onDelete} disabled={formik.isSubmitting} />}
+                {editMode && onCancel && (
+                  <BackButton onClick={onCancel} disabled={formik.isSubmitting}>
+                    {t('buttons.cancel')}
+                  </BackButton>
+                )}
                 <FormikSubmitButtonPure
                   variant="contained"
                   formik={formik}

--- a/src/domain/templates/components/Dialogs/CreateEditTemplateDialog/CreateTemplateDialog.tsx
+++ b/src/domain/templates/components/Dialogs/CreateEditTemplateDialog/CreateTemplateDialog.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 interface CreateTemplateDialogProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (values: AnyTemplateFormSubmittedValues) => void;
+  onSubmit: (values: AnyTemplateFormSubmittedValues) => Promise<unknown>;
   templateType: TemplateType;
   getDefaultValues?: () => Promise<Partial<AnyTemplate>>;
   temporaryLocation?: boolean;

--- a/src/domain/templates/components/Dialogs/CreateEditTemplateDialog/EditTemplateDialog.tsx
+++ b/src/domain/templates/components/Dialogs/CreateEditTemplateDialog/EditTemplateDialog.tsx
@@ -11,7 +11,7 @@ interface EditTemplateDialogProps {
   open: boolean;
   onClose: DialogHeaderProps['onClose'];
   onCancel?: () => void;
-  onSubmit: (values: AnyTemplateFormSubmittedValues) => void;
+  onSubmit: (values: AnyTemplateFormSubmittedValues) => Promise<unknown>;
   onDelete?: () => void;
   template: AnyTemplate | undefined;
   templateType: TemplateType;

--- a/src/domain/templates/components/Forms/SpaceContentFromSpaceUrlForm.tsx
+++ b/src/domain/templates/components/Forms/SpaceContentFromSpaceUrlForm.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, TextField } from '@mui/material';
-import React, { useState } from 'react';
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text } from '@/core/ui/typography';
 import useLoadingState from '@/domain/shared/utils/useLoadingState';
@@ -8,95 +8,107 @@ import { useUrlResolverLazyQuery } from '@/core/apollo/generated/apollo-hooks';
 import Gutters from '@/core/ui/grid/Gutters';
 import { UrlType } from '@/core/apollo/generated/graphql-schema';
 
+export interface SpaceContentFromSpaceUrlFormRef {
+  resetForm: () => void;
+}
 interface SpaceContentFromSpaceUrlFormProps {
   onUseSpace: (spaceId: string) => Promise<unknown>; // Callback function to handle click on "Use this space" button
+  disabled?: boolean;
   collapsible?: boolean;
   onCollapse?: () => void;
 }
 
-const SpaceContentFromSpaceUrlForm: React.FC<SpaceContentFromSpaceUrlFormProps> = ({
-  onUseSpace,
-  collapsible,
-  onCollapse,
-}) => {
-  const { t } = useTranslation();
-  const [url, setUrl] = useState('');
-  const [urlError, setUrlError] = useState<string>();
-  const [collapsed, setCollapsed] = useState<boolean>(collapsible ?? false);
-  const [parseUrl] = useUrlResolverLazyQuery();
+const SpaceContentFromSpaceUrlForm = forwardRef<SpaceContentFromSpaceUrlFormRef, SpaceContentFromSpaceUrlFormProps>(
+  ({ onUseSpace, disabled, collapsible, onCollapse }: SpaceContentFromSpaceUrlFormProps, ref) => {
+    const { t } = useTranslation();
+    const [url, setUrl] = useState('');
+    const [urlError, setUrlError] = useState<string>();
+    const [collapsed, setCollapsed] = useState<boolean>(collapsible ?? false);
+    const [parseUrl] = useUrlResolverLazyQuery();
 
-  const [handleUse, loading] = useLoadingState(async () => {
-    setUrlError(undefined);
-    if (!url) {
-      setUrlError(t('templateLibrary.spaceTemplates.findByUrl.urlRequired'));
-      return;
-    }
-    const { data, error } = await parseUrl({
-      variables: { url },
+    useImperativeHandle(
+      ref,
+      () => ({
+        resetForm: () => setUrl(''),
+      }),
+      []
+    );
+
+    const [handleUse, loading] = useLoadingState(async () => {
+      setUrlError(undefined);
+      if (!url) {
+        setUrlError(t('templateLibrary.spaceTemplates.findByUrl.urlRequired'));
+        return;
+      }
+      const { data, error } = await parseUrl({
+        variables: { url },
+      });
+      if (error) {
+        setUrlError(error.message);
+        return;
+      }
+      if (data?.urlResolver.type !== UrlType.Space) {
+        setUrlError(t('templateLibrary.spaceTemplates.findByUrl.invalidUrl'));
+        return;
+      }
+      const spaceId = data.urlResolver.space?.id;
+      if (!spaceId) {
+        setUrlError(t('templateLibrary.spaceTemplates.findByUrl.spaceNotFoundError'));
+      } else {
+        // Finally, if everything went well, return the spaceId
+        await onUseSpace(spaceId);
+      }
     });
-    if (error) {
-      setUrlError(error.message);
-      return;
-    }
-    if (data?.urlResolver.type !== UrlType.Space) {
-      setUrlError(t('templateLibrary.spaceTemplates.findByUrl.invalidUrl'));
-      return;
-    }
-    const spaceId = data.urlResolver.space?.id;
-    if (!spaceId) {
-      setUrlError(t('templateLibrary.spaceTemplates.findByUrl.spaceNotFoundError'));
-    } else {
-      // Finally, if everything went well, return the spaceId
-      await onUseSpace(spaceId);
-    }
-  });
 
-  return (
-    <>
-      {collapsed && (
-        <Box textAlign="right">
-          <Button variant="outlined" onClick={() => setCollapsed(false)}>
-            {t('templateLibrary.spaceTemplates.findByUrl.selectAnother')}
-          </Button>
-        </Box>
-      )}
-      {!collapsed && (
-        <form onSubmit={e => e.preventDefault()}>
-          <PageContentBlock>
-            <Text>{t('templateLibrary.spaceTemplates.findByUrl.description')}</Text>
-            <Gutters disablePadding row alignItems="baseline">
-              <TextField
-                value={url}
-                onChange={e => setUrl(e.target.value)}
-                placeholder={t('templateLibrary.spaceTemplates.findByUrl.title')}
-                sx={{ flexGrow: 1 }}
-                error={Boolean(urlError)}
-                helperText={urlError}
-              />
-              <Box>
-                {collapsible && (
-                  <Button
-                    variant="outlined"
-                    onClick={() => {
-                      setCollapsed(true);
-                      onCollapse?.();
-                    }}
-                  >
-                    {t('buttons.cancel')}
+    return (
+      <>
+        {collapsed && (
+          <Box textAlign="right">
+            <Button variant="outlined" onClick={() => setCollapsed(false)} disabled={disabled}>
+              {t('templateLibrary.spaceTemplates.findByUrl.selectAnother')}
+            </Button>
+          </Box>
+        )}
+        {!collapsed && (
+          <form onSubmit={e => e.preventDefault()}>
+            <PageContentBlock>
+              <Text>{t('templateLibrary.spaceTemplates.findByUrl.description')}</Text>
+              <Gutters disablePadding row alignItems="baseline">
+                <TextField
+                  value={url}
+                  onChange={e => setUrl(e.target.value)}
+                  disabled={disabled}
+                  placeholder={t('templateLibrary.spaceTemplates.findByUrl.title')}
+                  sx={{ flexGrow: 1 }}
+                  error={Boolean(urlError)}
+                  helperText={urlError}
+                />
+                <Box>
+                  {collapsible && (
+                    <Button
+                      variant="outlined"
+                      disabled={disabled}
+                      onClick={() => {
+                        setCollapsed(true);
+                        onCollapse?.();
+                      }}
+                    >
+                      {t('buttons.cancel')}
+                    </Button>
+                  )}
+                </Box>
+                <Box>
+                  <Button variant="contained" loading={loading} onClick={handleUse} disabled={disabled}>
+                    {t('templateLibrary.spaceTemplates.findByUrl.use')}
                   </Button>
-                )}
-              </Box>
-              <Box>
-                <Button variant="contained" loading={loading} onClick={handleUse}>
-                  {t('templateLibrary.spaceTemplates.findByUrl.use')}
-                </Button>
-              </Box>
-            </Gutters>
-          </PageContentBlock>
-        </form>
-      )}
-    </>
-  );
-};
+                </Box>
+              </Gutters>
+            </PageContentBlock>
+          </form>
+        )}
+      </>
+    );
+  }
+);
 
 export default SpaceContentFromSpaceUrlForm;

--- a/src/domain/templates/components/Forms/SpaceContentFromSpaceUrlForm.tsx
+++ b/src/domain/templates/components/Forms/SpaceContentFromSpaceUrlForm.tsx
@@ -111,4 +111,6 @@ const SpaceContentFromSpaceUrlForm = forwardRef<SpaceContentFromSpaceUrlFormRef,
   }
 );
 
+SpaceContentFromSpaceUrlForm.displayName = 'SpaceContentFromSpaceUrlForm';
+
 export default SpaceContentFromSpaceUrlForm;

--- a/src/domain/templates/components/Forms/TemplateForm.tsx
+++ b/src/domain/templates/components/Forms/TemplateForm.tsx
@@ -12,7 +12,7 @@ import TemplateWhiteboardForm, { TemplateWhiteboardFormSubmittedValues } from '.
 
 interface TemplateFormProps {
   template: AnyTemplate;
-  onSubmit: (values: AnyTemplateFormSubmittedValues) => void;
+  onSubmit: (values: AnyTemplateFormSubmittedValues) => Promise<unknown>;
   actions: ReactNode | ((formState: FormikProps<AnyTemplateFormSubmittedValues>) => ReactNode);
   temporaryLocation?: boolean;
 }

--- a/src/domain/templates/components/Forms/common/mappings.ts
+++ b/src/domain/templates/components/Forms/common/mappings.ts
@@ -406,11 +406,12 @@ export const toUpdateTemplateMutationVariables = (
       // Then updateSpaceContentTemplateVariables will be returned and the mutation will be called.
       // If the spaceId remains the same, we just update the template profile.
       const oldSelectedSpaceId = (template as SpaceTemplate).contentSpace?.id;
-      const newModelSpaceId = (newValues as TemplateSpaceFormSubmittedValues).spaceId;
+      const { spaceId: newModelSpaceId, recursive } = newValues as TemplateSpaceFormSubmittedValues;
       if (oldSelectedSpaceId && newModelSpaceId && oldSelectedSpaceId !== newModelSpaceId) {
         const updateSpaceContentTemplateVariables: UpdateTemplateFromSpaceMutationVariables = {
           templateId,
           spaceId: newModelSpaceId,
+          recursive,
         };
         return {
           updateTemplateVariables,

--- a/src/domain/templates/components/Previews/TemplateContentSpacePreview.tsx
+++ b/src/domain/templates/components/Previews/TemplateContentSpacePreview.tsx
@@ -62,6 +62,7 @@ const TemplateContentSpacePreview = ({ template, loading }: TemplateContentSpace
                   about: subspace.about,
                   level: SpaceLevel.L1,
                 }}
+                disableLink
               />
             ))}
           </Gutters>

--- a/src/domain/templates/components/Previews/TemplateContentSpacePreview.tsx
+++ b/src/domain/templates/components/Previews/TemplateContentSpacePreview.tsx
@@ -53,12 +53,13 @@ const TemplateContentSpacePreview = ({ template, loading }: TemplateContentSpace
       return (
         <>
           <Caption>{t('templateLibrary.spaceTemplates.includesSubspaces')}</Caption>
-          <Gutters row disablePadding>
+          <Gutters row disablePadding flexWrap="wrap">
             {template.contentSpace.subspaces.map((subspace, index) => (
               <SpaceTile
                 key={index}
                 columns={cardColumns}
                 space={{
+                  id: subspace.id,
                   about: subspace.about,
                   level: SpaceLevel.L1,
                 }}

--- a/src/domain/templates/components/TemplateSelectors/SpaceTemplateSelector.tsx
+++ b/src/domain/templates/components/TemplateSelectors/SpaceTemplateSelector.tsx
@@ -49,7 +49,7 @@ export const SpaceTemplateSelector: FC<SpaceTemplateSelectorProps> = ({
   const [isDialogOpen, setDialogOpen] = useState(false);
   const [importTemplateConfirmOpen, setImportTemplateConfirmOpen] = useState(false);
   const [field, , helpers] = useField<string>(name);
-  const { setFieldValue, validateForm, dirty } = useFormikContext();
+  const { getFieldProps, setFieldValue, validateForm, dirty } = useFormikContext();
 
   const templateId: string | undefined = typeof field.value === 'string' ? field.value : undefined;
 
@@ -94,9 +94,12 @@ export const SpaceTemplateSelector: FC<SpaceTemplateSelectorProps> = ({
       helpers.setValue(templateId);
 
       if (profile.displayName) {
-        await setFieldValue('displayName', profile.displayName);
-        // make sure the submit is enabled if displayName is set
-        await validateForm();
+        const currentValue = getFieldProps('displayName').value;
+        if (!currentValue) {
+          await setFieldValue('displayName', profile.displayName);
+          // make sure the submit is enabled if displayName is set
+          await validateForm();
+        }
       }
       if (profile.tagline) {
         setFieldValue('tagline', profile.tagline);

--- a/src/domain/templates/components/TemplatesAdmin/TemplatesAdmin.tsx
+++ b/src/domain/templates/components/TemplatesAdmin/TemplatesAdmin.tsx
@@ -38,6 +38,7 @@ import { TemplateSpaceFormSubmittedValues } from '../Forms/TemplateSpaceForm';
 import { TemplateCalloutFormSubmittedValues } from '../Forms/TemplateCalloutForm';
 import { TemplateWhiteboardFormSubmittedValues } from '../Forms/TemplateWhiteboardForm';
 import { SpaceTemplate } from '../../models/SpaceTemplate';
+import { useNotification } from '@/core/ui/notifications/useNotification';
 
 type TemplatePermissionCallback = (templateType: TemplateType) => boolean;
 const defaultPermissionDenied: TemplatePermissionCallback = () => false;
@@ -84,6 +85,7 @@ const TemplatesAdmin = ({
   canDeleteTemplates = defaultPermissionDenied,
 }: PropsWithChildren<TemplatesAdminProps>) => {
   const { t } = useTranslation();
+  const notify = useNotification();
   const backToTemplates = useBackWithDefaultUrl(baseUrl);
   const { handlePreviewTemplates } = useHandlePreviewImages();
 
@@ -110,7 +112,7 @@ const TemplatesAdmin = ({
   // Update Template
   const [editTemplateMode, setEditTemplateMode] = useState(alwaysEditTemplate);
 
-  const refetchQueries = ['AllTemplatesInTemplatesSet', 'TemplateContent'];
+  const refetchQueries = ['AllTemplatesInTemplatesSet', 'TemplateContent', 'SpaceTemplateContent'];
   const [updateTemplate] = useUpdateTemplateMutation({ refetchQueries });
   const [updateCallout] = useUpdateCalloutTemplateMutation({ refetchQueries });
   const [updateCommunityGuidelines] = useUpdateCommunityGuidelinesMutation({ refetchQueries });
@@ -161,6 +163,7 @@ const TemplatesAdmin = ({
     if (!alwaysEditTemplate) {
       setEditTemplateMode(false);
     }
+    notify(t('templateLibrary.notifications.templateSaved'), 'success');
   };
 
   // Create Template

--- a/src/domain/templates/contentSpace/model/TemplateContentSpaceModel.tsx
+++ b/src/domain/templates/contentSpace/model/TemplateContentSpaceModel.tsx
@@ -3,11 +3,10 @@ import { InnovationFlowState } from '@/core/apollo/generated/graphql-schema';
 import { SpaceAboutLightModel } from '@/domain/space/about/model/spaceAboutLight.model';
 import { SpaceSettingsModel } from '@/domain/space/settings/SpaceSettingsModel';
 import { SpaceAboutTileModel } from '@/domain/space/about/model/SpaceAboutTile.model';
+import { Identifiable } from '@/core/utils/Identifiable';
 
-export interface TemplateContentSpaceModel {
-  id: string;
-  collaboration: {
-    id: string;
+export interface TemplateContentSpaceModel extends Identifiable {
+  collaboration: Identifiable & {
     innovationFlow: {
       id: string;
       states: InnovationFlowState[];
@@ -18,7 +17,7 @@ export interface TemplateContentSpaceModel {
   };
   about?: SpaceAboutLightModel;
   settings?: SpaceSettingsModel;
-  subspaces?: {
+  subspaces?: (Identifiable & {
     about: SpaceAboutTileModel;
-  }[];
+  })[];
 }

--- a/src/domain/templates/graphql/TemplateContent.graphql
+++ b/src/domain/templates/graphql/TemplateContent.graphql
@@ -53,8 +53,11 @@ query SpaceTemplateContent($spaceId: UUID!) {
       settings {
         ...SpaceTemplateContent_Settings
       }
-      about {
-        ...SpaceTemplateContent_Subspaces
+      subspaces {
+        id
+        about {
+          ...SpaceTemplateContent_Subspaces
+        }
       }
     }
   }

--- a/src/domain/templates/graphql/TemplateMutations.graphql
+++ b/src/domain/templates/graphql/TemplateMutations.graphql
@@ -173,8 +173,8 @@ mutation UpdateCalloutTemplate($calloutData: UpdateCalloutEntityInput!) {
 }
 
 # Special case for updating a collaboration template from an existing collaboration
-mutation UpdateTemplateFromSpace($templateId: UUID!, $spaceId: UUID!) {
-  updateTemplateFromSpace(updateData: { templateID: $templateId, spaceID: $spaceId }) {
+mutation UpdateTemplateFromSpace($templateId: UUID!, $spaceId: UUID!, $recursive: Boolean), {
+  updateTemplateFromSpace(updateData: { templateID: $templateId, spaceID: $spaceId, recursive: $recursive }) {
     id
   }
 }

--- a/src/domain/templates/graphql/TemplateMutations.graphql
+++ b/src/domain/templates/graphql/TemplateMutations.graphql
@@ -173,7 +173,7 @@ mutation UpdateCalloutTemplate($calloutData: UpdateCalloutEntityInput!) {
 }
 
 # Special case for updating a collaboration template from an existing collaboration
-mutation UpdateTemplateFromSpace($templateId: UUID!, $spaceId: UUID!, $recursive: Boolean), {
+mutation UpdateTemplateFromSpace($templateId: UUID!, $spaceId: UUID!, $recursive: Boolean) {
   updateTemplateFromSpace(updateData: { templateID: $templateId, spaceID: $spaceId, recursive: $recursive }) {
     id
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user notification when a template is saved successfully.
  * Improved form controls to disable buttons during submission for better user feedback.
  * Enhanced form components to support asynchronous submission and loading states.
  * Added the ability to reset certain forms programmatically after submission.
  * Added option to disable links on space tiles in previews and listings.

* **Bug Fixes**
  * Updated GraphQL queries to prevent duplicated fields and ensure correct subspace data retrieval.

* **Refactor**
  * Updated form components and prop types to support asynchronous operations and improved control flow.
  * Unified identity handling in template content space models for consistency.

* **Chores**
  * Extended GraphQL mutation to support a new optional parameter for recursive updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->