### PR TITLE
[Mobile] Fix the platform navigation not working

### DIFF
--- a/src/core/ui/menu/NavigatableMenuItem.tsx
+++ b/src/core/ui/menu/NavigatableMenuItem.tsx
@@ -25,12 +25,21 @@ const NavigatableMenuItem = ({
   children,
   typographyComponent: Typography = DefaultTypography,
 }: PropsWithChildren<NavigatableMenuItemProps>) => {
-  const menuItemProps = route ? { component: RouterLink, replace, to: route, blank: false } : {};
+  // Separate routing props from click handling
+  const menuItemProps = route
+    ? {
+        component: RouterLink,
+        replace,
+        to: route,
+        blank: false,
+        // Don't pass onClick when using routing to avoid conflicts
+        onClick: undefined,
+      }
+    : { onClick };
 
   return (
     <MenuItem
       {...menuItemProps}
-      onClick={onClick}
       sx={visibleOnFocus({ skip: !tabOnly })({ paddingX: gutters(), textTransform: 'none' })}
     >
       <ListItemIcon>


### PR DESCRIPTION
This is an important breaking change with the React update:

> After React 19, there's a conflict between how MUI handles the component prop and the onClick prop when they're used together.
The issue is that when a route is provided, the component sets component: RouterLink but still passes the onClick handler. In React 19, this can cause the click event to be handled differently, leading to the drawer closing without navigation occurring.

@polibb , @ccanos FYI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigational menu items now reliably navigate without triggering unintended click actions.
  * Non-navigational menu items consistently execute their click actions without routing side effects.
  * Overall menu interaction is more predictable, preventing conflicts between navigation and click handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->