### PR TITLE
[Patch] Fix the broken list styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-web",
-  "version": "0.139.1",
+  "version": "0.139.2",
   "description": "Alkemio client, enabling users to interact with Challenges hosted on the Alkemio platform.",
   "type": "module",
   "repository": {

--- a/src/core/ui/forms/MarkdownInput/hooks/MarkdownInputStyles.tsx
+++ b/src/core/ui/forms/MarkdownInput/hooks/MarkdownInputStyles.tsx
@@ -8,6 +8,16 @@ export const MarkdownInputStyles = (
         '& :first-child': {
           marginTop: 0,
         },
+        // Restore browser-default list rendering that Tailwind v4 preflight strips globally.
+        'ul, ol': {
+          paddingInlineStart: '2rem',
+          marginBlock: '0.5rem',
+        },
+        ul: { listStyleType: 'disc' },
+        ol: { listStyleType: 'decimal' },
+        'ul ul, ol ul': { listStyleType: 'circle' },
+        'ul ul ul, ol ol ul': { listStyleType: 'square' },
+        li: { display: 'list-item' },
         blockquote: {
           borderLeft: '3px solid gray',
           margin: '1.5rem 0',

--- a/src/core/ui/markdown/WrapperMarkdown.tsx
+++ b/src/core/ui/markdown/WrapperMarkdown.tsx
@@ -56,7 +56,13 @@ export const WrapperMarkdown = ({
   const { integration: { iframeAllowedUrls = [] } = {} } = useConfig();
 
   const mergedSx: SxProps<Theme> = {
-    li: { marginY: caption ? 0 : 1 },
+    // Restore browser-default list rendering that Tailwind v4 preflight strips globally.
+    'ul, ol': { paddingInlineStart: '2rem', marginBlock: 1 },
+    ul: { listStyleType: 'disc' },
+    ol: { listStyleType: 'decimal' },
+    'ul ul, ol ul': { listStyleType: 'circle' },
+    'ul ul ul, ol ol ul': { listStyleType: 'square' },
+    li: { display: 'list-item', marginY: caption ? 0 : 1 },
     display: plain ? 'inline' : undefined,
     table: theme => ({ borderCollapse: theme.palette.markdownTable.borderCollapse }),
     tr: theme => ({


### PR DESCRIPTION
It's the Tailwind/shadcn code - not Tiptap or the MD logic.                                                                                                                                              
                                                                                                                                                                                                           
  PR #9460 (CRD Phase #0) added src/crd/styles/crd.css, which is imported globally from src/index.tsx. That file does @import 'tailwindcss', and Tailwind v4's preflight (verified in                      
  node_modules/.../tailwindcss/index.css lines 534–747) applies globally. It resets:                                                                                                                       
                                                                                                                                                                                                           
  - *, ::before, ::after { margin: 0; padding: 0; }                                                                                                                                                        
  - ol, ul, menu { list-style: none; }                                                                                                                                                                     
  - h1–h6 { font-size: inherit; font-weight: inherit; }                                                                                                                                                    
                                                            
  The CRD CLAUDE.md claims preflight is scoped to .crd-root, but in practice it isn't - so every MUI page, including MDEditor (.tiptap) and Markdown viewer (.markdown), loses its browser defaults.       
                                                            
  The Fix:                                                                                                                                                                                              
                                                            
  Restored list rendering on the two MD surfaces:                                                                                                                                                          
                                                            
  - src/core/ui/forms/MarkdownInput/hooks/MarkdownInputStyles.tsx - list-style, padding, nested bullets inside .tiptap                                                                                     
  - src/core/ui/markdown/WrapperMarkdown.tsx - same inside .markdown                                                                                                                                                                                                                         
                                                                                                                                                                                                           
  Longer-term                                                                                                                                                                                              
                                                            
  The real architectural fix is to actually scope Tailwind preflight to .crd-root (drop @import 'tailwindcss' and import theme.css + utilities.css separately, with preflight wrapped in .crd-root). Worth 
  doing in a follow-up — other regressions (heading sizes in MD content, stripped <a> underlines, etc.) likely exist from the same root cause.