### PR TITLE
Fix about dialog edit links

### DIFF
--- a/src/domain/space/about/SpaceAboutDialog.tsx
+++ b/src/domain/space/about/SpaceAboutDialog.tsx
@@ -264,7 +264,7 @@ const SpaceAboutDialog = ({
                   description={about.why}
                   loading={loading}
                   canEdit={hasEditPrivilege}
-                  onEditClick={openEditDialog}
+                  onEditClick={() => openEditDialog('/about#why')}
                 />
               </PageContentBlock>
             )}
@@ -277,7 +277,7 @@ const SpaceAboutDialog = ({
                   description={about.who}
                   loading={loading}
                   canEdit={hasEditPrivilege}
-                  onEditClick={openEditDialog}
+                  onEditClick={() => openEditDialog('/about#who')}
                 />
               </PageContentBlock>
             )}
@@ -292,7 +292,7 @@ const SpaceAboutDialog = ({
                   title={t('components.referenceSegment.title')}
                   loading={loading}
                   canEdit={hasEditPrivilege}
-                  onEditClick={openEditDialog}
+                  onEditClick={() => openEditDialog('/about')}
                 >
                   <Box paddingTop={gutters(1)}>
                     <References references={aboutProfile?.references} />

--- a/src/domain/space/about/SpaceAboutSegment.tsx
+++ b/src/domain/space/about/SpaceAboutSegment.tsx
@@ -3,6 +3,7 @@ import * as yup from 'yup';
 import { SMALL_TEXT_LENGTH, MARKDOWN_TEXT_LENGTH } from '@/core/ui/forms/field-length.constants';
 import MarkdownValidator from '@/core/ui/forms/MarkdownInput/MarkdownValidator';
 import { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
+import { Box } from '@mui/material';
 import FormikMarkdownField from '@/core/ui/forms/MarkdownInput/FormikMarkdownFieldLazy';
 import Gutters from '@/core/ui/grid/Gutters';
 import { useScreenSize } from '@/core/ui/grid/constants';
@@ -25,7 +26,7 @@ export const SpaceAboutSegment = ({ loading, spaceLevel }: ContextSegmentProps &
   const { isMediumSmallScreen } = useScreenSize();
   return (
     <Gutters disablePadding>
-      <Gutters disableGap disablePadding>
+      <Gutters id="description" disableGap disablePadding>
         <FormikMarkdownField
           name="description"
           title={t(`context.${spaceLevel}.description.title` as const)}
@@ -37,25 +38,29 @@ export const SpaceAboutSegment = ({ loading, spaceLevel }: ContextSegmentProps &
         />
       </Gutters>
       <Gutters disablePadding row={!isMediumSmallScreen}>
-        <FormikMarkdownField
-          name="why"
-          title={t(`context.${spaceLevel}.why.title` as const)}
-          placeholder={t(`context.${spaceLevel}.why.title` as const)}
-          helperText={t(`context.${spaceLevel}.why.description` as const)}
-          rows={10}
-          maxLength={MARKDOWN_TEXT_LENGTH}
-          loading={loading}
-        />
+        <Box id="why" flex={1} minWidth={0}>
+          <FormikMarkdownField
+            name="why"
+            title={t(`context.${spaceLevel}.why.title` as const)}
+            placeholder={t(`context.${spaceLevel}.why.title` as const)}
+            helperText={t(`context.${spaceLevel}.why.description` as const)}
+            rows={10}
+            maxLength={MARKDOWN_TEXT_LENGTH}
+            loading={loading}
+          />
+        </Box>
 
-        <FormikMarkdownField
-          name="who"
-          title={t(`context.${spaceLevel}.who.title` as const)}
-          placeholder={t(`context.${spaceLevel}.who.title` as const)}
-          helperText={t(`context.${spaceLevel}.who.description` as const)}
-          rows={10}
-          maxLength={MARKDOWN_TEXT_LENGTH}
-          loading={loading}
-        />
+        <Box id="who" flex={1} minWidth={0}>
+          <FormikMarkdownField
+            name="who"
+            title={t(`context.${spaceLevel}.who.title` as const)}
+            placeholder={t(`context.${spaceLevel}.who.title` as const)}
+            helperText={t(`context.${spaceLevel}.who.description` as const)}
+            rows={10}
+            maxLength={MARKDOWN_TEXT_LENGTH}
+            loading={loading}
+          />
+        </Box>
       </Gutters>
     </Gutters>
   );

--- a/src/domain/spaceAdmin/SpaceAdminAbout/SpaceAdminAboutPage.tsx
+++ b/src/domain/spaceAdmin/SpaceAdminAbout/SpaceAdminAboutPage.tsx
@@ -33,8 +33,25 @@ const SpaceAdminAboutPage: FC<SpaceAdminAboutPageProps> = ({ useL0Layout, spaceI
 
   useEffect(() => {
     if (hash) {
-      const element = document.getElementById(hash.slice(1));
-      element?.scrollIntoView({ behavior: 'smooth' });
+      const scrollToHash = () => {
+        const element = document.getElementById(hash.slice(1));
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth' });
+          return true;
+        }
+        return false;
+      };
+
+      if (!scrollToHash()) {
+        // Element may not be rendered yet due to async data loading; retry with observer
+        const observer = new MutationObserver(() => {
+          if (scrollToHash()) {
+            observer.disconnect();
+          }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        return () => observer.disconnect();
+      }
     }
   }, [hash]);
 
@@ -87,7 +104,7 @@ const SpaceAdminAboutPage: FC<SpaceAdminAboutPageProps> = ({ useL0Layout, spaceI
             <SaveButton loading={loading} onClick={() => profileFormRef.current?.submit()} />
           </Actions>
         </PageContentBlock>
-        <PageContentBlock id="description">
+        <PageContentBlock>
           <PageContentBlockHeader title={t('common.description')} />
           <SpaceAboutView />
         </PageContentBlock>


### PR DESCRIPTION
At some point the logic for anchor links in about dialog (to about fields) regressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth scrolling functionality with improved handling for navigating to specific sections in the About page, including retry mechanisms for dynamically-loaded content.

* **Bug Fixes**
  * Fixed navigation anchors for the "why" and "who" sections to ensure reliable linking within the About page.

* **Style**
  * Improved layout structure and spacing of form fields in the About sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->