### PR TITLE
Tiptap: Don't try to access the editor until it's fully mounted

### DIFF
--- a/src/core/ui/forms/MarkdownInputControls/MarkdownInputControls.tsx
+++ b/src/core/ui/forms/MarkdownInputControls/MarkdownInputControls.tsx
@@ -60,9 +60,16 @@ const ControlsButton = memo(
   ({ editor, command, specs, ...buttonProps }: ControlsButtonProps) => {
     const isActiveArgs = specs && ((typeof specs === 'string' ? [specs] : specs) as Parameters<Editor['isActive']>);
 
-    const getActiveState = () => (isActiveArgs ? editor?.isActive(...isActiveArgs) : false);
+    const getActiveState = () => (isActiveArgs && editor ? editor.isActive(...isActiveArgs) : false);
 
-    const getDisabledState = () => !editor || !command(editor.can().chain().focus()).run();
+    const getDisabledState = () => {
+      if (!editor || !editor.view) return true;
+      try {
+        return !command(editor.can().chain().focus()).run();
+      } catch {
+        return true;
+      }
+    };
 
     const produceButtonState = (prevState: ButtonState = {}) =>
       produce(prevState, nextState => {
@@ -70,7 +77,7 @@ const ControlsButton = memo(
         nextState.disabled = getDisabledState();
       });
 
-    const [state, setState] = useState<ButtonState>(produceButtonState());
+    const [state, setState] = useState<ButtonState>({ disabled: true, active: false });
 
     const refreshOnEditorUpdate = (editor: Editor) => {
       const handleStateChange = async () => {


### PR DESCRIPTION
### Describe the background of your pull request

There is some problem with tiptap's integration into our react app, it only shows up when going from any other page/tab to the tab About in page Settings of a space or a subspace. the error is:

```
react-dom_client.js?v=ad4243ff:6411 Uncaught Error: There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root.
at throwException (react-dom_client.js?v=ad4243ff:6411:11)
at MessagePort.performWorkUntilDeadline (react-dom_client.js?v=ad4243ff:36:50)Caused by: Error: [tiptap error]: The editor view is not available. Cannot access view['hasFocus']. The editor may not be mounted yet.
at getDisabledState (MarkdownInputControls.tsx:65:77)
at MarkdownInputControls.tsx:70:30
at produceButtonState (MarkdownInputControls.tsx:68:7)
at ControlsButton (MarkdownInputControls.tsx:73:53)
```

### Additional context

[Performance guides](https://tiptap.dev/docs/guides/performance)

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
