### PR TITLE
Dropping portuguese from supported languages (for now)

### DIFF
--- a/src/core/i18n/config.ts
+++ b/src/core/i18n/config.ts
@@ -7,7 +7,7 @@ import { env } from '@/main/env';
 export const defaultNS = 'translation';
 
 const defaultLang = 'en';
-export const supportedLngs = [defaultLang, 'nl', 'es', 'bg', 'de', 'fr', 'pt'];
+export const supportedLngs = [defaultLang, 'nl', 'es', 'bg', 'de', 'fr'];
 
 if (env?.VITE_APP_IN_CONTEXT_TRANSLATION === 'true') {
   supportedLngs.push('inContextTool');


### PR DESCRIPTION
Dropping this due to constraints in Crowdin.
Cleared with product.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported languages by removing Portuguese.
  * Portuguese will no longer appear as an option in language settings.
  * Users previously set to Portuguese will fall back to their default or next available language.
  * No changes to how translations are loaded or applied for remaining languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->