### PR TITLE
Add Dashboard page to CRD standalone demo app

### DIFF
--- a/src/crd/app/CrdApp.tsx
+++ b/src/crd/app/CrdApp.tsx
@@ -1,6 +1,7 @@
 import { BookOpen, Compass, Lightbulb, MessageCircle } from 'lucide-react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { CrdLayout } from '@/crd/layouts/CrdLayout';
+import { DashboardPage } from './pages/DashboardPage';
 import { SpacesPage } from './pages/SpacesPage';
 
 const MOCK_USER = {
@@ -56,8 +57,9 @@ export function CrdApp() {
         footerLinks={{ terms: '/terms', privacy: '/privacy', security: '/security', about: '/about' }}
       >
         <Routes>
+          <Route path="/" element={<DashboardPage />} />
           <Route path="/spaces" element={<SpacesPage />} />
-          <Route path="*" element={<Navigate to="/spaces" replace={true} />} />
+          <Route path="*" element={<Navigate to="/" replace={true} />} />
         </Routes>
       </CrdLayout>
     </BrowserRouter>

--- a/src/crd/app/data/dashboard.ts
+++ b/src/crd/app/data/dashboard.ts
@@ -1,0 +1,251 @@
+export const MOCK_RECENT_SPACES = [
+  {
+    id: 'rs-1',
+    name: 'Innovation Lab',
+    href: '/space/innovation-lab',
+    bannerUrl:
+      'https://images.unsplash.com/photo-1623652554515-91c833e3080e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb2xsYWJvcmF0aW9uJTIwdGVhbXdvcmslMjBpbm5vdmF0aW9uJTIwZGVzaWduJTIwdGhpbmtpbmclMjB3b3Jrc2hvcHxlbnwxfHx8fDE3NjkwODc1ODd8MA&ixlib=rb-4.1.0&q=80&w=1080',
+    isPrivate: true,
+    isHomeSpace: true,
+    initials: 'IL',
+  },
+  {
+    id: 'rs-2',
+    name: 'Design Workshop',
+    href: '/space/design-workshop',
+    bannerUrl:
+      'https://images.unsplash.com/photo-1735639013995-086e648eaa38?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxicmFpbnN0b3JtaW5nJTIwY3JlYXRpdmUlMjB3b3Jrc2hvcCUyMHRlYW18ZW58MXx8fHwxNzY5MDg3NTg3fDA&ixlib=rb-4.1.0&q=80&w=1080',
+    isPrivate: false,
+    isHomeSpace: false,
+    initials: 'DW',
+  },
+  {
+    id: 'rs-3',
+    name: 'Team Sync',
+    href: '/space/team-sync',
+    bannerUrl:
+      'https://images.unsplash.com/photo-1768659347532-74d3b1efb0ae?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxkZXNpZ24lMjBtZWV0aW5nJTIwY29sbGFib3JhdGlvbiUyMHRlYW18ZW58MXx8fHwxNzY5MDg3NTg3fDA&ixlib=rb-4.1.0&q=80&w=1080',
+    isPrivate: true,
+    isHomeSpace: false,
+    initials: 'TS',
+  },
+  {
+    id: 'rs-4',
+    name: 'Future Strategy',
+    href: '/space/future-strategy',
+    bannerUrl:
+      'https://images.unsplash.com/photo-1676276376052-dc9c9c0b6917?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxpbm5vdmF0aW9uJTIwbGFiJTIwdGVhbXdvcmslMjBtb2Rlcm4lMjBvZmZpY2V8ZW58MXx8fHwxNzY5MDg3NTg2fDA&ixlib=rb-4.1.0&q=80&w=1080',
+    isPrivate: false,
+    isHomeSpace: false,
+    initials: 'FS',
+  },
+];
+
+export const MOCK_SPACE_ACTIVITIES = [
+  {
+    id: 'sa-1',
+    avatarUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=64&h=64',
+    avatarInitials: 'SC',
+    userName: 'Sarah Chen',
+    actionText: 'posted a new challenge in',
+    targetName: 'Innovation Lab',
+    targetHref: '/space/innovation-lab',
+    timestamp: '2 hours ago',
+  },
+  {
+    id: 'sa-2',
+    avatarUrl: 'https://images.unsplash.com/photo-1599566150163-29194dcaad36?auto=format&fit=crop&w=64&h=64',
+    avatarInitials: 'MR',
+    userName: 'Mike Ross',
+    actionText: 'commented on',
+    targetName: 'Design Review',
+    targetHref: '/space/design-workshop',
+    timestamp: '4 hours ago',
+  },
+  {
+    id: 'sa-3',
+    avatarUrl: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?auto=format&fit=crop&w=64&h=64',
+    avatarInitials: 'AS',
+    userName: 'Anna Smith',
+    actionText: 'shared a file in',
+    targetName: 'Marketing Strategy',
+    targetHref: '/space/marketing',
+    timestamp: 'Yesterday',
+  },
+  {
+    id: 'sa-4',
+    avatarUrl:
+      'https://images.unsplash.com/photo-1672685667592-0392f458f46f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwcm9mZXNzaW9uYWwlMjBwb3J0cmFpdCUyMG1hbnxlbnwxfHx8fDE3Njk0Nzg0NTZ8MA&ixlib=rb-4.1.0&q=80&w=64&h=64',
+    avatarInitials: 'DK',
+    userName: 'David Kim',
+    actionText: 'updated the description of',
+    targetName: 'Product Roadmap',
+    targetHref: '/space/product',
+    timestamp: 'Yesterday',
+  },
+  {
+    id: 'sa-5',
+    avatarUrl:
+      'https://images.unsplash.com/photo-1649589244330-09ca58e4fa64?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwcm9mZXNzaW9uYWwlMjBwb3J0cmFpdCUyMHdvbWFufGVufDF8fHx8MTc2OTQ3ODMzMnww&ixlib=rb-4.1.0&q=80&w=64&h=64',
+    avatarInitials: 'ER',
+    userName: 'Elena Rodriguez',
+    actionText: 'added 5 new members to',
+    targetName: 'Community Hub',
+    targetHref: '/space/community',
+    timestamp: '2 days ago',
+  },
+  {
+    id: 'sa-6',
+    avatarUrl:
+      'https://images.unsplash.com/photo-1603143704710-99d6011f107e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxkZXZlbG9wZXIlMjBoZWFkc2hvdHxlbnwxfHx8fDE3Njk1MzI5NjB8MA&ixlib=rb-4.1.0&q=80&w=64&h=64',
+    avatarInitials: 'JW',
+    userName: 'James Wilson',
+    actionText: 'archived',
+    targetName: 'Q3 Goals',
+    timestamp: '3 days ago',
+  },
+  {
+    id: 'sa-7',
+    avatarUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=64&h=64',
+    avatarInitials: 'SC',
+    userName: 'Sarah Chen',
+    actionText: 'scheduled a meeting in',
+    targetName: 'Innovation Lab',
+    targetHref: '/space/innovation-lab',
+    timestamp: '3 days ago',
+  },
+];
+
+const PERSONAL_AVATAR = 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?auto=format&fit=crop&w=64&h=64';
+
+export const MOCK_PERSONAL_ACTIVITIES = [
+  {
+    id: 'pa-1',
+    avatarUrl: PERSONAL_AVATAR,
+    avatarInitials: 'AR',
+    userName: 'You',
+    actionText: 'created a new space',
+    targetName: 'Project Alpha',
+    targetHref: '/space/project-alpha',
+    timestamp: '1 day ago',
+  },
+  {
+    id: 'pa-2',
+    avatarUrl: PERSONAL_AVATAR,
+    avatarInitials: 'AR',
+    userName: 'You',
+    actionText: 'invited 3 members to',
+    targetName: 'Team Sync',
+    targetHref: '/space/team-sync',
+    timestamp: '2 days ago',
+  },
+  {
+    id: 'pa-3',
+    avatarUrl: PERSONAL_AVATAR,
+    avatarInitials: 'AR',
+    userName: 'You',
+    actionText: 'joined',
+    targetName: 'Data Science Team',
+    targetHref: '/space/data-science',
+    timestamp: '3 days ago',
+  },
+  {
+    id: 'pa-4',
+    avatarUrl: PERSONAL_AVATAR,
+    avatarInitials: 'AR',
+    userName: 'You',
+    actionText: 'replied to a comment in',
+    targetName: 'Design Review',
+    targetHref: '/space/design-workshop',
+    timestamp: '4 days ago',
+  },
+  {
+    id: 'pa-5',
+    avatarUrl: PERSONAL_AVATAR,
+    avatarInitials: 'AR',
+    userName: 'You',
+    actionText: 'downloaded a report from',
+    targetName: 'Analytics Dashboard',
+    targetHref: '/space/analytics',
+    timestamp: '1 week ago',
+  },
+  {
+    id: 'pa-6',
+    avatarUrl: PERSONAL_AVATAR,
+    avatarInitials: 'AR',
+    userName: 'You',
+    actionText: 'updated your settings',
+    targetName: 'Profile',
+    timestamp: '1 week ago',
+  },
+];
+
+export const MOCK_SIDEBAR_MENU_ITEMS = [
+  { id: 'inv', label: 'Invitations', iconName: 'Mail', badgeCount: 2 },
+  { id: 'create', label: 'Create my own Space', iconName: 'Rocket', href: '#' },
+  { id: 'tips', label: 'Tips & Tricks', iconName: 'Lightbulb' },
+  { id: 'account', label: 'My Account', iconName: 'Tag', href: '/user/alex-rivera/settings/account' },
+];
+
+export const MOCK_SIDEBAR_RESOURCE_SECTIONS = [
+  {
+    title: 'My Spaces',
+    items: [
+      { id: 'sp-1', name: 'Green Energy Space', href: '/space/green-energy', initials: 'GE' },
+      { id: 'sp-2', name: 'Community Garden', href: '/space/community-garden', initials: 'CG' },
+      { id: 'sp-3', name: 'Digital Transformation', href: '/space/digital-trans', initials: 'DT' },
+    ],
+  },
+  {
+    title: 'Virtual Contributors',
+    items: [
+      { id: 'vc-1', name: 'Softmann', href: '#', initials: 'SM', avatarColor: 'var(--chart-2)' },
+      {
+        id: 'vc-2',
+        name: 'The Collaboration Methodologist',
+        href: '#',
+        initials: 'CM',
+        avatarColor: 'var(--chart-2)',
+      },
+    ],
+  },
+];
+
+export const MOCK_INVITATIONS = [
+  {
+    id: 'inv-1',
+    spaceId: 's-sustainability',
+    spaceName: 'Sustainability Goals 2024',
+    spaceHref: '/space/sustainability-goals',
+    spaceAvatarUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&q=80&w=150',
+    role: 'Editor',
+  },
+  {
+    id: 'inv-2',
+    spaceId: 's-urban-mobility',
+    spaceName: 'Urban Mobility Lab',
+    spaceHref: '/space/urban-mobility',
+    spaceAvatarUrl: 'https://images.unsplash.com/photo-1599566150163-29194dcaad36?auto=format&fit=crop&q=80&w=150',
+    role: 'Viewer',
+  },
+  {
+    id: 'inv-3',
+    spaceId: 's-financial',
+    spaceName: 'Q1 Financial Planning',
+    spaceHref: '/space/financial-planning',
+    spaceAvatarUrl: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&q=80&w=150',
+    role: 'Admin',
+  },
+];
+
+export const MOCK_SPACE_FILTER_OPTIONS = [
+  { value: 'all-spaces', label: 'Space: All Spaces' },
+  { value: 'green-energy', label: 'Green Energy Space' },
+  { value: 'community-garden', label: 'Community Garden' },
+];
+
+export const MOCK_ROLE_FILTER_OPTIONS = [
+  { value: 'all-roles', label: 'My role: All roles' },
+  { value: 'facilitator', label: 'Facilitator' },
+  { value: 'contributor', label: 'Contributor' },
+];

--- a/src/crd/app/main.tsx
+++ b/src/crd/app/main.tsx
@@ -2,6 +2,7 @@ import i18n from 'i18next';
 import { createRoot } from 'react-dom/client';
 import { initReactI18next } from 'react-i18next';
 import crdCommonEN from '@/crd/i18n/common/common.en.json';
+import crdDashboardEN from '@/crd/i18n/dashboard/dashboard.en.json';
 import crdExploreSpacesEN from '@/crd/i18n/exploreSpaces/exploreSpaces.en.json';
 import crdLayoutEN from '@/crd/i18n/layout/layout.en.json';
 import '@/crd/styles/crd.css';
@@ -13,10 +14,11 @@ i18n.use(initReactI18next).init({
       'crd-layout': crdLayoutEN,
       'crd-common': crdCommonEN,
       'crd-exploreSpaces': crdExploreSpacesEN,
+      'crd-dashboard': crdDashboardEN,
     },
   },
   lng: 'en',
-  ns: ['crd-layout', 'crd-common', 'crd-exploreSpaces'],
+  ns: ['crd-layout', 'crd-common', 'crd-exploreSpaces', 'crd-dashboard'],
   defaultNS: 'crd-layout',
   fallbackLng: 'en',
   interpolation: {

--- a/src/crd/app/pages/DashboardPage.tsx
+++ b/src/crd/app/pages/DashboardPage.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ActivityFeed } from '@/crd/components/dashboard/ActivityFeed';
+import { CampaignBanner } from '@/crd/components/dashboard/CampaignBanner';
+import { DashboardLayout } from '@/crd/components/dashboard/DashboardLayout';
+import { DashboardSidebar } from '@/crd/components/dashboard/DashboardSidebar';
+import { InvitationsBlock } from '@/crd/components/dashboard/InvitationsBlock';
+import { RecentSpaces } from '@/crd/components/dashboard/RecentSpaces';
+import { TipsAndTricksDialog } from '@/crd/components/dashboard/TipsAndTricksDialog';
+import {
+  MOCK_INVITATIONS,
+  MOCK_PERSONAL_ACTIVITIES,
+  MOCK_RECENT_SPACES,
+  MOCK_ROLE_FILTER_OPTIONS,
+  MOCK_SIDEBAR_MENU_ITEMS,
+  MOCK_SIDEBAR_RESOURCE_SECTIONS,
+  MOCK_SPACE_ACTIVITIES,
+  MOCK_SPACE_FILTER_OPTIONS,
+} from '../data/dashboard';
+
+type TipFromI18n = {
+  title: string;
+  description: string;
+  imageUrl?: string;
+  url?: string;
+};
+
+export function DashboardPage() {
+  const { t } = useTranslation('crd-dashboard');
+
+  const [spaceFilter, setSpaceFilter] = useState('all-spaces');
+  const [roleFilter, setRoleFilter] = useState('all-roles');
+  const [personalSpaceFilter, setPersonalSpaceFilter] = useState('all-spaces');
+  const [showTipsDialog, setShowTipsDialog] = useState(false);
+  const [invitations, setInvitations] = useState(MOCK_INVITATIONS);
+  const [activityEnabled, setActivityEnabled] = useState(false);
+
+  const tipsRaw = t('tips.items', { returnObjects: true }) as TipFromI18n[];
+  const tips = tipsRaw.map((tip, index) => ({
+    id: `tip-${index}`,
+    title: tip.title,
+    description: tip.description,
+    href: tip.url,
+    imageUrl: tip.imageUrl,
+  }));
+
+  const menuItems = MOCK_SIDEBAR_MENU_ITEMS.map(item => {
+    if (item.id === 'tips') {
+      return { ...item, onClick: () => setShowTipsDialog(true) };
+    }
+    if (item.id === 'inv') {
+      return { ...item, onClick: () => console.log('Invitations clicked'), badgeCount: invitations.length };
+    }
+    return item;
+  });
+
+  const handleAcceptInvitation = (id: string) => {
+    console.log('Accepted invitation', id);
+    setInvitations(prev => prev.filter(inv => inv.id !== id));
+  };
+
+  const handleDeclineInvitation = (id: string) => {
+    console.log('Declined invitation', id);
+    setInvitations(prev => prev.filter(inv => inv.id !== id));
+  };
+
+  const hasHomeSpace = MOCK_RECENT_SPACES.some(s => s.isHomeSpace);
+
+  const sidebar = (
+    <DashboardSidebar
+      menuItems={menuItems}
+      resourceSections={MOCK_SIDEBAR_RESOURCE_SECTIONS}
+      activityEnabled={activityEnabled}
+      onActivityToggle={setActivityEnabled}
+      showActivityToggle={true}
+    />
+  );
+
+  return (
+    <>
+      <DashboardLayout sidebar={sidebar}>
+        <RecentSpaces
+          spaces={MOCK_RECENT_SPACES}
+          hasHomeSpace={hasHomeSpace}
+          onExploreAllClick={() => (window.location.href = '/spaces')}
+          onPinClick={() => console.log('Pin clicked')}
+        />
+
+        <div className="grid grid-cols-1 lg:grid-cols-9 gap-6">
+          <ActivityFeed
+            variant="spaces"
+            title={t('activity.spacesTitle')}
+            items={MOCK_SPACE_ACTIVITIES}
+            spaceFilter={spaceFilter}
+            spaceFilterOptions={MOCK_SPACE_FILTER_OPTIONS}
+            onSpaceFilterChange={setSpaceFilter}
+            roleFilter={roleFilter}
+            roleFilterOptions={MOCK_ROLE_FILTER_OPTIONS}
+            onRoleFilterChange={setRoleFilter}
+            maxItems={5}
+            onShowMore={() => console.log('Show more space activity')}
+            feedId="spaces"
+            className="lg:col-span-5"
+          />
+          <ActivityFeed
+            variant="personal"
+            title={t('activity.personalTitle')}
+            items={MOCK_PERSONAL_ACTIVITIES}
+            spaceFilter={personalSpaceFilter}
+            spaceFilterOptions={MOCK_SPACE_FILTER_OPTIONS}
+            onSpaceFilterChange={setPersonalSpaceFilter}
+            maxItems={5}
+            onShowMore={() => console.log('Show more personal activity')}
+            feedId="personal"
+            className="lg:col-span-4"
+          />
+        </div>
+
+        {invitations.length > 0 && (
+          <InvitationsBlock
+            invitations={invitations}
+            onAccept={handleAcceptInvitation}
+            onDecline={handleDeclineInvitation}
+          />
+        )}
+
+        <CampaignBanner onAction={() => console.log('Create virtual contributor clicked')} />
+      </DashboardLayout>
+
+      <TipsAndTricksDialog
+        open={showTipsDialog}
+        onClose={() => setShowTipsDialog(false)}
+        tips={tips}
+        findMoreHref={t('dialogs.findMoreUrl')}
+        findMoreLabel={t('dialogs.findMore')}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Wire mock data to existing CRD dashboard components (DashboardLayout, DashboardSidebar, RecentSpaces, ActivityFeed, InvitationsBlock, TipsAndTricksDialog, CampaignBanner) and make it the default route.

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
