### PR TITLE
Extends iframe URL validation with wildcard support

### DIFF
--- a/src/core/ui/forms/MarkdownInputControls/InsertEmbedCodeButton/InsertEmbedCodeButton.tsx
+++ b/src/core/ui/forms/MarkdownInputControls/InsertEmbedCodeButton/InsertEmbedCodeButton.tsx
@@ -100,8 +100,36 @@ export const InsertEmbedCodeButton = ({
       return;
     }
 
-    const srcOrigin = new URL(embedCodeSrc).origin;
-    const isValidSource = iframeAllowedUrls.some(vS => vS === srcOrigin);
+    const srcUrl = new URL(embedCodeSrc);
+    const srcOrigin = srcUrl.origin;
+
+    // Check if the source URL matches any of the allowed patterns
+    const isValidSource = iframeAllowedUrls.some(pattern => {
+      // Exact match
+      if (pattern === srcOrigin) {
+        return true;
+      }
+
+      // Handle wildcard patterns
+      if (pattern.includes('*')) {
+        // Convert the wildcard pattern to a regex pattern
+        const regexPattern = pattern.replace(/\./g, '\\.').replace(/\*/g, '.*');
+
+        const regex = new RegExp(`^${regexPattern}$`);
+
+        // Check against origin
+        if (regex.test(srcOrigin)) {
+          return true;
+        }
+
+        // Check against full URL if the pattern includes path components
+        if (pattern.includes('/') && regex.test(embedCodeSrc)) {
+          return true;
+        }
+      }
+
+      return false;
+    });
 
     if (!isValidSource) {
       notify(t('components.wysiwyg-editor.embed.invalidOrUnsupportedEmbed'), 'error');


### PR DESCRIPTION
Improves the validation of iframe embed codes by allowing wildcard patterns in the allowed URLs.

This allows for more flexible configuration of allowed sources, enabling the inclusion of entire subdomains or paths. The validation now checks for both exact matches and wildcard matches against the origin and, when applicable, the full URL of the embed code.

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
