### PR TITLE
[CRD] old vs new pages simple switch mechanism

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,6 +329,22 @@ Tailwind CSS (via `@tailwindcss/vite`) is loaded globally from `src/index.tsx` v
 
 **The pragmatic choice:** Global CSS load + `.crd-root` scoping. Moving MUI's ThemeProvider below non-CRD routes would require significant `root.tsx` restructuring with no functional benefit. The current approach works, is simple, and avoids unnecessary complexity.
 
+## CRD Feature Toggle
+
+The CRD design system migration uses a localStorage toggle (default: **OFF**). Deployed environments render the old MUI pages; developers/QA can opt in to the new CRD pages.
+
+```js
+// Enable:  open browser console and run:
+localStorage.setItem('alkemio-crd-enabled', 'true');
+location.reload();
+
+// Disable:
+localStorage.removeItem('alkemio-crd-enabled');
+location.reload();
+```
+
+Toggle logic lives in `src/main/crdPages/useCrdEnabled.ts`. Conditional routing is in `TopLevelRoutes.tsx`. When all pages are migrated and validated, remove the toggle, delete old MUI page files, and make CRD routes the only routes.
+
 ## Recent Changes
 - 039-crd-exploreSpaces-page: Added TypeScript 5.x, React 19, Node >= 22.0.0 + shadcn/ui (Radix UI + Tailwind CSS v4), class-variance-authority, lucide-react, Apollo Client (existing, unchanged)
 

--- a/docs/crd/migration-guide.md
+++ b/docs/crd/migration-guide.md
@@ -12,10 +12,34 @@ The prototype in `prototype/` (generated from Figma Make) is the design referenc
 TopLevelRoutes.tsx
   ├── MUI routes  → TopLevelLayout (existing MUI header/footer)
   └── CRD routes  → CrdLayoutWrapper → CrdLayout (CRD header/footer)
-                                         └── <Outlet /> → Your page
+       (gated by       └── <Outlet /> → Your page
+        localStorage
+        toggle)
 ```
 
 CRD pages get a completely different shell — CRD header, CRD footer, Tailwind styling. MUI pages are untouched.
+
+During migration, CRD routes are gated behind a **localStorage toggle** (`alkemio-crd-enabled`, default OFF). Deployed environments always render the old MUI pages. Developers and QA opt in locally.
+
+## Feature Toggle
+
+The toggle lives in `src/main/crdPages/useCrdEnabled.ts` and is used in `TopLevelRoutes.tsx` to conditionally render CRD or MUI pages.
+
+**Enable CRD pages** (browser console):
+```js
+localStorage.setItem('alkemio-crd-enabled', 'true');
+location.reload();
+```
+
+**Disable CRD pages** (back to MUI):
+```js
+localStorage.removeItem('alkemio-crd-enabled');
+location.reload();
+```
+
+Both page versions are lazy-loaded — the unused chunk is never fetched, so there is no bundle penalty.
+
+When migration is complete and all CRD pages are validated, remove the toggle: delete `useCrdEnabled.ts`, remove conditional routing in `TopLevelRoutes.tsx`, delete old MUI page files from `src/main/topLevelPages/`.
 
 ## The Three Layers
 
@@ -106,18 +130,44 @@ const MyPage = () => {
 
 The data hook can be imported from the existing MUI page or copied — the GraphQL layer is shared.
 
-### Step 5: Wire the Route
+### Step 5: Wire the Route (with Feature Toggle)
 
-In `TopLevelRoutes.tsx`, add a lazy-loaded route under the CRD layout:
+In `TopLevelRoutes.tsx`, add both lazy imports and a conditional route based on the toggle:
 
 ```typescript
