### PR TITLE
Template Packs: reorder list for template types

### DIFF
--- a/src/domain/InnovationPack/InnovationPackProfilePage/InnovationPackTemplateMenu.tsx
+++ b/src/domain/InnovationPack/InnovationPackProfilePage/InnovationPackTemplateMenu.tsx
@@ -44,6 +44,12 @@ const InnovationPackTemplateMenu = ({ templatesSetId }: InnovationPackTemplateMe
           count: whiteboardTemplates?.length ?? 0,
         },
         {
+          id: 'postTemplates',
+          title: t(`common.enums.templateType.${TemplateType.Post}_plural`),
+          url: postTemplates && postTemplates.length > 0 ? `#${TemplateType.Post.toLowerCase()}` : undefined,
+          count: postTemplates?.length ?? 0,
+        },
+        {
           id: 'communityGuidelinesTemplates',
           title: t(`common.enums.templateType.${TemplateType.CommunityGuidelines}_plural`),
           url:
@@ -51,12 +57,6 @@ const InnovationPackTemplateMenu = ({ templatesSetId }: InnovationPackTemplateMe
               ? `#${TemplateType.CommunityGuidelines.toLowerCase()}`
               : undefined,
           count: communityGuidelinesTemplates?.length ?? 0,
-        },
-        {
-          id: 'postTemplates',
-          title: t(`common.enums.templateType.${TemplateType.Post}_plural`),
-          url: postTemplates && postTemplates.length > 0 ? `#${TemplateType.Post.toLowerCase()}` : undefined,
-          count: postTemplates?.length ?? 0,
         },
       ]}
       emptyListCaption={t('common.noneTemplates')}


### PR DESCRIPTION
### Describe the background of your pull request

Reorder list of sub-menu 

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Post templates” link in the Innovation Pack template menu, shown after Whiteboard templates.
  * Displays the count of post templates and links directly to the section when available.

* **Bug Fixes**
  * Removed a duplicated “Post templates” entry that previously appeared later in the menu.
  * Standardized menu order: Space, Callout, Whiteboard, Post, Community Guidelines templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->