### PR TITLE
Add cooldown mechanism for password recovery and restyled the text

### DIFF
--- a/src/core/auth/authentication/components/Kratos/KratosButton.tsx
+++ b/src/core/auth/authentication/components/Kratos/KratosButton.tsx
@@ -12,12 +12,22 @@ interface KratosButtonProps extends KratosProps {
   disabled?: boolean;
   sx?: SxProps<Theme>;
   startIcon?: ReactNode;
+  labelOverride?: (originalLabel: string | undefined) => ReactNode;
 }
 
-export const KratosButton: FC<KratosButtonProps> = ({ disabled, node, sx, variant = 'contained', startIcon }) => {
+export const KratosButton: FC<KratosButtonProps> = ({
+  disabled,
+  node,
+  sx,
+  variant = 'contained',
+  startIcon,
+  labelOverride,
+}) => {
   const attributes = node.attributes as UiNodeInputAttributes;
   const { onBeforeSubmit } = useContext(KratosUIContext);
   const { t } = useTranslation();
+
+  const originalLabel = getNodeTitle(node, t);
 
   return (
     <GridLegacy item={true} xs={12}>
@@ -39,7 +49,7 @@ export const KratosButton: FC<KratosButtonProps> = ({ disabled, node, sx, varian
             sx={sx}
             startIcon={startIcon}
           >
-            {getNodeTitle(node, t)}
+            {labelOverride ? labelOverride(originalLabel) : originalLabel}
           </AuthActionButton>
         </Box>
       </Tooltip>

--- a/src/core/auth/authentication/components/KratosUI.tsx
+++ b/src/core/auth/authentication/components/KratosUI.tsx
@@ -53,6 +53,8 @@ interface KratosUIProps extends PropsWithChildren {
   flowType?: 'login' | 'registration' | 'settings' | 'recovery' | 'verification';
   onInputChange?: (node: UiNode, value: string) => void;
   submitDisabled?: boolean;
+  beforeInputs?: ReactNode;
+  submitLabelOverride?: (originalLabel: string | undefined) => ReactNode;
 }
 
 const toAlertVariant = (type: string) => {
@@ -100,6 +102,8 @@ export const KratosUI: FC<KratosUIProps> = ({
   flowType,
   onInputChange,
   submitDisabled = false,
+  beforeInputs,
+  submitLabelOverride,
   ...rest
 }) => {
   const { t } = useTranslation();
@@ -279,6 +283,7 @@ export const KratosUI: FC<KratosUIProps> = ({
             key={key}
             node={node}
             disabled={disableInputs || submitDisabled}
+            labelOverride={submitLabelOverride}
           />
         );
       case 'checkbox':
@@ -318,6 +323,7 @@ export const KratosUI: FC<KratosUIProps> = ({
         minWidth={theme => ({ sm: theme.spacing(36) })}
       >
         <KratosMessages messages={ui.messages} />
+        {beforeInputs}
         {nodesByGroup.default.map(toUiControl)}
         {nodesByGroup.password.map(toUiControl)}
         {resetPasswordElement}

--- a/src/core/auth/authentication/pages/RecoveryPage.tsx
+++ b/src/core/auth/authentication/pages/RecoveryPage.tsx
@@ -68,6 +68,11 @@ export const RecoveryPage: FC<RegisterPageProps> = ({ flow }) => {
   const hasEmailSentNotice = recoveryFlow?.ui.messages?.some(message => message.type === 'info') ?? false;
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    // Cooldown only applies to the email-request stage. The code stage must be
+    // free to submit the recovery code immediately, even if the cooldown is active.
+    if (!isEmailStage) {
+      return;
+    }
     if (cooldownRemaining > 0) {
       event.preventDefault();
       return;

--- a/src/core/auth/authentication/pages/RecoveryPage.tsx
+++ b/src/core/auth/authentication/pages/RecoveryPage.tsx
@@ -1,7 +1,7 @@
-import { Box } from '@mui/material';
+import { Alert, Box, Divider } from '@mui/material';
 import type { UiContainer } from '@ory/kratos-client/dist/api';
-import type { FC } from 'react';
-import { useTranslation } from 'react-i18next';
+import { type FC, type FormEvent, useEffect, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import useKratosFlow, { FlowTypeName } from '@/core/auth/authentication/hooks/useKratosFlow';
 import Loading from '@/core/ui/loading/Loading';
 import { ErrorDisplay } from '@/domain/shared/components/ErrorDisplay';
@@ -21,12 +21,38 @@ enum RecoveryFlowStage {
   Code = 'code',
 }
 
+const COOLDOWN_SECONDS = 30;
+const COOLDOWN_STORAGE_KEY = 'alkemio-recovery-cooldown-until';
+
 const hasCodeInput = (ui: UiContainer) =>
   ui.nodes.some(node => isInputNode(node) && node.attributes.node_type === 'input' && node.attributes.name === 'code');
+
+const readRemainingCooldown = (): number => {
+  const stored = sessionStorage.getItem(COOLDOWN_STORAGE_KEY);
+  if (!stored) return 0;
+  const expiry = Number(stored);
+  if (!Number.isFinite(expiry)) return 0;
+  const remaining = Math.ceil((expiry - Date.now()) / 1000);
+  if (remaining <= 0) {
+    sessionStorage.removeItem(COOLDOWN_STORAGE_KEY);
+    return 0;
+  }
+  return Math.min(remaining, COOLDOWN_SECONDS);
+};
 
 export const RecoveryPage: FC<RegisterPageProps> = ({ flow }) => {
   const { t } = useTranslation();
   const { flow: recoveryFlow, loading, error } = useKratosFlow(FlowTypeName.Recovery, flow);
+
+  const [cooldownRemaining, setCooldownRemaining] = useState<number>(() => readRemainingCooldown());
+
+  useEffect(() => {
+    if (cooldownRemaining <= 0) return;
+    const interval = setInterval(() => {
+      setCooldownRemaining(readRemainingCooldown());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [cooldownRemaining]);
 
   if (loading) {
     return <Loading text={t('kratos.loading-flow')} />;
@@ -37,18 +63,53 @@ export const RecoveryPage: FC<RegisterPageProps> = ({ flow }) => {
   }
 
   const flowStage = recoveryFlow && (hasCodeInput(recoveryFlow.ui) ? RecoveryFlowStage.Code : RecoveryFlowStage.Email);
+  const isEmailStage = flowStage === RecoveryFlowStage.Email;
+  const isCoolingDown = isEmailStage && cooldownRemaining > 0;
+  const hasEmailSentNotice = recoveryFlow?.ui.messages?.some(message => message.type === 'info') ?? false;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    if (cooldownRemaining > 0) {
+      event.preventDefault();
+      return;
+    }
+    // Only persist to storage here — do NOT setState. A re-render before the browser
+    // collects form data would disable the submit button and drop its `method=<strategy>`
+    // value from the POST body, causing Kratos to reject the request.
+    sessionStorage.setItem(COOLDOWN_STORAGE_KEY, String(Date.now() + COOLDOWN_SECONDS * 1000));
+  };
+
+  const instructions = isEmailStage ? (
+    hasEmailSentNotice ? (
+      <>
+        <Divider sx={{ marginY: 1 }} />
+        <Alert severity="info" variant="outlined">
+          <Trans i18nKey="pages.recovery.message.resend" components={{ strong: <strong />, br: <br /> }} />
+        </Alert>
+      </>
+    ) : (
+      <Box fontSize={14} color="neutral.light">
+        {t('pages.recovery.message.initial')}
+      </Box>
+    )
+  ) : null;
+
+  const submitLabelOverride = isCoolingDown
+    ? (original: string | undefined) =>
+        t('pages.recovery.cooldown.button', { label: original ?? '', seconds: cooldownRemaining })
+    : undefined;
 
   return (
     <AuthenticationLayout>
       <AuthFormHeader title={t('pages.recovery.header')} />
-      <KratosForm ui={recoveryFlow?.ui}>
+      <KratosForm ui={recoveryFlow?.ui} onSubmit={handleSubmit}>
         <AuthPageContentContainer>
-          {flowStage === RecoveryFlowStage.Email && (
-            <Box fontSize="14" color="neutral.light">
-              {t('pages.recovery.message.initial')}
-            </Box>
-          )}
-          <KratosUI ui={recoveryFlow?.ui} flowType="recovery" />
+          <KratosUI
+            ui={recoveryFlow?.ui}
+            flowType="recovery"
+            beforeInputs={instructions}
+            submitDisabled={isCoolingDown}
+            submitLabelOverride={submitLabelOverride}
+          />
         </AuthPageContentContainer>
       </KratosForm>
     </AuthenticationLayout>

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -3805,7 +3805,11 @@
     "recovery": {
       "header": "Password recovery",
       "message": {
-        "initial": "Please enter your email address below to receive a recovery link that will allow you to reset your password."
+        "initial": "Please enter your email address below to receive a recovery link that will allow you to reset your password.",
+        "resend": "<strong>Haven't received the email?</strong><br/>Check your spam folder, confirm the address below is correct, then request a new recovery email once the timer ends."
+      },
+      "cooldown": {
+        "button": "{{label}} in {{seconds}}s"
       }
     },
     "verification": {


### PR DESCRIPTION
- Introduced cooldown so user is not able to resend email multiple times
- Text is rearranged to guide the user better
- Changed the styling of the text
- Before and after below

## Initial form stays the same
<img width="446" height="365" alt="image" src="https://github.com/user-attachments/assets/9a37c342-808d-49aa-977d-eb619d76e95f" />

## Secondary form is changed (before => after)
<img width="350" alt="image" src="https://github.com/user-attachments/assets/827234ff-9a7f-4ec4-9341-8ca2a6b7391c" />

<img width="350"  alt="image" src="https://github.com/user-attachments/assets/5a302a08-80e5-464c-b181-ab3c0e097990" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password recovery: resend cooldown timer with submit button disabled during cooldown and dynamic countdown label.
  * Recovery messaging: clearer instructions, spam-folder guidance, and inline resend info displayed above inputs.
  * Form customization: ability to render custom content before inputs and to override submit/button labels for better localization or custom UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->