### PR TITLE
Show and send error on wb preview fail

### DIFF
--- a/src/domain/collaboration/whiteboard/WhiteboardPreviewSettings/WhiteboardPreviewSettingsDialog.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardPreviewSettings/WhiteboardPreviewSettingsDialog.tsx
@@ -4,9 +4,11 @@ import { Box } from '@mui/system';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { WhiteboardPreviewMode } from '@/core/apollo/generated/graphql-schema';
+import { error as logError } from '@/core/logging/sentry/log';
 import DialogHeader from '@/core/ui/dialog/DialogHeader';
 import DialogWithGrid, { DialogFooter } from '@/core/ui/dialog/DialogWithGrid';
 import { gutters } from '@/core/ui/grid/utils';
+import { useNotification } from '@/core/ui/notifications/useNotification';
 import { Caption } from '@/core/ui/typography';
 import useEnsurePresence from '@/core/utils/ensurePresence';
 import type { CropConfig } from '@/core/utils/images/cropImage';
@@ -65,6 +67,7 @@ const WhiteboardPreviewSettingsDialog = ({
 }: WhiteboardPreviewSettingsDialogProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
+  const notify = useNotification();
   const ensurePresence = useEnsurePresence();
   const [selectedMode, setSelectedMode] = useState<WhiteboardPreviewMode>(whiteboard.previewSettings.mode);
   const [cropDialogOpen, setCropDialogOpen] = useState(false);
@@ -74,7 +77,11 @@ const WhiteboardPreviewSettingsDialog = ({
     const excalidrawAPIrequired = ensurePresence(excalidrawAPI);
     setCropDialogOpen(true);
 
-    const { image } = await getWhiteboardPreviewImage(excalidrawAPIrequired);
+    const { image, error } = await getWhiteboardPreviewImage(excalidrawAPIrequired);
+    if (error) {
+      logError(new Error('Error generating whiteboard preview image.'));
+      notify(t('pages.whiteboard.preview.errorGeneratingPreview'), 'error');
+    }
     const blob = await toBlobPromise(image).catch(async () => toBlobPromise(await createFallbackWhiteboardPreview()));
     setWhiteboardPreviewImage(blob);
   };


### PR DESCRIPTION
Related to: https://github.com/alkem-io/client-web/issues/9453

Now we:

- show message to the users;
- log error on every fail to Sentry;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for whiteboard preview generation. Users now receive notifications when preview generation fails, with graceful fallback support to ensure functionality continues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->