### PR TITLE
Remove sorting from SpaceExplorer — deferred until backend supports orderBy

### DIFF
--- a/specs/039-crd-spaces-page/plan.md
+++ b/specs/039-crd-spaces-page/plan.md
@@ -213,10 +213,10 @@ The `CrdLayoutWrapper` in `src/main/ui/layout/`:
 - Resolves navigation hrefs from `ROUTE_HOME`, `ROUTE_USER_ME`, `buildUserAccountUrl()`, `TopLevelRoutePath`
 - Resolves platform role display name from `platformRoles` (same logic as MUI `PlatformNavigationUserMenu`)
 
-### D10: Prototype-Matching Filter Bar (Sort + Filters Dropdowns)
+### D10: Prototype-Matching Filter Bar (Filters Dropdown)
 
 The CRD SpaceExplorer uses the prototype's filter bar pattern instead of the MUI's flat buttons:
-- **Sort dropdown** (Select): Most Recent, Alphabetical, Most Active — client-side sorting
+- **Sort dropdown**: Deferred — the `spacesPaginated` GraphQL query has no `orderBy` parameter, and client-side sorting with cursor-based pagination is misleading (only sorts loaded items, not the full dataset). Will be implemented when backend support is added.
 - **Filters dropdown** (DropdownMenu) with 3 sections:
   - **Membership** (server-side): All, My Spaces, Public — maps to existing `onMembershipFilterChange` which drives the GraphQL query
   - **Privacy** (client-side): All, Public only, Private only — filters by `isPrivate`

--- a/specs/039-crd-spaces-page/spec.md
+++ b/specs/039-crd-spaces-page/spec.md
@@ -254,6 +254,10 @@ A designer runs `pnpm crd:dev` and sees a standalone web application at `http://
 - Q: Should only the inner content area be CRD, or the entire page including header/footer? → A: **The entire page.** When a route is CRD, the complete page shell (header, content, footer) renders in CRD. No MUI layout wraps CRD routes. This is a full visual replacement per route.
 - Q: Should the CRD Header be fully functional (real search, notifications, messages) for the PoC? → A: Messages and Notifications buttons directly open the existing MUI dialogs via context providers (`useUserMessagingContext`, `useInAppNotificationsContext`). These providers wrap all routes in `root.tsx`, so the dialogs work on CRD pages without navigation. Real search overlay and unread counts are deferred to follow-up tasks.
 
+### Session 2026-03-31
+
+- Q: The CRD SpaceExplorer has sorting options (Recent, Alphabetical, Active) but "Recent" and "Active" just keep server order since `spacesPaginated` has no `orderBy` parameter. Keep them? → A: **Hide sorting entirely.** The GraphQL API doesn't support server-side sorting, and client-side sorting with pagination is misleading (only sorts loaded items). Sorting will be implemented when backend support is added. Client-side privacy and type filters remain.
+
 ---
 
 ## Assumptions

--- a/src/crd/components/space/SpaceExplorer.tsx
+++ b/src/crd/components/space/SpaceExplorer.tsx
@@ -1,5 +1,5 @@
-import { ArrowUpDown, ChevronDown, FolderOpen, Search, SlidersHorizontal, X } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { ChevronDown, FolderOpen, Search, SlidersHorizontal, X } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { SpaceCardData, SpaceCardParent } from '@/crd/components/space/SpaceCard';
 import { SpaceCard, SpaceCardSkeleton } from '@/crd/components/space/SpaceCard';
@@ -15,11 +15,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/crd/primitives/dropdown-menu';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/crd/primitives/select';
 
 export type SpacesFilterValue = 'all' | 'member' | 'public';
 
-type SortOption = 'recent' | 'alpha' | 'active';
 type TypeFilter = 'all' | 'spaces' | 'subspaces';
 type PrivacyFilter = 'all' | 'public' | 'private';
 
@@ -57,8 +55,7 @@ export function SpaceExplorer({
   const { t } = useTranslation(['crd-exploreSpaces', 'crd-common']);
   const [loadingMore, setLoadingMore] = useState(false);
 
-  // Client-side filters & sorting
-  const [sortBy, setSortBy] = useState<SortOption>('recent');
+  // Client-side filters
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [privacyFilter, setPrivacyFilter] = useState<PrivacyFilter>('all');
 
@@ -71,33 +68,24 @@ export function SpaceExplorer({
     }
   };
 
-  // Client-side filtering + sorting
-  const displayedSpaces = useMemo(() => {
-    let result = [...spaces];
+  // Client-side filtering
+  const displayedSpaces = (() => {
+    let result = spaces;
 
-    // Privacy filter
     if (privacyFilter === 'public') result = result.filter(s => !s.isPrivate);
     if (privacyFilter === 'private') result = result.filter(s => s.isPrivate);
 
-    // Type filter
     if (typeFilter === 'spaces') result = result.filter(s => !s.parent);
     if (typeFilter === 'subspaces') result = result.filter(s => !!s.parent);
 
-    // Sort
-    if (sortBy === 'alpha') {
-      result.sort((a, b) => a.name.localeCompare(b.name));
-    }
-    // 'recent' and 'active' keep server order (we don't have activity data)
-
     return result;
-  }, [spaces, privacyFilter, typeFilter, sortBy]);
+  })();
 
   const activeFilterCount = (privacyFilter !== 'all' ? 1 : 0) + (typeFilter !== 'all' ? 1 : 0);
 
   const clearFilters = () => {
     setPrivacyFilter('all');
     setTypeFilter('all');
-    setSortBy('recent');
     onMembershipFilterChange?.('all');
   };
 
@@ -122,22 +110,6 @@ export function SpaceExplorer({
           className="flex-1"
           icon={<Search className="shrink-0 size-4 text-muted-foreground" />}
         />
-
-        {/* Sort dropdown */}
-        <Select value={sortBy} onValueChange={v => setSortBy(v as SortOption)}>
-          <SelectTrigger
-            aria-label={t('spaces.sortBy')}
-            className="w-auto min-w-40 h-10 gap-2 text-sm bg-background border border-border rounded-lg"
-          >
-            <ArrowUpDown className="size-3.5 text-muted-foreground" />
-            <SelectValue placeholder={t('spaces.sortBy')} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="recent">{t('spaces.sortRecent')}</SelectItem>
-            <SelectItem value="alpha">{t('spaces.sortAlpha')}</SelectItem>
-            <SelectItem value="active">{t('spaces.sortActive')}</SelectItem>
-          </SelectContent>
-        </Select>
 
         {/* Filters dropdown */}
         <DropdownMenu>


### PR DESCRIPTION
The spacesPaginated GraphQL query has no orderBy parameter, so client-side sorting with cursor-based pagination only sorts loaded items, not the full dataset. Removed the Sort dropdown (Recent/Alphabetical/Active) to avoid misleading UX. Client-side privacy and type filters remain.