-const MyPageCrd = lazyWithGlobalErrorHandler(
+// CRD (new) version
+const CrdMyPage = lazyWithGlobalErrorHandler(
   () => import('@/main/crdPages/myPage/MyPage')
 );
-
-// Inside routes, under CrdLayoutWrapper:
-<Route path="my-page" element={<MyPageCrd />} />
+// MUI (old) version — stays until migration is validated
+const MuiMyPage = lazyWithGlobalErrorHandler(
+  () => import('@/main/topLevelPages/myPage/MyPage')
+);
 ```
+
+Then in the JSX, add a conditional block (the `crdEnabled` value comes from `useCrdEnabled()` already called in the component):
+
+```tsx
+{crdEnabled ? (
+  <Route element={<NonIdentity><CrdLayoutWrapper /></NonIdentity>}>
+    <Route path="/my-page" element={
+      <WithApmTransaction path="/my-page">
+        <Suspense fallback={<Loading />}><CrdMyPage /></Suspense>
+      </WithApmTransaction>
+    } />
+  </Route>
+) : (
+  <Route path="/my-page" element={
+    <NonIdentity>
+      <WithApmTransaction path="/my-page">
+        <Suspense fallback={<Loading />}><MuiMyPage /></Suspense>
+      </WithApmTransaction>
+    </NonIdentity>
+  } />
+)}
+```
+
+The old MUI page files stay in `src/main/topLevelPages/` and are the default. The CRD version only renders when the toggle is on.
 
 ### Step 6: Add Translations
 
@@ -148,7 +198,11 @@ Run `pnpm crd:dev` to see CRD components with mock data on `localhost:5200`. No 
 
 ### Don't Over-Migrate
 
-Only migrate what's asked. The existing MUI page continues to work — CRD is an alternative route, not a replacement that needs to happen all at once.
+Only migrate what's asked. The existing MUI page continues to work and is the default (toggle OFF). CRD is an alternative gated behind the toggle, not a replacement that needs to happen all at once.
+
+### Old MUI Files Stay in the Codebase
+
+When migrating a page, **do not delete** the old MUI page files from `src/main/topLevelPages/`. They remain as the default rendering path until the toggle is removed. Both versions coexist — lazy loading ensures only the active version's chunk is fetched.
 
 ## File Layout Example
 
@@ -163,8 +217,16 @@ src/crd/i18n/
 └── exploreSpaces/             # Space explorer translations
     └── exploreSpaces.en.json (+ .es, .nl, .bg, .de, .fr)
 
-src/main/crdPages/spaces/
-├── SpaceExplorerPage.tsx      # Page component (calls hook, renders CRD)
-├── spaceCardDataMapper.ts     # GraphQL → CRD prop mapping
-└── useSpaceExplorer.ts        # Data hook (GraphQL queries)
+src/main/crdPages/
+├── useCrdEnabled.ts           # Feature toggle hook (localStorage, default OFF)
+└── spaces/
+    ├── SpaceExplorerPage.tsx      # CRD page component (calls hook, renders CRD)
+    ├── spaceCardDataMapper.ts     # GraphQL → CRD prop mapping
+    └── useSpaceExplorer.ts        # Data hook (GraphQL queries)
+
+src/main/topLevelPages/topLevelSpaces/   # Old MUI page (rendered when toggle is OFF)
+├── SpaceExplorerPage.tsx
+├── SpaceExplorerView.tsx
+├── useSpaceExplorer.ts
+└── useSpaceExplorerViewState.ts
 ```

--- a/specs/039-crd-spaces-page/plan.md
+++ b/specs/039-crd-spaces-page/plan.md
@@ -5,13 +5,13 @@
 
 ## Summary
 
-Migrate the `/spaces` page from MUI to shadcn/ui + Tailwind CSS as the first proof-of-concept for the CRD (Client Re-Design) migration. The approach is a **parallel design system** with a **route-level layout split** — CRD routes in `TopLevelRoutes.tsx` are wrapped in `CrdLayoutWrapper`, which renders a fully CRD page shell (Header + content + Footer). MUI routes continue using `TopLevelLayout` unchanged. Inside the CRD shell, a data mapper bridges GraphQL responses to CRD component props. No runtime toggle — migrated routes simply render CRD. The data layer (`useSpaceExplorer` hook, GraphQL queries) remains completely untouched.
+Migrate the `/spaces` page from MUI to shadcn/ui + Tailwind CSS as the first proof-of-concept for the CRD (Client Re-Design) migration. The approach is a **parallel design system** with a **route-level layout split** — CRD routes in `TopLevelRoutes.tsx` are wrapped in `CrdLayoutWrapper`, which renders a fully CRD page shell (Header + content + Footer). MUI routes continue using `TopLevelLayout` unchanged. Inside the CRD shell, a data mapper bridges GraphQL responses to CRD component props. A **localStorage toggle** (`alkemio-crd-enabled`, default OFF) gates CRD routes so the branch can be merged to develop without affecting end users — developers and QA opt in locally. The data layer (`useSpaceExplorer` hook, GraphQL queries) remains completely untouched.
 
 ## Technical Context
 
 **Language/Version**: TypeScript 5.x, React 19, Node >= 22.0.0
 **Primary Dependencies**: shadcn/ui (Radix UI + Tailwind CSS v4), class-variance-authority, lucide-react, Apollo Client (existing, unchanged)
-**Storage**: N/A (GraphQL data layer unchanged)
+**Storage**: localStorage (`alkemio-crd-enabled`) for CRD feature toggle; GraphQL data layer unchanged
 **Testing**: Vitest with jsdom (`pnpm vitest run`)
 **Target Platform**: Web SPA (Vite dev server on localhost:3001)
 **Project Type**: Web application (frontend only — no backend changes)
@@ -108,13 +108,20 @@ src/
 │
 ├── main/
 │   ├── crdPages/                     # CRD page integrations (wires CRD components to data)
+│   │   ├── useCrdEnabled.ts                 # NEW: localStorage toggle hook (default OFF)
 │   │   └── spaces/
 │   │       ├── SpaceExplorerPage.tsx         # Page entry — hook + data mapping + CRD SpaceExplorer
 │   │       ├── SpaceExplorerQueries.graphql  # GraphQL queries for the spaces page
 │   │       ├── spaceCardDataMapper.ts        # GraphQL → SpaceCardData mapper
 │   │       └── useSpaceExplorer.ts           # Data hook
+│   ├── topLevelPages/
+│   │   └── topLevelSpaces/                  # RESTORED: Old MUI page (rendered when toggle is OFF)
+│   │       ├── SpaceExplorerPage.tsx
+│   │       ├── SpaceExplorerView.tsx
+│   │       ├── useSpaceExplorer.ts
+│   │       └── useSpaceExplorerViewState.ts
 │   ├── routing/
-│   │   └── TopLevelRoutes.tsx        # MODIFIED: wrap CRD routes in CrdLayoutWrapper
+│   │   └── TopLevelRoutes.tsx        # MODIFIED: conditional CRD/MUI routing based on useCrdEnabled()
 │   └── ui/
 │       └── layout/
 │           └── CrdLayoutWrapper.tsx  # Connects CrdLayout to app data (auth, user, roles, navigation, pending memberships, lazy HelpDialog)
@@ -142,9 +149,19 @@ When a route is migrated to CRD, the **entire page** renders in CRD — header, 
 - The `CrdLayoutWrapper` in `src/main/ui/layout/` is the smart container that connects CrdLayout to app data (auth, user info, navigation)
 - Future page migrations add their route under the `CrdLayoutWrapper` in `TopLevelRoutes.tsx`
 
-### D3: Direct Route Wiring (No Runtime Toggle)
+### D3: localStorage Feature Toggle (Safe Merge Strategy)
 
-Migration is a code-level decision. No runtime toggle, no feature flags, no URL params. The old MUI view files are kept in the codebase but no longer imported. Future page migrations follow the same pattern: move the route under `CrdLayoutWrapper` and swap the view component.
+During migration, CRD routes are gated behind a localStorage toggle so the branch can be merged to develop without affecting end users. The toggle defaults to OFF — deployed environments render the old MUI page. Developers and QA opt in via `localStorage.setItem('alkemio-crd-enabled', 'true')` + page refresh.
+
+**Implementation:**
+- `src/main/crdPages/useCrdEnabled.ts` — reads `alkemio-crd-enabled` from localStorage (default `false`)
+- `TopLevelRoutes.tsx` — conditionally routes `/spaces` to either `CrdSpaceExplorerPage` (with `CrdLayoutWrapper`) or `MuiSpaceExplorerPage` (with `TopLevelLayout`)
+- Old MUI page files are restored at `src/main/topLevelPages/topLevelSpaces/` alongside the CRD alternatives in `src/main/crdPages/spaces/`
+- Both versions are lazy-loaded — the unused chunk is never fetched, so there is no bundle penalty
+
+**Why localStorage over env var:** No Docker/CI config changes needed. QA can test on staging without a redeploy. No dev server restart to toggle. Easiest to remove when migration is complete.
+
+**Removal:** When all pages are migrated and validated, delete `useCrdEnabled.ts`, remove conditional routing, delete old MUI page files. CRD routes become the only routes.
 
 ### D4: Data Mapper in Page Directory
 
@@ -267,7 +284,7 @@ The CRD system follows the project's established lazy loading patterns to minimi
 
 ### D15: `src/main/crdPages/` as the Page Integration Layer
 
-CRD-migrated page components live in `src/main/crdPages/<pageName>/` rather than modifying existing files in `src/main/topLevelPages/`. This keeps MUI and CRD page implementations cleanly separated — the original MUI pages in `src/main/topLevelPages/` remain untouched and can be removed once migration is complete. `src/main/crdPages/` may import from `@/crd/`, `@/domain/`, and `@/core/`, but MUST NOT import from `@mui/*`. The `CrdLayoutWrapper` remains in `src/main/ui/layout/` because it is an app-level concern, not page-specific.
+CRD-migrated page components live in `src/main/crdPages/<pageName>/` rather than modifying existing files in `src/main/topLevelPages/`. This keeps MUI and CRD page implementations cleanly separated — the original MUI pages in `src/main/topLevelPages/` remain in the codebase and are rendered by default (toggle OFF). They can be removed once migration is complete and the toggle is deleted. `src/main/crdPages/` may import from `@/crd/`, `@/domain/`, and `@/core/`, but MUST NOT import from `@mui/*`. The `CrdLayoutWrapper` remains in `src/main/ui/layout/` because it is an app-level concern, not page-specific.
 
 ### D16: PlatformNavigation Menu & Layout Building Blocks
 

--- a/specs/039-crd-spaces-page/spec.md
+++ b/specs/039-crd-spaces-page/spec.md
@@ -224,7 +224,7 @@ A designer runs `pnpm crd:dev` and sees a standalone web application at `http://
 
 - **SpaceCardData**: The CRD view model for a space card — plain TypeScript type with fields: id, name, description, bannerImageUrl, initials, avatarColor, isPrivate, tags, leads, href, optional parent info
 - **SpaceLead**: A lead person or organization displayed on the card — name, avatarUrl, type ('person' or 'org')
-- **Route Migration State**: A code-level decision per route — each route is assigned to either the CRD layout group (`CrdLayoutWrapper`) or the MUI layout group (`TopLevelLayout`) in `TopLevelRoutes.tsx`. No runtime configuration needed
+- **Route Migration State**: Each route is assigned to either the CRD layout group (`CrdLayoutWrapper`) or the MUI layout group (`TopLevelLayout`) in `TopLevelRoutes.tsx`. During migration, CRD routes are gated behind a localStorage toggle (`alkemio-crd-enabled`) so deployed environments default to MUI. Toggle logic in `src/main/crdPages/useCrdEnabled.ts`
 
 ---
 
@@ -248,7 +248,7 @@ A designer runs `pnpm crd:dev` and sees a standalone web application at `http://
 ### Session 2026-03-26
 
 - Q: Should the MUI/CRD toggle be global (all pages at once) or per-route? → A: Per-route — each migrated URL is independently switchable between MUI and CRD. Starting with `/spaces`, more routes will follow.
-- Q: How does a user activate the MUI/CRD toggle? → A: No runtime toggle. Routes are simply wired to CRD or MUI at the code level. When a route is migrated, it uses the new design — no URL param, no UI toggle, no localStorage switch.
+- Q: How does a user activate the MUI/CRD toggle? → A: A localStorage runtime toggle (`alkemio-crd-enabled`). Default is OFF — deployed environments render the old MUI page. Developers and QA can opt in via `localStorage.setItem('alkemio-crd-enabled', 'true')` + page refresh. Toggle logic lives in `src/main/crdPages/useCrdEnabled.ts`, conditional routing in `TopLevelRoutes.tsx`. When migration is complete and validated, the toggle and old MUI pages are removed.
 - Q: What level of visual fidelity to the prototype is required? → A: Same layout structure and design language — minor spacing/shadow differences acceptable. Pixel-perfection is not required.
 - Q: Member count is in the prototype but not in the current GraphQL fragment. Include it? → A: Drop it. General rule: if a prototype feature requires data layer changes, omit it from the CRD card. Add in a follow-up.
 - Q: Should only the inner content area be CRD, or the entire page including header/footer? → A: **The entire page.** When a route is CRD, the complete page shell (header, content, footer) renders in CRD. No MUI layout wraps CRD routes. This is a full visual replacement per route.
@@ -259,7 +259,7 @@ A designer runs `pnpm crd:dev` and sees a standalone web application at `http://
 ## Assumptions
 
 - The existing `useSpaceExplorer` hook and GraphQL queries provide all data needed for the CRD SpaceCard — no new queries are required
-- No runtime toggle mechanism is needed — migrated routes simply use CRD views at the code level
+- A localStorage runtime toggle (`alkemio-crd-enabled`, default OFF) gates CRD routes so deployed environments show the old MUI pages. Old MUI page files are kept alongside CRD alternatives in the codebase
 - The prototype's `SpaceCard` and `BrowseSpacesPage` are the definitive design reference for the CRD version
 - Tailwind CSS v4 and the necessary build configuration have been set up as Phase 1 of this spec (T001-T005, completed)
 - The `src/crd/` folder already exists with its CLAUDE.md conventions established

--- a/src/main/crdPages/useCrdEnabled.ts
+++ b/src/main/crdPages/useCrdEnabled.ts
@@ -1,0 +1,9 @@
+const STORAGE_KEY = 'alkemio-crd-enabled';
+
+export function useCrdEnabled(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}

--- a/src/main/routing/TopLevelRoutes.tsx
+++ b/src/main/routing/TopLevelRoutes.tsx
@@ -13,6 +13,7 @@ import NonIdentity from '@/domain/platform/routes/NonIdentity';
 import RedirectToLanding from '@/domain/platform/routes/RedirectToLanding';
 import RedirectToWelcomeSite from '@/domain/platform/routes/RedirectToWelcomeSite';
 import { WithApmTransaction } from '@/domain/shared/components/WithApmTransaction/WithApmTransaction';
+import { useCrdEnabled } from '../crdPages/useCrdEnabled';
 import { CrdLayoutWrapper } from '../ui/layout/CrdLayoutWrapper';
 import TopLevelLayout from '../ui/layout/TopLevelLayout';
 import App from '../ui/layout/topLevelWrappers/App';
@@ -24,7 +25,10 @@ const HomePage = lazyWithGlobalErrorHandler(() => import('@/main/topLevelPages/H
 const PublicWhiteboardPage = lazyWithGlobalErrorHandler(() => import('@/main/public/whiteboard/PublicWhiteboardPage'));
 const DocumentationPage = lazyWithGlobalErrorHandler(() => import('@/main/documentation/DocumentationPage'));
 const RedirectDocumentation = lazyWithGlobalErrorHandler(() => import('@/main/documentation/RedirectDocumentation'));
-const SpaceExplorerPage = lazyWithGlobalErrorHandler(() => import('@/main/crdPages/spaces/SpaceExplorerPage'));
+const CrdSpaceExplorerPage = lazyWithGlobalErrorHandler(() => import('@/main/crdPages/spaces/SpaceExplorerPage'));
+const MuiSpaceExplorerPage = lazyWithGlobalErrorHandler(
+  () => import('@/main/topLevelPages/topLevelSpaces/SpaceExplorerPage')
+);
 const InnovationLibraryPage = lazyWithGlobalErrorHandler(
   () => import('@/main/topLevelPages/InnovationLibraryPage/InnovationLibraryPage')
 );
@@ -47,6 +51,7 @@ const SpaceRoutes = lazyWithGlobalErrorHandler(() => import('@/domain/space/rout
 
 export const TopLevelRoutes = () => {
   useRedirectToIdentityDomain();
+  const crdEnabled = useCrdEnabled();
 
   return (
     <Routes>
@@ -101,25 +106,40 @@ export const TopLevelRoutes = () => {
             </Suspense>
           }
         />
-        {/* CRD routes — wrapped in CrdLayoutWrapper (full shadcn/ui page shell) */}
-        <Route
-          element={
-            <NonIdentity>
-              <CrdLayoutWrapper />
-            </NonIdentity>
-          }
-        >
+        {/* Spaces page — toggleable between CRD (new) and MUI (old) via localStorage */}
+        {crdEnabled ? (
+          <Route
+            element={
+              <NonIdentity>
+                <CrdLayoutWrapper />
+              </NonIdentity>
+            }
+          >
+            <Route
+              path={`/${TopLevelRoutePath.Spaces}`}
+              element={
+                <WithApmTransaction path={`/${TopLevelRoutePath.Spaces}`}>
+                  <Suspense fallback={<Loading />}>
+                    <CrdSpaceExplorerPage />
+                  </Suspense>
+                </WithApmTransaction>
+              }
+            />
+          </Route>
+        ) : (
           <Route
             path={`/${TopLevelRoutePath.Spaces}`}
             element={
-              <WithApmTransaction path={`/${TopLevelRoutePath.Spaces}`}>
-                <Suspense fallback={<Loading />}>
-                  <SpaceExplorerPage />
-                </Suspense>
-              </WithApmTransaction>
+              <NonIdentity>
+                <WithApmTransaction path={`/${TopLevelRoutePath.Spaces}`}>
+                  <Suspense fallback={<Loading />}>
+                    <MuiSpaceExplorerPage />
+                  </Suspense>
+                </WithApmTransaction>
+              </NonIdentity>
             }
           />
-        </Route>
+        )}
         <Route
           path={`/${TopLevelRoutePath.Contributors}`}
           element={

--- a/src/main/topLevelPages/topLevelSpaces/SpaceExplorerPage.tsx
+++ b/src/main/topLevelPages/topLevelSpaces/SpaceExplorerPage.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from 'react-i18next';
+import { usePageTitle } from '@/core/routing/usePageTitle';
+import BreadcrumbsItem from '@/core/ui/navigation/BreadcrumbsItem';
+import useInnovationHubOutsideRibbon from '@/domain/innovationHub/InnovationHubOutsideRibbon/useInnovationHubOutsideRibbon';
+import { SpaceL0Icon } from '@/domain/space/icons/SpaceL0Icon';
+import TopLevelPageLayout from '@/main/ui/layout/topLevelPageLayout/TopLevelPageLayout';
+import TopLevelPageBreadcrumbs from '../topLevelPageBreadcrumbs/TopLevelPageBreadcrumbs';
+import { SpaceExplorerView } from './SpaceExplorerView';
+import useSpaceExplorer from './useSpaceExplorer';
+
+const SpaceExplorerPage = () => {
+  const { t } = useTranslation();
+
+  // Set browser tab title to "Spaces | Alkemio"
+  usePageTitle(t('pages.titles.spaces'));
+
+  const ribbon = useInnovationHubOutsideRibbon({ label: 'innovationHub.outsideOfSpace.subspaces' });
+
+  const provided = useSpaceExplorer();
+
+  return (
+    <TopLevelPageLayout
+      iconComponent={SpaceL0Icon}
+      title={t('pages.exploreSpaces.fullName')}
+      subtitle={t('pages.exploreSpaces.subtitle')}
+      ribbon={ribbon}
+      breadcrumbs={
+        <TopLevelPageBreadcrumbs>
+          <BreadcrumbsItem iconComponent={SpaceL0Icon}>{t('pages.exploreSpaces.shortName')}</BreadcrumbsItem>
+        </TopLevelPageBreadcrumbs>
+      }
+    >
+      <SpaceExplorerView {...provided} />
+    </TopLevelPageLayout>
+  );
+};
+
+export default SpaceExplorerPage;

--- a/src/main/topLevelPages/topLevelSpaces/SpaceExplorerView.tsx
+++ b/src/main/topLevelPages/topLevelSpaces/SpaceExplorerView.tsx
@@ -1,0 +1,265 @@
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { Box, Button, DialogContent, IconButton } from '@mui/material';
+import { compact } from 'lodash-es';
+import type React from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
+import ScrollableCardsLayoutContainer from '@/core/ui/card/cardsLayout/ScrollableCardsLayoutContainer';
+import PageContentBlock from '@/core/ui/content/PageContentBlock';
+import SeeMoreExpandable from '@/core/ui/content/SeeMoreExpandable';
+import DialogHeader from '@/core/ui/dialog/DialogHeader';
+import DialogWithGrid from '@/core/ui/dialog/DialogWithGrid';
+import Gutters from '@/core/ui/grid/Gutters';
+import { gutters, useGridItem } from '@/core/ui/grid/utils';
+import RouterLink from '@/core/ui/link/RouterLink';
+import Loading from '@/core/ui/loading/Loading';
+import WrapperMarkdown from '@/core/ui/markdown/WrapperMarkdown';
+import { Caption, CaptionSmall } from '@/core/ui/typography';
+import type { Identifiable } from '@/core/utils/Identifiable';
+import type { Visual } from '@/domain/common/visual/Visual';
+import SearchTagsInput from '@/domain/shared/components/SearchTagsInput/SearchTagsInput';
+import useLazyLoading from '@/domain/shared/pagination/useLazyLoading';
+import type { SpaceAboutLightModel } from '@/domain/space/about/model/spaceAboutLight.model';
+import type { Lead, LeadOrganization } from '@/domain/space/components/cards/components/SpaceLeads';
+import SpaceCard from '@/domain/space/components/cards/SpaceCard';
+import { collectParentAvatars } from '@/domain/space/components/cards/utils/useSubspaceCardData';
+import { buildLoginUrl } from '@/main/routing/urlBuilders';
+import { useSpaceExplorerViewState } from './useSpaceExplorerViewState';
+export interface SpaceExplorerViewProps {
+  spaces: SpaceWithParent[] | undefined;
+  setSearchTerms: React.Dispatch<React.SetStateAction<string[]>>;
+  membershipFilter: SpacesExplorerMembershipFilter;
+  searchTerms: string[];
+  onMembershipFilterChange?: (filter: SpacesExplorerMembershipFilter) => void;
+  loading: boolean;
+  hasMore: boolean | undefined;
+  fetchMore: () => Promise<void>;
+  authenticated: boolean;
+  loadingSearchResults?: boolean | null;
+}
+
+export enum SpacesExplorerMembershipFilter {
+  All = 'all',
+  Member = 'member',
+  Public = 'public',
+}
+
+export type SpaceWithParent = Space & WithParent<ParentSpace>;
+
+interface ParentSpace extends Identifiable {
+  level: SpaceLevel;
+  about: {
+    profile: {
+      displayName: string;
+      avatar?: Visual;
+      cardBanner?: Visual;
+      url: string;
+    };
+  };
+}
+
+type WithParent<ParentInfo extends {}> = {
+  parent?: ParentInfo & WithParent<ParentInfo>;
+};
+
+interface Space extends Identifiable {
+  level: SpaceLevel;
+  about: SpaceAboutLightModel;
+  matchedTerms?: string[];
+}
+
+export const ITEMS_LIMIT = 10;
+
+export const SpaceExplorerView = ({
+  spaces,
+  searchTerms,
+  setSearchTerms,
+  membershipFilter,
+  loading,
+  onMembershipFilterChange,
+  fetchMore,
+  hasMore,
+  authenticated,
+  loadingSearchResults = null,
+}: SpaceExplorerViewProps) => {
+  const { t } = useTranslation();
+  const { handleContactLead, directMessageDialog, welcomeSpace } = useSpaceExplorerViewState();
+
+  const [hasExpanded, setHasExpanded] = useState(false);
+  const [infoOpen, setInfoOpen] = useState(false);
+  const enabledFilters = compact([
+    SpacesExplorerMembershipFilter.All,
+    authenticated ? SpacesExplorerMembershipFilter.Member : undefined,
+    SpacesExplorerMembershipFilter.Public,
+  ]);
+
+  const isCollapsed = !hasExpanded && membershipFilter !== SpacesExplorerMembershipFilter.Member;
+
+  const enableLazyLoading = !isCollapsed || (spaces && spaces.length < ITEMS_LIMIT);
+
+  const enableShowAll = isCollapsed && spaces && (spaces.length > ITEMS_LIMIT || hasMore);
+
+  const loader = useLazyLoading(ref => <Box ref={ref} />, { fetchMore, loading, hasMore });
+
+  const _shouldDisplayPrivacyInfo = membershipFilter !== SpacesExplorerMembershipFilter.Member;
+
+  const visibleSpaces = isCollapsed ? spaces?.slice(0, ITEMS_LIMIT) : spaces;
+
+  const hasNoMemberSpaces =
+    (membershipFilter === SpacesExplorerMembershipFilter.Member && !authenticated) || spaces?.length === 0;
+
+  const renderVisibleSpaces = () => {
+    const vs: React.ReactElement[] = [];
+
+    if (!visibleSpaces) {
+      return vs;
+    }
+
+    visibleSpaces.forEach(space => {
+      if (!space) {
+        return;
+      }
+      const { id, level, about } = space;
+
+      const { profile, isContentPublic, membership } = about;
+
+      // TypeScript doesn't know that membership has leadUsers/leadOrganizations
+      // but the actual GraphQL fragment SpaceExplorerSpace includes them
+      const membershipWithLeads = membership as typeof membership & {
+        leadUsers?: Lead[];
+        leadOrganizations?: LeadOrganization[];
+      };
+
+      const parentInfo = space.parent
+        ? {
+            displayName: space.parent.about.profile.displayName,
+            url: space.parent.about.profile.url,
+            avatar: space.parent.about.profile.avatar
+              ? {
+                  id: '',
+                  uri: space.parent.about.profile.avatar.uri,
+                  alternativeText: space.parent.about.profile.avatar.alternativeText,
+                }
+              : undefined,
+          }
+        : undefined;
+
+      vs.push(
+        <SpaceCard
+          key={id}
+          spaceId={id}
+          tagline={profile?.tagline ?? ''}
+          displayName={profile?.displayName}
+          spaceUri={profile?.url}
+          level={level}
+          banner={profile?.cardBanner}
+          tags={profile?.tagset?.tags}
+          avatarUris={collectParentAvatars(space) ?? []}
+          parentInfo={parentInfo}
+          matchedTerms={!!space.matchedTerms}
+          leadUsers={membershipWithLeads?.leadUsers}
+          leadOrganizations={membershipWithLeads?.leadOrganizations}
+          showLeads={authenticated}
+          isPrivate={!isContentPublic}
+          onContactLead={handleContactLead}
+        />
+      );
+    });
+
+    return vs;
+  };
+
+  const getGridItemStyle = useGridItem();
+
+  const spacesLength = spaces?.length ?? 0;
+
+  return (
+    <PageContentBlock>
+      <Gutters row={true} disablePadding={true} flexWrap="wrap" justifyContent="center" paddingTop={gutters(0.2)}>
+        <SearchTagsInput
+          value={searchTerms}
+          placeholder={t('pages.exploreSpaces.search.placeholder')}
+          onChange={(_event: unknown, newValue: string[]) => setSearchTerms(newValue)}
+          fullWidth={false}
+          sx={{ flexGrow: 1, flexBasis: getGridItemStyle(4).width }}
+        />
+        <Gutters row={true} disablePadding={true} maxWidth="100%" alignItems="center">
+          {enabledFilters.map(filter => (
+            <Button
+              key={filter}
+              variant={filter === membershipFilter ? 'contained' : 'outlined'}
+              sx={{ textTransform: 'none', flexShrink: 1 }}
+              onClick={() => onMembershipFilterChange?.(filter)}
+            >
+              <Caption noWrap={true}>{t(`pages.exploreSpaces.membershipFilter.${filter}` as const)}</Caption>
+            </Button>
+          ))}
+          <IconButton
+            onClick={() => {
+              setInfoOpen(true);
+            }}
+            aria-label={t('tooltips.click-more-info')}
+            aria-haspopup="dialog"
+            aria-controls={infoOpen ? 'space-explorer-info-dialog' : undefined}
+          >
+            <InfoOutlinedIcon color="primary" fontSize="small" />
+          </IconButton>
+        </Gutters>
+      </Gutters>
+      {hasNoMemberSpaces && (
+        <CaptionSmall
+          component={RouterLink}
+          to={(authenticated ? welcomeSpace?.about.profile.url : buildLoginUrl(welcomeSpace?.about.profile.url)) ?? ''}
+          marginX="auto"
+          paddingY={gutters()}
+        >
+          {t('pages.exploreSpaces.noSpaceMemberships', { welcomeSpace: welcomeSpace?.about.profile.displayName })}
+        </CaptionSmall>
+      )}
+      {searchTerms.length !== 0 && spacesLength === 0 && loadingSearchResults === false && (
+        <CaptionSmall marginX="auto" paddingY={gutters()}>
+          {t('pages.exploreSpaces.search.noResults')}
+        </CaptionSmall>
+      )}
+      {loadingSearchResults && <Loading text={t('pages.exploreSpaces.search.searching')} />}
+      {spacesLength > 0 && (
+        <>
+          <ScrollableCardsLayoutContainer>
+            {renderVisibleSpaces()}
+
+            {enableLazyLoading && loader}
+          </ScrollableCardsLayoutContainer>
+          {enableShowAll && (
+            <SeeMoreExpandable onExpand={() => setHasExpanded(true)} label={t('pages.exploreSpaces.seeAll')} />
+          )}
+        </>
+      )}
+      {hasNoMemberSpaces && (
+        <SeeMoreExpandable
+          onExpand={() => onMembershipFilterChange?.(SpacesExplorerMembershipFilter.All)}
+          label={t('pages.exploreSpaces.seeAll')}
+        />
+      )}
+      {infoOpen && (
+        <DialogWithGrid
+          open={infoOpen}
+          onClose={() => setInfoOpen(false)}
+          columns={4}
+          id="space-explorer-info-dialog"
+          aria-labelledby="space-explorer-info-dialog-title"
+        >
+          <DialogHeader
+            id="space-explorer-info-dialog-title"
+            title={t('pages.exploreSpaces.fullName')}
+            onClose={() => setInfoOpen(false)}
+          />
+          <DialogContent sx={{ paddingTop: 0 }}>
+            <WrapperMarkdown caption={true}>{t('pages.exploreSpaces.caption')}</WrapperMarkdown>
+          </DialogContent>
+        </DialogWithGrid>
+      )}
+      {directMessageDialog}
+    </PageContentBlock>
+  );
+};

--- a/src/main/topLevelPages/topLevelSpaces/useSpaceExplorer.ts
+++ b/src/main/topLevelPages/topLevelSpaces/useSpaceExplorer.ts
@@ -1,0 +1,224 @@
+import { uniqBy } from 'lodash-es';
+import { type Dispatch, useEffect, useState } from 'react';
+import {
+  useMySpacesExplorerPageQuery,
+  useSpaceExplorerAllSpacesQuery,
+  useSpaceExplorerMemberSpacesQuery,
+  useSpaceExplorerSearchQuery,
+  useSpaceExplorerSubspacesLazyQuery,
+} from '@/core/apollo/generated/apollo-hooks';
+import {
+  AuthorizationPrivilege,
+  CommunityMembershipStatus,
+  SearchCategory,
+  SearchResultType,
+  type SpaceExplorerSearchSpaceFragment,
+  type SpaceExplorerSubspacesQuery,
+} from '@/core/apollo/generated/graphql-schema';
+import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
+import type { TypedSearchResult } from '@/main/search/SearchView';
+import { ITEMS_LIMIT, SpacesExplorerMembershipFilter, type SpaceWithParent } from './SpaceExplorerView';
+
+export interface SpacesExplorerContainerEntities {
+  spaces: SpaceWithParent[] | undefined;
+  searchTerms: string[];
+  membershipFilter: SpacesExplorerMembershipFilter;
+  onMembershipFilterChange: Dispatch<SpacesExplorerMembershipFilter>;
+  fetchMore: () => Promise<void>;
+  loading: boolean;
+  hasMore: boolean | undefined;
+  authenticated: boolean;
+  setSearchTerms: React.Dispatch<React.SetStateAction<string[]>>;
+  loadingSearchResults: boolean | null;
+}
+
+const useSpaceExplorer = (): SpacesExplorerContainerEntities => {
+  const { userModel, isAuthenticated, loading: loadingUser } = useCurrentUserContext();
+
+  const [searchTerms, setSearchTerms] = useState<string[]>([]);
+  const [membershipFilter, setMembershipFilter] = useState(SpacesExplorerMembershipFilter.All);
+
+  const shouldSearch = searchTerms.length > 0;
+
+  // PRIVATE: Spaces if the user is logged in
+  const { data: spaceMembershipsData, loading: loadingUserData } = useMySpacesExplorerPageQuery({
+    skip: !userModel?.id || shouldSearch || membershipFilter !== SpacesExplorerMembershipFilter.Member,
+  });
+
+  const mySpaceIds = spaceMembershipsData?.me.spaceMembershipsFlat.map(space => space.id);
+
+  const { data: spacesExplorerData, loading: isLoadingMemberSpaces } = useSpaceExplorerMemberSpacesQuery({
+    variables: {
+      spaceIDs: mySpaceIds,
+    },
+    skip: !mySpaceIds || shouldSearch,
+  });
+
+  // PUBLIC: Search for spaces and subspaces
+  const { data: rawSearchResults, loading: loadingSearchResults } = useSpaceExplorerSearchQuery({
+    variables: {
+      searchData: {
+        terms: searchTerms,
+        tagsetNames: ['skills', 'keywords'],
+        filters: [
+          {
+            category: SearchCategory.Spaces,
+            size: ITEMS_LIMIT,
+          },
+        ],
+      },
+    },
+    fetchPolicy: 'no-cache',
+    skip: !shouldSearch,
+  });
+
+  const usesPagination =
+    (membershipFilter === SpacesExplorerMembershipFilter.All ||
+      membershipFilter === SpacesExplorerMembershipFilter.Public) &&
+    !shouldSearch;
+
+  // Call the query hook directly instead of passing it to usePaginatedQuery
+  const {
+    data: spacesData,
+    fetchMore: fetchMoreSpacesRaw,
+    loading: isLoadingSpaces,
+  } = useSpaceExplorerAllSpacesQuery({
+    variables: {
+      first: ITEMS_LIMIT,
+    },
+    skip: !usesPagination,
+  });
+
+  const spacePageInfo = spacesData?.spacesPaginated.pageInfo;
+  const hasMoreSpaces = spacePageInfo?.hasNextPage ?? false;
+
+  const fetchMoreSpaces = async () => {
+    if (!spacesData) {
+      return;
+    }
+
+    await fetchMoreSpacesRaw({
+      variables: {
+        first: ITEMS_LIMIT,
+        after: spacePageInfo?.endCursor,
+      },
+    });
+  };
+
+  const fetchMore = usesPagination ? fetchMoreSpaces : () => Promise.resolve();
+
+  const hasMore = usesPagination ? hasMoreSpaces : false;
+
+  const fetchedSpaces = (() => {
+    switch (membershipFilter) {
+      case SpacesExplorerMembershipFilter.All:
+      case SpacesExplorerMembershipFilter.Public:
+        return spacesData?.spacesPaginated.spaces;
+      case SpacesExplorerMembershipFilter.Member:
+        return spacesExplorerData?.spaces;
+    }
+  })();
+
+  // Spaces which allow this user read their subspaces:
+  const readableSpacesIds = fetchedSpaces
+    ?.filter(space => space.authorization?.myPrivileges?.includes(AuthorizationPrivilege.Read))
+    .map(space => space.id);
+
+  const [fetchSubspaces, { loading: loadingSubspaces }] = useSpaceExplorerSubspacesLazyQuery();
+  const [fetchedSpacesWithSubspaces, setFetchedSpacesWithSubspaces] = useState<SpaceExplorerSubspacesQuery['spaces']>(
+    []
+  );
+
+  useEffect(() => {
+    const fetchSubspacesData = async () => {
+      // Fetch the spaces that are not already fetched
+      const missingSubspaces = readableSpacesIds?.filter(
+        spaceId => !fetchedSpacesWithSubspaces.some(space => space.id === spaceId)
+      );
+      if (!missingSubspaces || missingSubspaces.length === 0) {
+        return;
+      }
+      const { data } = await fetchSubspaces({
+        variables: {
+          IDs: missingSubspaces,
+        },
+      });
+      setFetchedSpacesWithSubspaces(prev => uniqBy([...prev, ...(data?.spaces ?? [])], space => space.id));
+    };
+    fetchSubspacesData();
+  }, [readableSpacesIds]);
+
+  const loading =
+    isLoadingSpaces ||
+    isLoadingMemberSpaces ||
+    loadingSearchResults ||
+    loadingUserData ||
+    loadingUser ||
+    loadingSubspaces;
+
+  const flattenedSpaces = (() => {
+    if (shouldSearch) {
+      return rawSearchResults?.search?.spaceResults?.results.map(result => {
+        const entry = result as TypedSearchResult<SearchResultType.Space, SpaceExplorerSearchSpaceFragment>;
+
+        if (entry.type === SearchResultType.Space || entry.type === SearchResultType.Subspace) {
+          return {
+            ...entry.space,
+            parent: undefined,
+            matchedTerms: entry.terms,
+          };
+        }
+
+        return null as never;
+      });
+    }
+
+    return fetchedSpaces?.flatMap<SpaceWithParent>(space => {
+      const subspaces = fetchedSpacesWithSubspaces?.find(
+        spaceWithSubspaces => spaceWithSubspaces.id === space.id
+      )?.subspaces;
+
+      if (!subspaces || subspaces.length === 0) {
+        return space;
+      }
+      return [
+        space,
+        ...subspaces.map(subspace => ({
+          ...subspace,
+          parent: space,
+        })),
+      ];
+    });
+  })();
+
+  const filteredSpaces = (() => {
+    if (membershipFilter === SpacesExplorerMembershipFilter.Member) {
+      if (!shouldSearch) {
+        // already filtered by the query
+        return flattenedSpaces;
+      }
+      return flattenedSpaces?.filter(
+        space => space.about.membership?.myMembershipStatus === CommunityMembershipStatus.Member
+      );
+    }
+    if (membershipFilter === SpacesExplorerMembershipFilter.Public) {
+      return flattenedSpaces?.filter(space => space.about.isContentPublic);
+    }
+    return flattenedSpaces;
+  })();
+
+  return {
+    spaces: filteredSpaces,
+    authenticated: isAuthenticated,
+    searchTerms,
+    membershipFilter,
+    onMembershipFilterChange: setMembershipFilter,
+    fetchMore,
+    loading,
+    hasMore,
+    setSearchTerms,
+    loadingSearchResults,
+  };
+};
+
+export default useSpaceExplorer;

--- a/src/main/topLevelPages/topLevelSpaces/useSpaceExplorerViewState.ts
+++ b/src/main/topLevelPages/topLevelSpaces/useSpaceExplorerViewState.ts
@@ -1,0 +1,39 @@
+import { useTranslation } from 'react-i18next';
+import { useSpaceExplorerWelcomeSpaceQuery, useSpaceUrlResolverQuery } from '@/core/apollo/generated/apollo-hooks';
+import useDirectMessageDialog from '@/domain/communication/messaging/DirectMessaging/useDirectMessageDialog';
+import type { LeadType } from '@/domain/space/components/cards/components/SpaceLeads';
+
+export const useSpaceExplorerViewState = () => {
+  const { t } = useTranslation();
+
+  const { sendMessage, directMessageDialog } = useDirectMessageDialog({
+    dialogTitle: t('send-message-dialog.direct-message-title'),
+  });
+
+  const handleContactLead = (leadType: LeadType, leadId: string, leadDisplayName: string, leadAvatarUri?: string) => {
+    sendMessage(leadType, {
+      id: leadId,
+      displayName: leadDisplayName,
+      avatarUri: leadAvatarUri,
+    });
+  };
+
+  const spaceNameId = t('pages.home.sections.membershipSuggestions.suggestedSpace.nameId');
+  const { data: spaceIdData } = useSpaceUrlResolverQuery({
+    variables: { spaceNameId },
+    skip: !spaceNameId,
+  });
+  const welcomeSpaceId = spaceIdData?.lookupByName.space?.id;
+
+  const { data: spaceExplorerData } = useSpaceExplorerWelcomeSpaceQuery({
+    variables: { spaceId: welcomeSpaceId! },
+    skip: !welcomeSpaceId,
+  });
+  const welcomeSpace = spaceExplorerData?.lookup.space;
+
+  return {
+    handleContactLead,
+    directMessageDialog,
+    welcomeSpace,
+  };
+};


### PR DESCRIPTION
_Target - feature branch_

  How it works:
  - Default (all environments): old MUI /spaces page renders
  - To enable CRD locally or on staging: localStorage.setItem('alkemio-crd-enabled', 'true') + refresh
  - Both versions are lazy-loaded — the unused chunk is never fetched
