### PR TITLE
Multiselect for the invite dialog

### DIFF
--- a/src/core/ui/forms/FormikMultiSelect.tsx
+++ b/src/core/ui/forms/FormikMultiSelect.tsx
@@ -1,0 +1,89 @@
+import { Autocomplete, Chip, TextField, TextFieldProps } from '@mui/material';
+import { useField } from 'formik';
+import { useMemo, ReactElement, SyntheticEvent } from 'react';
+import { useValidationMessageTranslation } from '@/domain/shared/i18n/ValidationMessageTranslation';
+import TranslationKey from '@/core/i18n/utils/TranslationKey';
+
+export interface FormikSelectValue {
+  id: string;
+  name: string;
+  icon?: ReactElement;
+}
+
+export type FormikMultiSelectProps = TextFieldProps & {
+  name: string;
+  values: readonly FormikSelectValue[];
+  helpText?: string;
+  disablePortal?: boolean;
+  disabled?: boolean;
+  onChange?: (values: FormikSelectValue[]) => void;
+};
+
+export const FormikMultiSelect = ({
+  name,
+  values,
+  helpText,
+  sx,
+  disablePortal = true,
+  disabled,
+  onChange,
+  ...textFieldProps
+}: FormikMultiSelectProps) => {
+  const tErr = useValidationMessageTranslation();
+
+  const [field, meta, helpers] = useField<string[]>(name);
+
+  const isError = Boolean(meta.error) && meta.touched;
+
+  const helperText = useMemo(() => {
+    if (!isError) {
+      return helpText;
+    }
+
+    return tErr(meta.error as TranslationKey, { field: name });
+  }, [isError, meta.error, helpText, name, tErr]);
+
+  const selectedValues = useMemo(() => {
+    return values.filter(option => field.value?.includes(option.id)) ?? [];
+  }, [values, field.value]);
+
+  const handleChange = (event: SyntheticEvent, newValues: FormikSelectValue[]) => {
+    const selectedIds = newValues.map(value => value.id);
+    helpers.setValue(selectedIds);
+    onChange?.(newValues);
+  };
+
+  return (
+    <Autocomplete
+      multiple
+      disablePortal={disablePortal}
+      value={selectedValues}
+      options={values}
+      onBlur={e => {
+        helpers.setTouched(true);
+        field.onBlur(e);
+      }}
+      onChange={handleChange}
+      getOptionLabel={option => option?.name}
+      sx={sx}
+      disabled={disabled}
+      renderTags={(value, getTagProps) =>
+        value.map((option, index) => (
+          <Chip variant="outlined" label={option.name} {...getTagProps({ index })} key={option.id} />
+        ))
+      }
+      renderInput={params => (
+        <TextField
+          variant="outlined"
+          {...textFieldProps}
+          {...params}
+          InputLabelProps={{ shrink: true }}
+          helperText={Boolean(helperText) ? <>{helperText}</> : null}
+          error={isError}
+        />
+      )}
+    />
+  );
+};
+
+export default FormikMultiSelect;

--- a/src/core/ui/forms/FormikMultiSelect.tsx
+++ b/src/core/ui/forms/FormikMultiSelect.tsx
@@ -40,6 +40,10 @@ export const FormikMultiSelect = ({
       return helpText;
     }
 
+    if (typeof meta.error === 'string' && meta.error.indexOf('must have at least') !== -1) {
+      return tErr('forms.validations.required');
+    }
+
     return tErr(meta.error as TranslationKey, { field: name });
   }, [isError, meta.error, helpText, name, tErr]);
 

--- a/src/domain/access/ApplicationsAndInvitations/useRoleSetApplicationsAndInvitations.ts
+++ b/src/domain/access/ApplicationsAndInvitations/useRoleSetApplicationsAndInvitations.ts
@@ -34,7 +34,7 @@ type useRoleSetApplicationsAndInvitationsProvided = {
     invitedContributorIds: string[];
     invitedUserEmails: string[];
     welcomeMessage: string;
-    extraRole?: RoleName;
+    extraRoles: RoleName[];
   }) => Promise<InvitationResultModel[]>;
   invitationStateChange: (invitationId: string, eventName: string) => Promise<unknown>;
   deleteInvitation: (invitationId: string) => Promise<unknown>;
