### PR TITLE
Fix: Navigating from Welcome page to Sign In page, throws console errors #8545

### DIFF
--- a/src/core/auth/authentication/components/Kratos/KratosInput.tsx
+++ b/src/core/auth/authentication/components/Kratos/KratosInput.tsx
@@ -1,4 +1,4 @@
-import { GridLegacy, InputAdornment, OutlinedInputProps, TextField, Tooltip } from '@mui/material';
+import { InputAdornment, OutlinedInputProps, TextField, Tooltip } from '@mui/material';
 import { UiNodeInputAttributes } from '@ory/kratos-client';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
@@ -54,34 +54,32 @@ export const KratosInput: FC<KratosInputProps> = ({ node, autoCapitalize, autoCo
   }
 
   return (
-    <GridLegacy xs={12} item>
-      <Tooltip
-        title={t('pages.accept-terms.tooltip')}
-        arrow
-        placement="top"
-        disableFocusListener={!disabled}
-        disableHoverListener={!disabled}
-      >
-        <TextField
-          name={name}
-          label={getNodeTitle(node, t)}
-          onBlur={() => setTouched(true)}
-          onChange={e => setValue(e.target.value)}
-          value={value ? String(value) : ''}
-          variant={'outlined'}
-          type={inputType}
-          error={touched && invalid}
-          helperText={helperText}
-          required={required}
-          disabled={attributes.disabled || disabled}
-          autoComplete={autoComplete}
-          fullWidth
-          InputProps={{ ...InputProps }}
-          InputLabelProps={{ shrink: true }}
-          sx={{ marginY: inputType === 'hidden' ? 0 : 0.5 }}
-        />
-      </Tooltip>
-    </GridLegacy>
+    <Tooltip
+      title={t('pages.accept-terms.tooltip')}
+      arrow
+      placement="top"
+      disableFocusListener={!disabled}
+      disableHoverListener={!disabled}
+    >
+      <TextField
+        name={name}
+        label={getNodeTitle(node, t)}
+        onBlur={() => setTouched(true)}
+        onChange={e => setValue(e.target.value)}
+        value={value ? String(value) : ''}
+        variant={'outlined'}
+        type={inputType}
+        error={touched && invalid}
+        helperText={helperText}
+        required={required}
+        disabled={attributes.disabled || disabled}
+        autoComplete={autoComplete}
+        fullWidth
+        InputProps={{ ...InputProps }}
+        InputLabelProps={{ shrink: true }}
+        sx={{ marginY: inputType === 'hidden' ? 0 : 0.5 }}
+      />
+    </Tooltip>
   );
 };
 

--- a/src/core/auth/authentication/components/Kratos/KratosInput.tsx
+++ b/src/core/auth/authentication/components/Kratos/KratosInput.tsx
@@ -54,7 +54,7 @@ export const KratosInput: FC<KratosInputProps> = ({ node, autoCapitalize, autoCo
   }
 
   return (
-    <GridLegacy xs={12}>
+    <GridLegacy xs={12} item>
       <Tooltip
         title={t('pages.accept-terms.tooltip')}
         arrow

--- a/src/core/container/ComponentOrChildrenFn.tsx
+++ b/src/core/container/ComponentOrChildrenFn.tsx
@@ -19,7 +19,12 @@ export const renderComponentOrChildrenFn = <Consumed extends {}, Provided extend
 ) => {
   if ('component' in props) {
     const Component = props.component;
-    return <Component {...provided} />;
+    if ('key' in props && typeof props.key === 'string') {
+      const key = props.key;
+      return <Component key={key} {...provided} />;
+    } else {
+      return <Component {...provided} />;
+    }
   }
   return props.children(provided);
 };

--- a/src/core/container/ComponentOrChildrenFn.tsx
+++ b/src/core/container/ComponentOrChildrenFn.tsx
@@ -20,6 +20,7 @@ export const renderComponentOrChildrenFn = <Consumed extends {}, Provided extend
   if ('component' in props) {
     const Component = props.component;
     if ('key' in props && typeof props.key === 'string') {
+      // React keys must be passed directly to JSX without using spread
       const key = props.key;
       return <Component key={key} {...provided} />;
     } else {


### PR DESCRIPTION
I was not seeing the console error anymore but it makes sense, in the docs when you set any breakpoint to a Grid you are referring to a GridItem.
I started adding `item` as prop to GridLegacy and saw no difference visually.
So I have removed <GridLegacy> completely. Tested it visually and looks exactly the same. KratosUI (the parent that renders all the `KratosInput`s is not an MUI Grid anyway.

Tested a few screens: Sign In, Sign Up, set password, Enter email verification code, reset password (maybe not all) but tested forms look exactly the same.
So one less GridLegacy item to migrate when we upgrade MUI 🎉

<hr/>
Also fixes this other console error:
<img width="1870" height="93" alt="image" src="https://github.com/user-attachments/assets/4f2d23ca-6578-4eb6-a6f1-48c34f6d9c58" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the input layout: inputs now render as a TextField wrapped by a Tooltip (grid wrapper removed). Visual spacing/alignment and responsive behavior may be slightly different; typing, focus/blur, validation, error display, helper text, disabled state, and password visibility remain unchanged.
  * Improved component rendering to ensure stable React key handling with no user-visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->