### PR TITLE
A11y: Home list padding

### DIFF
--- a/src/main/topLevelPages/myDashboard/DashboardMenu/DashboardMenu.tsx
+++ b/src/main/topLevelPages/myDashboard/DashboardMenu/DashboardMenu.tsx
@@ -70,8 +70,8 @@ export const DashboardMenu = ({ compact = false, expandable = false }: Dashboard
     switch (item.type) {
       case 'invites':
         return (
-          <ListItem key={index} sx={{ paddingY: gutters(0.75) }}>
-            <ListItemButton onClick={openMembershipsDialog}>
+          <ListItem key={index} sx={{ padding: 0 }}>
+            <ListItemButton onClick={openMembershipsDialog} sx={{ paddingY: gutters(0.75) }}>
               {getItemContent(item)}
               {pendingInvitationsCount > 0 && (
                 <>
@@ -84,16 +84,23 @@ export const DashboardMenu = ({ compact = false, expandable = false }: Dashboard
         );
       case 'link':
         return (
-          <ListItem key={index} sx={{ paddingY: gutters(0.75) }}>
-            <ListItemButton component={RouterLink} to={item.to ?? ''} disabled={!item.to}>
+          <ListItem key={index} sx={{ padding: 0 }}>
+            <ListItemButton
+              component={RouterLink}
+              to={item.to ?? ''}
+              disabled={!item.to}
+              sx={{ paddingY: gutters(0.75) }}
+            >
               {getItemContent(item)}
             </ListItemButton>
           </ListItem>
         );
       case 'dialog':
         return (
-          <ListItem key={index} sx={{ paddingY: gutters(0.75) }}>
-            <ListItemButton onClick={openDialog(item.dialog)}>{getItemContent(item)}</ListItemButton>
+          <ListItem key={index} sx={{ padding: 0 }}>
+            <ListItemButton onClick={openDialog(item.dialog)} sx={{ paddingY: gutters(0.75) }}>
+              {getItemContent(item)}
+            </ListItemButton>
           </ListItem>
         );
       case 'switch':


### PR DESCRIPTION
### Describe the background of your pull request

MUI requires ListItem to be placed in lists, because ListItemButton needs to be wrapped in ListItem.

### Additional context

Fixed padding in this PR to select correct list item in home page.



### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Memo” content field in callout framing.
  - Expanded Notification Settings with new grouped sections (Space, Space Admin, Organization, User, Membership, Platform Admin, Forum, Virtual Contributor) and additional options.
  - Share settings now dynamically reference the element name for clearer ownership/editing labels.
- Removed/Breaking Changes
  - Removed callout type selection from the callout template dialog.
- Localization
  - Significant updates and restructuring across Acholi, Bulgarian, German, Spanish, French, Dutch, and Portuguese translations, including new placeholders and English-aligned labels.
- Style
  - Dashboard menu spacing refined for consistent padding.
- Chores
  - Version bumped to 0.110.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->