### PR TITLE
Subspace tabs spacing fix

### DIFF
--- a/src/domain/collaboration/InnovationFlow/InnovationFlowVisualizers/InnovationFlowChips.tsx
+++ b/src/domain/collaboration/InnovationFlow/InnovationFlowVisualizers/InnovationFlowChips.tsx
@@ -5,10 +5,11 @@ import Gutters from '@/core/ui/grid/Gutters';
 import WrapperMarkdown from '@/core/ui/markdown/WrapperMarkdown';
 import { Caption } from '@/core/ui/typography';
 import { ArrowRight } from '@mui/icons-material';
-import { Button, Divider, styled, Tooltip } from '@mui/material';
+import { Button, Divider, styled, Tooltip, Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { InnovationFlowStateModel } from '../models/InnovationFlowStateModel';
 import { InnovationFlowVisualizerProps } from './InnovationFlowVisualizer';
+import { gutters } from '@/core/ui/grid/utils';
 
 interface InnovationFlowChipsProps extends InnovationFlowVisualizerProps {}
 
@@ -106,7 +107,12 @@ const InnovationFlowChips = ({
           </Gutters>
         )}
       </Gutters>
-      {selectedStateDescription && <FlowStateDescription>{selectedStateDescription}</FlowStateDescription>}
+      {selectedStateDescription ? (
+        <FlowStateDescription>{selectedStateDescription}</FlowStateDescription>
+      ) : (
+        // fixes the offset when no description is present
+        <Box sx={{ marginBottom: gutters(0.7) }} />
+      )}
     </>
   );
 };

--- a/src/domain/space/layout/SubspacePageLayout.tsx
+++ b/src/domain/space/layout/SubspacePageLayout.tsx
@@ -142,7 +142,7 @@ export const SubspacePageLayout = () => {
                 position: 'sticky',
                 top: 0,
                 marginTop: gutters(-1),
-                marginBottom: gutters(-1),
+                marginBottom: gutters(-0.7),
                 paddingTop: gutters(1),
                 background: theme.palette.background.default,
                 width: '100%',


### PR DESCRIPTION
fix subspace margin in the layout so it works with no desc and doesn't hide the outline of the Posts

<img width="736" height="160" alt="image" src="https://github.com/user-attachments/assets/70234b6d-095c-4895-b92f-30ed03ce6324" />
<img width="744" height="168" alt="image" src="https://github.com/user-attachments/assets/780094e2-8c0f-4595-a293-b9567c052707" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved vertical spacing and layout consistency in the Innovation Flow visualizer and Subspace page layout for a more polished user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->