### PR TITLE
[CRD] fix the links and in-app notifications

### DIFF
--- a/docs/crd/migration-guide.md
+++ b/docs/crd/migration-guide.md
@@ -9,29 +9,38 @@ The prototype in `prototype/` (generated from Figma Make) is the design referenc
 ## Architecture at a Glance
 
 ```
-TopLevelRoutes.tsx
-  ├── MUI routes  → TopLevelLayout (existing MUI header/footer)
-  └── CRD routes  → CrdLayoutWrapper → CrdLayout (CRD header/footer)
-       (gated by       └── <Outlet /> → Your page
-        localStorage
-        toggle)
+root.tsx
+  ├── NotificationsGate (global)
+  │   ├── CRD enabled  → CrdNotificationsPanelConnector (shadcn dialog)
+  │   └── CRD disabled → InAppNotificationsDialog (MUI dialog)
+  │
+  └── TopLevelRoutes.tsx
+      ├── MUI routes  → TopLevelLayout (existing MUI header/footer)
+      └── CRD routes  → CrdLayoutWrapper → CrdLayout (CRD header/footer)
+           (gated by       └── <Outlet /> → Your page
+            localStorage
+            toggle)
 ```
 
-CRD pages get a completely different shell — CRD header, CRD footer, Tailwind styling. MUI pages are untouched.
+CRD pages get a completely different shell — CRD header, CRD footer, Tailwind styling. MUI pages are untouched. Global dialogs (notifications) are handled at `root.tsx` level and work on all pages regardless of layout.
 
-During migration, CRD routes are gated behind a **localStorage toggle** (`alkemio-crd-enabled`, default OFF). Deployed environments always render the old MUI pages. Developers and QA opt in locally.
+During migration, CRD routes are gated behind a **localStorage toggle** (`alkemio-crd-enabled`, default OFF). Deployed environments always render the old MUI pages. Developers and QA opt in via the **Admin UI** (Administration → Platform Settings → Design System) or the browser console.
 
 ## Feature Toggle
 
 The toggle lives in `src/main/crdPages/useCrdEnabled.ts` and is used in `TopLevelRoutes.tsx` to conditionally render CRD or MUI pages.
 
-**Enable CRD pages** (browser console):
+**Enable CRD pages via Admin UI:**
+Navigate to **Administration → Platform Settings** (the layout settings page). Under the "Design System" section, select **CRD (New Design)** and the page reloads with the new design. This sets `localStorage('alkemio-crd-enabled', 'true')` under the hood.
+
+**Enable via browser console** (alternative):
 ```js
 localStorage.setItem('alkemio-crd-enabled', 'true');
 location.reload();
 ```
 
 **Disable CRD pages** (back to MUI):
+Use the Admin UI toggle, or via console:
 ```js
 localStorage.removeItem('alkemio-crd-enabled');
 location.reload();
@@ -39,7 +48,7 @@ location.reload();
 
 Both page versions are lazy-loaded — the unused chunk is never fetched, so there is no bundle penalty.
 
-When migration is complete and all CRD pages are validated, remove the toggle: delete `useCrdEnabled.ts`, remove conditional routing in `TopLevelRoutes.tsx`, delete old MUI page files from `src/main/topLevelPages/`.
+When migration is complete and all CRD pages are validated, remove the toggle: delete `useCrdEnabled.ts`, remove conditional routing in `TopLevelRoutes.tsx`, remove `NotificationsGate` from `root.tsx`, delete old MUI page files from `src/main/topLevelPages/`.
 
 ## The Three Layers
 
@@ -184,9 +193,11 @@ See [translations.md](./translations.md) for the full guide. Short version:
 
 Tailwind is loaded globally but scoped via `.crd-root` — MUI pages outside this scope are unaffected. CRD pages must never import MUI, ensuring no MUI CSS is loaded for CRD routes.
 
-### Existing MUI Dialogs
+### Global Dialogs (Messages, Notifications)
 
-Some app-wide features (Messages, Notifications) are MUI dialogs rendered in `root.tsx`. CRD pages trigger them via callback props (`onMessagesClick`, `onNotificationsClick`) — the CRD component doesn't know they're MUI under the hood.
+**Messages**: The MUI Messages dialog is rendered in `root.tsx` and shared across all routes. CRD pages trigger it via `onMessagesClick` callback prop.
+
+**Notifications**: Handled globally in `root.tsx` via `NotificationsGate`, which renders either the CRD `NotificationsPanel` or the MUI `InAppNotificationsDialog` based on the CRD toggle. Both are lazy-loaded — only one is ever fetched. The bell icon click (from either CRD Header or MUI AppBar) sets `InAppNotificationsContext.setIsOpen(true)` and the correct dialog opens on any page. The CRD component doesn't know about the toggle — it just calls a callback prop.
 
 ### Data Hooks Are Shared
 

--- a/specs/039-crd-spaces-page/contracts/crd-layout.ts
+++ b/specs/039-crd-spaces-page/contracts/crd-layout.ts
@@ -78,6 +78,27 @@ export type CrdFooterProps = {
   className?: string;
 };
 
+// --- Notification item data (used by NotificationsPanel) ---
+
+export type CrdNotificationItemData = {
+  id: string;
+  title: string;
+  description: string;
+  /** Raw message/comment body, rendered separately from the translated description. */
+  comment?: string;
+  avatarUrl?: string;
+  avatarFallback: string;
+  timestamp: string;
+  isUnread: boolean;
+  href?: string;
+  typeBadgeIcon?: React.ReactNode;
+};
+
+export type CrdNotificationFilter = {
+  key: string;
+  label: string;
+};
+
 // --- CrdLayout (full-page shell) ---
 
 export type CrdLayoutProps = {

--- a/specs/039-crd-spaces-page/data-model.md
+++ b/specs/039-crd-spaces-page/data-model.md
@@ -41,24 +41,45 @@ The plain TypeScript type consumed by the CRD SpaceCard component. Lives in `src
 | `avatarUrl` | `string` | yes | `profile.avatar?.uri ?? ''` |
 | `type` | `'person' \| 'org'` | yes | Determined by source list (leadUsers vs leadOrganizations) |
 
