### PR TITLE
Fix the dashboard layout on non-desktop, non-mobile res.

### DIFF
--- a/src/core/ui/content/ContentColumn.tsx
+++ b/src/core/ui/content/ContentColumn.tsx
@@ -1,8 +1,11 @@
 import PageContentColumn from './PageContentColumn';
 import { BoxProps } from '@mui/material';
+import { useColumns } from '../grid/GridContext';
+import { GRID_COLUMNS_MOBILE } from '../grid/constants';
 
 // GRID COLUMNS - INFO_COLUMNS => 12 - 3
 const CONTENT_COLUMNS = 9;
+const INFO_COLUMNS = 3;
 
 const ContentColumn = ({
   ref,
@@ -10,10 +13,24 @@ const ContentColumn = ({
   ...props
 }: BoxProps & {
   ref?: React.Ref<HTMLDivElement>;
-}) => (
-  <PageContentColumn columns={CONTENT_COLUMNS} {...props} ref={ref}>
-    {children}
-  </PageContentColumn>
-);
+}) => {
+  const availableColumns = useColumns();
+
+  let columnsToUse = CONTENT_COLUMNS;
+
+  if (availableColumns === GRID_COLUMNS_MOBILE) {
+    // On mobile, use full width
+    columnsToUse = GRID_COLUMNS_MOBILE;
+  } else if (availableColumns < 12) {
+    // On tablet (8 columns), use remaining columns after info column
+    columnsToUse = availableColumns - INFO_COLUMNS;
+  }
+
+  return (
+    <PageContentColumn columns={columnsToUse} {...props} ref={ref}>
+      {children}
+    </PageContentColumn>
+  );
+};
 
 export default ContentColumn;


### PR DESCRIPTION
Now the main content block is shrinking next to the InfoColumnt (left sidebar).

After / Before
<img width="1889" height="699" alt="image" src="https://github.com/user-attachments/assets/25fec429-0f87-47a8-ae1c-6ce9741fb1f0" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content area now adapts to available columns for improved responsiveness and readability: full-width on mobile, smarter column allocation on smaller viewports, and consistent 9-column layout on large screens.

* **Refactor**
  * Updated layout logic to compute column width dynamically while preserving existing behavior and public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->