### PR TITLE
Improves push notification management

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -2737,6 +2737,7 @@ export type MutationKeySpecifier = (
   | 'deleteVirtualContributor'
   | 'deleteVisualFromMediaGallery'
   | 'deleteWhiteboard'
+  | 'enablePushSubscription'
   | 'eventOnApplication'
   | 'eventOnInvitation'
   | 'eventOnOrganizationVerification'
@@ -2945,6 +2946,7 @@ export type MutationFieldPolicy = {
   deleteVirtualContributor?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteVisualFromMediaGallery?: FieldPolicy<any> | FieldReadFunction<any>;
   deleteWhiteboard?: FieldPolicy<any> | FieldReadFunction<any>;
+  enablePushSubscription?: FieldPolicy<any> | FieldReadFunction<any>;
   eventOnApplication?: FieldPolicy<any> | FieldReadFunction<any>;
   eventOnInvitation?: FieldPolicy<any> | FieldReadFunction<any>;
   eventOnOrganizationVerification?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -4574,6 +4574,8 @@ export type Mutation = {
   deleteVisualFromMediaGallery: Visual;
   /** Deletes the specified Whiteboard. */
   deleteWhiteboard: Whiteboard;
+  /** Re-enable a previously disabled push notification subscription for the current user. */
+  enablePushSubscription: PushSubscription;
   /** Trigger an event on the Application. */
   eventOnApplication: Application;
   /** Trigger an event on the Invitation. */
@@ -4678,7 +4680,7 @@ export type Mutation = {
   transferSpaceToAccount: Space;
   /** Transfer the specified Virtual Contributor to another Account. */
   transferVirtualContributorToAccount: InnovationPack;
-  /** Remove a push notification subscription for the current user. */
+  /** Disable a push notification subscription for the current user. The subscription is retained but will not receive notifications until re-enabled. */
   unsubscribeFromPushNotifications: PushSubscription;
   /** Update the Application Form used by this RoleSet. */
   updateApplicationFormOnRoleSet: RoleSet;
@@ -5134,6 +5136,10 @@ export type MutationDeleteVisualFromMediaGalleryArgs = {
 
 export type MutationDeleteWhiteboardArgs = {
   whiteboardData: DeleteWhiteboardInput;
+};
+
+export type MutationEnablePushSubscriptionArgs = {
+  subscriptionData: UnsubscribeFromPushNotificationsInput;
 };
 
 export type MutationEventOnApplicationArgs = {
@@ -6562,6 +6568,7 @@ export type PushSubscription = {
 /** Status of a push notification subscription. */
 export enum PushSubscriptionStatus {
   Active = 'ACTIVE',
+  Disabled = 'DISABLED',
   Expired = 'EXPIRED',
 }
 
@@ -6593,7 +6600,7 @@ export type Query = {
   lookupByName: LookupByNameQueryResults;
   /** Information about the current authenticated user */
   me: MeQueryResults;
-  /** Returns the current user's active push notification subscriptions. Requires authentication. */
+  /** Returns the current user's push notification subscriptions (active and disabled). Requires authentication. */
   myPushSubscriptions: Array<PushSubscription>;
   /** The notificationRecipients for the provided event on the given entity. */
   notificationRecipients: NotificationRecipientResult;

--- a/src/core/auth/authentication/pages/LogoutPage.tsx
+++ b/src/core/auth/authentication/pages/LogoutPage.tsx
@@ -7,6 +7,7 @@ import { useReturnUrl } from '@/core/auth/authentication/utils/useSignUpReturnUr
 import Loading from '@/core/ui/loading/Loading';
 
 const PUSH_SUBSCRIPTION_ID_KEY = 'alkemio_push_subscription_id';
+const PUSH_USER_DISABLED_KEY = 'alkemio_push_user_disabled';
 
 async function cleanupPushSubscription(
   unsubscribeMutation: ReturnType<typeof useUnsubscribeFromPushNotificationsMutation>[0]
@@ -28,8 +29,9 @@ async function cleanupPushSubscription(
       }
     }
   } finally {
-    // Always clear the cached ID, even if cleanup partially fails
+    // Always clear cached state, even if cleanup partially fails
     localStorage.removeItem(PUSH_SUBSCRIPTION_ID_KEY);
+    localStorage.removeItem(PUSH_USER_DISABLED_KEY);
   }
 }
 

--- a/src/core/auth/authentication/pages/LogoutPage.tsx
+++ b/src/core/auth/authentication/pages/LogoutPage.tsx
@@ -5,9 +5,7 @@ import { useUnsubscribeFromPushNotificationsMutation } from '@/core/apollo/gener
 import { useLogoutUrl } from '@/core/auth/authentication/hooks/useLogoutUrl';
 import { useReturnUrl } from '@/core/auth/authentication/utils/useSignUpReturnUrl';
 import Loading from '@/core/ui/loading/Loading';
-
-const PUSH_SUBSCRIPTION_ID_KEY = 'alkemio_push_subscription_id';
-const PUSH_USER_DISABLED_KEY = 'alkemio_push_user_disabled';
+import { PUSH_SUBSCRIPTION_ID_KEY, PUSH_USER_DISABLED_KEY } from '@/main/pushNotifications/constants';
 
 async function cleanupPushSubscription(
   unsubscribeMutation: ReturnType<typeof useUnsubscribeFromPushNotificationsMutation>[0]

--- a/src/domain/community/userAdmin/tabs/components/PushSubscriptionsList.tsx
+++ b/src/domain/community/userAdmin/tabs/components/PushSubscriptionsList.tsx
@@ -5,6 +5,7 @@ import {
   useMyPushSubscriptionsQuery,
   useUnsubscribeFromPushNotificationsMutation,
 } from '@/core/apollo/generated/apollo-hooks';
+import { PushSubscriptionStatus } from '@/core/apollo/generated/graphql-schema';
 import { Caption } from '@/core/ui/typography/components';
 
 function parseUserAgent(userAgent: string | null | undefined): string {
@@ -36,7 +37,7 @@ export const PushSubscriptionsList = () => {
   const [unsubscribeMutation] = useUnsubscribeFromPushNotificationsMutation();
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
 
-  const subscriptions = data?.myPushSubscriptions ?? [];
+  const subscriptions = (data?.myPushSubscriptions ?? []).filter(sub => sub.status !== PushSubscriptionStatus.Disabled);
   const currentSubscriptionId = localStorage.getItem('alkemio_push_subscription_id');
 
   if (loading) return null;

--- a/src/main/pushNotifications/PushNotificationProvider.tsx
+++ b/src/main/pushNotifications/PushNotificationProvider.tsx
@@ -5,10 +5,8 @@ import {
   useSubscribeToPushNotificationsMutation,
 } from '@/core/apollo/generated/apollo-hooks';
 import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
+import { PUSH_SUBSCRIPTION_ID_KEY, PUSH_USER_DISABLED_KEY } from '@/main/pushNotifications/constants';
 import { type PushNotificationState, usePushNotifications } from '@/main/pushNotifications/usePushNotifications';
-
-const PUSH_SUBSCRIPTION_ID_KEY = 'alkemio_push_subscription_id';
-const PUSH_USER_DISABLED_KEY = 'alkemio_push_user_disabled';
 
 const defaultState: PushNotificationState = {
   isSupported: false,

--- a/src/main/pushNotifications/PushNotificationProvider.tsx
+++ b/src/main/pushNotifications/PushNotificationProvider.tsx
@@ -8,6 +8,7 @@ import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrent
 import { type PushNotificationState, usePushNotifications } from '@/main/pushNotifications/usePushNotifications';
 
 const PUSH_SUBSCRIPTION_ID_KEY = 'alkemio_push_subscription_id';
+const PUSH_USER_DISABLED_KEY = 'alkemio_push_user_disabled';
 
 const defaultState: PushNotificationState = {
   isSupported: false,
@@ -36,6 +37,8 @@ const PushNotificationProviderInner: FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     if (!pushState.isSupported || !pushState.isServerEnabled) return;
     if (Notification.permission !== 'granted') return;
+    // User explicitly disabled push — don't auto-resubscribe
+    if (localStorage.getItem(PUSH_USER_DISABLED_KEY)) return;
 
     const silentRefresh = async () => {
       try {
@@ -91,6 +94,8 @@ const PushNotificationProviderInner: FC<PropsWithChildren> = ({ children }) => {
       }
 
       if (event.data?.type === 'PUSH_SUBSCRIPTION_CHANGED' && event.data.subscription) {
+        // User explicitly disabled push — don't re-register
+        if (localStorage.getItem(PUSH_USER_DISABLED_KEY)) return;
         // Re-register the new subscription with server
         const sub = event.data.subscription;
         subscribeMutation({

--- a/src/main/pushNotifications/constants.ts
+++ b/src/main/pushNotifications/constants.ts
@@ -1,0 +1,2 @@
+export const PUSH_SUBSCRIPTION_ID_KEY = 'alkemio_push_subscription_id';
+export const PUSH_USER_DISABLED_KEY = 'alkemio_push_user_disabled';

--- a/src/main/pushNotifications/usePushNotifications.ts
+++ b/src/main/pushNotifications/usePushNotifications.ts
@@ -7,6 +7,7 @@ import {
 import { urlBase64ToUint8Array } from '@/main/pushNotifications/urlBase64ToUint8Array';
 
 const PUSH_SUBSCRIPTION_ID_KEY = 'alkemio_push_subscription_id';
+const PUSH_USER_DISABLED_KEY = 'alkemio_push_user_disabled';
 
 export type PushNotificationState = {
   isSupported: boolean;
@@ -119,6 +120,7 @@ export function usePushNotifications(): PushNotificationState {
         localStorage.setItem(PUSH_SUBSCRIPTION_ID_KEY, serverSubscriptionId);
         setCurrentSubscriptionId(serverSubscriptionId);
       }
+      localStorage.removeItem(PUSH_USER_DISABLED_KEY);
       setIsSubscribed(true);
     } catch (error) {
       // FR-014: Rollback browser subscription on server error
@@ -160,6 +162,7 @@ export function usePushNotifications(): PushNotificationState {
       }
 
       localStorage.removeItem(PUSH_SUBSCRIPTION_ID_KEY);
+      localStorage.setItem(PUSH_USER_DISABLED_KEY, 'true');
       setCurrentSubscriptionId(null);
       setIsSubscribed(false);
     } finally {

--- a/src/main/pushNotifications/usePushNotifications.ts
+++ b/src/main/pushNotifications/usePushNotifications.ts
@@ -4,10 +4,8 @@ import {
   useUnsubscribeFromPushNotificationsMutation,
   useVapidPublicKeyQuery,
 } from '@/core/apollo/generated/apollo-hooks';
+import { PUSH_SUBSCRIPTION_ID_KEY, PUSH_USER_DISABLED_KEY } from '@/main/pushNotifications/constants';
 import { urlBase64ToUint8Array } from '@/main/pushNotifications/urlBase64ToUint8Array';
-
-const PUSH_SUBSCRIPTION_ID_KEY = 'alkemio_push_subscription_id';
-const PUSH_USER_DISABLED_KEY = 'alkemio_push_user_disabled';
 
 export type PushNotificationState = {
   isSupported: boolean;


### PR DESCRIPTION
### Describe the background of your pull request

This pull request enhances push notification management by introducing a "disabled" state for subscriptions. Users can now disable push notifications without fully deleting their subscription, and later re-enable them. This provides greater control over push notification preferences and improves the user experience.

The changes include:
- A new GraphQL mutation `enablePushSubscription` to re-activate a previously disabled subscription.
- Updates to the `unsubscribeFromPushNotifications` mutation, clarifying its purpose to disable rather than permanently remove a subscription.
- A new `DISABLED` status for push subscriptions within the GraphQL schema.
- Introduction of a local storage flag (`PUSH_USER_DISABLED_KEY`) to track if a user has explicitly disabled notifications, preventing automatic re-subscription attempts.
- Updates to the logout process to correctly clear this local state.

### Additional context

These changes are part of the `fix/pwa-settings` initiative, aiming to improve the functionality and user control within the Progressive Web App's notification features.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled push subscriptions no longer display in the subscription management list.
  * Push notification opt-out state is now properly maintained and prevents automatic resubscription.
  * Push notification state is correctly cleared during logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->