### PR TITLE
In-app improvements

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -1419,8 +1419,17 @@ export type DiscussionFieldPolicy = {
   timestamp?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type DiscussionDetailsKeySpecifier = ('displayName' | 'id' | 'url' | DiscussionDetailsKeySpecifier)[];
+export type DiscussionDetailsKeySpecifier = (
+  | 'category'
+  | 'description'
+  | 'displayName'
+  | 'id'
+  | 'url'
+  | DiscussionDetailsKeySpecifier
+)[];
 export type DiscussionDetailsFieldPolicy = {
+  category?: FieldPolicy<any> | FieldReadFunction<any>;
+  description?: FieldPolicy<any> | FieldReadFunction<any>;
   displayName?: FieldPolicy<any> | FieldReadFunction<any>;
   id?: FieldPolicy<any> | FieldReadFunction<any>;
   url?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -2953,6 +2953,8 @@ export const InAppNotificationPayloadPlatformForumDiscussionFragmentDoc = gql`
     discussion {
       id
       displayName
+      description
+      category
       url
     }
   }

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -2519,6 +2519,10 @@ export type Discussion = {
 
 export type DiscussionDetails = {
   __typename?: 'DiscussionDetails';
+  /** The discussion category. */
+  category?: Maybe<Scalars['String']['output']>;
+  /** The discussion content. */
+  description?: Maybe<Scalars['String']['output']>;
   /** The discussion display name. */
   displayName: Scalars['String']['output'];
   /** The discussion ID. */
@@ -30068,7 +30072,16 @@ export type InAppNotificationReceivedSubscription = {
           __typename?: 'InAppNotificationPayloadPlatformForumDiscussion';
           type: NotificationEventPayload;
           comment?: string | undefined;
-          discussion?: { __typename?: 'DiscussionDetails'; id: string; displayName: string; url: string } | undefined;
+          discussion?:
+            | {
+                __typename?: 'DiscussionDetails';
+                id: string;
+                displayName: string;
+                description?: string | undefined;
+                category?: string | undefined;
+                url: string;
+              }
+            | undefined;
         }
       | {
           __typename?: 'InAppNotificationPayloadPlatformGlobalRoleChange';
@@ -31076,7 +31089,14 @@ export type InAppNotificationsQuery = {
               type: NotificationEventPayload;
               comment?: string | undefined;
               discussion?:
-                | { __typename?: 'DiscussionDetails'; id: string; displayName: string; url: string }
+                | {
+                    __typename?: 'DiscussionDetails';
+                    id: string;
+                    displayName: string;
+                    description?: string | undefined;
+                    category?: string | undefined;
+                    url: string;
+                  }
                 | undefined;
             }
           | {
@@ -32066,7 +32086,16 @@ export type InAppNotificationAllTypesFragment = {
         __typename?: 'InAppNotificationPayloadPlatformForumDiscussion';
         type: NotificationEventPayload;
         comment?: string | undefined;
-        discussion?: { __typename?: 'DiscussionDetails'; id: string; displayName: string; url: string } | undefined;
+        discussion?:
+          | {
+              __typename?: 'DiscussionDetails';
+              id: string;
+              displayName: string;
+              description?: string | undefined;
+              category?: string | undefined;
+              url: string;
+            }
+          | undefined;
       }
     | {
         __typename?: 'InAppNotificationPayloadPlatformGlobalRoleChange';
@@ -33203,7 +33232,16 @@ export type InAppNotificationPayloadPlatformForumDiscussionFragment = {
   __typename?: 'InAppNotificationPayloadPlatformForumDiscussion';
   type: NotificationEventPayload;
   comment?: string | undefined;
-  discussion?: { __typename?: 'DiscussionDetails'; id: string; displayName: string; url: string } | undefined;
+  discussion?:
+    | {
+        __typename?: 'DiscussionDetails';
+        id: string;
+        displayName: string;
+        description?: string | undefined;
+        category?: string | undefined;
+        url: string;
+      }
+    | undefined;
 };
 
 export type InAppNotificationPayloadPlatformUserFragment = {

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -1963,11 +1963,11 @@
           "description": ""
         },
         "SPACE_COLLABORATION_CALLOUT_CONTRIBUTION": {
-          "subject": "{{triggeredByName}} created a post \"{{calloutName}}\"",
+          "subject": "{{triggeredByName}} created a contribution in \"{{calloutName}}\"",
           "description": "In <b>{{spaceName}}</b>, of which you are a member."
         },
         "SPACE_ADMIN_COLLABORATION_CALLOUT_CONTRIBUTION": {
-          "subject": "{{triggeredByName}} created a post \"{{calloutName}}\"",
+          "subject": "{{triggeredByName}} created a contribution in \"{{calloutName}}\"",
           "description": "In <b>{{spaceName}}</b>, of which you are an admin."
         },
         "SPACE_ADMIN_COMMUNITY_APPLICATION": {
@@ -1996,7 +1996,7 @@
         },
         "ORGANIZATION_ADMIN_MESSAGE": {
           "subject": "{{triggeredByName}} sent a message to your organization {{organizationName}}",
-          "description": ""
+          "description": "See the message in you email inbox"
         },
         "ORGANIZATION_MESSAGE_SENDER": {
           "subject": "You sent a message to {{organizationName}}",
@@ -2007,8 +2007,8 @@
           "description": ""
         },
         "PLATFORM_FORUM_DISCUSSION_CREATED": {
-          "subject": "{{triggeredByName}} started a new discussion in the forum {{discussionName}}",
-          "description": ""
+          "subject": "{{triggeredByName}} started a new discussion in the forum {{category}}",
+          "description": "{{discussionName}}"
         },
         "PLATFORM_FORUM_DISCUSSION_COMMENT": {
           "subject": "{{triggeredByName}} commented on your forum post in {{discussionName}}",

--- a/src/main/inAppNotifications/graphql/InAppNotificationsFragments.graphql
+++ b/src/main/inAppNotifications/graphql/InAppNotificationsFragments.graphql
@@ -204,6 +204,8 @@ fragment InAppNotificationPayloadPlatformForumDiscussion on InAppNotificationPay
   discussion {
     id
     displayName
+    description
+    category
     url
   }
 }

--- a/src/main/inAppNotifications/model/InAppNotificationPayloadModel.tsx
+++ b/src/main/inAppNotifications/model/InAppNotificationPayloadModel.tsx
@@ -86,6 +86,8 @@ export interface InAppNotificationPayloadModel {
   discussion?: {
     id: string;
     displayName: string;
+    description?: string;
+    category?: string;
     url: string;
   };
   comment?: string;

--- a/src/main/inAppNotifications/views/organization/InAppOrganizationAdminMessageView.tsx
+++ b/src/main/inAppNotifications/views/organization/InAppOrganizationAdminMessageView.tsx
@@ -12,14 +12,14 @@ export const InAppOrganizationAdminMessageView = (notification: InAppNotificatio
   const notificationTextValues = {
     triggeredByName: triggeredBy.profile.displayName,
     organizationName: payload.organization?.profile?.displayName,
-    comment: payload.organizationMessage,
+    // comment: payload.organizationMessage,
   };
 
   return (
     <InAppNotificationBaseView
       notification={notification}
       values={notificationTextValues}
-      url={payload.organization?.profile?.url}
+      url={triggeredBy.profile?.url}
     />
   );
 };

--- a/src/main/inAppNotifications/views/platform/InAppPlatformForumDiscussionCreatedView.tsx
+++ b/src/main/inAppNotifications/views/platform/InAppPlatformForumDiscussionCreatedView.tsx
@@ -1,8 +1,10 @@
 import { InAppNotificationModel } from '../../model/InAppNotificationModel';
 import { InAppNotificationBaseView } from '../InAppNotificationBaseView';
+import { useTranslation } from 'react-i18next';
 
 export const InAppPlatformForumDiscussionCreatedView = (notification: InAppNotificationModel) => {
   const { payload, triggeredBy } = notification;
+  const { t } = useTranslation();
 
   // do not display notification if these are missing
   if (!triggeredBy?.profile?.displayName || !payload.discussion) {
@@ -13,6 +15,10 @@ export const InAppPlatformForumDiscussionCreatedView = (notification: InAppNotif
   const notificationTextValues = {
     triggeredByName: triggeredBy.profile.displayName,
     discussionName: discussion.displayName,
+    category: discussion.category
+      ? t(`common.enums.discussion-category.${discussion.category.toUpperCase().replace(/-/g, '_')}`)
+      : '',
+    comment: discussion.description || '',
   };
 
   return (

--- a/src/main/inAppNotifications/views/space/InAppSpaceAdminCommunityNewMemberView.tsx
+++ b/src/main/inAppNotifications/views/space/InAppSpaceAdminCommunityNewMemberView.tsx
@@ -12,14 +12,13 @@ export const InAppSpaceAdminCommunityNewMemberView = (notification: InAppNotific
   const notificationTextValues = {
     spaceName: payload.space?.about?.profile?.displayName,
     memberName: payload.contributor?.profile?.displayName,
-    memberType: '', // todo: missing memberType (Admin, member, lead)
   };
 
   return (
     <InAppNotificationBaseView
       notification={notification}
       values={notificationTextValues}
-      url={payload.space?.about?.profile?.url}
+      url={payload.contributor?.profile?.url}
     />
   );
 };

--- a/src/main/inAppNotifications/views/space/InAppSpaceCommunicationUpdateView.tsx
+++ b/src/main/inAppNotifications/views/space/InAppSpaceCommunicationUpdateView.tsx
@@ -1,5 +1,6 @@
 import { InAppNotificationModel } from '../../model/InAppNotificationModel';
 import { InAppNotificationBaseView } from '../InAppNotificationBaseView';
+import { buildUpdatesUrl } from '@/main/routing/urlBuilders';
 
 export const InAppSpaceCommunicationUpdateView = (notification: InAppNotificationModel) => {
   const { payload, triggeredBy } = notification;
@@ -9,18 +10,19 @@ export const InAppSpaceCommunicationUpdateView = (notification: InAppNotificatio
     return null;
   }
   const space = payload.space;
+  const spaceUrl = space?.about?.profile?.url;
 
   const notificationTextValues = {
     triggeredByName: triggeredBy.profile.displayName,
     spaceName: space?.about?.profile?.displayName,
-    update: payload.update || '',
+    comment: payload.update || '',
   };
 
   return (
     <InAppNotificationBaseView
       notification={notification}
       values={notificationTextValues}
-      url={payload.space?.about?.profile?.url}
+      url={spaceUrl ? buildUpdatesUrl(spaceUrl) : undefined}
     />
   );
 };


### PR DESCRIPTION
Dependant on https://github.com/alkem-io/server/pull/5417

Improve the payload and displya of the following in-apps:

1. ORGANIZATION_ADMIN_MESSAGE:
  1.1 Switch the URL to user's profile.
  1.2. Static content - "See the message in you email inbox".
2. ORGANIZATION_MESSAGE_SENDER  - no changes, linking to ORG profile, showing part of the message.
3. SPACE_COLLABORATION_CALLOUT_CONTRIBUTION - simple copy changes - 'collaboration' instead of 'post'.
4. SPACE_COMMUNICATION_UPDATE
  4.1. URL to the /updates.
  4.2. Display the update message as content (note, there's no title/description, only message).
5. SPACE_ADMIN_COMMUNITY_NEW_MEMBER
  5.1. URL to contributor profile instead of the space.
6. PLATFORM_FORUM_DISCUSSION_CREATED
  6.1. Show the title & description in content;
  6.2. Fix the Subject providing the category (forumName);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - In-app notifications for forum discussions now include category and description.
  - Added notification text for sending messages to space leads.
  - Improved English wording and subjects across several notifications; added category translations.
  - Organization admin messages now include a descriptive detail.

- Bug Fixes
  - Updated notification links to point to the most relevant profiles or section pages (e.g., settings/community, updates).
  - Refined space community and lead message notification targets for better navigation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->