### PR TITLE
Support for Space tabs beyond knowledge-base.

### DIFF
--- a/src/domain/space/layout/tabbedLayout/Tabs/FlowStateTabPage/FlowStateTabPage.tsx
+++ b/src/domain/space/layout/tabbedLayout/Tabs/FlowStateTabPage/FlowStateTabPage.tsx
@@ -17,11 +17,11 @@ const CreateCalloutDialog = lazyWithGlobalErrorHandler(
   () => import('@/domain/collaboration/callout/CalloutDialogs/CreateCalloutDialog')
 );
 
-type KnowledgeBasePageProps = {
+type FlowStateTabPageProps = {
   sectionIndex: number;
 };
 
-const SpaceKnowledgeBasePage = ({ sectionIndex }: KnowledgeBasePageProps) => {
+const FlowStateTabPage = ({ sectionIndex }: FlowStateTabPageProps) => {
   const { urlInfo, classificationTagsets, flowStateForNewCallouts, tabDescription } = useSpaceTabProvider({
     tabPosition: sectionIndex,
   });
@@ -81,4 +81,4 @@ const SpaceKnowledgeBasePage = ({ sectionIndex }: KnowledgeBasePageProps) => {
   );
 };
 
-export default SpaceKnowledgeBasePage;
+export default FlowStateTabPage;

--- a/src/domain/space/routing/SpaceRoutes.tsx
+++ b/src/domain/space/routing/SpaceRoutes.tsx
@@ -12,13 +12,14 @@ import { SpaceContext, SpaceContextProvider } from '../context/SpaceContext';
 import { SpacePageLayout } from '../layout/SpacePageLayout';
 import SpaceCommunityPage from '../layout/tabbedLayout/Tabs/SpaceCommunityPage/SpaceCommunityPage';
 import SpaceSubspacesPage from '../layout/tabbedLayout/Tabs/SpaceSubspacesPage';
-import SpaceKnowledgeBasePage from '../layout/tabbedLayout/Tabs/SpaceKnowledgeBase/SpaceKnowledgeBasePage';
+import FlowStateTabPage from '../layout/tabbedLayout/Tabs/FlowStateTabPage/FlowStateTabPage';
 import SubspaceRoutes from './SubspaceRoutes';
 import SpaceCalloutPage from '../pages/SpaceCalloutPage';
 import CalloutRoute from '@/domain/collaboration/callout/routing/CalloutRoute';
 import Loading from '@/core/ui/loading/Loading';
 import { TabbedLayoutParams } from '@/main/routing/urlBuilders';
 import { useSectionIndex } from '../layout/useSectionIndex';
+import useSpaceTabs from '../layout/tabbedLayout/layout/useSpaceTabs';
 
 const LegacyRoutesRedirects = () => {
   const {
@@ -72,13 +73,20 @@ export const SpaceTabbedPages = () => {
   const { spaceId, spaceLevel } = useUrlResolver();
 
   const sectionIndex = useSectionIndex({ spaceId, spaceLevel });
+  const { tabs } = useSpaceTabs({ spaceId, skip: !spaceId });
+
+  // Convert sectionIndex to number for comparison
+  const currentSectionNumber = parseInt(sectionIndex);
+  const totalTabs = tabs.length;
 
   return (
     <>
       {sectionIndex === '0' && <SpaceDashboardPage />}
       {sectionIndex === '1' && <SpaceCommunityPage />}
       {sectionIndex === '2' && <SpaceSubspacesPage />}
-      {sectionIndex === '3' && <SpaceKnowledgeBasePage sectionIndex={3} />}
+      {currentSectionNumber >= 3 && currentSectionNumber < totalTabs && (
+        <FlowStateTabPage sectionIndex={currentSectionNumber} />
+      )}
     </>
   );
 };


### PR DESCRIPTION
I couldn't find the right mutation so I temporary disabled the check for `createStateOnInnovationFlow` on the server to create a 5th state for L0 space.

Now we can even add more without the need for client changes. 

<img width="1378" height="913" alt="image" src="https://github.com/user-attachments/assets/f4421222-2747-46e9-b37d-7f4646b52d8e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dynamic rendering for tabs beyond the first three, enabling additional sections to appear based on the space’s configuration.
  - Flow State tab pages are now available for higher-index tabs, ensuring consistent navigation across all sections.

- Refactor
  - Updated page names to better reflect their purpose, with no functional impact on users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->