### PR TITLE
Remove the betaTesters only condition for in-app isEnabled.

### DIFF
--- a/src/main/inAppNotifications/InAppNotificationsContext.tsx
+++ b/src/main/inAppNotifications/InAppNotificationsContext.tsx
@@ -1,4 +1,3 @@
-import { RoleName } from '@/core/apollo/generated/graphql-schema';
 import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
 import { createContext, useState, useContext, ReactNode, useMemo } from 'react';
 
@@ -20,8 +19,9 @@ export const InAppNotificationsProvider = ({ children }: { children: ReactNode }
   const { userModel, platformRoles } = useCurrentUserContext();
   const [isOpen, setIsOpen] = useState(false);
 
+  // let's keep that logic in case we want to enable/disable the feature in the future
   const isEnabled = useMemo(() => {
-    return Boolean(userModel?.id && platformRoles?.includes(RoleName.PlatformBetaTester));
+    return Boolean(userModel?.id);
   }, [userModel, platformRoles]);
 
   return <InAppNotifications value={{ isEnabled, isOpen, setIsOpen }}>{children}</InAppNotifications>;


### PR DESCRIPTION
Works together with: https://github.com/alkem-io/server/pull/5486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - In-app notifications are now enabled for all signed-in users, no longer limited to beta testers. Once authenticated, users will automatically see notifications wherever supported in the app, improving visibility of updates, alerts, and reminders. Logged-out users remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->