### PR TITLE
Restricts framing types in template mode.

### DIFF
--- a/src/domain/templates/components/Forms/TemplateCalloutForm.tsx
+++ b/src/domain/templates/components/Forms/TemplateCalloutForm.tsx
@@ -114,10 +114,9 @@ const TemplateCalloutForm = ({ template, onSubmit, actions }: TemplateCalloutFor
                 readOnlyAllowedTypes: !createMode,
                 temporaryLocation: createMode,
                 readOnlyContributions: true,
-                // In template mode, only allow None framing type, disable all others
-                disableWhiteboards: true,
-                disableMemos: true,
-                disableLinks: true,
+                disableWhiteboards: !createMode,
+                disableMemos: !createMode,
+                disableLinks: !createMode,
               }}
               onChange={calloutFormValues => {
                 setFieldValue('callout', calloutFormValues);


### PR DESCRIPTION
Ensures that in template creation mode, users can only select 'None' as the framing type for callouts. This is achieved by disabling whiteboard, memo, and link framing options, simplifying the template creation process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template Callout creation now disables Whiteboards, Memos, and Links (only “None” framing available) while in create mode; edit mode leaves these options enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->