### PR TITLE
Memo fullscreen fixes

### DIFF
--- a/src/core/ui/forms/CollaborativeMarkdownInput/CollaborativeMarkdownInput.tsx
+++ b/src/core/ui/forms/CollaborativeMarkdownInput/CollaborativeMarkdownInput.tsx
@@ -22,6 +22,7 @@ interface MarkdownInputProps extends InputBaseComponentProps {
   onChangeCollaborationState?: (state: RealTimeCollaborationState) => void;
   disabled?: boolean;
   storageBucketId?: string;
+  fullScreen?: boolean;
 }
 
 export const CollaborativeMarkdownInput = memo<MarkdownInputProps>(
@@ -36,6 +37,7 @@ export const CollaborativeMarkdownInput = memo<MarkdownInputProps>(
     onChangeCollaborationState,
     disabled,
     storageBucketId = '',
+    fullScreen = false,
   }) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const toolbarRef = useRef<HTMLDivElement>(null);
@@ -144,7 +146,7 @@ export const CollaborativeMarkdownInput = memo<MarkdownInputProps>(
         onFocus={handleFocus}
         onBlur={handleBlur}
         sx={{
-          height: inputMinHeight,
+          height: fullScreen ? '100%' : inputMinHeight,
           display: 'flex',
           flexDirection: 'column',
           position: 'relative',

--- a/src/domain/collaboration/memo/MemoDialog/MemoDialog.tsx
+++ b/src/domain/collaboration/memo/MemoDialog/MemoDialog.tsx
@@ -65,7 +65,7 @@ const MemoDialog = ({ open = false, onClose, memoId, calloutId }: MemoDialogProp
             <ShareButton url={memo?.profile.url} entityTypeName="memo" disabled={!memo?.profile.url}>
               {hasUpdatePrivileges && <CollaborationSettings element={memo} elementType="memo" />}
             </ShareButton>
-            <FullscreenButton element={dialogRef.current || undefined} />
+            <FullscreenButton />
             <UserPresencing
               collaborationState={collaborationState}
               hideSaveRequestIndicator={

--- a/src/domain/collaboration/memo/MemoDialog/MemoDialog.tsx
+++ b/src/domain/collaboration/memo/MemoDialog/MemoDialog.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import DialogWithGrid, { DialogFooter } from '@/core/ui/dialog/DialogWithGrid';
 import CollaborativeMarkdownInput from '@/core/ui/forms/CollaborativeMarkdownInput/CollaborativeMarkdownInput';
@@ -9,13 +10,13 @@ import Loading from '@/core/ui/loading/Loading';
 import ShareButton from '@/domain/shared/components/ShareDialog/ShareButton';
 import { StorageConfigContextProvider } from '@/domain/storage/StorageBucket/StorageConfigContext';
 import FullscreenButton from '@/core/ui/button/FullscreenButton';
-import { useEffect, useRef, useState } from 'react';
 import UserPresencing from '../../realTimeCollaboration/UserPresencing';
 import { MemoStatus, RealTimeCollaborationState } from '../../realTimeCollaboration/RealTimeCollaborationState';
 import MemoFooter from './MemoFooter';
 import { AuthorizationPrivilege } from '@/core/apollo/generated/graphql-schema';
 import { useTranslation } from 'react-i18next';
 import CollaborationSettings from '../../realTimeCollaboration/CollaborationSettings/CollaborationSettings';
+import { useFullscreen } from '@/core/ui/fullscreen/useFullscreen';
 
 interface MemoDialogProps {
   open?: boolean;
@@ -26,29 +27,19 @@ interface MemoDialogProps {
 
 const MemoDialog = ({ open = false, onClose, memoId, calloutId }: MemoDialogProps) => {
   const { t } = useTranslation();
-  const [fullScreen, setFullScreen] = useState(false);
-  const [forceExitFullscreen, setForceExitFullscreen] = useState(false);
   const [collaborationState, setCollaborationState] = useState<RealTimeCollaborationState>();
   const dialogRef = useRef<HTMLDivElement>(null);
+  const { fullscreen, setFullscreen } = useFullscreen();
 
   const { memo, loading } = useMemoManager({ id: memoId });
 
   const handleClose = () => {
-    // Declaratively trigger fullscreen exit
-    setForceExitFullscreen(true);
-    setFullScreen(false);
+    if (fullscreen) {
+      setFullscreen(false);
+    }
+
     onClose?.();
   };
-
-  const handleDialogOpen = () => {
-    if (open) {
-      setForceExitFullscreen(false);
-    }
-  };
-
-  useEffect(() => {
-    handleDialogOpen();
-  }, [open]);
 
   const hasUpdatePrivileges = (memo?.authorization?.myPrivileges ?? []).includes(AuthorizationPrivilege.Update);
   const hasContributePrivileges = (memo?.authorization?.myPrivileges ?? []).includes(AuthorizationPrivilege.Contribute);
@@ -63,7 +54,7 @@ const MemoDialog = ({ open = false, onClose, memoId, calloutId }: MemoDialogProp
       onClose={handleClose}
       fullWidth
       fullHeight
-      fullScreen={fullScreen}
+      fullScreen={fullscreen}
       aria-labelledby="memo-dialog-title"
     >
       <DialogHeader
@@ -74,11 +65,7 @@ const MemoDialog = ({ open = false, onClose, memoId, calloutId }: MemoDialogProp
             <ShareButton url={memo?.profile.url} entityTypeName="memo" disabled={!memo?.profile.url}>
               {hasUpdatePrivileges && <CollaborationSettings element={memo} elementType="memo" />}
             </ShareButton>
-            <FullscreenButton
-              element={dialogRef.current || undefined}
-              onChange={setFullScreen}
-              forceExit={forceExitFullscreen}
-            />
+            <FullscreenButton element={dialogRef.current || undefined} />
             <UserPresencing
               collaborationState={collaborationState}
               hideSaveRequestIndicator={
@@ -119,6 +106,7 @@ const MemoDialog = ({ open = false, onClose, memoId, calloutId }: MemoDialogProp
                     controlsVisible: 'always',
                     collaborationId: memoId,
                     height: '100%',
+                    fullScreen: fullscreen,
                     onChangeCollaborationState: setCollaborationState,
                     storageBucketId: memo?.profile.storageBucket.id,
                   }}


### PR DESCRIPTION
Fixing:

- height of the memo in fullscreen;
- exit full screen with the escape key;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-screen mode to the collaborative markdown editor so it can occupy the full height when enabled.
  * Memo dialog passes the editor’s full-screen state for a more immersive writing experience.

* **Refactor**
  * Centralized and streamlined full-screen handling in the memo dialog for more consistent behavior.
  * Simplified the full-screen toggle integration and removed redundant lifecycle/state logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->