### PR TITLE
BUGFix: Console Warning Apollo Cache warning on space page

### DIFF
--- a/src/core/apollo/config/typePolicies.ts
+++ b/src/core/apollo/config/typePolicies.ts
@@ -18,6 +18,13 @@ export const typePolicies: TypedTypePolicies = {
       },
     },
   },
+  SpaceAbout: {
+    fields: {
+      membership: {
+        merge: true,
+      },
+    },
+  },
   UserGroup: {
     fields: {
       members: {


### PR DESCRIPTION
- Adds a typePolicy to the field membership in SpaceAbout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data handling for membership information, ensuring more accurate and consistent updates in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->