+### CrdNotificationItemData (CRD View Model)
+
+The plain TypeScript type consumed by the CRD NotificationItem component. Lives in `src/crd/layouts/types.ts`.
+
+| Field | Type | Required | Source |
+| --- | --- | --- | --- |
+| `id` | `string` | yes | `notification.id` |
+| `title` | `string` | yes | Translated via `t('components.inAppNotifications.type.{TYPE}.subject', values)` |
+| `description` | `string` | yes | Translated via `t('components.inAppNotifications.type.{TYPE}.description', values)` |
+| `comment` | `string \| undefined` | no | Raw message body from `payload.comment`, `messageDetails.message`, `userMessage`, etc. |
+| `avatarUrl` | `string \| undefined` | no | `notification.triggeredBy.profile.visual?.uri` |
+| `avatarFallback` | `string` | yes | Initials from `triggeredBy.profile.displayName` |
+| `timestamp` | `string` | yes | `formatTimeElapsed(notification.triggeredAt, t)` |
+| `isUnread` | `boolean` | yes | `notification.state === NotificationEventInAppState.Unread` |
+| `href` | `string \| undefined` | no | Resolved from payload URLs (messageDetails, callout, space, discussion, etc.) |
+
 ## Relationships
 
 ```
-TopLevelRoutes.tsx
-  ├── [MUI routes] → TopLevelLayout (MUI header/nav/footer)
+root.tsx (global providers)
+  ├── NotificationsGate
+  │   ├── CRD enabled  → CrdNotificationsPanelConnector (lazy) → useCrdNotifications()
+  │   └── CRD disabled → InAppNotificationsDialog (lazy, MUI)
   │
-  └── [CRD routes] → CrdLayoutWrapper (src/main/, smart container)
-                      └── CrdLayout (src/crd/layouts/, presentational)
-                          ├── Header (CRD, Tailwind)
-                          ├── <main>
-                          │   └── SpaceExplorerPage
-                          │       ├── useSpaceExplorer()        → SpaceWithParent[]  (GraphQL, unchanged)
-                          │       └── SpaceExplorerCrdView      → mapSpaceToCardData() → SpaceCardData[]
-                          │                                     → CRD SpaceExplorer / SpaceCard
-                          └── Footer (CRD, Tailwind)
+  └── TopLevelRoutes.tsx
+      ├── [MUI routes] → TopLevelLayout (MUI header/nav/footer)
+      │
+      └── [CRD routes] → CrdLayoutWrapper (composes useCrdUser, useCrdNavigation)
+                          └── CrdLayout (src/crd/layouts/, presentational)
+                              ├── Header (CRD, with HeaderIconButton helper)
+                              ├── <main>
+                              │   └── SpaceExplorerPage
+                              │       ├── useSpaceExplorer()        → SpaceWithParent[]  (GraphQL, unchanged)
+                              │       └── mapSpacesToCardDataList() → SpaceCardData[]
+                              │                                     → CRD SpaceExplorer / SpaceCard
+                              └── Footer (CRD, Tailwind)
 ```
 
-The route-level split happens in `TopLevelRoutes.tsx`: CRD routes are wrapped in `CrdLayoutWrapper`, which renders the full CRD page shell. MUI routes continue using `TopLevelLayout`. The old MUI `SpaceExplorerView` is kept in the codebase but no longer imported.
+The route-level split happens in `TopLevelRoutes.tsx`: CRD routes are wrapped in `CrdLayoutWrapper`, which renders the full CRD page shell. MUI routes continue using `TopLevelLayout`. Notifications are handled globally in `root.tsx` via `NotificationsGate` — works on all pages regardless of layout. The old MUI `SpaceExplorerView` is kept in the codebase but no longer imported.
 
 ## Derived Field Computation
 

