### PR TITLE
In-app settings only for beta testers + ui improvements.

### DIFF
--- a/src/domain/community/userAdmin/tabs/components/CombinedPlatformNotificationsSettings.tsx
+++ b/src/domain/community/userAdmin/tabs/components/CombinedPlatformNotificationsSettings.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { BlockTitle, Caption } from '@/core/ui/typography/components';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
+import { Divider } from '@mui/material';
 import DualSwitchSettingsGroup from '@/core/ui/forms/SettingsGroups/DualSwitchSettingsGroup';
 import {
   PlatformNotificationSettings,
@@ -80,22 +81,46 @@ export const CombinedPlatformNotificationsSettings = ({
 
   const allOptions = buildOptions();
 
-  const handleChange = (key: string, type: 'inApp' | 'email', value: boolean) => {
-    // Route to appropriate handler based on setting type
-    const platformAdminKeys = ['userProfileCreated', 'userProfileRemoved', 'userGlobalRoleChanged', 'spaceCreated'];
+  // Create wrapper functions to match DualSwitchSettingsGroup's expected signature
+  const handlePlatformSettingsChange = (key: string | number, type: 'inApp' | 'email', newValue: boolean) => {
+    return onUpdatePlatformSettings(String(key), type, newValue);
+  };
 
-    if (platformAdminKeys.includes(key)) {
-      return onUpdatePlatformAdminSettings(key, type, value);
-    } else {
-      return onUpdatePlatformSettings(key, type, value);
-    }
+  const handlePlatformAdminSettingsChange = (key: string | number, type: 'inApp' | 'email', newValue: boolean) => {
+    return onUpdatePlatformAdminSettings(String(key), type, newValue);
   };
 
   return (
     <PageContentBlock>
       <BlockTitle>{t('pages.userNotificationsSettings.platformAdmin.title')}</BlockTitle>
-      <Caption>{t('pages.userNotificationsSettings.platformAdmin.subtitle')}</Caption>
-      <DualSwitchSettingsGroup options={allOptions} onChange={handleChange} />
+      <Caption>{t('pages.userNotificationsSettings.forum.subtitle')}</Caption>
+
+      {/* Forum notifications (always visible) */}
+      <DualSwitchSettingsGroup
+        options={Object.fromEntries(
+          Object.entries(allOptions).filter(
+            ([key]) =>
+              !['userProfileCreated', 'userProfileRemoved', 'userGlobalRoleChanged', 'spaceCreated'].includes(key)
+          )
+        )}
+        onChange={handlePlatformSettingsChange}
+      />
+
+      {/* Divider and platform admin settings */}
+      {isPlatformAdmin && (
+        <>
+          <Divider />
+          <Caption>{t('pages.userNotificationsSettings.platformAdmin.subtitle')}</Caption>
+          <DualSwitchSettingsGroup
+            options={Object.fromEntries(
+              Object.entries(allOptions).filter(([key]) =>
+                ['userProfileCreated', 'userProfileRemoved', 'userGlobalRoleChanged', 'spaceCreated'].includes(key)
+              )
+            )}
+            onChange={handlePlatformAdminSettingsChange}
+          />
+        </>
+      )}
     </PageContentBlock>
   );
 };

--- a/src/domain/community/userAdmin/tabs/components/CombinedSpaceNotificationsSettings.tsx
+++ b/src/domain/community/userAdmin/tabs/components/CombinedSpaceNotificationsSettings.tsx
@@ -154,7 +154,7 @@ export const CombinedSpaceNotificationsSettings = ({
       {/* Divider and space admin settings */}
       {showSpaceAdminSettings && (
         <>
-          <Divider sx={{ my: 3 }} />
+          <Divider />
           <Caption>{t('pages.userNotificationsSettings.spaceAdmin.subtitle')}</Caption>
           <DualSwitchSettingsGroup
             options={Object.fromEntries(


### PR DESCRIPTION
from the story:

- Less offset around switches, more space for the description.
- Divider on platform settings similar to the one in the spaces (separate the admin part).
- Show the in-app options only for beta testers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split notification settings into two sections: forum notifications (always visible) and platform admin notifications (shown only to admins), with clear subtitles and a divider.

* **Refactor**
  * Rebuilt the notification settings layout from grid to flexible rows for clearer labels and switch alignment.
  * In-app notification column now appears only when in-app notifications are enabled.
  * Preserved and streamlined per-item loading indicators.

* **Style**
  * Adjusted divider usage and spacing for improved visual separation between sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->