### PR TITLE
Encodes guest name for public requests

### DIFF
--- a/src/core/apollo/graphqlLinks/guestHeaderLink.ts
+++ b/src/core/apollo/graphqlLinks/guestHeaderLink.ts
@@ -4,6 +4,19 @@ import { ApolloLink } from '@apollo/client';
  * Apollo Link middleware to inject x-guest-name header for public routes
  * Reads guest name from session storage and adds it to GraphQL requests
  */
+/**
+ * Encodes a string to Base64, handling Unicode characters properly.
+ * This is necessary because HTTP headers only support ISO-8859-1 characters.
+ */
+const encodeToBase64 = (str: string): string => {
+  // TextEncoder converts the string to UTF-8 bytes
+  const bytes = new TextEncoder().encode(str);
+  // Convert bytes to a binary string
+  const binaryString = Array.from(bytes, byte => String.fromCharCode(byte)).join('');
+  // Encode to Base64
+  return btoa(binaryString);
+};
+
 export const guestHeaderLink = new ApolloLink((operation, forward) => {
   // Only inject header for public whiteboard routes
   if (globalThis.window?.location.pathname.startsWith('/public/whiteboard')) {
@@ -14,7 +27,7 @@ export const guestHeaderLink = new ApolloLink((operation, forward) => {
         operation.setContext(({ headers = {} }) => ({
           headers: {
             ...headers,
-            'x-guest-name': guestName,
+            'x-guest-name': encodeToBase64(guestName),
           },
         }));
       }

--- a/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
+++ b/src/domain/common/whiteboard/excalidraw/useWhiteboardFilesManager.ts
@@ -50,11 +50,24 @@ const blobToDataURL = (blob: Blob): Promise<string> => {
   });
 };
 
+/**
+ * Encodes a string to Base64, handling Unicode characters properly.
+ * This is necessary because HTTP headers only support ISO-8859-1 characters.
+ */
+const encodeToBase64 = (str: string): string => {
+  // TextEncoder converts the string to UTF-8 bytes
+  const bytes = new TextEncoder().encode(str);
+  // Convert bytes to a binary string
+  const binaryString = Array.from(bytes, byte => String.fromCharCode(byte)).join('');
+  // Encode to Base64
+  return btoa(binaryString);
+};
+
 const fetchFileToDataURL = async (url: string, guestName?: string | null): Promise<string> => {
-  const headers = {};
+  const headers: Record<string, string> = {};
 
   if (guestName) {
-    Object.assign(headers, { 'x-guest-name': guestName });
+    Object.assign(headers, { 'x-guest-name': encodeToBase64(guestName) });
   }
   const response = await fetch(url, { headers });
 


### PR DESCRIPTION
Ensures proper handling of Unicode characters in guest names
by encoding them to Base64 before sending in HTTP headers.
This resolves potential issues with ISO-8859-1 compatibility
for public whiteboard requests.

Use the same branch from the server as well