--- a/specs/039-crd-spaces-page/migration-pattern.md
+++ b/specs/039-crd-spaces-page/migration-pattern.md
@@ -82,7 +82,8 @@ const MyPage = lazyWithGlobalErrorHandler(() => import('@/main/crdPages/<page>/M
 - Page components: always lazy-loaded via `lazyWithGlobalErrorHandler()` + `<Suspense fallback={<Loading />}>`
 - Dialogs triggered from CRD: lazy-loaded with `<Suspense fallback={null}>` (e.g., `HelpDialog`)
 - `CrdLayoutWrapper` itself: eager (must be available to render the page shell immediately)
-- Existing MUI dialogs (Messages, Notifications): already lazy-loaded in `root.tsx`, reuse via context providers — never duplicate
+- Existing MUI dialogs (Messages): already lazy-loaded in `root.tsx`, reuse via context providers — never duplicate
+- **Notifications**: handled globally in `root.tsx` via `NotificationsGate` — renders either the CRD `NotificationsPanel` or MUI `InAppNotificationsDialog` based on `useCrdEnabled()`. Both are lazy-loaded. The bell icon click sets `InAppNotificationsContext.setIsOpen(true)` and the correct dialog opens on any page.
 - CRD primitives: bundled with the page chunk (small, no separate vendor chunk needed)
 
 ### 8. Add i18n Keys

--- a/specs/039-crd-spaces-page/plan.md
+++ b/specs/039-crd-spaces-page/plan.md
@@ -223,14 +223,16 @@ The `CrdLayout` component in `src/crd/layouts/` is purely presentational and rec
 
 Shared types (`CrdUserInfo`, `CrdNavigationHrefs`, `CrdLanguageOption`) are defined once in `src/crd/layouts/types.ts` and imported by Header, Footer, and CrdLayout.
 
-The `CrdLayoutWrapper` in `src/main/ui/layout/`:
-- Reads auth state, user profile, platform roles, platform privileges from `useCurrentUserContext()`
+The `CrdLayoutWrapper` in `src/main/ui/layout/` composes three extracted hooks to keep the component focused:
+- `useCrdUser()` — reads auth state, user profile, platform roles/privileges from `useCurrentUserContext()`, resolves role display name
+- `useCrdNavigation()` — resolves navigation hrefs, footer links, platform nav items, language options from config/i18n
+- The bell icon click sets `InAppNotificationsContext.setIsOpen(true)` — notifications are handled globally (see D17)
 - Reads pending invitation count from `usePendingInvitationsCount()`
-- Wires Messages/Notifications callbacks to existing dialog context providers
+- Wires Messages callback to `useUserMessagingContext()`
 - Wires Pending Memberships callback to `usePendingMembershipsDialog()` context
 - Lazy-loads `HelpDialog` via `lazyWithGlobalErrorHandler()`
-- Resolves navigation hrefs from `ROUTE_HOME`, `ROUTE_USER_ME`, `buildUserAccountUrl()`, `TopLevelRoutePath`
-- Resolves platform role display name from `platformRoles` (same logic as MUI `PlatformNavigationUserMenu`)
+
+The `Header` component uses a `HeaderIconButton` helper to reduce duplication across the icon bar (Search, Messages, Notifications) — each icon conditionally renders as a callback button or an `<a href>` fallback.
 
 ### D10: Prototype-Matching Filter Bar (Filters Dropdown)
 
@@ -275,7 +277,8 @@ The CRD system follows the project's established lazy loading patterns to minimi
 - **Page components** (e.g., `SpaceExplorerPage`) — lazy-loaded via `lazyWithGlobalErrorHandler()` in `TopLevelRoutes.tsx`, wrapped in `<Suspense fallback={<Loading />}>`. Each page creates its own chunk.
 - **HelpDialog** — lazy-loaded in `CrdLayoutWrapper` via `lazyWithGlobalErrorHandler()`, only loaded when user clicks "Get Help"
 - **PendingMembershipsDialog** — already lazy-loaded at the root level, triggered via context provider
-- **Messages/Notifications dialogs** — already lazy-loaded in `root.tsx`, reused via context providers
+- **Messages dialog** — already lazy-loaded in `root.tsx`, reused via context provider
+- **Notifications dialog** — lazy-loaded in `root.tsx` via `NotificationsGate`, which renders either `CrdNotificationsPanelConnector` or `InAppNotificationsDialog` based on the CRD toggle (see D17)
 
 **Bundle chunking** (from `vite.config.mjs` `manualChunks`):
 - CRD components are NOT in a separate vendor chunk — Radix UI deps are small compared to MUI and don't warrant a dedicated chunk
@@ -306,24 +309,35 @@ As part of this work, the existing user profile dropdown (~120 lines) is extract
 
 **i18n:** Menu item labels are passed as translated strings from the consumer (via `CrdLayoutWrapper` using the main `translation` namespace). The PlatformNavigationMenu component itself does not call `useTranslation` for item labels — they arrive as props. Any structural UI text (e.g., a menu heading) uses the `crd-layout` namespace.
 
-### D17: CRD Notifications Panel — Generic Item + Dialog Pattern
+### D17: CRD Notifications Panel — Global Dialog with Generic Items
 
 The MUI `InAppNotificationsDialog` is a full modal with 40+ type-specific notification view components, filter chips, infinite scroll, and state transitions. The CRD migration replaces the **presentational shell** while keeping the **data layer and type-specific logic** untouched.
 
 **Architecture split:**
 
-- **CRD layer** (`src/crd/layouts/components/NotificationsPanel.tsx`): A presentational dialog component that renders a generic notification list. Receives all data and callbacks as props. Contains:
-  - `NotificationsPanel` — dialog with header (title, mark-all-read, settings link), filter chips, scrollable list, empty state
-  - `NotificationItem` — generic item: avatar, title, description, timestamp, unread dot, actions menu. Works for all 40+ notification types via a flat props interface
-- **Integration layer** (`src/main/ui/layout/CrdLayoutWrapper.tsx`): Renders `NotificationsPanel` conditionally when `isOpen` is true. Maps `InAppNotificationModel[]` from the existing `useInAppNotifications()` hook to `NotificationItemData[]` (plain CRD props). The 40+ type-specific views in `src/main/inAppNotifications/views/` are NOT migrated — instead, a data mapper extracts `{ title, description, avatarUrl, timestamp, isUnread, href }` from each `InAppNotificationModel` for the generic CRD item.
-- **Data layer** (unchanged): `useInAppNotifications()` hook, `InAppNotificationsContext`, GraphQL queries/subscriptions/mutations, notification type filters — all stay in `src/main/inAppNotifications/`
+- **CRD layer** (`src/crd/components/notifications/`): Presentational dialog components that render a generic notification list. Receive all data and callbacks as props:
+  - `NotificationsPanel` — dialog with header (title, mark-all-read, settings link), filter chips, scrollable list, empty state. Full-screen on mobile, bounded dialog on desktop (`sm:max-w-xl`).
+  - `NotificationItem` — generic item: avatar, title, description, comment (italic, separate from translated description), timestamp + actions menu (right column). Works for all 40+ notification types via a flat props interface.
+- **Global integration** (`src/main/ui/layout/CrdNotificationsPanelConnector.tsx`): Rendered in `root.tsx` via `NotificationsGate`, which conditionally renders either the CRD connector or the MUI dialog based on `useCrdEnabled()`. This ensures notifications work on **all pages** regardless of which layout wraps them — not just CRD routes.
+  - `useCrdNotifications()` hook encapsulates all notification wiring: maps `InAppNotificationModel[]` to `CrdNotificationItemData[]`, builds filter UI, handles click/state transitions.
+  - `notificationDataMapper.ts` resolves each notification type's i18n template with **all 34 interpolation values** (including pre-translated values like `spaceLevel` and `category`), plus a separate `comment` field for the raw message body.
+  - Uses `@/core/routing/useNavigate` for click navigation (handles absolute URL normalization automatically).
+- **Data layer** (unchanged): `useInAppNotifications()` hook, `InAppNotificationsContext`, GraphQL queries/subscriptions/mutations, notification type filters — all stay in `src/main/inAppNotifications/`.
 
-**Why a generic item instead of 40+ CRD views:** The type-specific views only differ in which i18n key and which payload fields they extract. A single mapper function can resolve each notification type to `{ title, description }` by calling `t()` with the appropriate key and values. This eliminates 40+ tiny CRD components that would each be ~10 lines of prop extraction.
+**Why a generic item instead of 40+ CRD views:** The type-specific views only differ in which i18n key and which payload fields they extract. A single mapper function can resolve each notification type to `{ title, description, comment }` by calling `t()` with the appropriate key and values. This eliminates 40+ tiny CRD components that would each be ~10 lines of prop extraction.
 
-**Dialog vs dropdown:** The MUI version uses a full modal dialog, and the developer confirmed this approach. The CRD version uses a Radix `Dialog` primitive (to be ported from prototype if not yet available) rather than a `DropdownMenu`, since the notification list needs scrolling, filters, and a header bar.
+**Why global rendering in `root.tsx`:** Notifications are a global concern — users expect to open notifications from any page. Rendering the dialog inside `CrdLayoutWrapper` would only work on CRD routes; MUI-layout pages would have no notification dialog when CRD is enabled. The `NotificationsGate` pattern solves this:
+```
+root.tsx → NotificationsGate
+  ├── CRD enabled  → CrdNotificationsPanelConnector (lazy)
+  └── CRD disabled → InAppNotificationsDialog (lazy, MUI)
+```
+Both read `isOpen` from `InAppNotificationsContext`. The bell icon click (from either CRD Header or MUI AppBar) sets `context.setIsOpen(true)` and the correct dialog opens. Only one is ever loaded — no bundle overhead.
 
-**Unread badge:** The bell icon in `Header.tsx` gains an `unreadCount?: number` prop. When > 0, a small badge dot or count is shown on the bell icon, matching the MUI `BadgeCounter` behavior.
+**Dialog layout:** The CRD version uses a Radix `Dialog` primitive. Full-screen on mobile (`h-[100dvh]`, no border radius), bounded on desktop (`sm:max-w-xl`, `sm:max-h-[60vh]` for the list). Notification items show the timestamp and three-dots action menu in a right-aligned column.
+
+**Unread badge:** The bell icon in `Header.tsx` gains an `unreadCount?: number` prop. When > 0, a small badge dot is shown on the bell icon, matching the MUI `BadgeCounter` behavior.
 
 **Filter chips:** The 4 filter categories (All, Messages & Replies, Space, Platform) are rendered as CRD `Button` variants (ghost/secondary toggle). The selected filter maps to `NotificationEvent[]` types in the existing `notificationFilters.ts` — this mapping stays in the integration layer.
 
-**Rendering location:** The `NotificationsPanel` is rendered in `CrdLayoutWrapper` (like `HelpDialog` and `PendingMembershipsDialog`), lazy-loaded via `lazyWithGlobalErrorHandler()`. It replaces the MUI `InAppNotificationsDialog` for CRD routes. The MUI dialog in `root.tsx` continues to serve MUI routes.
+**i18n strategy:** Notification type strings (34 subject/description templates) and filter labels remain in the main `translation` namespace (`components.inAppNotifications` in `translation.en.json`). They are shared between the MUI `InAppNotificationsDialog` and the CRD `NotificationsPanel` — duplicating would create drift risk, and moving would break the MUI dialog. The `crd-notifications` namespace (`src/crd/i18n/notifications/`) contains only CRD dialog chrome (title, actions, empty state). Once the MUI dialog is removed, the type strings should be moved to the `crd-notifications` namespace. This is tracked by a `_migration_note` in a TODO in `notificationDataMapper.ts`.

--- a/src/crd/components/notifications/NotificationItem.tsx
+++ b/src/crd/components/notifications/NotificationItem.tsx
@@ -57,14 +57,18 @@ export function NotificationItem({ notification, onClick, onRead, onUnread, onAr
             )}
             <span className={cn(notification.isUnread && 'font-semibold')}>{notification.title}</span>
           </p>
-          <p className="text-sm text-muted-foreground line-clamp-2">{notification.description}</p>
-          <p className="text-xs text-muted-foreground">{notification.timestamp}</p>
+          {notification.description && (
+            <p className="text-sm text-muted-foreground line-clamp-2">{notification.description}</p>
+          )}
+          {notification.comment && (
+            <p className="text-sm text-muted-foreground line-clamp-2 italic">{notification.comment}</p>
+          )}
         </div>
       </button>
 
-      {/* Actions menu */}
-      {(onRead || onUnread || onArchive) && (
-        <div className="shrink-0 self-center">
+      {/* Right column: actions + timestamp */}
+      <div className="shrink-0 flex flex-col items-center gap-1 self-start pt-0.5">
+        {(onRead || onUnread || onArchive) && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild={true}>
               <Button
@@ -98,8 +102,9 @@ export function NotificationItem({ notification, onClick, onRead, onUnread, onAr
               )}
             </DropdownMenuContent>
           </DropdownMenu>
-        </div>
-      )}
+        )}
+        <span className="text-[11px] text-muted-foreground whitespace-nowrap">{notification.timestamp}</span>
+      </div>
     </div>
   );
 }

