### PR TITLE
Hide wbPreviewSettings button when not able to edit + Fix wbPreview visualization issue on mobile

### DIFF
--- a/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDialog/WhiteboardDialog.tsx
@@ -8,7 +8,7 @@ import Loading from '@/core/ui/loading/Loading';
 import { useNotification } from '@/core/ui/notifications/useNotification';
 import { Identifiable } from '@/core/utils/Identifiable';
 import CollaborativeExcalidrawWrapper from '@/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper';
-import { CollabAPI } from '@/domain/common/whiteboard/excalidraw/collab/useCollab';
+import { CollabAPI, CollabState } from '@/domain/common/whiteboard/excalidraw/collab/useCollab';
 import useWhiteboardFilesManager from '@/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager';
 import useLoadingState from '@/domain/shared/utils/useLoadingState';
 import WhiteboardDialogTemplatesLibrary from '@/domain/templates/components/WhiteboardDialog/WhiteboardDialogTemplatesLibrary';
@@ -77,7 +77,7 @@ interface WhiteboardDialogProps {
     show: boolean;
     canEdit?: boolean;
     canDelete?: boolean;
-    headerActions?: ReactNode;
+    headerActions?: (state: CollabState) => ReactNode;
     dialogTitle: ReactNode;
     fullscreen?: boolean;
     allowFilesAttached?: boolean;
@@ -283,7 +283,7 @@ const WhiteboardDialog = ({ entities, actions, options, state, lastSuccessfulSav
           onSceneInitChange: setSceneInitialized,
         }}
       >
-        {({ children, mode, modeReason, restartCollaboration }) => {
+        {({ children, mode, modeReason, collaborating, connecting, restartCollaboration }) => {
           return (
             <Formik
               innerRef={formikRef}
@@ -301,7 +301,7 @@ const WhiteboardDialog = ({ entities, actions, options, state, lastSuccessfulSav
                 fullScreen={options.fullscreen || columns <= 4}
               >
                 <DialogHeader
-                  actions={options.headerActions}
+                  actions={options.headerActions?.({ mode, modeReason, collaborating, connecting })}
                   onClose={onClose}
                   titleContainerProps={{ flexDirection: 'row', gap: 0, marginRight: -1 }}
                 >
@@ -312,7 +312,7 @@ const WhiteboardDialog = ({ entities, actions, options, state, lastSuccessfulSav
                     onChangeDisplayName={newDisplayName => actions.onChangeDisplayName(whiteboard?.id, newDisplayName)}
                   />
                   <WhiteboardDialogTemplatesLibrary
-                    editModeEnabled={editModeEnabled}
+                    editModeEnabled={editModeEnabled && mode === 'write'}
                     disabled={!isSceneInitialized}
                     onImportTemplate={handleImportTemplate}
                   />

--- a/src/domain/collaboration/whiteboard/WhiteboardPreview/WhiteboardPreview.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardPreview/WhiteboardPreview.tsx
@@ -102,6 +102,9 @@ const WhiteboardChipButton = ({ disableClick, ...props }: ButtonProps & { disabl
         left: gutters(1)(theme),
         textTransform: 'none',
         pointerEvents: disableClick ? 'none' : 'auto',
+        [theme.breakpoints.down('sm')]: {
+          display: 'none',
+        },
       })}
       aria-label={
         disableClick ? t('pages.whiteboard.preview.ariaLabelDisabled') : t('pages.whiteboard.preview.ariaLabel')

--- a/src/domain/collaboration/whiteboard/WhiteboardsManagement/WhiteboardView.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardsManagement/WhiteboardView.tsx
@@ -9,6 +9,7 @@ import CollaborationSettings from '../../realTimeCollaboration/CollaborationSett
 import { SaveRequestIndicatorIcon } from '@/domain/collaboration/realTimeCollaboration/SaveRequestIndicatorIcon';
 import { useWhiteboardLastUpdatedDateQuery } from '@/core/apollo/generated/apollo-hooks';
 import WhiteboardPreviewSettingsButton from '../WhiteboardPreviewSettings/WhiteboardPreviewSettingsButton';
+import { CollabState } from '@/domain/common/whiteboard/excalidraw/collab/useCollab';
 
 export interface ActiveWhiteboardIdHolder {
   whiteboardId?: string;
@@ -102,7 +103,7 @@ const WhiteboardView = ({
             readOnlyDisplayName: readOnlyDisplayName || !hasUpdatePrivileges,
             fullscreen,
             previewSettingsDialogOpen: previewSettingsDialogOpen,
-            headerActions: (
+            headerActions: (collabState: CollabState) => (
               <>
                 <ShareButton url={whiteboardShareUrl} entityTypeName="whiteboard" disabled={!whiteboardShareUrl}>
                   {hasUpdatePrivileges && <CollaborationSettings element={whiteboard} elementType="whiteboard" />}
@@ -112,7 +113,9 @@ const WhiteboardView = ({
 
                 <SaveRequestIndicatorIcon isSaved={consecutiveSaveErrors < 6} date={lastSuccessfulSavedDate} />
 
-                <WhiteboardPreviewSettingsButton onClick={() => setPreviewSettingsDialogOpen(true)} />
+                {hasUpdateContentPrivileges && collabState.mode === 'write' && (
+                  <WhiteboardPreviewSettingsButton onClick={() => setPreviewSettingsDialogOpen(true)} />
+                )}
               </>
             ),
           }}

--- a/src/domain/space/components/CreateSpace/hooks/useSubspaceCreation/useSubspaceCreation.ts
+++ b/src/domain/space/components/CreateSpace/hooks/useSubspaceCreation/useSubspaceCreation.ts
@@ -52,7 +52,6 @@ export const useSubspaceCreation = (mutationOptions: CreateSubspaceMutationOptio
     ...restMutationOptions
   } = mutationOptions;
 
-  console.log('in useSubspaceCreation, mutationOptions:', mutationOptions);
   const [createSubspaceLazy, { loading }] = useCreateSubspaceMutation({
     update: (cache, { data }) => {
       if (subscriptionsEnabled || !data) {


### PR DESCRIPTION
#8951 
#8797 

- Hide the top left tag "Whiteboard" on mobile so it doesn't overlap with the "Click to open whiteboard" button
- Made header actions a callback function so it can receive the state of the collaboration and return the buttons accordingly
- Also hidden the Find templates button, that shouldn't be available in read only mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Whiteboard collaboration state now controls editing capabilities and settings visibility based on user permissions and write mode.

* **Bug Fixes**
  * Improved responsive design by hiding whiteboard chip button on small screens.

* **Chores**
  * Removed debug logging statement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->