### PR TITLE
Fixes: R46 - Application form and registration form

### DIFF
--- a/src/core/auth/authentication/pages/RegistrationPage.tsx
+++ b/src/core/auth/authentication/pages/RegistrationPage.tsx
@@ -110,8 +110,6 @@ export const RegistrationPage = ({ flow }: { flow?: string }) => {
       <Card
         sx={{
           maxWidth: { xs: '100%', sm: '100%', md: '444px' },
-          minWidth: '375px',
-          marginTop: { xs: 1, sm: 1, md: 20 },
           height: 'fit-content',
         }}
       >

--- a/src/domain/community/applicationButton/ApplicationDialog.tsx
+++ b/src/domain/community/applicationButton/ApplicationDialog.tsx
@@ -142,7 +142,7 @@ const ApplicationDialog = ({
                     <FormikInputField
                       key={i}
                       title={x.question}
-                      name={`['${x.question}']`}
+                      name={`['${x.question.replace(/'/g, "\\'")}']`}
                       rows={2}
                       multiline
                       required={x.required}


### PR DESCRIPTION
Fix for a couple of problems spotted testing release 46.

- The new "Apply for a community" form has a quote `'` in the question (see [#server 5822](https://github.com/alkem-io/server/pull/5822)) that causes apply to a community to fail because the object sent to the server gets built with a quote. This is an existing issue in production.
- The Registration form was like this on certain resolutions:
<img width="537" height="711" alt="image" src="https://github.com/user-attachments/assets/d51d3dd7-f181-4e89-beb5-3ec00763a7ab" />
