### PR TITLE
Add an email to the available users' list (GA)

### DIFF
--- a/src/domain/platformAdmin/components/Community/EditMembersUsers.tsx
+++ b/src/domain/platformAdmin/components/Community/EditMembersUsers.tsx
@@ -110,7 +110,9 @@ export const EditMemberUsers: FC<EditMemberUsersProps> = ({
               loading={loadingAvailableMembers}
               updating={updating}
               header={<TableCell>Full Name (email)</TableCell>}
-              renderRow={m => <TableCell>{`${m.profile.displayName} (${m.email})`}</TableCell>}
+              renderRow={m => (
+                <TableCell>{m.email ? `${m.profile.displayName} (${m.email})` : m.profile.displayName}</TableCell>
+              )}
               renderEmptyRow={Cell => (
                 <TableCell>
                   <Cell />

--- a/src/domain/platformAdmin/components/Community/EditMembersUsers.tsx
+++ b/src/domain/platformAdmin/components/Community/EditMembersUsers.tsx
@@ -12,6 +12,7 @@ export interface EditMemberUsersProps {
   availableMembers: {
     id: string;
     profile: { displayName: string };
+    email?: string;
   }[];
   updating?: boolean;
   loadingAvailableMembers?: boolean;
@@ -108,8 +109,8 @@ export const EditMemberUsers: FC<EditMemberUsersProps> = ({
               filteredMembers={availableMembers}
               loading={loadingAvailableMembers}
               updating={updating}
-              header={<TableCell>Full Name</TableCell>}
-              renderRow={m => <TableCell>{m.profile.displayName}</TableCell>}
+              header={<TableCell>Full Name (email)</TableCell>}
+              renderRow={m => <TableCell>{`${m.profile.displayName} (${m.email})`}</TableCell>}
               renderEmptyRow={Cell => (
                 <TableCell>
                   <Cell />


### PR DESCRIPTION
<img width="453" height="211" alt="image" src="https://github.com/user-attachments/assets/a1fac890-b022-4513-888f-7273e0530d02" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Available Members list in Community member editor now shows email addresses alongside full names to help distinguish users.
  * Table rows render as "Full Name (email)" when an email is present, otherwise just the name.
  * Column header updated to "Full Name (email)" to reflect the added email visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->