### PR TITLE
Notification Settings, compile after codegen 

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -680,7 +680,6 @@ export type CalloutKeySpecifier = (
   | 'publishedDate'
   | 'settings'
   | 'sortOrder'
-  | 'type'
   | 'updatedDate'
   | CalloutKeySpecifier
 )[];
@@ -702,7 +701,6 @@ export type CalloutFieldPolicy = {
   publishedDate?: FieldPolicy<any> | FieldReadFunction<any>;
   settings?: FieldPolicy<any> | FieldReadFunction<any>;
   sortOrder?: FieldPolicy<any> | FieldReadFunction<any>;
-  type?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CalloutContributionKeySpecifier = (
@@ -2636,6 +2634,17 @@ export type NVPFieldPolicy = {
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
   value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
+export type NotificationRecipientResultKeySpecifier = (
+  | 'emailRecipients'
+  | 'inAppRecipients'
+  | 'triggeredBy'
+  | NotificationRecipientResultKeySpecifier
+)[];
+export type NotificationRecipientResultFieldPolicy = {
+  emailRecipients?: FieldPolicy<any> | FieldReadFunction<any>;
+  inAppRecipients?: FieldPolicy<any> | FieldReadFunction<any>;
+  triggeredBy?: FieldPolicy<any> | FieldReadFunction<any>;
+};
 export type OrganizationKeySpecifier = (
   | 'account'
   | 'agent'
@@ -2995,6 +3004,7 @@ export type QueryKeySpecifier = (
   | 'lookup'
   | 'lookupByName'
   | 'me'
+  | 'notificationRecipients'
   | 'notifications'
   | 'organization'
   | 'organizations'
@@ -3033,6 +3043,7 @@ export type QueryFieldPolicy = {
   lookup?: FieldPolicy<any> | FieldReadFunction<any>;
   lookupByName?: FieldPolicy<any> | FieldReadFunction<any>;
   me?: FieldPolicy<any> | FieldReadFunction<any>;
+  notificationRecipients?: FieldPolicy<any> | FieldReadFunction<any>;
   notifications?: FieldPolicy<any> | FieldReadFunction<any>;
   organization?: FieldPolicy<any> | FieldReadFunction<any>;
   organizations?: FieldPolicy<any> | FieldReadFunction<any>;
@@ -4142,12 +4153,14 @@ export type UserSettingsNotificationKeySpecifier = (
   | 'organization'
   | 'platform'
   | 'space'
+  | 'user'
   | UserSettingsNotificationKeySpecifier
 )[];
 export type UserSettingsNotificationFieldPolicy = {
   organization?: FieldPolicy<any> | FieldReadFunction<any>;
   platform?: FieldPolicy<any> | FieldReadFunction<any>;
   space?: FieldPolicy<any> | FieldReadFunction<any>;
+  user?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type UserSettingsNotificationOrganizationKeySpecifier = (
   | 'mentioned'
@@ -4162,6 +4175,7 @@ export type UserSettingsNotificationPlatformKeySpecifier = (
   | 'forumDiscussionComment'
   | 'forumDiscussionCreated'
   | 'newUserSignUp'
+  | 'spaceCreated'
   | 'userProfileRemoved'
   | UserSettingsNotificationPlatformKeySpecifier
 )[];
@@ -4169,6 +4183,7 @@ export type UserSettingsNotificationPlatformFieldPolicy = {
   forumDiscussionComment?: FieldPolicy<any> | FieldReadFunction<any>;
   forumDiscussionCreated?: FieldPolicy<any> | FieldReadFunction<any>;
   newUserSignUp?: FieldPolicy<any> | FieldReadFunction<any>;
+  spaceCreated?: FieldPolicy<any> | FieldReadFunction<any>;
   userProfileRemoved?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type UserSettingsNotificationSpaceKeySpecifier = (
@@ -4203,6 +4218,19 @@ export type UserSettingsNotificationSpaceFieldPolicy = {
   postCreated?: FieldPolicy<any> | FieldReadFunction<any>;
   postCreatedAdmin?: FieldPolicy<any> | FieldReadFunction<any>;
   whiteboardCreated?: FieldPolicy<any> | FieldReadFunction<any>;
+};
+export type UserSettingsNotificationUserKeySpecifier = (
+  | 'commentReply'
+  | 'mentioned'
+  | 'messageReceived'
+  | 'messageSent'
+  | UserSettingsNotificationUserKeySpecifier
+)[];
+export type UserSettingsNotificationUserFieldPolicy = {
+  commentReply?: FieldPolicy<any> | FieldReadFunction<any>;
+  mentioned?: FieldPolicy<any> | FieldReadFunction<any>;
+  messageReceived?: FieldPolicy<any> | FieldReadFunction<any>;
+  messageSent?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type UserSettingsPrivacyKeySpecifier = ('contributionRolesPubliclyVisible' | UserSettingsPrivacyKeySpecifier)[];
 export type UserSettingsPrivacyFieldPolicy = {
@@ -5095,6 +5123,13 @@ export type StrictTypedTypePolicies = {
     keyFields?: false | NVPKeySpecifier | (() => undefined | NVPKeySpecifier);
     fields?: NVPFieldPolicy;
   };
+  NotificationRecipientResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | NotificationRecipientResultKeySpecifier
+      | (() => undefined | NotificationRecipientResultKeySpecifier);
+    fields?: NotificationRecipientResultFieldPolicy;
+  };
   Organization?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | OrganizationKeySpecifier | (() => undefined | OrganizationKeySpecifier);
     fields?: OrganizationFieldPolicy;
@@ -5523,6 +5558,13 @@ export type StrictTypedTypePolicies = {
       | UserSettingsNotificationSpaceKeySpecifier
       | (() => undefined | UserSettingsNotificationSpaceKeySpecifier);
     fields?: UserSettingsNotificationSpaceFieldPolicy;
+  };
+  UserSettingsNotificationUser?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | UserSettingsNotificationUserKeySpecifier
+      | (() => undefined | UserSettingsNotificationUserKeySpecifier);
+    fields?: UserSettingsNotificationUserFieldPolicy;
   };
   UserSettingsPrivacy?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
     keyFields?: false | UserSettingsPrivacyKeySpecifier | (() => undefined | UserSettingsPrivacyKeySpecifier);

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -275,7 +275,6 @@ export const InnovationFlowCollaborationFragmentDoc = gql`
       id
       callouts {
         id
-        calloutTypeDeprecated: type
         activity
         sortOrder
         classification {
@@ -625,7 +624,6 @@ export const WhiteboardCollectionCalloutCardFragmentDoc = gql`
 export const CalloutFragmentDoc = gql`
   fragment Callout on Callout {
     id
-    calloutTypeDeprecated: type
     sortOrder
     activity
     authorization {
@@ -902,7 +900,6 @@ export const CalloutSettingsFullFragmentDoc = gql`
 export const CalloutDetailsFragmentDoc = gql`
   fragment CalloutDetails on Callout {
     id
-    calloutTypeDeprecated: type
     framing {
       id
       profile {
@@ -997,7 +994,6 @@ export const PostSettingsFragmentDoc = gql`
 export const PostSettingsCalloutFragmentDoc = gql`
   fragment PostSettingsCallout on Callout {
     id
-    calloutTypeDeprecated: type
     contributions {
       id
       post {
@@ -2354,7 +2350,6 @@ export const TemplateCardProfileInfoFragmentDoc = gql`
 export const CalloutTemplateContentFragmentDoc = gql`
   fragment CalloutTemplateContent on Callout {
     id
-    calloutTypeDeprecated: type
     framing {
       id
       profile {
@@ -2427,7 +2422,6 @@ export const SpaceTemplateContent_CollaborationFragmentDoc = gql`
       id
       callouts {
         id
-        calloutTypeDeprecated: type
         classification {
           id
           flowState: tagset(tagsetName: FLOW_STATE) {
@@ -2581,7 +2575,6 @@ export const CalloutTemplateFragmentDoc = gql`
     ...TemplateProfileInfo
     callout {
       id
-      calloutTypeDeprecated: type
       settings {
         contribution {
           enabled
@@ -2995,7 +2988,6 @@ export const SearchResultCalloutFragmentDoc = gql`
     id
     callout {
       id
-      calloutTypeDeprecated: type
       framing {
         id
         profile {
@@ -18973,7 +18965,6 @@ export const SpaceAdminDefaultSpaceTemplatesDetailsDocument = gql`
                     id
                     callouts {
                       id
-                      calloutTypeDeprecated: type
                       sortOrder
                       classification {
                         id
@@ -20251,7 +20242,6 @@ export const ImportTemplateDialogDocument = gql`
           ...TemplateProfileInfo
           callout @include(if: $includeCallout) {
             id
-            calloutTypeDeprecated: type
           }
           contentSpace @include(if: $includeSpace) {
             id
@@ -20352,7 +20342,6 @@ export const ImportTemplateDialogPlatformTemplatesDocument = gql`
             ...TemplateProfileInfo
             callout @include(if: $includeCallout) {
               id
-              calloutTypeDeprecated: type
             }
             contentSpace @include(if: $includeSpace) {
               id
@@ -21073,7 +21062,6 @@ export const UpdateCalloutTemplateDocument = gql`
   mutation UpdateCalloutTemplate($calloutData: UpdateCalloutEntityInput!) {
     updateCallout(calloutData: $calloutData) {
       id
-      calloutTypeDeprecated: type
       framing {
         id
         profile {
@@ -22866,7 +22854,6 @@ export const InnovationLibraryDocument = gql`
             ...TemplateProfileInfo
             callout {
               id
-              type
             }
           }
           innovationPack {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -925,6 +925,7 @@ export enum AuthorizationPrivilege {
   ReadUserSettings = 'READ_USER_SETTINGS',
   ReceiveNotifications = 'RECEIVE_NOTIFICATIONS',
   ReceiveNotificationsAdmin = 'RECEIVE_NOTIFICATIONS_ADMIN',
+  ReceiveNotificationsInApp = 'RECEIVE_NOTIFICATIONS_IN_APP',
   RolesetEntryRoleApply = 'ROLESET_ENTRY_ROLE_APPLY',
   RolesetEntryRoleAssign = 'ROLESET_ENTRY_ROLE_ASSIGN',
   RolesetEntryRoleAssignOrganization = 'ROLESET_ENTRY_ROLE_ASSIGN_ORGANIZATION',
@@ -1040,8 +1041,6 @@ export type Callout = {
   settings: CalloutSettings;
   /** The sorting order for this Callout. */
   sortOrder: Scalars['Float']['output'];
-  /** The type of this Callout. WARNING. This field is deprecated and will be removed in the future. Use `framing.type` + `settings.contribution.allowedTypes` instead. */
-  type: CalloutType;
   /** The date at which the entity was last updated. */
   updatedDate: Scalars['DateTime']['output'];
 };
@@ -1170,14 +1169,6 @@ export type CalloutSettingsFraming = {
   /** Can comment to callout framing. */
   commentsEnabled: Scalars['Boolean']['output'];
 };
-
-export enum CalloutType {
-  LinkCollection = 'LINK_COLLECTION',
-  Post = 'POST',
-  PostCollection = 'POST_COLLECTION',
-  Whiteboard = 'WHITEBOARD',
-  WhiteboardCollection = 'WHITEBOARD_COLLECTION',
-}
 
 export enum CalloutVisibility {
   Draft = 'DRAFT',
@@ -2717,7 +2708,7 @@ export type InAppNotification = {
   /** The Contributor who triggered the notification. */
   triggeredBy?: Maybe<Contributor>;
   /** The type of the notification */
-  type: NotificationEventType;
+  type: NotificationEvent;
 };
 
 export type InAppNotificationCalloutPublished = InAppNotification & {
@@ -2738,7 +2729,7 @@ export type InAppNotificationCalloutPublished = InAppNotification & {
   /** The Contributor who triggered the notification. */
   triggeredBy?: Maybe<Contributor>;
   /** The type of the notification */
-  type: NotificationEventType;
+  type: NotificationEvent;
 };
 
 /** Which category (role) is this notification targeted to. */
@@ -2768,7 +2759,7 @@ export type InAppNotificationCommunityNewMember = InAppNotification & {
   /** The Contributor who triggered the notification. */
   triggeredBy?: Maybe<Contributor>;
   /** The type of the notification */
-  type: NotificationEventType;
+  type: NotificationEvent;
 };
 
 export enum InAppNotificationState {
@@ -2799,7 +2790,7 @@ export type InAppNotificationUserMentioned = InAppNotification & {
   /** The Contributor who triggered the notification. */
   triggeredBy?: Maybe<Contributor>;
   /** The type of the notification */
-  type: NotificationEventType;
+  type: NotificationEvent;
 };
 
 export type InnovationFlow = {
@@ -4926,34 +4917,57 @@ export type Nvp = {
   value: Scalars['String']['output'];
 };
 
-/** The type of the notification */
-export enum NotificationEventType {
-  CollaborationCalloutPublished = 'COLLABORATION_CALLOUT_PUBLISHED',
-  CollaborationDiscussionComment = 'COLLABORATION_DISCUSSION_COMMENT',
-  CollaborationPostComment = 'COLLABORATION_POST_COMMENT',
-  CollaborationPostCreated = 'COLLABORATION_POST_CREATED',
-  CollaborationWhiteboardCreated = 'COLLABORATION_WHITEBOARD_CREATED',
-  CommentReply = 'COMMENT_REPLY',
-  CommunicationCommentSent = 'COMMUNICATION_COMMENT_SENT',
-  CommunicationCommunityMessage = 'COMMUNICATION_COMMUNITY_MESSAGE',
-  CommunicationOrganizationMention = 'COMMUNICATION_ORGANIZATION_MENTION',
-  CommunicationOrganizationMessage = 'COMMUNICATION_ORGANIZATION_MESSAGE',
-  CommunicationUpdateSent = 'COMMUNICATION_UPDATE_SENT',
-  CommunicationUserMention = 'COMMUNICATION_USER_MENTION',
-  CommunicationUserMessage = 'COMMUNICATION_USER_MESSAGE',
-  CommunityApplicationCreated = 'COMMUNITY_APPLICATION_CREATED',
-  CommunityInvitationCreated = 'COMMUNITY_INVITATION_CREATED',
-  CommunityInvitationCreatedVc = 'COMMUNITY_INVITATION_CREATED_VC',
-  CommunityNewMember = 'COMMUNITY_NEW_MEMBER',
-  CommunityPlatformInvitationCreated = 'COMMUNITY_PLATFORM_INVITATION_CREATED',
+export enum NotificationEvent {
+  OrganizationMentioned = 'ORGANIZATION_MENTIONED',
+  OrganizationMessageRecipient = 'ORGANIZATION_MESSAGE_RECIPIENT',
+  OrganizationMessageSender = 'ORGANIZATION_MESSAGE_SENDER',
   PlatformForumDiscussionComment = 'PLATFORM_FORUM_DISCUSSION_COMMENT',
   PlatformForumDiscussionCreated = 'PLATFORM_FORUM_DISCUSSION_CREATED',
   PlatformGlobalRoleChange = 'PLATFORM_GLOBAL_ROLE_CHANGE',
-  PlatformUserInvitedToRole = 'PLATFORM_USER_INVITED_TO_ROLE',
-  PlatformUserRegistered = 'PLATFORM_USER_REGISTERED',
-  PlatformUserRemoved = 'PLATFORM_USER_REMOVED',
-  SpaceCreated = 'SPACE_CREATED',
+  PlatformSpaceCreated = 'PLATFORM_SPACE_CREATED',
+  PlatformUserProfileCreated = 'PLATFORM_USER_PROFILE_CREATED',
+  PlatformUserProfileCreatedAdmin = 'PLATFORM_USER_PROFILE_CREATED_ADMIN',
+  PlatformUserProfileRemoved = 'PLATFORM_USER_PROFILE_REMOVED',
+  SpaceCalloutPublished = 'SPACE_CALLOUT_PUBLISHED',
+  SpaceCommunicationUpdate = 'SPACE_COMMUNICATION_UPDATE',
+  SpaceCommunicationUpdateAdmin = 'SPACE_COMMUNICATION_UPDATE_ADMIN',
+  SpaceCommunityApplicationApplicant = 'SPACE_COMMUNITY_APPLICATION_APPLICANT',
+  SpaceCommunityApplicationRecipient = 'SPACE_COMMUNITY_APPLICATION_RECIPIENT',
+  SpaceCommunityInvitationUser = 'SPACE_COMMUNITY_INVITATION_USER',
+  SpaceCommunityInvitationUserPlatform = 'SPACE_COMMUNITY_INVITATION_USER_PLATFORM',
+  SpaceCommunityInvitationVc = 'SPACE_COMMUNITY_INVITATION_VC',
+  SpaceCommunityNewMember = 'SPACE_COMMUNITY_NEW_MEMBER',
+  SpaceCommunityNewMemberAdmin = 'SPACE_COMMUNITY_NEW_MEMBER_ADMIN',
+  SpaceContactMessageRecipient = 'SPACE_CONTACT_MESSAGE_RECIPIENT',
+  SpaceContactMessageSender = 'SPACE_CONTACT_MESSAGE_SENDER',
+  SpacePostCommentCreated = 'SPACE_POST_COMMENT_CREATED',
+  SpacePostCreated = 'SPACE_POST_CREATED',
+  SpacePostCreatedAdmin = 'SPACE_POST_CREATED_ADMIN',
+  SpaceWhiteboardCreated = 'SPACE_WHITEBOARD_CREATED',
+  UserCommentReply = 'USER_COMMENT_REPLY',
+  UserMention = 'USER_MENTION',
+  UserMessageRecipient = 'USER_MESSAGE_RECIPIENT',
+  UserMessageSender = 'USER_MESSAGE_SENDER',
 }
+
+export type NotificationRecipientResult = {
+  __typename?: 'NotificationRecipientResult';
+  /** The email recipients for the notification. */
+  emailRecipients: Array<User>;
+  /** The in-app recipients for the notification. */
+  inAppRecipients: Array<User>;
+  /** The user that triggered the event. */
+  triggeredBy?: Maybe<User>;
+};
+
+export type NotificationRecipientsInput = {
+  /** The ID of the entity to retrieve the recipients for. This could be a Space, Organization etc, and is specific to the event type. */
+  entityID?: InputMaybe<Scalars['UUID']['input']>;
+  /** The type of notification setting to look up recipients for. */
+  eventType: NotificationEvent;
+  /** The ID of the User that triggered the event. */
+  triggeredBy?: InputMaybe<Scalars['UUID']['input']>;
+};
 
 export enum OpenAiModel {
   Babbage_002 = 'BABBAGE_002',
@@ -5422,6 +5436,8 @@ export type Query = {
   lookupByName: LookupByNameQueryResults;
   /** Information about the current authenticated user */
   me: MeQueryResults;
+  /** The notificationRecipients for the provided event on the given entity. */
+  notificationRecipients: NotificationRecipientResult;
   /** Get all notifications for the logged in user. */
   notifications: Array<InAppNotification>;
   /** A particular Organization */
@@ -5490,6 +5506,10 @@ export type QueryAdminCommunicationMembershipArgs = {
 
 export type QueryExploreSpacesArgs = {
   options?: InputMaybe<ExploreSpacesInput>;
+};
+
+export type QueryNotificationRecipientsArgs = {
+  eventData: NotificationRecipientsInput;
 };
 
 export type QueryOrganizationArgs = {
@@ -7477,6 +7497,8 @@ export type UpdateUserSettingsNotificationInput = {
   platform?: InputMaybe<UpdateUserSettingsNotificationPlatformInput>;
   /** Settings related to Space Notifications. */
   space?: InputMaybe<UpdateUserSettingsNotificationSpaceInput>;
+  /** Settings related to User Notifications. */
+  user?: InputMaybe<UpdateUserSettingsNotificationUserInput>;
 };
 
 export type UpdateUserSettingsNotificationOrganizationInput = {
@@ -7493,6 +7515,8 @@ export type UpdateUserSettingsNotificationPlatformInput = {
   forumDiscussionCreated?: InputMaybe<Scalars['Boolean']['input']>;
   /** [Admin] Receive notification when a new user signs up */
   newUserSignUp?: InputMaybe<Scalars['Boolean']['input']>;
+  /** [Admin] Receive a notification when a new L0 Space is created */
+  spaceCreated?: InputMaybe<Scalars['Boolean']['input']>;
   /** [Admin] Receive a notification when a user profile is removed */
   userProfileRemoved?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -7510,7 +7534,7 @@ export type UpdateUserSettingsNotificationSpaceInput = {
   communicationMention?: InputMaybe<Scalars['Boolean']['input']>;
   /** Receive a notification for community updates */
   communicationUpdates?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Receive a notification for community updates */
+  /** Receive a notification for community updates as admin */
   communicationUpdatesAdmin?: InputMaybe<Scalars['Boolean']['input']>;
   /** Receive a notification for community invitation */
   communityInvitationUser?: InputMaybe<Scalars['Boolean']['input']>;
@@ -7526,6 +7550,17 @@ export type UpdateUserSettingsNotificationSpaceInput = {
   postCreatedAdmin?: InputMaybe<Scalars['Boolean']['input']>;
   /** Receive a notification when a whiteboard is created */
   whiteboardCreated?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type UpdateUserSettingsNotificationUserInput = {
+  /** Receive a notification when someone replies to a comment I made. */
+  commentReply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Receive a notification you are mentioned */
+  mentioned?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Receive notification when I receive a message. */
+  messageReceived?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Receive notification I send a message. */
+  messageSent?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type UpdateUserSettingsPrivacyInput = {
@@ -7802,6 +7837,8 @@ export type UserSettingsNotification = {
   platform: UserSettingsNotificationPlatform;
   /** The notifications settings for Space events for this User */
   space: UserSettingsNotificationSpace;
+  /** The notifications settings for User events for this User */
+  user: UserSettingsNotificationUser;
 };
 
 export type UserSettingsNotificationOrganization = {
@@ -7820,6 +7857,8 @@ export type UserSettingsNotificationPlatform = {
   forumDiscussionCreated: Scalars['Boolean']['output'];
   /** Receive notification when a new user signs up */
   newUserSignUp: Scalars['Boolean']['output'];
+  /** Receive a notification when a new L0 Space is created */
+  spaceCreated: Scalars['Boolean']['output'];
   /** Receive a notification when a user profile is removed */
   userProfileRemoved: Scalars['Boolean']['output'];
 };
@@ -7854,6 +7893,18 @@ export type UserSettingsNotificationSpace = {
   postCreatedAdmin: Scalars['Boolean']['output'];
   /** Receive a notification when a whiteboard is created */
   whiteboardCreated: Scalars['Boolean']['output'];
+};
+
+export type UserSettingsNotificationUser = {
+  __typename?: 'UserSettingsNotificationUser';
+  /** Receive a notification when someone replies to a comment I made. */
+  commentReply: Scalars['Boolean']['output'];
+  /** Receive a notification you are mentioned */
+  mentioned: Scalars['Boolean']['output'];
+  /** Receive notification when I receive a message. */
+  messageReceived: Scalars['Boolean']['output'];
+  /** Receive notification I send a message. */
+  messageSent: Scalars['Boolean']['output'];
 };
 
 export type UserSettingsPrivacy = {
@@ -9613,7 +9664,6 @@ export type CalloutPageCalloutQuery = {
           id: string;
           sortOrder: number;
           activity: number;
-          calloutTypeDeprecated: CalloutType;
           framing: {
             __typename?: 'CalloutFraming';
             id: string;
@@ -10114,7 +10164,6 @@ export type InnovationFlowSettingsQuery = {
               id: string;
               activity: number;
               sortOrder: number;
-              calloutTypeDeprecated: CalloutType;
               classification?:
                 | {
                     __typename?: 'Classification';
@@ -10271,7 +10320,6 @@ export type InnovationFlowCollaborationFragment = {
       id: string;
       activity: number;
       sortOrder: number;
-      calloutTypeDeprecated: CalloutType;
       classification?:
         | {
             __typename?: 'Classification';
@@ -12396,7 +12444,6 @@ export type UpdateCalloutContentMutation = {
     id: string;
     sortOrder: number;
     activity: number;
-    calloutTypeDeprecated: CalloutType;
     framing: {
       __typename?: 'CalloutFraming';
       id: string;
@@ -12761,7 +12808,6 @@ export type UpdateCalloutVisibilityMutation = {
     id: string;
     sortOrder: number;
     activity: number;
-    calloutTypeDeprecated: CalloutType;
     framing: {
       __typename?: 'CalloutFraming';
       id: string;
@@ -13213,7 +13259,6 @@ export type CreateCalloutMutation = {
     id: string;
     sortOrder: number;
     activity: number;
-    calloutTypeDeprecated: CalloutType;
     framing: {
       __typename?: 'CalloutFraming';
       id: string;
@@ -13589,7 +13634,6 @@ export type CalloutsOnCalloutsSetUsingClassificationQuery = {
             id: string;
             sortOrder: number;
             activity: number;
-            calloutTypeDeprecated: CalloutType;
             authorization?:
               | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
               | undefined;
@@ -13627,7 +13671,6 @@ export type CalloutFragment = {
   id: string;
   sortOrder: number;
   activity: number;
-  calloutTypeDeprecated: CalloutType;
   authorization?:
     | { __typename?: 'Authorization'; id: string; myPrivileges?: Array<AuthorizationPrivilege> | undefined }
     | undefined;
@@ -13655,7 +13698,6 @@ export type CalloutDetailsQuery = {
           id: string;
           sortOrder: number;
           activity: number;
-          calloutTypeDeprecated: CalloutType;
           framing: {
             __typename?: 'CalloutFraming';
             id: string;
@@ -14109,7 +14151,6 @@ export type CalloutDetailsFragment = {
   id: string;
   sortOrder: number;
   activity: number;
-  calloutTypeDeprecated: CalloutType;
   framing: {
     __typename?: 'CalloutFraming';
     id: string;
@@ -14919,7 +14960,6 @@ export type PostSettingsQuery = {
       | {
           __typename?: 'Callout';
           id: string;
-          calloutTypeDeprecated: CalloutType;
           contributions: Array<{
             __typename?: 'CalloutContribution';
             id: string;
@@ -15068,7 +15108,6 @@ export type PostSettingsFragment = {
 export type PostSettingsCalloutFragment = {
   __typename?: 'Callout';
   id: string;
-  calloutTypeDeprecated: CalloutType;
   contributions: Array<{
     __typename?: 'CalloutContribution';
     id: string;
@@ -25051,7 +25090,6 @@ export type SpaceAdminDefaultSpaceTemplatesDetailsQuery = {
                                     __typename?: 'Callout';
                                     id: string;
                                     sortOrder: number;
-                                    calloutTypeDeprecated: CalloutType;
                                     classification?:
                                       | {
                                           __typename?: 'Classification';
@@ -25642,7 +25680,7 @@ export type ImportTemplateDialogQuery = {
             __typename?: 'Template';
             id: string;
             type: TemplateType;
-            callout?: { __typename?: 'Callout'; id: string; calloutTypeDeprecated: CalloutType } | undefined;
+            callout?: { __typename?: 'Callout'; id: string } | undefined;
             contentSpace?:
               | {
                   __typename?: 'TemplateContentSpace';
@@ -25702,7 +25740,7 @@ export type ImportTemplateDialogPlatformTemplatesQuery = {
           __typename?: 'Template';
           id: string;
           type: TemplateType;
-          callout?: { __typename?: 'Callout'; id: string; calloutTypeDeprecated: CalloutType } | undefined;
+          callout?: { __typename?: 'Callout'; id: string } | undefined;
           contentSpace?:
             | {
                 __typename?: 'TemplateContentSpace';
@@ -25806,7 +25844,6 @@ export type AllTemplatesInTemplatesSetQuery = {
               | {
                   __typename?: 'Callout';
                   id: string;
-                  calloutTypeDeprecated: CalloutType;
                   settings: {
                     __typename?: 'CalloutSettings';
                     contribution: {
@@ -26042,7 +26079,6 @@ export type TemplateContentQuery = {
             | {
                 __typename?: 'Callout';
                 id: string;
-                calloutTypeDeprecated: CalloutType;
                 framing: {
                   __typename?: 'CalloutFraming';
                   id: string;
@@ -26279,7 +26315,6 @@ export type TemplateContentQuery = {
                       __typename?: 'Callout';
                       id: string;
                       sortOrder: number;
-                      calloutTypeDeprecated: CalloutType;
                       classification?:
                         | {
                             __typename?: 'Classification';
@@ -26456,7 +26491,6 @@ export type SpaceTemplateContentQuery = {
                 __typename?: 'Callout';
                 id: string;
                 sortOrder: number;
-                calloutTypeDeprecated: CalloutType;
                 classification?:
                   | {
                       __typename?: 'Classification';
@@ -26597,7 +26631,6 @@ export type SpaceTemplateContentQuery = {
 export type CalloutTemplateContentFragment = {
   __typename?: 'Callout';
   id: string;
-  calloutTypeDeprecated: CalloutType;
   framing: {
     __typename?: 'CalloutFraming';
     id: string;
@@ -26795,7 +26828,6 @@ export type SpaceTemplateContentFragment = {
         __typename?: 'Callout';
         id: string;
         sortOrder: number;
-        calloutTypeDeprecated: CalloutType;
         classification?:
           | {
               __typename?: 'Classification';
@@ -26931,7 +26963,6 @@ export type SpaceTemplateContent_CollaborationFragment = {
       __typename?: 'Callout';
       id: string;
       sortOrder: number;
-      calloutTypeDeprecated: CalloutType;
       classification?:
         | {
             __typename?: 'Classification';
@@ -27089,7 +27120,6 @@ export type CalloutTemplateFragment = {
     | {
         __typename?: 'Callout';
         id: string;
-        calloutTypeDeprecated: CalloutType;
         settings: {
           __typename?: 'CalloutSettings';
           contribution: {
@@ -27376,7 +27406,6 @@ export type UpdateCalloutTemplateMutation = {
   updateCallout: {
     __typename?: 'Callout';
     id: string;
-    calloutTypeDeprecated: CalloutType;
     framing: {
       __typename?: 'CalloutFraming';
       id: string;
@@ -27484,7 +27513,6 @@ export type TemplatesSetTemplatesFragment = {
       | {
           __typename?: 'Callout';
           id: string;
-          calloutTypeDeprecated: CalloutType;
           settings: {
             __typename?: 'CalloutSettings';
             contribution: {
@@ -29170,7 +29198,7 @@ export type InAppNotificationReceivedSubscription = {
     | {
         __typename?: 'InAppNotificationCalloutPublished';
         id: string;
-        type: NotificationEventType;
+        type: NotificationEvent;
         category: InAppNotificationCategory;
         state: InAppNotificationState;
         triggeredAt: Date;
@@ -29299,7 +29327,7 @@ export type InAppNotificationReceivedSubscription = {
     | {
         __typename?: 'InAppNotificationCommunityNewMember';
         id: string;
-        type: NotificationEventType;
+        type: NotificationEvent;
         category: InAppNotificationCategory;
         state: InAppNotificationState;
         triggeredAt: Date;
@@ -29462,7 +29490,7 @@ export type InAppNotificationReceivedSubscription = {
     | {
         __typename?: 'InAppNotificationUserMentioned';
         id: string;
-        type: NotificationEventType;
+        type: NotificationEvent;
         category: InAppNotificationCategory;
         state: InAppNotificationState;
         triggeredAt: Date;
@@ -29540,7 +29568,7 @@ export type InAppNotificationsQuery = {
     | {
         __typename?: 'InAppNotificationCalloutPublished';
         id: string;
-        type: NotificationEventType;
+        type: NotificationEvent;
         category: InAppNotificationCategory;
         state: InAppNotificationState;
         triggeredAt: Date;
@@ -29669,7 +29697,7 @@ export type InAppNotificationsQuery = {
     | {
         __typename?: 'InAppNotificationCommunityNewMember';
         id: string;
-        type: NotificationEventType;
+        type: NotificationEvent;
         category: InAppNotificationCategory;
         state: InAppNotificationState;
         triggeredAt: Date;
@@ -29832,7 +29860,7 @@ export type InAppNotificationsQuery = {
     | {
         __typename?: 'InAppNotificationUserMentioned';
         id: string;
-        type: NotificationEventType;
+        type: NotificationEvent;
         category: InAppNotificationCategory;
         state: InAppNotificationState;
         triggeredAt: Date;
@@ -29922,7 +29950,7 @@ export type MarkNotificationsAsReadMutation = { __typename?: 'Mutation'; markNot
 type InAppNotificationAllTypes_InAppNotificationCalloutPublished_Fragment = {
   __typename?: 'InAppNotificationCalloutPublished';
   id: string;
-  type: NotificationEventType;
+  type: NotificationEvent;
   category: InAppNotificationCategory;
   state: InAppNotificationState;
   triggeredAt: Date;
@@ -30022,7 +30050,7 @@ type InAppNotificationAllTypes_InAppNotificationCalloutPublished_Fragment = {
 type InAppNotificationAllTypes_InAppNotificationCommunityNewMember_Fragment = {
   __typename?: 'InAppNotificationCommunityNewMember';
   id: string;
-  type: NotificationEventType;
+  type: NotificationEvent;
   category: InAppNotificationCategory;
   state: InAppNotificationState;
   triggeredAt: Date;
@@ -30144,7 +30172,7 @@ type InAppNotificationAllTypes_InAppNotificationCommunityNewMember_Fragment = {
 type InAppNotificationAllTypes_InAppNotificationUserMentioned_Fragment = {
   __typename?: 'InAppNotificationUserMentioned';
   id: string;
-  type: NotificationEventType;
+  type: NotificationEvent;
   category: InAppNotificationCategory;
   state: InAppNotificationState;
   triggeredAt: Date;
@@ -30693,7 +30721,6 @@ export type SearchQuery = {
             callout: {
               __typename?: 'Callout';
               id: string;
-              calloutTypeDeprecated: CalloutType;
               framing: {
                 __typename?: 'CalloutFraming';
                 id: string;
@@ -30796,7 +30823,6 @@ export type SearchQuery = {
             callout: {
               __typename?: 'Callout';
               id: string;
-              calloutTypeDeprecated: CalloutType;
               framing: {
                 __typename?: 'CalloutFraming';
                 id: string;
@@ -31246,7 +31272,6 @@ export type SearchResultCalloutFragment = {
   callout: {
     __typename?: 'Callout';
     id: string;
-    calloutTypeDeprecated: CalloutType;
     framing: {
       __typename?: 'CalloutFraming';
       id: string;
@@ -31560,7 +31585,7 @@ export type InnovationLibraryQuery = {
           __typename?: 'Template';
           id: string;
           type: TemplateType;
-          callout?: { __typename?: 'Callout'; id: string; type: CalloutType } | undefined;
+          callout?: { __typename?: 'Callout'; id: string } | undefined;
           profile: {
             __typename?: 'Profile';
             id: string;

--- a/src/domain/collaboration/InnovationFlow/graphql/InnovationFlowCollaboration.fragment.graphql
+++ b/src/domain/collaboration/InnovationFlow/graphql/InnovationFlowCollaboration.fragment.graphql
@@ -8,7 +8,6 @@ fragment InnovationFlowCollaboration on Collaboration {
     id
     callouts {
       id
-      calloutTypeDeprecated: type
       activity
       sortOrder
       classification {

--- a/src/domain/collaboration/callout/CalloutForm/CalloutFormContributionSettings.tsx
+++ b/src/domain/collaboration/callout/CalloutForm/CalloutFormContributionSettings.tsx
@@ -14,7 +14,7 @@ import { CalloutFormSubmittedValues } from './CalloutFormModel';
 import BlockIcon from '@mui/icons-material/Block';
 import AttachFileOutlinedIcon from '@mui/icons-material/AttachFileOutlined';
 import calloutIcons from '../../callout/icons/calloutIcons';
-import { CalloutContributionType, CalloutType } from '@/core/apollo/generated/graphql-schema';
+import { CalloutContributionType } from '@/core/apollo/generated/graphql-schema';
 import ContributionSettingsDialog from './ContributionSettingsDialog/ContributionSettingsDialog';
 import ContributionsSettingsLink from './ContributionSettingsDialog/ContributionsSettingsLink';
 import ContributionsSettingsPost from './ContributionSettingsDialog/ContributionsSettingsPost';
@@ -22,6 +22,7 @@ import ContributionsSettingsWhiteboard from './ContributionSettingsDialog/Contri
 import { CalloutRestrictions } from '../../callout/CalloutRestrictionsTypes';
 import { nameOf } from '@/core/utils/nameOf';
 import { useField } from 'formik';
+import { CalloutType } from '@/domain/collaboration/callout/CalloutViewTypes';
 
 interface CalloutFormContributionSettingsProps {
   calloutRestrictions?: CalloutRestrictions;

--- a/src/domain/collaboration/callout/CalloutViewTypes.tsx
+++ b/src/domain/collaboration/callout/CalloutViewTypes.tsx
@@ -22,3 +22,12 @@ export interface BaseCalloutViewProps extends CalloutLayoutEvents, Partial<Callo
   onCalloutUpdate?: () => Promise<unknown> | void;
   calloutRestrictions?: CalloutRestrictions;
 }
+
+/** @deprecated **/
+export enum CalloutType {
+  PostCollection = 'POST_COLLECTION',
+  WhiteboardCollection = 'WHITEBOARD_COLLECTION',
+  Post = 'POST',
+  LinkCollection = 'LINK_COLLECTION',
+  Whiteboard = 'WHITEBOARD',
+}

--- a/src/domain/collaboration/callout/icons/calloutIcons.ts
+++ b/src/domain/collaboration/callout/icons/calloutIcons.ts
@@ -1,6 +1,6 @@
 import { ComponentType } from 'react';
 import { SvgIconProps } from '@mui/material';
-import { CalloutContributionType, CalloutType } from '@/core/apollo/generated/graphql-schema';
+import { CalloutContributionType } from '@/core/apollo/generated/graphql-schema';
 import {
   FormatListBulletedOutlined,
   ForumOutlined,
@@ -9,6 +9,7 @@ import {
 } from '@mui/icons-material';
 import { WhiteboardIcon } from '@/domain/collaboration/whiteboard/icon/WhiteboardIcon';
 import { ReferenceIcon } from '@/domain/shared/components/References/icons/ReferenceIcon';
+import { CalloutType } from '@/domain/collaboration/callout/CalloutViewTypes';
 
 const calloutIcons: Record<CalloutType, ComponentType<SvgIconProps>> = {
   [CalloutType.PostCollection]: LibraryBooksOutlined,

--- a/src/domain/collaboration/callout/models/CalloutModelLight.tsx
+++ b/src/domain/collaboration/callout/models/CalloutModelLight.tsx
@@ -1,9 +1,8 @@
-import { CalloutFramingType, CalloutType } from '@/core/apollo/generated/graphql-schema';
+import { CalloutFramingType } from '@/core/apollo/generated/graphql-schema';
 import { ClassificationTagsetModel } from '../../calloutsSet/Classification/ClassificationTagset.model';
 
 export interface CalloutModelLight {
   id: string;
-  calloutTypeDeprecated: CalloutType;
   framing: {
     profile: {
       displayName: string;

--- a/src/domain/collaboration/calloutsSet/useCalloutsSet/CalloutsSetQueries.graphql
+++ b/src/domain/collaboration/calloutsSet/useCalloutsSet/CalloutsSetQueries.graphql
@@ -20,7 +20,6 @@ query CalloutsOnCalloutsSetUsingClassification(
 
 fragment Callout on Callout {
   id
-  calloutTypeDeprecated: type
   sortOrder
   activity
   authorization {
@@ -61,7 +60,6 @@ fragment ClassificationDetails on Callout {
 
 fragment CalloutDetails on Callout {
   id
-  calloutTypeDeprecated: type
   framing {
     id
     profile {

--- a/src/domain/collaboration/post/PostCreationDialog/PostCreationDialog.tsx
+++ b/src/domain/collaboration/post/PostCreationDialog/PostCreationDialog.tsx
@@ -2,11 +2,12 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, Button, DialogActions, DialogContent } from '@mui/material';
 import PostForm, { PostFormOutput } from '../PostForm/PostForm';
-import { CalloutType, CreatePostInput } from '@/core/apollo/generated/graphql-schema';
+import { CreatePostInput } from '@/core/apollo/generated/graphql-schema';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import calloutIcons from '@/domain/collaboration/callout/icons/calloutIcons';
 import ConfirmationDialog from '@/core/ui/dialogs/ConfirmationDialog';
 import DialogWithGrid from '@/core/ui/dialog/DialogWithGrid';
+import { CalloutType } from '@/domain/collaboration/callout/CalloutViewTypes';
 
 export type PostCreationType = Partial<CreatePostInput>;
 export type PostCreationOutput = CreatePostInput;

--- a/src/domain/collaboration/post/graphql/PostSettingsQueries.graphql
+++ b/src/domain/collaboration/post/graphql/PostSettingsQueries.graphql
@@ -36,7 +36,6 @@ fragment PostSettings on Post {
 
 fragment PostSettingsCallout on Callout {
   id
-  calloutTypeDeprecated: type
   # TODO This is done to find the contributionId for this postId (see usePostSettings), there must be an easier way
   contributions {
     id

--- a/src/domain/shared/components/References/CreateLinksDialog.tsx
+++ b/src/domain/shared/components/References/CreateLinksDialog.tsx
@@ -1,5 +1,4 @@
 import { FC, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { CalloutType } from '@/core/apollo/generated/graphql-schema';
 import { Box, Button, DialogContent, IconButton, Link, Tooltip } from '@mui/material';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +21,7 @@ import DialogWithGrid from '@/core/ui/dialog/DialogWithGrid';
 import { TranslatedValidatedMessageWithPayload } from '@/domain/shared/i18n/ValidationMessageTranslation';
 import { LONG_TEXT_LENGTH, MID_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@/core/ui/forms/field-length.constants';
 import { newLinkName } from '@/domain/common/link/newLinkName';
+import { CalloutType } from '@/domain/collaboration/callout/CalloutViewTypes';
 
 export interface CreateLinkFormValues {
   id: string;

--- a/src/domain/shared/components/References/EditLinkDialog.tsx
+++ b/src/domain/shared/components/References/EditLinkDialog.tsx
@@ -1,5 +1,4 @@
 import { FC, ReactNode, useMemo } from 'react';
-import { CalloutType } from '@/core/apollo/generated/graphql-schema';
 import { Box, Button, Dialog, DialogContent, IconButton } from '@mui/material';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import { useTranslation } from 'react-i18next';
@@ -16,6 +15,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import FormikFileInput from '@/core/ui/forms/FormikFileInput/FormikFileInput';
 import { TranslatedValidatedMessageWithPayload } from '@/domain/shared/i18n/ValidationMessageTranslation';
 import { LONG_TEXT_LENGTH, MID_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@/core/ui/forms/field-length.constants';
+import { CalloutType } from '@/domain/collaboration/callout/CalloutViewTypes';
 
 export interface EditLinkFormValues {
   id: string;

--- a/src/domain/spaceAdmin/SpaceAdminSubspaces/graphql/SpaceAdminDefaultSpaceTemplatesDetails.graphql
+++ b/src/domain/spaceAdmin/SpaceAdminSubspaces/graphql/SpaceAdminDefaultSpaceTemplatesDetails.graphql
@@ -26,7 +26,6 @@ query SpaceAdminDefaultSpaceTemplatesDetails($spaceId: UUID!) {
                   id
                   callouts {
                     id
-                    calloutTypeDeprecated: type
                     sortOrder
                     classification {
                       id

--- a/src/domain/templates/components/Dialogs/ImportTemplateDialog/ImportTemplateDialog.graphql
+++ b/src/domain/templates/components/Dialogs/ImportTemplateDialog/ImportTemplateDialog.graphql
@@ -10,7 +10,6 @@ query ImportTemplateDialog(
         ...TemplateProfileInfo
         callout @include(if: $includeCallout) {
           id
-          calloutTypeDeprecated: type
         }
         contentSpace @include(if: $includeSpace) {
           id
@@ -41,7 +40,6 @@ query ImportTemplateDialogPlatformTemplates(
           ...TemplateProfileInfo
           callout @include(if: $includeCallout) {
             id
-            calloutTypeDeprecated: type
           }
           contentSpace @include(if: $includeSpace) {
             id

--- a/src/domain/templates/components/cards/CalloutTemplateCard.tsx
+++ b/src/domain/templates/components/cards/CalloutTemplateCard.tsx
@@ -1,7 +1,5 @@
 import React, { FC } from 'react';
-import { useTranslation } from 'react-i18next';
-import { Box, CardContent, Skeleton } from '@mui/material';
-import { CalloutType } from '@/core/apollo/generated/graphql-schema';
+import { Skeleton } from '@mui/material';
 import ContributeCard from '@/core/ui/card/ContributeCard';
 import CardHeader from '@/core/ui/card/CardHeader';
 import CardHeaderCaption from '@/core/ui/card/CardHeaderCaption';
@@ -11,9 +9,6 @@ import { Caption } from '@/core/ui/typography';
 import CardSegmentCaption from '@/core/ui/card/CardSegmentCaption';
 import InnovationPackIcon from '@/domain/InnovationPack/InnovationPackIcon';
 import CardTags from '@/core/ui/card/CardTags';
-import calloutIcons from '@/domain/collaboration/callout/icons/calloutIcons';
-import RoundedIcon from '@/core/ui/icon/RoundedIcon';
-import { gutters } from '@/core/ui/grid/utils';
 import { CalloutTemplate } from '@/domain/templates/models/CalloutTemplate';
 import { TemplateCardProps } from './TemplateCard';
 
@@ -21,15 +16,11 @@ interface CalloutTemplateCardProps extends TemplateCardProps {
   template: CalloutTemplate;
 }
 
+// TODO:CalloutType fix missing content
 const CalloutTemplateCard: FC<CalloutTemplateCardProps> = ({ template, innovationPack, loading, ...props }) => {
-  const { t } = useTranslation();
-
   const hasTags = (template?.profile.defaultTagset?.tags ?? []).length > 0;
-  const footerHeight =
-    template?.callout?.calloutTypeDeprecated === CalloutType.LinkCollection ? (hasTags ? 3 : 1) : hasTags ? 2 : 0;
+  const footerHeight = hasTags ? 2 : 0;
   const descriptionHeightGutters = DEFAULT_CARDDESCRIPTION_HEIGHT_GUTTERS - footerHeight;
-
-  const Icon = template?.callout?.calloutTypeDeprecated && calloutIcons[template.callout.calloutTypeDeprecated];
 
   return (
     <ContributeCard {...props}>
@@ -41,20 +32,6 @@ const CalloutTemplateCard: FC<CalloutTemplateCardProps> = ({ template, innovatio
       </CardHeader>
       <CardDetails>
         <CardDescription heightGutters={descriptionHeightGutters}>{template?.profile.description}</CardDescription>
-      </CardDetails>
-      <CardDetails>
-        <CardContent sx={{ '&:last-child': { paddingBottom: gutters(0.2) } }}>
-          {template && (
-            <Box display="flex" alignItems="center" marginLeft={-0.5} gap={gutters(0.5)}>
-              {Icon && <RoundedIcon marginLeft={0.5} size="xsmall" component={Icon} flexShrink={0} />}
-              {template.callout?.calloutTypeDeprecated && (
-                <Caption>
-                  {t(`components.calloutTypeSelect.label.${template.callout.calloutTypeDeprecated}` as const)}
-                </Caption>
-              )}
-            </Box>
-          )}
-        </CardContent>
       </CardDetails>
       <CardDetails>
         <CardTags tags={template?.profile.defaultTagset?.tags ?? []} marginY={1} hideIfEmpty />

--- a/src/domain/templates/graphql/TemplateContent.graphql
+++ b/src/domain/templates/graphql/TemplateContent.graphql
@@ -65,7 +65,6 @@ query SpaceTemplateContent($spaceId: UUID!) {
 
 fragment CalloutTemplateContent on Callout {
   id
-  calloutTypeDeprecated: type
   framing {
     id
     profile {
@@ -149,7 +148,6 @@ fragment SpaceTemplateContent_Collaboration on Collaboration {
     id
     callouts {
       id
-      calloutTypeDeprecated: type
       classification {
         id
         flowState: tagset(tagsetName: FLOW_STATE) {

--- a/src/domain/templates/graphql/TemplateFragments.graphql
+++ b/src/domain/templates/graphql/TemplateFragments.graphql
@@ -19,7 +19,6 @@ fragment CalloutTemplate on Template {
   ...TemplateProfileInfo
   callout {
     id
-    calloutTypeDeprecated: type
     settings {
       contribution {
         enabled

--- a/src/domain/templates/graphql/TemplateMutations.graphql
+++ b/src/domain/templates/graphql/TemplateMutations.graphql
@@ -128,7 +128,6 @@ mutation UpdateTemplate(
 mutation UpdateCalloutTemplate($calloutData: UpdateCalloutEntityInput!) {
   updateCallout(calloutData: $calloutData) {
     id
-    calloutTypeDeprecated: type
     framing {
       id
       profile {

--- a/src/domain/templates/models/CalloutTemplate.tsx
+++ b/src/domain/templates/models/CalloutTemplate.tsx
@@ -1,5 +1,5 @@
 import { TemplateBase } from './TemplateBase';
-import { CalloutFramingType, CalloutType, TemplateType, VisualType } from '@/core/apollo/generated/graphql-schema';
+import { CalloutFramingType, TemplateType, VisualType } from '@/core/apollo/generated/graphql-schema';
 import { CalloutSettingsModelFull } from '@/domain/collaboration/callout/models/CalloutSettingsModel';
 import { ReferenceModel } from '@/domain/common/reference/ReferenceModel';
 import { TagsetModel } from '@/domain/common/tagset/TagsetModel';
@@ -11,7 +11,6 @@ export interface CalloutTemplate extends TemplateBase {
     /**
      * @deprecated
      */
-    calloutTypeDeprecated?: CalloutType;
     framing: {
       profile: {
         id?: string;

--- a/src/main/inAppNotifications/InAppNotificationItem.tsx
+++ b/src/main/inAppNotifications/InAppNotificationItem.tsx
@@ -1,22 +1,18 @@
-import { InAppNotificationCategory, NotificationEventType } from '@/core/apollo/generated/graphql-schema';
 import { warn as logWarn, TagCategoryValues } from '@/core/logging/sentry/log';
 import { InAppNotificationProps } from './useInAppNotifications';
-import { CollaborationCalloutPublishedView } from './views/CollaborationCalloutPublishedView';
-import { CommunicationUserMentionView } from './views/CommunicationUserMentionView';
-import { CommunityNewMemberAdminView } from './views/CommunityNewMemberAdminView';
-import { CommunityNewMemberView } from './views/CommunityNewMemberView';
 
+// TODO:NotificationEventType fix
 export const InAppNotificationItem = ({ ...item }: InAppNotificationProps) => {
   switch (item.type) {
-    case NotificationEventType.CollaborationCalloutPublished:
-      return <CollaborationCalloutPublishedView {...item} />;
-    case NotificationEventType.CommunicationUserMention:
-      return <CommunicationUserMentionView {...item} />;
-    case NotificationEventType.CommunityNewMember:
-      if (item.category === InAppNotificationCategory.Admin) {
-        return <CommunityNewMemberAdminView {...item} />;
-      }
-      return <CommunityNewMemberView {...item} />;
+    // case NotificationEventType.CollaborationCalloutPublished:
+    //   return <CollaborationCalloutPublishedView {...item} />;
+    // case NotificationEventType.CommunicationUserMention:
+    //   return <CommunicationUserMentionView {...item} />;
+    // case NotificationEventType.CommunityNewMember:
+    //   if (item.category === InAppNotificationCategory.Admin) {
+    //     return <CommunityNewMemberAdminView {...item} />;
+    //   }
+    //   return <CommunityNewMemberView {...item} />;
     default:
       logWarn(`Unsupported Notification type: ${item.type}`, {
         category: TagCategoryValues.NOTIFICATIONS,

--- a/src/main/inAppNotifications/useInAppNotifications.ts
+++ b/src/main/inAppNotifications/useInAppNotifications.ts
@@ -3,7 +3,6 @@ import {
   RoleSetContributorType,
   InAppNotificationCategory,
   InAppNotificationState,
-  NotificationEventType,
   SpaceLevel,
   InAppNotificationsQuery,
 } from '@/core/apollo/generated/graphql-schema';
@@ -18,7 +17,8 @@ import { ApolloCache } from '@apollo/client';
 
 export interface InAppNotificationProps {
   id: string;
-  type: NotificationEventType;
+  // @ts-ignore
+  type: any;
   triggeredAt: Date;
   state: InAppNotificationState;
   category: InAppNotificationCategory;

--- a/src/main/search/SearchQueries.graphql
+++ b/src/main/search/SearchQueries.graphql
@@ -117,7 +117,6 @@ fragment SearchResultCallout on SearchResultCallout {
   id
   callout {
     id
-    calloutTypeDeprecated: type
     framing {
       id
       profile {

--- a/src/main/topLevelPages/InnovationLibraryPage/InnovationLibraryPage.graphql
+++ b/src/main/topLevelPages/InnovationLibraryPage/InnovationLibraryPage.graphql
@@ -8,7 +8,6 @@ query InnovationLibrary($filterTemplateType: [TemplateType!]) {
           ...TemplateProfileInfo
           callout {
             id
-            type
           }
         }
         innovationPack {


### PR DESCRIPTION
Compile the project after server chagnes.

- fix the TODO:NotificationEventType;
- fix the TODO:CalloutType;

In app notifications broken (unsupported ATM).
Template cards not rendering content based on the type. Plus some more usages of CalloutType (to be removed).