### PR TITLE
Fix recent spaces layout if less than 3 memberships available.

### DIFF
--- a/src/main/topLevelPages/myDashboard/recentSpaces/RecentSpacesList.tsx
+++ b/src/main/topLevelPages/myDashboard/recentSpaces/RecentSpacesList.tsx
@@ -19,8 +19,13 @@ const RecentSpacesList = ({ onSeeMore }: RecentSpacesListProps) => {
 
   const { data } = useRecentSpacesQuery({ variables: { limit: visibleSpaces } });
 
+  // an edge case, a different layout should be shown in this case
+  if (!data?.me.mySpaces.length) {
+    return null;
+  }
+
   return (
-    <Gutters disablePadding>
+    <Gutters disablePadding sx={{ width: '100%' }}>
       <Gutters row disablePadding>
         {data?.me.mySpaces.slice(0, visibleSpaces).map(result => (
           <GridItem key={result.space.id} columns={cardColumns}>
@@ -35,9 +40,11 @@ const RecentSpacesList = ({ onSeeMore }: RecentSpacesListProps) => {
           </GridItem>
         ))}
       </Gutters>
-      <Button endIcon={<DoubleArrowOutlined />} sx={{ textTransform: 'none' }} onClick={onSeeMore}>
-        <Caption>{t('pages.home.sections.recentSpaces.seeMore')}</Caption>
-      </Button>
+      {data?.me.mySpaces.length >= visibleSpaces && (
+        <Button endIcon={<DoubleArrowOutlined />} sx={{ textTransform: 'none' }} onClick={onSeeMore}>
+          <Caption>{t('pages.home.sections.recentSpaces.seeMore')}</Caption>
+        </Button>
+      )}
     </Gutters>
   );
 };


### PR DESCRIPTION
Fixing:

<img width="1388" height="670" alt="Screenshot 2025-11-20 at 16 18 26" src="https://github.com/user-attachments/assets/6170e3f0-fb9c-46a0-930d-169ab59fde44" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed display handling for cases with no recent spaces.
  * "See More" button now only appears when additional spaces are available to view.

* **Style**
  * Recent spaces section now spans full width of the dashboard for better space utilization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->