### PR TITLE
Fix the 'notify the community' on a post creation.

### DIFF
--- a/src/domain/collaboration/callout/CalloutDialogs/CreateCalloutDialog.tsx
+++ b/src/domain/collaboration/callout/CalloutDialogs/CreateCalloutDialog.tsx
@@ -161,6 +161,7 @@ const CreateCalloutDialog = ({
         classification,
         contributionDefaults,
         contributions,
+        sendNotification,
       };
 
       await handleCreateCallout(createCalloutInput);


### PR DESCRIPTION
The form field was missing from the callout data sent to the mutation/server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to send a notification when creating a callout, controlled by a checkbox in the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->