@@ -154,27 +154,24 @@ const useRoleSetApplicationsAndInvitations = ({
     invitedContributorIds,
     invitedUserEmails,
     welcomeMessage,
-    extraRole,
+    extraRoles,
   }: {
     roleSetId: string;
     invitedContributorIds: string[];
     invitedUserEmails: string[];
     welcomeMessage: string;
-    extraRole?: RoleName;
+    extraRoles: RoleName[];
   }) => {
-    const role = extraRole === RoleName.Member ? undefined : extraRole;
+    // Filter out the Member role as it's not an extra role
+    const filteredExtraRoles = extraRoles.filter(role => role !== RoleName.Member);
 
-    let extraRoles: RoleName[] = [];
-    if (role) {
-      extraRoles = [role];
-    }
     const result = await inviteForEntryRoleOnRoleSet({
       variables: {
         roleSetId,
         invitedContributorIds,
         invitedUserEmails,
         welcomeMessage,
-        extraRoles,
+        extraRoles: filteredExtraRoles,
       },
       onCompleted: () => refetch(),
     });

--- a/src/domain/access/ApplicationsAndInvitations/useRoleSetApplicationsAndInvitations.ts
+++ b/src/domain/access/ApplicationsAndInvitations/useRoleSetApplicationsAndInvitations.ts
@@ -34,7 +34,7 @@ type useRoleSetApplicationsAndInvitationsProvided = {
     invitedContributorIds: string[];
     invitedUserEmails: string[];
     welcomeMessage: string;
-    extraRoles: RoleName[];
+    extraRoles?: RoleName[];
   }) => Promise<InvitationResultModel[]>;
   invitationStateChange: (invitationId: string, eventName: string) => Promise<unknown>;
   deleteInvitation: (invitationId: string) => Promise<unknown>;
