### PR TITLE
Reload on join to community notification click

### DIFF
--- a/src/main/inAppNotifications/views/InAppNotificationBaseView.tsx
+++ b/src/main/inAppNotifications/views/InAppNotificationBaseView.tsx
@@ -35,6 +35,7 @@ interface InAppNotificationBaseViewProps {
   notification: InAppNotificationModel;
   values: Record<string, string | undefined>;
   url: string | undefined;
+  forceReload?: boolean;
 }
 
 const Wrapper = <D extends React.ElementType = ListItemButtonTypeMap['defaultComponent'], P = {}>(
@@ -48,7 +49,12 @@ const getSpaceAvatar = (space?: {
   return space?.about?.profile?.avatar?.uri || space?.about?.profile?.cardBanner?.uri || null;
 };
 
-export const InAppNotificationBaseView = ({ notification, values, url }: InAppNotificationBaseViewProps) => {
+export const InAppNotificationBaseView = ({
+  notification,
+  values,
+  url,
+  forceReload,
+}: InAppNotificationBaseViewProps) => {
   const { id, state, triggeredAt, triggeredBy, payload, type } = notification;
 
   const { t } = useTranslation();
@@ -62,8 +68,11 @@ export const InAppNotificationBaseView = ({ notification, values, url }: InAppNo
     }
     if (url) {
       setIsOpen(false);
+      if (forceReload) {
+        window.location.href = url;
+      }
     }
-  }, [id, url, state]);
+  }, [id, url, state, forceReload]);
 
   const getReadAction = useCallback(() => {
     switch (state) {
@@ -158,7 +167,7 @@ export const InAppNotificationBaseView = ({ notification, values, url }: InAppNo
     <>
       <BadgeCardView
         component={Wrapper}
-        to={url}
+        to={forceReload ? undefined : url}
         onClick={onNotificationClick}
         paddingLeft={isMobile ? gutters(0.5) : gutters(2)}
         paddingY={gutters(0.5)}

--- a/src/main/inAppNotifications/views/user/InAppUserSpaceCommunityJoinedView.tsx
+++ b/src/main/inAppNotifications/views/user/InAppUserSpaceCommunityJoinedView.tsx
@@ -18,6 +18,7 @@ export const InAppUserSpaceCommunityJoinedView = (notification: InAppNotificatio
       notification={notification}
       values={notificationTextValues}
       url={payload.space?.about?.profile?.url}
+      forceReload
     />
   );
 };


### PR DESCRIPTION
Extend the notifications to support force reload instead of SPA navigation.

This fixes some edge cases where:

1. we have a subscription for in-app;
2. receiving an accepted application (join);
3. the application state is not refreshed on the space;
4. SPA navigation shows previous state;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for full page reload behavior in in-app notifications. When enabled, clicking certain notifications will refresh the entire page instead of using internal navigation, ensuring all data and UI are fully up-to-date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->