### PR TITLE
Added Base64 encoding utility for Unicode-safe HTTP headers

### DIFF
--- a/src/core/apollo/graphqlLinks/guestHeaderLink.ts
+++ b/src/core/apollo/graphqlLinks/guestHeaderLink.ts
@@ -1,21 +1,10 @@
 import { ApolloLink } from '@apollo/client';
+import { encodeToBase64 } from '@/core/utils/encodeToBase64';
 
 /**
  * Apollo Link middleware to inject x-guest-name header for public routes
  * Reads guest name from session storage and adds it to GraphQL requests
  */
-/**
- * Encodes a string to Base64, handling Unicode characters properly.
- * This is necessary because HTTP headers only support ISO-8859-1 characters.
- */
-const encodeToBase64 = (str: string): string => {
-  // TextEncoder converts the string to UTF-8 bytes
-  const bytes = new TextEncoder().encode(str);
-  // Convert bytes to a binary string
-  const binaryString = Array.from(bytes, byte => String.fromCharCode(byte)).join('');
-  // Encode to Base64
-  return btoa(binaryString);
-};
 
 export const guestHeaderLink = new ApolloLink((operation, forward) => {
   // Only inject header for public whiteboard routes

--- a/src/core/utils/encodeToBase64.ts
+++ b/src/core/utils/encodeToBase64.ts
@@ -1,0 +1,9 @@
+/**
+ * Encodes a string to Base64 with Unicode-safe handling.
+ * HTTP headers only support ISO-8859-1, so Unicode must be encoded.
+ */
+export const encodeToBase64 = (value: string): string => {
+  const bytes = new TextEncoder().encode(value);
+  const binaryString = Array.from(bytes, byte => String.fromCharCode(byte)).join('');
+  return btoa(binaryString);
+};

--- a/src/domain/common/whiteboard/excalidraw/fileStore/FileDownloader.ts
+++ b/src/domain/common/whiteboard/excalidraw/fileStore/FileDownloader.ts
@@ -1,4 +1,5 @@
 import { error, TagCategoryValues } from '@/core/logging/sentry/log';
+import { encodeToBase64 } from '@/core/utils/encodeToBase64';
 import { fetchFileToDataURL } from './fileConverters';
 import type { BinaryFileDataWithUrl, BinaryFileDataWithOptionalUrl } from '../types';
 
@@ -27,7 +28,7 @@ export class FileDownloader {
 
     const headers: Record<string, string> = {};
     if (options?.guestName) {
-      headers['x-guest-name'] = options.guestName;
+      headers['x-guest-name'] = encodeToBase64(options.guestName);
     }
 
     try {


### PR DESCRIPTION
## Bug
Guest users with cyrilic names were not able to download images on whiteboards.

## Summary
Root cause was a Unicode guest name being written directly to an HTTP header for file downloads; browsers reject non-ISO-8859-1 header values, so fetch throws before any request is sent. I encoded guest names to Base64 for file downloads (matching the GraphQL header) and centralized the encoding helper for consistent handling across the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of guest names with special characters and Unicode characters in HTTP headers through centralized encoding utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->