### PR TITLE
Fix memory leak on apollo error

### DIFF
--- a/src/core/apollo/graphqlLinks/useErrorHandlerLink.ts
+++ b/src/core/apollo/graphqlLinks/useErrorHandlerLink.ts
@@ -1,5 +1,6 @@
 import { ApolloError } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
+import { useMemo, useRef } from 'react';
 import { AlkemioGraphqlErrorCode } from '@/main/constants/errors';
 import { useApolloErrorHandler } from '../hooks/useApolloErrorHandler';
 
@@ -12,23 +13,31 @@ const EXCLUDE_FROM_GLOBAL_HANDLER_ERRORS = [
 
 export const useErrorHandlerLink = () => {
   const handleError = useApolloErrorHandler();
+  const handleErrorRef = useRef(handleError);
+  handleErrorRef.current = handleError;
 
-  return onError(({ graphQLErrors, networkError, operation }) => {
-    // Check if this operation should skip global error handling
-    const { skipGlobalErrorHandler } = operation.getContext();
-    if (skipGlobalErrorHandler) {
-      return;
-    }
+  // onError() is an external library call the React Compiler cannot auto-memoize.
+  // Use the "latest ref" pattern: create the link once, always call the latest handler.
+  return useMemo(
+    () =>
+      onError(({ graphQLErrors, networkError, operation }) => {
+        // Check if this operation should skip global error handling
+        const { skipGlobalErrorHandler } = operation.getContext();
+        if (skipGlobalErrorHandler) {
+          return;
+        }
 
-    const nonForbiddenGraphqlErrors = graphQLErrors?.filter(
-      x => !EXCLUDE_FROM_GLOBAL_HANDLER_ERRORS.includes(x.extensions?.code as AlkemioGraphqlErrorCode)
-    );
-    handleError(
-      new ApolloError({
-        graphQLErrors: nonForbiddenGraphqlErrors,
-        networkError,
-        extraInfo: 'Error caught from the errorReporterLink',
-      })
-    );
-  });
+        const nonForbiddenGraphqlErrors = graphQLErrors?.filter(
+          x => !EXCLUDE_FROM_GLOBAL_HANDLER_ERRORS.includes(x.extensions?.code as AlkemioGraphqlErrorCode)
+        );
+        handleErrorRef.current(
+          new ApolloError({
+            graphQLErrors: nonForbiddenGraphqlErrors,
+            networkError,
+            extraInfo: 'Error caught from the errorReporterLink',
+          })
+        );
+      }),
+    []
+  );
 };

--- a/src/core/apollo/graphqlLinks/useErrorLoggerLink.ts
+++ b/src/core/apollo/graphqlLinks/useErrorLoggerLink.ts
@@ -1,4 +1,5 @@
 import { onError } from '@apollo/client/link/error';
+import { useMemo, useRef } from 'react';
 import { useApm } from '@/core/analytics/apm/context';
 import { error as sentryError, TagCategoryValues } from '@/core/logging/sentry/log';
 
@@ -16,25 +17,36 @@ const getErrorMessage = (error: Error) => {
  */
 export const useErrorLoggerLink = (errorLogging = false) => {
   const apm = useApm();
+  const apmRef = useRef(apm);
+  apmRef.current = apm;
 
-  return onError(({ graphQLErrors, networkError }) => {
-    if (!errorLogging) {
-      return;
-    }
+  const errorLoggingRef = useRef(errorLogging);
+  errorLoggingRef.current = errorLogging;
 
-    const errors: Error[] = [];
-    if (graphQLErrors) {
-      errors.push(...(graphQLErrors as Error[]));
-    }
+  // onError() is an external library call the React Compiler cannot auto-memoize.
+  // Use the "latest ref" pattern: create the link once, always call the latest values.
+  return useMemo(
+    () =>
+      onError(({ graphQLErrors, networkError }) => {
+        if (!errorLoggingRef.current) {
+          return;
+        }
 
-    if (networkError) {
-      networkError.message = `[Network error]: ${networkError.message}`;
-      errors.push(networkError);
-    }
+        const errors: Error[] = [];
+        if (graphQLErrors) {
+          errors.push(...(graphQLErrors as Error[]));
+        }
 
-    errors.forEach(e => {
-      sentryError(e, { category: TagCategoryValues.SERVER, code: getErrorCode(e), label: getErrorMessage(e) });
-      apm?.captureError(e);
-    });
-  });
+        if (networkError) {
+          networkError.message = `[Network error]: ${networkError.message}`;
+          errors.push(networkError);
+        }
+
+        errors.forEach(e => {
+          sentryError(e, { category: TagCategoryValues.SERVER, code: getErrorCode(e), label: getErrorMessage(e) });
+          apmRef.current?.captureError(e);
+        });
+      }),
+    []
+  );
 };

--- a/src/core/apollo/hooks/useGraphQLClient.ts
+++ b/src/core/apollo/hooks/useGraphQLClient.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, from, InMemoryCache, type NormalizedCacheObject } from '@apollo/client';
 import { once } from 'lodash-es';
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { env } from '@/main/env';
 import { typePolicies } from '../config/typePolicies';
 import {
@@ -40,17 +40,21 @@ export const useGraphQLClient = (
   const errorHandlerLink = useErrorHandlerLink();
   const errorLoggerLink = useErrorLoggerLink(enableErrorLogging);
 
-  return new ApolloClient({
-    link: from([
-      omitTypenameLink,
-      consoleLink(enableQueryDebug),
-      guestHeaderLink,
-      errorLoggerLink,
-      errorHandlerLink,
-      retryLink,
-      redirectLink,
-      httpLink(graphQLEndpoint, enableWebSockets),
-    ]),
-    cache,
-  });
+  return useMemo(
+    () =>
+      new ApolloClient({
+        link: from([
+          omitTypenameLink,
+          consoleLink(enableQueryDebug),
+          guestHeaderLink,
+          errorLoggerLink,
+          errorHandlerLink,
+          retryLink,
+          redirectLink,
+          httpLink(graphQLEndpoint, enableWebSockets),
+        ]),
+        cache,
+      }),
+    [graphQLEndpoint, enableWebSockets, errorHandlerLink, errorLoggerLink, cache]
+  );
 };


### PR DESCRIPTION
Summary of changes:                                                                                                                                                                                     
                                                                                                                                                                                                          
  1. useErrorHandlerLink.ts — Store handleError in a ref, wrap onError() in useMemo(_, []). The link is created once but always calls the latest handler.                                                 
  2. useErrorLoggerLink.ts — Same pattern for apm and errorLogging. Link created once, reads latest values via refs.                                                                                      
  3. useGraphQLClient.ts — Restored useMemo around new ApolloClient(...). With the error links now stable, the client is only recreated when graphQLEndpoint or enableWebSockets actually change.         
                                                                                                                                                                                                          
  The root cause was that onError() from @apollo/client/link/error is an external library call the React Compiler can't auto-memoize, so removing the manual memoization caused new link instances (and   
  thus new ApolloClient instances) on every render. On server errors, the notification dispatch triggered a re-render cascade → new client → all queries re-fired → infinite loop. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Apollo GraphQL error handling by reducing callback re-instantiation during rendering.
  * Enhanced client initialization to reduce unnecessary recreation and improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->