### PR TITLE
Fix the order of comment replies

### DIFF
--- a/src/domain/communication/room/Comments/useMessagesTree.ts
+++ b/src/domain/communication/room/Comments/useMessagesTree.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { groupBy } from 'lodash';
+import { groupBy, sortBy } from 'lodash';
 import { Identifiable } from '@/core/utils/Identifiable';
 
 const ROOT_THREAD = Symbol('root');
@@ -25,7 +25,8 @@ export const buildMessagesTree = <Message extends IdentifiableReply>(
 
   return groupedMessages?.[ROOT_THREAD]?.map(message => ({
     ...message,
-    replies: groupedMessages[message.id],
+    replies:
+      groupedMessages[message.id] && sortBy(groupedMessages[message.id], r => ('createdAt' in r ? r.createdAt : 0)),
   }));
 };
 


### PR DESCRIPTION
Putting the PR in draft as Evgeni has arguments agains the fix. TBD

The comments are ordered now newest first.
However, the replies are a separate thread and they need to be ordered oldest first. This PR fixes the order of the replies.