--- a/src/crd/components/notifications/NotificationsPanel.tsx
+++ b/src/crd/components/notifications/NotificationsPanel.tsx
@@ -63,7 +63,7 @@ export function NotificationsPanel({
   return (
     <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
       <DialogContent
-        className="sm:max-w-md md:max-w-lg p-0 gap-0 overflow-hidden"
+        className="max-w-none h-[100dvh] sm:h-auto sm:max-w-lg md:max-w-xl rounded-none sm:rounded-lg p-0 gap-0 overflow-hidden flex flex-col"
         closeLabel={t('notifications.close')}
       >
         {/* Header */}
@@ -91,7 +91,7 @@ export function NotificationsPanel({
 
         {/* Filter chips */}
         {filters.length > 0 && (
-          <div className="flex gap-1 px-4 py-2 border-b border-border overflow-x-auto">
+          <div className="flex gap-1 px-4 py-1.5 border-b border-border overflow-x-auto">
             {filters.map(filter => (
               <Button
                 key={filter.key}
@@ -107,7 +107,7 @@ export function NotificationsPanel({
         )}
 
         {/* Notification list */}
-        <div className="max-h-[60vh] overflow-y-auto">
+        <div className="flex-1 overflow-y-auto sm:max-h-[60vh]">
           {showSkeletons && (
             <output aria-label={t('notifications.loading')}>
               {Array.from({ length: 5 }).map((_, i) => (

--- a/src/crd/components/space/SpaceExplorer.tsx
+++ b/src/crd/components/space/SpaceExplorer.tsx
@@ -244,11 +244,6 @@ export function SpaceExplorer({
         <div className="flex items-center justify-between mb-4">
           <p className="text-sm text-muted-foreground">
             {t('spaces.showing')} <span className="font-semibold text-foreground">{displayedSpaces.length}</span>{' '}
-            {activeFilterCount === 0 && (
-              <>
-                {t('spaces.of')} <span className="font-semibold text-foreground">{spaces.length}</span>{' '}
-              </>
-            )}
             {t('spaces.spacesLabel')}
           </p>
         </div>

--- a/src/crd/layouts/types.ts
+++ b/src/crd/layouts/types.ts
@@ -40,6 +40,7 @@ export type CrdNotificationItemData = {
   id: string;
   title: string;
   description: string;
+  comment?: string;
   avatarUrl?: string;
   avatarFallback: string;
   timestamp: string;

--- a/src/main/crdPages/spaces/SpaceExplorerPage.tsx
+++ b/src/main/crdPages/spaces/SpaceExplorerPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import type { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
+import useNavigate from '@/core/routing/useNavigate';
 import { usePageTitle } from '@/core/routing/usePageTitle';
 import type { Identifiable } from '@/core/utils/Identifiable';
 import { SpaceExplorer } from '@/crd/components/space/SpaceExplorer';

--- a/src/main/ui/layout/CrdLayoutWrapper.tsx
+++ b/src/main/ui/layout/CrdLayoutWrapper.tsx
@@ -1,17 +1,17 @@
 import { Suspense, useState } from 'react';
-import { Outlet, useNavigate } from 'react-router-dom';
-import { NotificationEventInAppState } from '@/core/apollo/generated/graphql-schema';
+import { Outlet } from 'react-router-dom';
 import { IdentityRoutes } from '@/core/auth/authentication/routing/IdentityRoute';
 import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
+import useNavigate from '@/core/routing/useNavigate';
 import { CrdLayout } from '@/crd/layouts/CrdLayout';
 import {
   PendingMembershipsDialogType,
   usePendingMembershipsDialog,
 } from '@/domain/community/pendingMembership/PendingMembershipsDialogContext';
 import { usePendingInvitationsCount } from '@/domain/community/pendingMembership/usePendingInvitationsCount';
-import type { NotificationFilterType } from '@/main/inAppNotifications/notificationFilters';
+import { useInAppNotificationsContext } from '@/main/inAppNotifications/InAppNotificationsContext';
+import { useInAppNotifications } from '@/main/inAppNotifications/useInAppNotifications';
 import { useCrdNavigation } from '@/main/ui/layout/useCrdNavigation';
-import { useCrdNotifications } from '@/main/ui/layout/useCrdNotifications';
 import { useCrdUser } from '@/main/ui/layout/useCrdUser';
 import { useUserMessagingContext } from '@/main/userMessaging/UserMessagingContext';
 
@@ -19,10 +19,6 @@ const PendingMembershipsDialog = lazyWithGlobalErrorHandler(
   () => import('@/domain/community/pendingMembership/PendingMembershipsDialog')
 );
 const HelpDialog = lazyWithGlobalErrorHandler(() => import('@/core/help/dialog/HelpDialog'));
-const NotificationsPanel = lazyWithGlobalErrorHandler(async () => {
-  const m = await import('@/crd/components/notifications/NotificationsPanel');
-  return { default: m.NotificationsPanel };
-});
 
 function CrdLayoutConnector() {
   const { user, userModel, isAuthenticated, isAdmin } = useCrdUser();
@@ -35,23 +31,9 @@ function CrdLayoutConnector() {
     handleLanguageChange,
     platformNavigationItems,
   } = useCrdNavigation();
-  const {
-    isNotificationsOpen,
-    setNotificationsOpen,
-    notificationsUnreadCount,
-    notificationItems,
-    notificationFilters,
-    notificationFilter,
-    setNotificationFilter,
-    isLoadingNotifications,
-    hasMoreNotifications,
-    notificationSettingsHref,
-    handleNotificationClick,
-    markNotificationsAsRead,
-    fetchMoreNotifications,
-    updateNotificationState,
-  } = useCrdNotifications(userModel?.profile?.url);
 
+  const { setIsOpen: setNotificationsOpen } = useInAppNotificationsContext();
+  const { unreadCount: notificationsUnreadCount } = useInAppNotifications();
   const { setIsOpen: setMessagingOpen } = useUserMessagingContext();
   const { setOpenDialog } = usePendingMembershipsDialog();
   const { count: pendingInvitationsCount } = usePendingInvitationsCount();
@@ -97,27 +79,6 @@ function CrdLayoutConnector() {
       <Suspense fallback={null}>
         <HelpDialog open={isHelpDialogOpen} onClose={() => setIsHelpDialogOpen(false)} />
       </Suspense>
-      {isAuthenticated && (
-        <Suspense fallback={null}>
-          <NotificationsPanel
-            open={isNotificationsOpen}
-            onClose={() => setNotificationsOpen(false)}
-            items={notificationItems}
-            filters={notificationFilters}
-            selectedFilter={notificationFilter}
-            loading={isLoadingNotifications}
-            hasMore={hasMoreNotifications}
-            settingsHref={notificationSettingsHref}
-            onFilterChange={key => setNotificationFilter(key as NotificationFilterType)}
-            onMarkAllRead={() => markNotificationsAsRead()}
-            onLoadMore={() => fetchMoreNotifications()}
-            onNotificationClick={handleNotificationClick}
-            onRead={id => updateNotificationState(id, NotificationEventInAppState.Read)}
-            onUnread={id => updateNotificationState(id, NotificationEventInAppState.Unread)}
-            onArchive={id => updateNotificationState(id, NotificationEventInAppState.Archived)}
-          />
-        </Suspense>
-      )}
     </>
   );
 }

--- a/src/main/ui/layout/CrdNotificationsPanelConnector.tsx
+++ b/src/main/ui/layout/CrdNotificationsPanelConnector.tsx
@@ -1,0 +1,56 @@
+import { Suspense } from 'react';
+import { NotificationEventInAppState } from '@/core/apollo/generated/graphql-schema';
+import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
+import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
+import type { NotificationFilterType } from '@/main/inAppNotifications/notificationFilters';
+import { useCrdNotifications } from '@/main/ui/layout/useCrdNotifications';
+
+const NotificationsPanel = lazyWithGlobalErrorHandler(async () => {
+  const m = await import('@/crd/components/notifications/NotificationsPanel');
+  return { default: m.NotificationsPanel };
+});
+
+function CrdNotificationsPanelConnector() {
+  const { isAuthenticated, userModel } = useCurrentUserContext();
+  const {
+    isNotificationsOpen,
+    setNotificationsOpen,
+    notificationItems,
+    notificationFilters,
+    notificationFilter,
+    setNotificationFilter,
+    isLoadingNotifications,
+    hasMoreNotifications,
+    notificationSettingsHref,
+    handleNotificationClick,
+    markNotificationsAsRead,
+    fetchMoreNotifications,
+    updateNotificationState,
+  } = useCrdNotifications(userModel?.profile?.url);
+
+  if (!isAuthenticated) return null;
+
+  return (
+    <Suspense fallback={null}>
+      <NotificationsPanel
+        open={isNotificationsOpen}
+        onClose={() => setNotificationsOpen(false)}
+        items={notificationItems}
+        filters={notificationFilters}
+        selectedFilter={notificationFilter}
+        loading={isLoadingNotifications}
+        hasMore={hasMoreNotifications}
+        settingsHref={notificationSettingsHref}
+        onFilterChange={key => setNotificationFilter(key as NotificationFilterType)}
+        onMarkAllRead={() => markNotificationsAsRead()}
+        onLoadMore={() => fetchMoreNotifications()}
+        onNotificationClick={handleNotificationClick}
+        onRead={id => updateNotificationState(id, NotificationEventInAppState.Read)}
+        onUnread={id => updateNotificationState(id, NotificationEventInAppState.Unread)}
+        onArchive={id => updateNotificationState(id, NotificationEventInAppState.Archived)}
+      />
+    </Suspense>
+  );
+}
+
+export default CrdNotificationsPanelConnector;

--- a/src/main/ui/layout/notificationDataMapper.ts
+++ b/src/main/ui/layout/notificationDataMapper.ts
@@ -1,5 +1,14 @@
+/**
+ * Maps InAppNotificationModel → CrdNotificationItemData for the CRD NotificationsPanel.
+ *
+ * Translation keys: notification type strings (subject/description templates) live in the
+ * main 'translation' namespace at `components.inAppNotifications.type.<TYPE>` in
+ * src/core/i18n/en/translation.en.json. They are shared with the MUI InAppNotificationsDialog.
+ * TODO: Move to 'crd-notifications' namespace once the MUI dialog is removed.
+ */
 import type { TFunction } from 'i18next';
-import type { NotificationEventInAppState } from '@/core/apollo/generated/graphql-schema';
+import type { ForumDiscussionCategory, NotificationEventInAppState } from '@/core/apollo/generated/graphql-schema';
+import { kebabToConstantCase } from '@/core/utils/string';
 import type { CrdNotificationItemData } from '@/crd/layouts/types';
 import { formatTimeElapsed } from '@/domain/shared/utils/formatTimeElapsed';
 import type { InAppNotificationModel } from '@/main/inAppNotifications/model/InAppNotificationModel';
@@ -15,8 +24,14 @@ export function getInitials(displayName: string): string {
 /**
  * Builds the interpolation values for notification i18n keys.
  * Each notification type uses a subset of these values in its translation template.
+ *
+ * Values must match the placeholders in src/core/i18n/en/translation.en.json
+ * under `components.inAppNotifications.type.<TYPE>.{subject,description}`.
  */
-function buildTranslationValues(notification: InAppNotificationModel): Record<string, string | undefined> {
+function buildTranslationValues(
+  notification: InAppNotificationModel,
+  t: TFunction
+): Record<string, string | undefined> {
   const { payload, triggeredBy } = notification;
 
   return {
@@ -32,49 +47,56 @@ function buildTranslationValues(notification: InAppNotificationModel): Record<st
       payload.spaceCommunicationMessage ??
       payload.organizationMessage,
     discussionName: payload.discussion?.displayName,
-    calendarEventName: payload.calendarEvent?.profile?.displayName,
     role: payload.role,
     userEmail: payload.userEmail,
     userDisplayName: payload.userDisplayName,
+    // memberName: used by SPACE_ADMIN_COMMUNITY_NEW_MEMBER — the new member is the actor
+    memberName: payload.actor?.profile?.displayName,
+    // parentName: used by USER_COMMENT_REPLY — the parent message/thread name
+    parentName: payload.messageDetails?.parent?.displayName,
+    // receiverName: used by USER_MESSAGE_SENDER — the person who received the DM
+    receiverName: payload.user?.profile?.displayName ?? payload.actor?.profile?.displayName,
+    // contributorName: used by VC invitation notifications — the virtual contributor
+    contributorName: payload.actor?.profile?.displayName,
+    // contributionName: used by SPACE_COLLABORATION_CALLOUT_POST_CONTRIBUTION_COMMENT
+    contributionName: payload.messageDetails?.parent?.displayName,
+    // message: used by ORGANIZATION_ADMIN_MENTIONED description
+    message:
+      payload.comment ??
+      payload.messageDetails?.message ??
+      payload.userMessage ??
+      payload.spaceCommunicationMessage ??
+      payload.organizationMessage,
+    // spaceLevel: pre-translated via t() — used by SPACE_COLLABORATION_CALLOUT_PUBLISHED
+    spaceLevel: payload.space?.level ? t(`common.space-level.${payload.space.level}`) : undefined,
+    // calendarEvent fields
+    eventTitle: payload.calendarEvent?.profile?.displayName,
+    type: payload.calendarEvent?.type,
+    // category: pre-translated — used by PLATFORM_FORUM_DISCUSSION_CREATED
+    category: payload.discussion?.category
+      ? t(
+          `common.enums.discussion-category.${kebabToConstantCase(payload.discussion.category) as ForumDiscussionCategory}`
+        )
+      : undefined,
   };
 }
 
 /**
  * Resolves the URL that clicking a notification should navigate to.
+ * Returns a pathname (not an absolute URL) for React Router compatibility.
  */
 function resolveNotificationUrl(notification: InAppNotificationModel): string | undefined {
   const { payload } = notification;
 
-  // Message details have a parent URL (the room/thread)
-  if (payload.messageDetails?.parent?.url) {
-    return payload.messageDetails.parent.url;
-  }
-  // Callout URL
-  if (payload.callout?.framing?.profile?.url) {
-    return payload.callout.framing.profile.url;
-  }
-  // Space URL
-  if (payload.space?.about?.profile?.url) {
-    return payload.space.about.profile.url;
-  }
-  // Discussion URL
-  if (payload.discussion?.url) {
-    return payload.discussion.url;
-  }
-  // Calendar event URL
-  if (payload.calendarEvent?.profile?.url) {
-    return payload.calendarEvent.profile.url;
-  }
-  // User/actor profile URL
-  if (payload.user?.profile?.url) {
-    return payload.user.profile.url;
-  }
-  // Organization URL
-  if (payload.organization?.profile?.url) {
-    return payload.organization.profile.url;
-  }
-
-  return undefined;
+  return (
+    payload.messageDetails?.parent?.url ??
+    payload.callout?.framing?.profile?.url ??
+    payload.space?.about?.profile?.url ??
+    payload.discussion?.url ??
+    payload.calendarEvent?.profile?.url ??
+    payload.user?.profile?.url ??
+    payload.organization?.profile?.url
+  );
 }
 
 export function mapNotificationToItemData(
@@ -82,13 +104,25 @@ export function mapNotificationToItemData(
   t: TFunction,
   unreadState: NotificationEventInAppState
 ): CrdNotificationItemData {
-  const values = buildTranslationValues(notification);
+  const values = buildTranslationValues(notification, t);
   const typeKey = `components.inAppNotifications.type.${notification.type}`;
+
+  // Keys are built dynamically so we need to bypass i18next's strict return type
+  const translate = (key: string) => t(key, '', values as Record<string, string>) as string;
+
+  const { payload } = notification;
+  const comment =
+    payload.comment ??
+    payload.messageDetails?.message ??
+    payload.userMessage ??
+    payload.spaceCommunicationMessage ??
+    payload.organizationMessage;
 
   return {
     id: notification.id,
-    title: t(`${typeKey}.subject` as unknown as TemplateStringsArray, values as Record<string, string>),
-    description: t(`${typeKey}.description` as unknown as TemplateStringsArray, values as Record<string, string>),
+    title: translate(`${typeKey}.subject`),
+    description: translate(`${typeKey}.description`),
+    comment,
     avatarUrl: notification.triggeredBy.profile.visual?.uri,
     avatarFallback: getInitials(notification.triggeredBy.profile.displayName),
     timestamp: formatTimeElapsed(notification.triggeredAt, t),

--- a/src/main/ui/layout/useCrdNotifications.ts
+++ b/src/main/ui/layout/useCrdNotifications.ts
@@ -1,7 +1,6 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import { NotificationEventInAppState } from '@/core/apollo/generated/graphql-schema';
+import useNavigate from '@/core/routing/useNavigate';
 import { useInAppNotificationsContext } from '@/main/inAppNotifications/InAppNotificationsContext';
 import { NotificationFilterType } from '@/main/inAppNotifications/notificationFilters';
 import { useInAppNotifications } from '@/main/inAppNotifications/useInAppNotifications';
@@ -11,9 +10,12 @@ import { mapNotificationsToItemDataList } from '@/main/ui/layout/notificationDat
 export function useCrdNotifications(userProfileUrl?: string) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { selectedFilter: notificationFilter, setSelectedFilter: setNotificationFilter } =
-    useInAppNotificationsContext();
-  const [isNotificationsOpen, setNotificationsOpen] = useState(false);
+  const {
+    isOpen: isNotificationsOpen,
+    setIsOpen: setNotificationsOpen,
+    selectedFilter: notificationFilter,
+    setSelectedFilter: setNotificationFilter,
+  } = useInAppNotificationsContext();
   const {
     notificationsInApp,
     unreadCount: notificationsUnreadCount,

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -26,6 +26,7 @@ import { TopLevelRoutes } from '@/main/routing/TopLevelRoutes';
 import TopLevelLayout from '@/main/ui/layout/TopLevelLayout';
 import { GlobalErrorProvider } from './core/lazyLoading/GlobalErrorContext';
 import { Error40X } from './core/pages/Errors/Error40X';
+import { useCrdEnabled } from './main/crdPages/useCrdEnabled';
 import { InAppNotificationsProvider } from './main/inAppNotifications/InAppNotificationsContext';
 import { OnlineStatusNotification } from './main/onlineStatus/OnlineStatusNotification';
 import { PushNotificationProvider } from './main/pushNotifications/PushNotificationProvider';
@@ -37,6 +38,20 @@ const InAppNotificationsDialog = lazyWithGlobalErrorHandler(
   () => import('./main/inAppNotifications/InAppNotificationsDialog')
 );
 const UserMessagingDialog = lazyWithGlobalErrorHandler(() => import('./main/userMessaging/UserMessagingDialog'));
+
+const CrdNotificationsPanelConnector = lazyWithGlobalErrorHandler(
+  () => import('./main/ui/layout/CrdNotificationsPanelConnector')
+);
+
+/** Renders either the CRD or MUI notifications dialog based on the design toggle. */
+function NotificationsGate() {
+  const crdEnabled = useCrdEnabled();
+  return (
+    <Suspense fallback={null}>
+      {crdEnabled ? <CrdNotificationsPanelConnector /> : <InAppNotificationsDialog />}
+    </Suspense>
+  );
+}
 
 // MARKDOWN_CLASS_NAME used in the styles below
 const globalStyles = (theme: Theme) => ({
@@ -139,9 +154,7 @@ const Root: FC = () => {
                                         <NavigationHistoryTracker />
                                         <ApmUserSetter />
                                         <ScrollToTop />
-                                        <Suspense fallback={null}>
-                                          <InAppNotificationsDialog />
-                                        </Suspense>
+                                        <NotificationsGate />
                                         <InAppNotificationCountSubscriber />
                                         <Suspense fallback={null}>
                                           <UserMessagingDialog />


### PR DESCRIPTION
There were a couple of bugs related to the links, preview of the spaces count and the in-app notifications not working - missing the proper display when switching to the new design. 
Mobile layout improvements.
Documentations updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced notification panel layout with improved mobile responsiveness and full-viewport display on smaller screens
  * Added comment field support in notification items for additional context
  * Refined notification panel styling with better spacing and border handling across breakpoints

* **Bug Fixes**
  * Made notification description display conditional to avoid rendering empty lines
  * Unified notification dialog handling across the application for consistent behavior

* **Removed**
  * Removed total space count display from spaces explorer results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->