### PR TITLE
[Release] Fix infinitely reloading page

### DIFF
--- a/src/main/routing/TopLevelRoutePath.ts
+++ b/src/main/routing/TopLevelRoutePath.ts
@@ -6,6 +6,9 @@ export enum TopLevelRoutePath {
   InnovationLibrary = 'innovation-library',
   InnovationPacks = 'innovation-packs',
   InnovationHubs = 'innovation-hubs',
+  /**
+   * @deprecated Create space doesn't have a dedicated url anymore
+   */
   CreateSpace = 'create-space',
   Home = 'home',
   Spaces = 'spaces',

--- a/src/main/routing/TopLevelRoutes.tsx
+++ b/src/main/routing/TopLevelRoutes.tsx
@@ -18,8 +18,6 @@ import Loading from '@/core/ui/loading/Loading';
 import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
 import { UrlResolverProvider } from './urlResolver/UrlResolverProvider';
 import TopLevelLayout from '../ui/layout/TopLevelLayout';
-import useNavigate from '@/core/routing/useNavigate';
-import { ROUTE_HOME } from '@/domain/platform/routes/constants';
 
 const DocumentationPage = lazyWithGlobalErrorHandler(() => import('@/main/documentation/DocumentationPage'));
 const RedirectDocumentation = lazyWithGlobalErrorHandler(() => import('@/main/documentation/RedirectDocumentation'));
@@ -41,14 +39,10 @@ const InnovationPackRoute = lazyWithGlobalErrorHandler(() => import('@/domain/In
 const InnovationHubsRoutes = lazyWithGlobalErrorHandler(
   () => import('@/domain/innovationHub/InnovationHubsSettings/InnovationHubsRoutes')
 );
-const CreateSpaceDialog = lazyWithGlobalErrorHandler(
-  () => import('@/domain/space/components/CreateSpace/createSpace/CreateSpace')
-);
 const SpaceRoutes = lazyWithGlobalErrorHandler(() => import('@/domain/space/routing/SpaceRoutes'));
 
 export const TopLevelRoutes = () => {
   useRedirectToIdentityDomain();
-  const navigate = useNavigate();
 
   return (
     <Routes>
@@ -64,21 +58,6 @@ export const TopLevelRoutes = () => {
         <Route path={TopLevelRoutePath._Landing} element={<RedirectToWelcomeSite />} />
         {IdentityRoute()}
         {devRoute()}
-        <Route
-          path={TopLevelRoutePath.CreateSpace}
-          element={
-            <NonIdentity>
-              <WithApmTransaction path={TopLevelRoutePath.CreateSpace}>
-                <>
-                  <HomePage />
-                  <Suspense fallback={<Loading />}>
-                    <CreateSpaceDialog open onClose={() => navigate(ROUTE_HOME)} />
-                  </Suspense>
-                </>
-              </WithApmTransaction>
-            </NonIdentity>
-          }
-        />
         <Route
           path={TopLevelRoutePath.Home}
           element={

--- a/src/main/routing/urlBuilders.ts
+++ b/src/main/routing/urlBuilders.ts
@@ -100,8 +100,8 @@ export const buildInnovationHubUrl = (subdomain: string): string => {
   }
 };
 
-export const getAccountLink = (profileUrl?: string) => {
-  return profileUrl ? `${profileUrl}/settings/account` : '';
+export const buildUserAccountUrl = (profileUrl?: string) => {
+  return profileUrl ? `${buildSettingsUrl(profileUrl)}/account` : '';
 };
 
 export const buildWelcomeSpaceUrl = () => '/welcome-space';

--- a/src/main/topLevelPages/myDashboard/DashboardMenu/useHomeMenuItems.ts
+++ b/src/main/topLevelPages/myDashboard/DashboardMenu/useHomeMenuItems.ts
@@ -6,7 +6,7 @@ import RocketLaunchOutlinedIcon from '@mui/icons-material/RocketLaunchOutlined';
 import DrawOutlinedIcon from '@mui/icons-material/DrawOutlined';
 import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
 import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
-import { getAccountLink } from '@/main/routing/urlBuilders';
+import { buildUserAccountUrl } from '@/main/routing/urlBuilders';
 import { MenuOptionProps } from './dashboardMenuTypes';
 import { DashboardDialog } from '../DashboardDialogs/DashboardDialogsProps';
 import { useCreateSpaceLink } from '../useCreateSpaceLink/useCreateSpaceLink';
@@ -52,7 +52,7 @@ export const useHomeMenuItems = () => {
       {
         label: 'pages.home.mainNavigation.myAccount',
         type: 'link',
-        to: getAccountLink(userModel?.profile?.url),
+        to: buildUserAccountUrl(userModel?.profile?.url),
         icon: LocalOfferOutlinedIcon,
         isVisible: (_, __) => true,
       },

--- a/src/main/topLevelPages/myDashboard/useCreateSpaceLink/useCreateSpaceLink.tsx
+++ b/src/main/topLevelPages/myDashboard/useCreateSpaceLink/useCreateSpaceLink.tsx
@@ -1,12 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
 import { AuthorizationPrivilege, LicenseEntitlementType } from '@/core/apollo/generated/graphql-schema';
-import { TopLevelRoutePath } from '@/main/routing/TopLevelRoutePath';
 import { useMemo } from 'react';
+import { buildUserAccountUrl } from '@/main/routing/urlBuilders';
 
 export const useCreateSpaceLink = () => {
   const { t } = useTranslation();
-  const { accountPrivileges, loading, accountEntitlements } = useCurrentUserContext();
+  const { userModel, accountPrivileges, loading, accountEntitlements } = useCurrentUserContext();
 
   const STATIC_PAGE_LINK = t('pages.home.sections.startingSpace.url');
 
@@ -22,7 +22,7 @@ export const useCreateSpaceLink = () => {
     ].some(entitlement => accountEntitlements.includes(entitlement));
 
     if (accountPrivileges.includes(AuthorizationPrivilege.CreateSpace) && isEntitledToCreateSpace) {
-      return `/${TopLevelRoutePath.CreateSpace}`;
+      return buildUserAccountUrl(userModel?.profile.url);
     }
 
     return STATIC_PAGE_LINK;

--- a/src/main/ui/platformNavigation/PlatformNavigationUserMenu.tsx
+++ b/src/main/ui/platformNavigation/PlatformNavigationUserMenu.tsx
@@ -2,7 +2,7 @@ import { forwardRef, PropsWithChildren, ReactNode, useMemo, useState } from 'rea
 import { Box, Divider, MenuList, Typography } from '@mui/material';
 import { BlockTitle, Caption } from '@/core/ui/typography';
 import { gutters } from '@/core/ui/grid/utils';
-import { buildLoginUrl, getAccountLink } from '@/main/routing/urlBuilders';
+import { buildLoginUrl, buildUserAccountUrl } from '@/main/routing/urlBuilders';
 import PendingMembershipsDialog from '@/domain/community/pendingMembership/PendingMembershipsDialog';
 import {
   AssignmentIndOutlined,
@@ -136,7 +136,7 @@ const PlatformNavigationUserMenu = forwardRef<HTMLDivElement, PropsWithChildren<
               {userModel && (
                 <NavigatableMenuItem
                   iconComponent={LocalOfferOutlinedIcon}
-                  route={getAccountLink(userModel.profile.url)}
+                  route={buildUserAccountUrl(userModel.profile.url)}
                   onClick={onClose}
                 >
                   {t('pages.home.mainNavigation.myAccount')}


### PR DESCRIPTION
- See #8520
- Page was reloading infinitely when opening a callout dialog in any subspace (not level 0), in any flow state that was not the first one.
- The fix is to remove `useNavigate` from topLevelRoutes. We've had to remove the CreateSpace dialog from the top level routes. We had a url `/create-space`, and for now instead of navigating there, we are going to bring to users to their "My Account" page.