### PR TITLE
Include onClick even on <a></a> tags

### DIFF
--- a/src/core/ui/menu/NavigatableMenuItem.tsx
+++ b/src/core/ui/menu/NavigatableMenuItem.tsx
@@ -25,21 +25,12 @@ const NavigatableMenuItem = ({
   children,
   typographyComponent: Typography = DefaultTypography,
 }: PropsWithChildren<NavigatableMenuItemProps>) => {
-  // Separate routing props from click handling
-  const menuItemProps = route
-    ? {
-        component: RouterLink,
-        replace,
-        to: route,
-        blank: false,
-        // Don't pass onClick when using routing to avoid conflicts
-        onClick: undefined,
-      }
-    : { onClick };
+  const menuItemProps = route ? { component: RouterLink, replace, to: route, blank: false } : {};
 
   return (
     <MenuItem
       {...menuItemProps}
+      onClick={onClick}
       sx={visibleOnFocus({ skip: !tabOnly })({ paddingX: gutters(), textTransform: 'none' })}
     >
       <ListItemIcon>


### PR DESCRIPTION
### Describe the background of your pull request

Attempt fixing not being able to click user menu items on iOS.

### Additional context

Cannot reproduce on a Mac, so let's see this deployed and on a mobile.

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Menu items with navigation now properly trigger assigned click actions, improving consistency in interactive menus.
  * In-app notifications display more reliably even when some profile image details are missing, reducing dropped or incomplete notifications.

* **Chores**
  * Version bumped to 0.109.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->