@@ -160,10 +160,10 @@ const useRoleSetApplicationsAndInvitations = ({
     invitedContributorIds: string[];
     invitedUserEmails: string[];
     welcomeMessage: string;
-    extraRoles: RoleName[];
+    extraRoles?: RoleName[];
   }) => {
     // Filter out the Member role as it's not an extra role
-    const filteredExtraRoles = extraRoles.filter(role => role !== RoleName.Member);
+    const filteredExtraRoles = (extraRoles ?? []).filter(role => role !== RoleName.Member);
 
     const result = await inviteForEntryRoleOnRoleSet({
       variables: {

--- a/src/domain/access/model/InvitationDataModel.ts
+++ b/src/domain/access/model/InvitationDataModel.ts
@@ -2,7 +2,7 @@ import { RoleName } from '@/core/apollo/generated/graphql-schema';
 
 export interface InviteContributorsData {
   welcomeMessage: string;
-  extraRole?: RoleName;
+  extraRoles?: RoleName[];
   invitedContributorIds: string[];
   invitedUserEmails: string[];
 }

--- a/src/domain/community/inviteContributors/users/InviteUsersDialog.tsx
+++ b/src/domain/community/inviteContributors/users/InviteUsersDialog.tsx
@@ -29,7 +29,7 @@ export const INVITE_USERS_TO_ROLES = [RoleName.Member, RoleName.Lead, RoleName.A
 type InviteUsersData = {
   welcomeMessage: string;
   selectedContributors: SelectedContributor[];
-  extraRole: RoleName;
+  extraRoles: RoleName[];
 };
 
 const InviteUsersDialog = ({
@@ -58,7 +58,7 @@ const InviteUsersDialog = ({
   const validationSchema = yup.object().shape({
     welcomeMessage: yup.string().required(),
     selectedContributors: SelectedContributorsArraySchema.min(1).required(),
-    extraRole: yup.string().oneOf(INVITE_USERS_TO_ROLES).required(),
+    extraRoles: yup.array().of(yup.string().oneOf(INVITE_USERS_TO_ROLES)).min(1).required(),
   });
 
   const initialValues: InviteUsersData = {
@@ -66,7 +66,7 @@ const InviteUsersDialog = ({
       spaceName,
     }),
     selectedContributors: [],
-    extraRole: RoleName.Member,
+    extraRoles: [RoleName.Member],
   };
 
   const handleClose = () => {
@@ -91,7 +91,7 @@ const InviteUsersDialog = ({
       invitedContributorIds,
       invitedUserEmails,
       welcomeMessage: data.welcomeMessage,
-      extraRole: data.extraRole,
+      extraRoles: data.extraRoles,
     });
     setInvitationSent(result);
   });

--- a/src/domain/community/inviteContributors/users/InviteUsersFormDialogContent.tsx
+++ b/src/domain/community/inviteContributors/users/InviteUsersFormDialogContent.tsx
@@ -12,6 +12,7 @@ import { gutters } from '@/core/ui/grid/utils';
 import FormikMultiSelect from '@/core/ui/forms/FormikMultiSelect';
 import { INVITE_USERS_TO_ROLES } from './InviteUsersDialog';
 import TranslationKey from '@/core/i18n/utils/TranslationKey';
+import { RoleName } from '@/core/apollo/generated/graphql-schema';
 
 interface InviteUsersFormDialogContentProps {
   filterUsers?: FormikContributorsSelectorFieldProps['filterUsers'];
@@ -52,6 +53,7 @@ const InviteUsersFormDialogContent: React.FC<InviteUsersFormDialogContentProps> 
             <Caption sx={{ whiteSpace: 'nowrap' }}>{t('community.invitations.inviteToRole')}</Caption>
             <FormikMultiSelect
               name="extraRoles"
+              fixedOptions={[{ id: RoleName.Member, name: t(`common.roles.${RoleName.Member}`) }]}
               values={INVITE_USERS_TO_ROLES.map(role => ({
                 id: role,
                 name: t(`common.roles.${role}`),

--- a/src/domain/community/inviteContributors/users/InviteUsersFormDialogContent.tsx
+++ b/src/domain/community/inviteContributors/users/InviteUsersFormDialogContent.tsx
@@ -9,7 +9,7 @@ import FormikInputField from '@/core/ui/forms/FormikInputField/FormikInputField'
 import { useTranslation } from 'react-i18next';
 import { LONG_TEXT_LENGTH } from '@/core/ui/forms/field-length.constants';
 import { gutters } from '@/core/ui/grid/utils';
-import FormikSelect from '@/core/ui/forms/FormikSelect';
+import FormikMultiSelect from '@/core/ui/forms/FormikMultiSelect';
 import { INVITE_USERS_TO_ROLES } from './InviteUsersDialog';
 import TranslationKey from '@/core/i18n/utils/TranslationKey';
 
@@ -50,8 +50,8 @@ const InviteUsersFormDialogContent: React.FC<InviteUsersFormDialogContentProps> 
           <Caption>{t('community.invitations.inviteContributorsDialog.users.note')}</Caption>
           <Box display="flex" gap={gutters()} alignItems="center">
             <Caption sx={{ whiteSpace: 'nowrap' }}>{t('community.invitations.inviteToRole')}</Caption>
-            <FormikSelect
-              name="extraRole"
+            <FormikMultiSelect
+              name="extraRoles"
               values={INVITE_USERS_TO_ROLES.map(role => ({
                 id: role,
                 name: t(`common.roles.${role}`),


### PR DESCRIPTION
Now the Invite Dialog supports multiple selection of roles. 

A new reusable FormikMultiSelect control was introduced.

Side note, I'm planning to extract all of the helper text logic into a util, but I didn't want to be part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a multi-select dropdown component for forms, allowing users to select multiple options with improved UI elements.

* **Enhancements**
  * Updated the invite users dialog and form to support selecting multiple roles instead of just one when inviting contributors.
  * Improved validation and handling for multiple role selections during user invitations.
  * Refined invitation logic to consistently handle multiple roles and exclude default member role automatically.

* **Bug Fixes**
  * Ensured consistent handling of role selection and invitation logic throughout the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->