### PR TITLE
no parentInfo on space subspaces page

### DIFF
--- a/src/domain/space/layout/tabbedLayout/Tabs/SpaceSubspacesPage.tsx
+++ b/src/domain/space/layout/tabbedLayout/Tabs/SpaceSubspacesPage.tsx
@@ -50,7 +50,7 @@ const SpaceSubspacesPage = () => {
   const subspaces = space?.subspaces ?? [];
 
   // Use shared hook for parent info and avatar stacking
-  const { parentInfo, collectAvatars } = useSubspaceCardData(space);
+  const { collectAvatars } = useSubspaceCardData(space);
 
   const { sendMessage, directMessageDialog } = useDirectMessageDialog({
     dialogTitle: t('send-message-dialog.direct-message-title'),
@@ -106,7 +106,6 @@ const SpaceSubspacesPage = () => {
             leadOrganizations={item.about.membership?.leadOrganizations}
             showLeads={isAuthenticated}
             onContactLead={handleContactLead}
-            parentInfo={parentInfo}
             avatarUris={collectAvatars(item)}
           />
         )}


### PR DESCRIPTION
Requested in the bug channel:

<img width="789" height="339" alt="Screenshot 2025-12-22 at 13 08 47" src="https://github.com/user-attachments/assets/9c59f148-d569-4d0d-99c2-c2465f4f06f2" />


And part of:
https://github.com/alkem-io/client-web/issues/9082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the subspace card data flow by removing unnecessary property passing. This streamlines the internal component structure while maintaining all existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->