### PR TITLE
Fix iPad Regex issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "markdown-it-link-attributes": "^4.0.1",
         "markdown-it-sanitizer": "^0.4.3",
         "markdown-it-sup": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "2.0.0",
         "react": "19.1.0",
         "react-calendar": "^5.1.0",
         "react-cookie": "^8.0.1",
@@ -15565,10 +15566,9 @@
       }
     },
     "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.0.tgz",
+      "integrity": "sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "ccount": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
         "markdown-it-link-attributes": "^4.0.1",
         "markdown-it-sanitizer": "^0.4.3",
         "markdown-it-sup": "^2.0.0",
-        "mdast-util-gfm-autolink-literal": "2.0.0",
         "react": "19.1.0",
         "react-calendar": "^5.1.0",
         "react-cookie": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
   },
   "resolutions": {
     "**/@emotion/styled": "^11.0.0",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "mdast-util-gfm-autolink-literal": "2.0.0"
   },
   "dependencies": {
     "@alkemio/excalidraw": "0.18.0-864353b-alkemio-5",
@@ -158,7 +159,6 @@
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",
-    "mdast-util-gfm-autolink-literal": "2.0.0",
     "remark-stringify": "^11.0.0",
     "socket.io-client": "^4.8.1",
     "ts-semaphore": "^1.0.0",
@@ -216,6 +216,7 @@
     "glob-parent": "^5.1.2",
     "got": "11.8.5",
     "nth-check": "^2.0.1",
-    "chokidar": "^3.5.3"
+    "chokidar": "^3.5.3",
+    "mdast-util-gfm-autolink-literal": "2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",
+    "mdast-util-gfm-autolink-literal": "2.0.0",
     "remark-stringify": "^11.0.0",
     "socket.io-client": "^4.8.1",
     "ts-semaphore": "^1.0.0",

--- a/src/core/ui/markdown/WrapperMarkdown.tsx
+++ b/src/core/ui/markdown/WrapperMarkdown.tsx
@@ -11,19 +11,22 @@ import { useConfig } from '@/domain/platform/config/useConfig';
  * WARNING: About `mdast-util-gfm-autolink-literal` package.
  * We are not using this package directly, but do not remove the dependency from our package.json
  * See client-web/8607
- * An update on this package used by remark-gfm, has introduced a change that causes a failure on iPad devices.
+ * An update on this package used by remark-gfm, has introduced a change that causes an error on iPad devices.
+ *
  * https://github.com/syntax-tree/mdast-util-gfm-autolink-literal/releases
- * Between version 2.0.0 and 2.0.1 they introduced a regular expression to check email address that is not compatible with iPad browsers (yet)
+ * Between version 2.0.0 and 2.0.1 they introduced a regular expression to check email address that is not compatible with iPad browsers (yet).
+ * That regex starts with `/(?<=` which is a lookbehind assertion, that causes an error that in the browser console reads like: "invalid group specifier name".
  *
  * For reference, the hierarchy of the packages used is as follows:
- * WrapperMarkdown - This component, used to render pieces of markdown
- *   react-markdown - The main package for rendering markdown in React, often shortened as remark
+ * WrapperMarkdown - This component, used to render pieces of markdown.
+ *   react-markdown - The main package for rendering markdown in React, often shortened as "remark".
  *     remark-gfm - A plugin for react-markdown that adds support for GitHub Flavored Markdown (GFM). This adds features like tables, strikethrough, task lists...
  *       mdast-util-gfm - Is a dependency of remark-gfm included in package.json as "^3.0.0"
  *         mdast-util-gfm-autolink-literal - This is the dependency causing issues. mdast-util-gfm includes it in package.json as "^2.0.0".
  *
  * So, as mdast-util-gfm is compatible with any 2.x.x version of mdast-util-gfm-autolink-literal, we want to force npm to use 2.0.0 and not 2.0.1 or higher.
- * They may fix the issue in the future, or Apple may update their browsers to support the regex, so we will monitor this and remove the dependency from our package.json when possible.
+ * They may fix the issue in the future, or Apple may update their browsers to support the regex, 
+ * so we will have to monitor this and remove the dependency from our package.json when possible.
  */
 const allowedNodeTypes = ['iframe'] as const;
 

--- a/src/core/ui/markdown/WrapperMarkdown.tsx
+++ b/src/core/ui/markdown/WrapperMarkdown.tsx
@@ -7,7 +7,24 @@ import { MarkdownOptions, MarkdownOptionsProvider } from './MarkdownOptionsConte
 import { Box, BoxProps } from '@mui/material';
 import { remarkVerifyIframe } from './embed/remarkVerifyIframe';
 import { useConfig } from '@/domain/platform/config/useConfig';
-
+/**
+ * WARNING: About `mdast-util-gfm-autolink-literal` package.
+ * We are not using this package directly, but do not remove the dependency from our package.json
+ * See client-web/8607
+ * An update on this package used by remark-gfm, has introduced a change that causes a failure on iPad devices.
+ * https://github.com/syntax-tree/mdast-util-gfm-autolink-literal/releases
+ * Between version 2.0.0 and 2.0.1 they introduced a regular expression to check email address that is not compatible with iPad browsers (yet)
+ *
+ * For reference, the hierarchy of the packages used is as follows:
+ * WrapperMarkdown - This component, used to render pieces of markdown
+ *   react-markdown - The main package for rendering markdown in React, often shortened as remark
+ *     remark-gfm - A plugin for react-markdown that adds support for GitHub Flavored Markdown (GFM). This adds features like tables, strikethrough, task lists...
+ *       mdast-util-gfm - Is a dependency of remark-gfm included in package.json as "^3.0.0"
+ *         mdast-util-gfm-autolink-literal - This is the dependency causing issues. mdast-util-gfm includes it in package.json as "^2.0.0".
+ *
+ * So, as mdast-util-gfm is compatible with any 2.x.x version of mdast-util-gfm-autolink-literal, we want to force npm to use 2.0.0 and not 2.0.1 or higher.
+ * They may fix the issue in the future, or Apple may update their browsers to support the regex, so we will monitor this and remove the dependency from our package.json when possible.
+ */
 const allowedNodeTypes = ['iframe'] as const;
 
 const MARKDOWN_CLASS_NAME = 'markdown'; // global styles applied


### PR DESCRIPTION
See comment in WrapperMarkdown, explanation is there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing features added.
- Bug Fixes
  - Fixed a markdown autolink compatibility issue that could cause errors on some iPad browsers by pinning a stable package version.
- Documentation
  - Added explanatory comments describing the compatibility concern and the rationale for the version pin.
- Chores
  - Updated package resolutions/overrides to ensure stable markdown rendering across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->