### PR TITLE
chore: update footer copyright year translations

### DIFF
--- a/src/core/i18n/bg/translation.bg.json
+++ b/src/core/i18n/bg/translation.bg.json
@@ -2231,7 +2231,7 @@
     "feedback": "Обратна връзка",
     "support": "Поддръжка",
     "about": "За нас",
-    "copyright": "© 2025 Alkemio B.V."
+    "copyright": "© 2026 Alkemio B.V."
   },
   "innovationHub": {
     "selectedSpaces": "{{space}} $t(common.spaces)",

--- a/src/core/i18n/de/translation.de.json
+++ b/src/core/i18n/de/translation.de.json
@@ -2231,7 +2231,7 @@
     "feedback": "Rückmeldung",
     "support": "Kundendienst",
     "about": "Über",
-    "copyright": "© 2025 Alkemio B.V."
+    "copyright": "© 2026 Alkemio B.V."
   },
   "innovationHub": {
     "selectedSpaces": "{{space}} $t(common.spaces)",

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -2247,7 +2247,7 @@
     "feedback": "Feedback",
     "support": "Support",
     "about": "About",
-    "copyright": "© 2025 Alkemio B.V."
+    "copyright": "© 2026 Alkemio B.V."
   },
   "innovationHub": {
     "selectedSpaces": "{{space}} $t(common.spaces)",

--- a/src/core/i18n/es/translation.es.json
+++ b/src/core/i18n/es/translation.es.json
@@ -2231,7 +2231,7 @@
     "feedback": "Comentarios",
     "support": "Soporte",
     "about": "Acerca de",
-    "copyright": "© 2025 Alkemio B.V."
+    "copyright": "© 2026 Alkemio B.V."
   },
   "innovationHub": {
     "selectedSpaces": "{{space}} $t(common.spaces)",

--- a/src/core/i18n/fr/translation.fr.json
+++ b/src/core/i18n/fr/translation.fr.json
@@ -2231,7 +2231,7 @@
     "feedback": "Vos commentaires",
     "support": "Assistance",
     "about": "À propos de",
-    "copyright": "© 2025 Alkemio B.V."
+    "copyright": "© 2026 Alkemio B.V."
   },
   "innovationHub": {
     "selectedSpaces": "{{space}} $t(common.spaces)",

--- a/src/core/i18n/nl/translation.nl.json
+++ b/src/core/i18n/nl/translation.nl.json
@@ -2231,7 +2231,7 @@
     "feedback": "Feedback",
     "support": "Ondersteuning",
     "about": "Over",
-    "copyright": "© 2025 Alkemio B.V."
+    "copyright": "© 2026 Alkemio B.V."
   },
   "innovationHub": {
     "selectedSpaces": "{{space}} $t(common.spaces)",


### PR DESCRIPTION
## Summary
- update footer copyright strings across supported locales from 2025 to 2026

## Testing
- not run (string-only change)

Closes #9198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year from 2025 to 2026 in the footer across all supported languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->