### PR TITLE
chore: update prototype to latest version

### DIFF
--- a/prototype/package-lock.json
+++ b/prototype/package-lock.json
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.9.tgz",
-      "integrity": "sha512-MOkOCTfbMJwLshlBCKJ59V2F/uaLYfmKnN76kksj6jlGUVdI25A9Hzs08m+zjBRdLv+sK7Rqdsefe8X7h/6PCw==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.10.tgz",
+      "integrity": "sha512-vrOpWRmPJSuwLo23J62wggEm/jvGdzqctej+UOCtgDUz6nZJQuj3ByPccVyaa7eQmwAzUwKN56FQPMKkqbj1GA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1146,13 +1146,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.9.tgz",
-      "integrity": "sha512-ErIyRQvsiQEq7Yvcvfw9UDHngaqjMy9P3JDPnRAaKG5qhpl2C4tX/W1S4zJvpu+feihmZJStjIyvnv6KDbIrlw==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.10.tgz",
+      "integrity": "sha512-j3EZN+zOctxUISvJSmsEPo5o2F8zse4l5vRkBY+ps6UtnL6J7o14kUaI4w7gwo73id9e3cDNMVQK/9BVaMHVBw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
-        "@mui/utils": "^7.3.9",
+        "@mui/utils": "^7.3.10",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1173,9 +1173,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.9.tgz",
-      "integrity": "sha512-JqujWt5bX4okjUPGpVof/7pvgClqh7HvIbsIBIOOlCh2u3wG/Bwp4+E1bc1dXSwkrkp9WUAoNdI5HEC+5HKvMw==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
+      "integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
@@ -1207,16 +1207,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.9.tgz",
-      "integrity": "sha512-aL1q9am8XpRrSabv9qWf5RHhJICJql34wnrc1nz0MuOglPRYF/liN+c8VqZdTvUn9qg+ZjRVbKf4sJVFfIDtmg==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.10.tgz",
+      "integrity": "sha512-/sfPpdpJaQn7BSF+avjIdHSYmxHp0UOBYNxSG9QGKfMOD6sLANCpRPCnanq1Pe0lFf0NHkO2iUk0TNzdWC1USQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
-        "@mui/private-theming": "^7.3.9",
-        "@mui/styled-engine": "^7.3.9",
+        "@mui/private-theming": "^7.3.10",
+        "@mui/styled-engine": "^7.3.10",
         "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
+        "@mui/utils": "^7.3.10",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
@@ -1264,9 +1264,9 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.9.tgz",
-      "integrity": "sha512-U6SdZaGbfb65fqTsH3V5oJdFj9uYwyLE2WVuNvmbggTSDBb8QHrFsqY8BN3taK9t3yJ8/BPHD/kNvLNyjwM7Yw==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.10.tgz",
+      "integrity": "sha512-7y2eIfy0h7JPz+Yy4pS+wgV68d46PuuxDqKBN4Q8VlPQSsCAGwroMCV6xWyc7g9dvEp8ZNFsknc59GHWO+r6Ow==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
@@ -2611,9 +2611,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
       ],
@@ -2625,9 +2625,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -2639,9 +2639,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -2653,9 +2653,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -2667,9 +2667,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
@@ -2681,9 +2681,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -2695,9 +2695,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
       ],
@@ -2709,9 +2709,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
       ],
@@ -2723,9 +2723,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
@@ -2737,9 +2737,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
       ],
@@ -2751,9 +2751,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
       ],
@@ -2765,9 +2765,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
       ],
@@ -2779,9 +2779,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
       ],
@@ -2793,9 +2793,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2807,9 +2807,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
       ],
@@ -2821,9 +2821,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2835,9 +2835,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
       ],
@@ -2849,9 +2849,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -2863,9 +2863,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -2877,9 +2877,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
       "cpu": [
         "x64"
       ],
@@ -2891,9 +2891,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
       ],
@@ -2905,9 +2905,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -2919,9 +2919,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
       ],
@@ -2933,9 +2933,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -2947,9 +2947,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -3504,9 +3504,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.9",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.9.tgz",
-      "integrity": "sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg==",
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3517,9 +3517,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -3537,11 +3537,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3551,14 +3551,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -3607,9 +3607,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001780",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
-      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -3785,9 +3785,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -4094,9 +4094,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4487,9 +4487,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5040,9 +5040,9 @@
       "license": "MIT"
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -6066,9 +6066,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6189,9 +6189,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6202,9 +6202,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -6388,9 +6388,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -6524,9 +6524,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -6546,12 +6546,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.14.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6776,11 +6776,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -6805,9 +6806,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6821,31 +6822,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -7029,9 +7030,9 @@
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7043,9 +7044,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -7076,14 +7077,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7443,9 +7444,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "optional": true,

--- a/prototype/src/app/components/dashboard/DashboardSidebar.tsx
+++ b/prototype/src/app/components/dashboard/DashboardSidebar.tsx
@@ -42,9 +42,9 @@ export function DashboardSidebar() {
   ];
 
   const spaces = [
-    { name: "Green Energy Space", initials: "GE", href: "/space/green-energy" },
-    { name: "Community Garden", initials: "CG", href: "/space/community-garden" },
-    { name: "Digital Transformation", initials: "DT", href: "/space/digital-trans" },
+    { name: "Green Energy Space", initials: "GE", href: "/space/green-energy", bannerImage: "https://images.unsplash.com/photo-1690191863988-f685cddde463?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100" },
+    { name: "Community Garden", initials: "CG", href: "/space/community-garden", bannerImage: "https://images.unsplash.com/photo-1768659347532-74d3b1efb0ae?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100" },
+    { name: "Digital Transformation", initials: "DT", href: "/space/digital-trans", bannerImage: "https://images.unsplash.com/photo-1676276376052-dc9c9c0b6917?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100" },
   ];
 
   const virtualContributors = [
@@ -107,9 +107,15 @@ export function DashboardSidebar() {
               to={space.href}
               className="flex items-center gap-2.5 rounded-md transition-colors h-9 px-2 text-sm font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground"
             >
-              <div className="w-6 h-6 rounded-md flex items-center justify-center shrink-0 bg-primary/10 text-primary text-[10px] font-bold">
-                {space.initials}
-              </div>
+              {space.bannerImage ? (
+                <div className="w-6 h-6 rounded-md shrink-0 overflow-hidden">
+                  <img src={space.bannerImage} alt={space.name} className="w-full h-full object-cover" />
+                </div>
+              ) : (
+                <div className="w-6 h-6 rounded-md flex items-center justify-center shrink-0 bg-primary/10 text-primary text-[10px] font-bold">
+                  {space.initials}
+                </div>
+              )}
               <span className="truncate">{space.name}</span>
             </Link>
           ))}

--- a/prototype/src/app/components/dashboard/RecentSpaces.tsx
+++ b/prototype/src/app/components/dashboard/RecentSpaces.tsx
@@ -1,6 +1,7 @@
+import { useState } from "react";
 import { Lock, ArrowRight } from "lucide-react";
 import { useNavigate } from "react-router";
-import { Link } from "react-router";
+import { MyMembershipsPanel } from "@/app/components/memberships/MyMembershipsPanel";
 
 const recentSpaces = [
   {
@@ -43,6 +44,7 @@ const recentSpaces = [
 
 export function RecentSpaces() {
   const navigate = useNavigate();
+  const [membershipsOpen, setMembershipsOpen] = useState(false);
 
   return (
     <div className="space-y-4" style={{ fontFamily: "'Inter', sans-serif" }}>
@@ -56,9 +58,9 @@ export function RecentSpaces() {
         >
           Recent Spaces
         </h2>
-        <Link
-          to="/spaces"
-          className="flex items-center gap-1 hover:opacity-80 transition-opacity"
+        <button
+          onClick={() => setMembershipsOpen(true)}
+          className="flex items-center gap-1 hover:opacity-80 transition-opacity cursor-pointer bg-transparent border-none"
           style={{
             fontSize: "var(--text-sm)",
             fontWeight: "var(--font-weight-medium)" as any,
@@ -66,10 +68,9 @@ export function RecentSpaces() {
           }}
         >
           Explore all your Spaces <ArrowRight className="w-4 h-4" />
-        </Link>
+        </button>
       </div>
 
-      {/* Flat horizontal row — no carousel */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         {recentSpaces.map((space) => (
           <div
@@ -89,7 +90,6 @@ export function RecentSpaces() {
               (e.currentTarget.style.boxShadow = "none")
             }
           >
-            {/* Thumbnail */}
             <div className="relative aspect-video overflow-hidden">
               <img
                 src={space.image}
@@ -111,18 +111,14 @@ export function RecentSpaces() {
               )}
             </div>
 
-            {/* Content */}
             <div className="p-4 flex items-center gap-3">
               <div
-                className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0"
+                className="w-10 h-10 rounded-lg shrink-0 overflow-hidden"
                 style={{
-                  background: "var(--primary)",
-                  color: "var(--primary-foreground)",
-                  fontSize: "var(--text-sm)",
-                  fontWeight: 700,
+                  border: "1.5px solid var(--border)",
                 }}
               >
-                {space.initials}
+                <img src={space.image} alt={space.name} className="w-full h-full object-cover" />
               </div>
               <div className="min-w-0 flex-1">
                 <h3
@@ -140,6 +136,11 @@ export function RecentSpaces() {
           </div>
         ))}
       </div>
+
+      <MyMembershipsPanel
+        open={membershipsOpen}
+        onOpenChange={setMembershipsOpen}
+      />
     </div>
   );
 }

--- a/prototype/src/app/components/dialogs/ExploreSpacesDialog.tsx
+++ b/prototype/src/app/components/dialogs/ExploreSpacesDialog.tsx
@@ -306,10 +306,10 @@ export function ExploreSpacesDialog({ open, onOpenChange }: ExploreSpacesDialogP
                 {RECENT_SPACES.map(space => (
                   <div 
                     key={space.id}
-                    className="group bg-card hover:bg-card/80 border border-border rounded-xl overflow-hidden cursor-pointer transition-all hover:shadow-lg hover:-translate-y-1 h-full flex flex-col"
+                    className="group bg-card hover:bg-card/80 border border-border rounded-xl overflow-hidden cursor-pointer transition-all duration-300 hover:shadow-md h-full flex flex-col"
                   >
                     <div className="relative aspect-video w-full overflow-hidden">
-                      <img src={space.image} alt={space.name} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110" />
+                      <img src={space.image} alt={space.name} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-60" />
                       <div className="absolute top-3 right-3 flex flex-col gap-1">
                         <Badge variant={getRoleBadgeVariant(space.role)} className="shadow-sm bg-background/90 backdrop-blur text-foreground border-transparent hover:bg-background text-xs px-2 py-0.5">

--- a/prototype/src/app/components/dialogs/PostDetailDialog.tsx
+++ b/prototype/src/app/components/dialogs/PostDetailDialog.tsx
@@ -180,7 +180,7 @@ export function PostDetailDialog({ open, onOpenChange, post }: PostDetailDialogP
                   {post.contentPreview?.whiteboards?.map((wb, idx) => (
                     <div 
                       key={`wb-${idx}`}
-                      className="group bg-background border border-border rounded-xl overflow-hidden hover:shadow-md hover:-translate-y-1 transition-all cursor-pointer"
+                      className="group bg-background border border-border rounded-xl overflow-hidden hover:shadow-md transition-all duration-300 cursor-pointer"
                       onClick={() => handleLevel3(wb.title)}
                     >
                       <div className="h-32 bg-muted relative overflow-hidden">
@@ -212,7 +212,7 @@ export function PostDetailDialog({ open, onOpenChange, post }: PostDetailDialogP
                   {post.contentPreview?.items?.map((item, idx) => (
                     <div 
                       key={`item-${idx}`}
-                      className="group bg-background border border-border rounded-xl overflow-hidden hover:shadow-md hover:-translate-y-1 transition-all cursor-pointer"
+                      className="group bg-background border border-border rounded-xl overflow-hidden hover:shadow-md transition-all duration-300 cursor-pointer"
                       onClick={() => handleLevel3(item.title)}
                     >
                       <div className="h-32 bg-accent/50 flex items-center justify-center relative">

--- a/prototype/src/app/components/layout/Header.tsx
+++ b/prototype/src/app/components/layout/Header.tsx
@@ -80,7 +80,7 @@ export function Header({
       )}
     >
       <div className="grid grid-cols-12 gap-6 h-full items-center">
-        <div className="col-span-12 lg:col-span-12 flex items-center justify-between">
+        <div className="col-span-12 lg:col-start-2 lg:col-span-10 flex items-center justify-between">
       {/* ─── Left: Logo + mobile menu ─── */}
       <div className="flex items-center gap-4">
         <button

--- a/prototype/src/app/components/layout/MessagesOverlay.tsx
+++ b/prototype/src/app/components/layout/MessagesOverlay.tsx
@@ -152,7 +152,7 @@ export function MessagesOverlay() {
           >
             <div
             className={cn(
-              "col-span-12 lg:col-start-2 lg:col-span-10 max-md:col-start-1 max-md:col-span-12",
+              "col-span-12 lg:col-start-3 lg:col-span-8 max-md:col-start-1 max-md:col-span-12",
               "flex flex-col overflow-hidden pointer-events-auto",
             )}
             style={{

--- a/prototype/src/app/components/memberships/MyMembershipsPanel.tsx
+++ b/prototype/src/app/components/memberships/MyMembershipsPanel.tsx
@@ -1,0 +1,473 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { Input } from "@/app/components/ui/input";
+import { Badge } from "@/app/components/ui/badge";
+import { Button } from "@/app/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/app/components/ui/select";
+import {
+  Search,
+  X,
+  Lock,
+  Globe,
+  Layers,
+  SearchX,
+  ChevronRight,
+} from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
+import { Separator } from "@/app/components/ui/separator";
+import { Skeleton } from "@/app/components/ui/skeleton";
+import {
+  MOCK_MEMBERSHIPS,
+  type MembershipItem,
+  type MembershipRole,
+} from "./membershipData";
+
+interface MyMembershipsPanelProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type PrivacyFilter = "All" | "Public" | "Private";
+
+type MembershipGroup = {
+  parent: MembershipItem;
+  subspaces: MembershipItem[];
+};
+
+/** Subtle role colour — used as a dot + muted text colour */
+function roleColor(role: MembershipRole) {
+  switch (role) {
+    case "Admin":
+      return "var(--destructive)";
+    case "Lead":
+      return "var(--primary)";
+    case "Member":
+      return "var(--muted-foreground)";
+  }
+}
+
+function initials(item: MembershipItem) {
+  return (
+    item.initials ||
+    item.name
+      .split(" ")
+      .map((w) => w[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase()
+  );
+}
+
+export function MyMembershipsPanel({
+  open,
+  onOpenChange,
+}: MyMembershipsPanelProps) {
+  const navigate = useNavigate();
+
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState<"All" | MembershipRole>("All");
+  const [privacyFilter, setPrivacyFilter] = useState<PrivacyFilter>("All");
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>(
+    {}
+  );
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Expand all groups by default when dialog opens
+  useEffect(() => {
+    if (!open) return;
+    setIsLoading(true);
+    const t = setTimeout(() => setIsLoading(false), 350);
+
+    const allIds: Record<string, boolean> = {};
+    MOCK_MEMBERSHIPS.filter((i) => i.type === "space").forEach((s) => {
+      allIds[s.id] = true;
+    });
+    setExpandedGroups(allIds);
+
+    return () => clearTimeout(t);
+  }, [open]);
+
+  const groups = useMemo<MembershipGroup[]>(() => {
+    const spaces = MOCK_MEMBERSHIPS.filter((i) => i.type === "space");
+    const subspaces = MOCK_MEMBERSHIPS.filter((i) => i.type === "subspace");
+
+    return spaces.map((parent) => ({
+      parent,
+      subspaces: subspaces
+        .filter((s) => s.parentId === parent.id)
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    }));
+  }, []);
+
+  const matchesFilters = (item: MembershipItem, parentName?: string) => {
+    if (roleFilter !== "All" && item.role !== roleFilter) return false;
+    if (privacyFilter === "Public" && item.isPrivate) return false;
+    if (privacyFilter === "Private" && !item.isPrivate) return false;
+
+    if (!search.trim()) return true;
+    const q = search.toLowerCase();
+    const haystack = [item.name, item.tagline || "", parentName || ""]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(q);
+  };
+
+  const filteredGroups = useMemo(() => {
+    return groups
+      .map((g) => {
+        const filteredSubspaces = g.subspaces.filter((s) =>
+          matchesFilters(s, g.parent.name)
+        );
+        const parentMatches = matchesFilters(g.parent);
+        if (!parentMatches && filteredSubspaces.length === 0) return null;
+        return { ...g, subspaces: filteredSubspaces };
+      })
+      .filter((g): g is MembershipGroup => Boolean(g))
+      .sort((a, b) => a.parent.name.localeCompare(b.parent.name));
+  }, [groups, roleFilter, privacyFilter, search]);
+
+  const spaceCount = filteredGroups.length;
+  const hasActiveFilters =
+    Boolean(search.trim()) ||
+    roleFilter !== "All" ||
+    privacyFilter !== "All";
+  const hasAnyMemberships = groups.length > 0;
+
+  const clearFilters = () => {
+    setSearch("");
+    setRoleFilter("All");
+    setPrivacyFilter("All");
+  };
+
+  const goToSpace = (slug: string) => {
+    navigate(`/space/${slug}`);
+    onOpenChange(false);
+  };
+
+  const toggleGroupExpand = (groupId: string) => {
+    setExpandedGroups((prev) => ({ ...prev, [groupId]: !prev[groupId] }));
+  };
+
+  if (!open) return null;
+
+  /* ── Role indicator — small dot + text ───────────────────── */
+  const RoleIndicator = ({ role }: { role: MembershipRole }) => (
+    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span
+        className="w-1.5 h-1.5 rounded-full shrink-0"
+        style={{ backgroundColor: roleColor(role) }}
+      />
+      {role}
+    </span>
+  );
+
+  /* ── Parent space row ────────────────────────────────────── */
+  const renderParentRow = (
+    parent: MembershipItem,
+    subspaceCount: number
+  ) => {
+    const isExpanded = Boolean(expandedGroups[parent.id]);
+
+    return (
+      <div
+        key={parent.id}
+        className="flex items-center gap-3 px-5 py-3 hover:bg-muted/40 transition-colors"
+      >
+        {/* Expand / collapse */}
+        {subspaceCount > 0 ? (
+          <button
+            type="button"
+            onClick={() => toggleGroupExpand(parent.id)}
+            className="shrink-0 p-0.5 rounded text-muted-foreground hover:text-foreground"
+          >
+            <ChevronRight
+              className={`w-4 h-4 transition-transform duration-150 ${
+                isExpanded ? "rotate-90" : ""
+              }`}
+            />
+          </button>
+        ) : (
+          <span className="w-5" />
+        )}
+
+        {/* Privacy icon — left side */}
+        {parent.isPrivate ? (
+          <Lock className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <Globe className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />
+        )}
+
+        {/* Banner thumbnail — only image for spaces */}
+        <button
+          type="button"
+          onClick={() => goToSpace(parent.slug)}
+          className="shrink-0 w-16 h-10 rounded-md overflow-hidden bg-muted"
+        >
+          {parent.image ? (
+            <img
+              src={parent.image}
+              alt=""
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <div
+              className="w-full h-full"
+              style={{
+                background: `linear-gradient(135deg, ${parent.color}, color-mix(in srgb, ${parent.color} 40%, black))`,
+              }}
+            />
+          )}
+        </button>
+
+        {/* Name / tagline */}
+        <button
+          type="button"
+          onClick={() => goToSpace(parent.slug)}
+          className="flex-1 min-w-0 text-left"
+        >
+          <p className="text-sm font-medium truncate">{parent.name}</p>
+          {parent.tagline && (
+            <p className="text-xs text-muted-foreground truncate mt-0.5">
+              {parent.tagline}
+            </p>
+          )}
+        </button>
+
+        {/* Metadata — right side */}
+        <div className="flex items-center gap-3 shrink-0">
+          {subspaceCount > 0 && (
+            <Badge variant="outline" className="text-[11px] font-normal px-2 py-0 h-5">
+              {subspaceCount} subspace{subspaceCount > 1 ? "s" : ""}
+            </Badge>
+          )}
+          <RoleIndicator role={parent.role} />
+        </div>
+      </div>
+    );
+  };
+
+  /* ── Subspace row ────────────────────────────────────────── */
+  const renderSubspaceRow = (sub: MembershipItem) => (
+    <button
+      key={sub.id}
+      type="button"
+      onClick={() => goToSpace(sub.slug)}
+      className="flex items-center gap-3 py-2.5 pr-5 hover:bg-muted/40 transition-colors w-full text-left"
+      style={{ paddingLeft: "5rem" }}
+    >
+      {/* Privacy icon — left side */}
+      {sub.isPrivate ? (
+        <Lock className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />
+      ) : (
+        <Globe className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />
+      )}
+
+      {/* Avatar — only image for subspaces */}
+      <Avatar className="w-8 h-8 shrink-0 rounded-md">
+        <AvatarImage src={sub.image} alt={sub.name} />
+        <AvatarFallback
+          style={{ backgroundColor: sub.color }}
+          className="text-white text-[10px] rounded-md"
+        >
+          {initials(sub)}
+        </AvatarFallback>
+      </Avatar>
+
+      {/* Name */}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm truncate">{sub.name}</p>
+      </div>
+
+      {/* Role */}
+      <RoleIndicator role={sub.role} />
+    </button>
+  );
+
+  /* ── Render ──────────────────────────────────────────────── */
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-[100]"
+        style={{
+          background:
+            "color-mix(in srgb, var(--foreground) 50%, transparent)",
+          backdropFilter: "blur(2px)",
+        }}
+        onClick={() => onOpenChange(false)}
+        aria-hidden
+      />
+
+      {/* Overlay container — 12-col grid, content in col 2–11 */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="My Spaces"
+        className="fixed inset-0 z-[101] grid grid-cols-12 gap-6 px-6 md:px-8 py-[5vh] max-md:p-0 pointer-events-none"
+      >
+        <div
+          className="col-span-12 lg:col-start-3 lg:col-span-8 max-md:col-start-1 max-md:col-span-12 flex flex-col overflow-hidden pointer-events-auto"
+          style={{
+            background: "var(--background)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-xl)",
+            boxShadow: "var(--elevation-sm)",
+          }}
+        >
+          {/* Header */}
+          <div className="px-6 py-5 border-b border-border">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold">My Spaces</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {spaceCount} space{spaceCount !== 1 ? "s" : ""} you&apos;re
+                  part of
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onOpenChange(false)}
+                className="rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+          </div>
+
+          {/* Search + filters */}
+          <div className="px-6 py-3 border-b border-border flex items-center gap-3">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+              <Input
+                className="pl-9 pr-9"
+                placeholder="Search your spaces..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+              {search && (
+                <button
+                  type="button"
+                  onClick={() => setSearch("")}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+
+            <Select
+              value={roleFilter}
+              onValueChange={(v) =>
+                setRoleFilter(v as "All" | MembershipRole)
+              }
+            >
+              <SelectTrigger className="w-[130px] shrink-0">
+                <SelectValue placeholder="All Roles" />
+              </SelectTrigger>
+              <SelectContent className="z-[200]">
+                <SelectItem value="All">All Roles</SelectItem>
+                <SelectItem value="Admin">Admin</SelectItem>
+                <SelectItem value="Lead">Lead</SelectItem>
+                <SelectItem value="Member">Member</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={privacyFilter}
+              onValueChange={(v) =>
+                setPrivacyFilter(v as PrivacyFilter)
+              }
+            >
+              <SelectTrigger className="w-[120px] shrink-0">
+                <SelectValue placeholder="Visibility" />
+              </SelectTrigger>
+              <SelectContent className="z-[200]">
+                <SelectItem value="All">All</SelectItem>
+                <SelectItem value="Public">Public</SelectItem>
+                <SelectItem value="Private">Private</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Content — list layout */}
+          <div className="flex-1 overflow-y-auto">
+            {isLoading ? (
+              <div className="px-5 py-2">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div key={i}>
+                    <div className="flex items-center gap-3 py-3">
+                      <Skeleton className="w-5 h-5 rounded" />
+                      <Skeleton className="w-3.5 h-3.5 rounded-full" />
+                      <Skeleton className="w-16 h-10 rounded-md" />
+                      <div className="flex-1 space-y-1.5">
+                        <Skeleton className="h-4 w-2/5" />
+                        <Skeleton className="h-3 w-3/5" />
+                      </div>
+                      <Skeleton className="h-4 w-12" />
+                    </div>
+                    {i < 4 && <Separator />}
+                  </div>
+                ))}
+              </div>
+            ) : !hasAnyMemberships ? (
+              <div className="h-full min-h-[260px] flex flex-col items-center justify-center text-center px-4">
+                <Layers className="w-10 h-10 text-muted-foreground" />
+                <p className="mt-3 text-sm text-muted-foreground">
+                  You&apos;re not part of any spaces yet.
+                </p>
+                <Button
+                  variant="outline"
+                  className="mt-4"
+                  onClick={() => goToSpace("spaces")}
+                >
+                  Browse all spaces
+                </Button>
+              </div>
+            ) : spaceCount === 0 ? (
+              <div className="h-full min-h-[260px] flex flex-col items-center justify-center text-center px-4">
+                <SearchX className="w-10 h-10 text-muted-foreground" />
+                <p className="mt-3 text-sm text-muted-foreground">
+                  No spaces match your search.
+                </p>
+                <Button
+                  variant="link"
+                  className="mt-2"
+                  onClick={clearFilters}
+                >
+                  Clear filters
+                </Button>
+              </div>
+            ) : (
+              <div>
+                {filteredGroups.map((group, gi) => {
+                  const { parent, subspaces } = group;
+                  const isExpanded = Boolean(expandedGroups[parent.id]);
+
+                  return (
+                    <div key={parent.id}>
+                      {gi > 0 && <Separator />}
+                      {renderParentRow(parent, subspaces.length)}
+
+                      {isExpanded && subspaces.length > 0 && (
+                        <div>
+                          {subspaces.map((sub) => renderSubspaceRow(sub))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/prototype/src/app/components/memberships/membershipData.ts
+++ b/prototype/src/app/components/memberships/membershipData.ts
@@ -1,0 +1,167 @@
+export type MembershipRole = "Admin" | "Lead" | "Member";
+
+export interface MembershipItem {
+  id: string;
+  name: string;
+  slug: string;
+  tagline?: string;
+  isPrivate: boolean;
+  role: MembershipRole;
+  initials: string;
+  color: string;
+  type: "space" | "subspace";
+  parentId?: string;
+  parentName?: string;
+  image?: string;
+}
+
+const colors = [
+  "#1d384a",
+  "#2563eb",
+  "#7c3aed",
+  "#059669",
+  "#d97706",
+  "#db2777",
+];
+
+const c = (i: number) => colors[i % colors.length];
+
+export const MOCK_MEMBERSHIPS: MembershipItem[] = [
+  {
+    id: "s1",
+    type: "space",
+    name: "Innovation Lab",
+    slug: "innovation-lab",
+    tagline: "Central hub for innovation initiatives and rapid experiments.",
+    isPrivate: true,
+    role: "Lead",
+    initials: "IL",
+    color: c(0),
+    image: "https://images.unsplash.com/photo-1623652554515-91c833e3080e?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s1-sub-1",
+    type: "subspace",
+    parentId: "s1",
+    parentName: "Innovation Lab",
+    name: "Q1 Experiments",
+    slug: "q1-experiments",
+    isPrivate: true,
+    role: "Lead",
+    initials: "Q1",
+    color: c(0),
+    image: "https://images.unsplash.com/photo-1532094349884-543bc11b234d?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s1-sub-2",
+    type: "subspace",
+    parentId: "s1",
+    parentName: "Innovation Lab",
+    name: "Idea Repository",
+    slug: "idea-repository",
+    isPrivate: false,
+    role: "Member",
+    initials: "IR",
+    color: c(0),
+    image: "https://images.unsplash.com/photo-1456324504439-367cee3b3c32?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s2",
+    type: "space",
+    name: "Design Workshop",
+    slug: "design-workshop",
+    tagline: "Design critiques, assets, and product exploration.",
+    isPrivate: false,
+    role: "Admin",
+    initials: "DW",
+    color: c(1),
+    image: "https://images.unsplash.com/photo-1735639013995-086e648eaa38?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s3",
+    type: "space",
+    name: "Team Sync",
+    slug: "team-sync",
+    tagline: "Weekly alignment and delivery planning for the core team.",
+    isPrivate: true,
+    role: "Member",
+    initials: "TS",
+    color: c(2),
+    image: "https://images.unsplash.com/photo-1768659347532-74d3b1efb0ae?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s3-sub-1",
+    type: "subspace",
+    parentId: "s3",
+    parentName: "Team Sync",
+    name: "Daily Standup",
+    slug: "daily-standup",
+    isPrivate: true,
+    role: "Member",
+    initials: "DS",
+    color: c(2),
+    image: "https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s4",
+    type: "space",
+    name: "Future Strategy",
+    slug: "future-strategy",
+    tagline: "Long-range planning and roadmap discussions.",
+    isPrivate: false,
+    role: "Member",
+    initials: "FS",
+    color: c(3),
+    image: "https://images.unsplash.com/photo-1676276376052-dc9c9c0b6917?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s4-sub-1",
+    type: "subspace",
+    parentId: "s4",
+    parentName: "Future Strategy",
+    name: "Market Research",
+    slug: "market-research",
+    isPrivate: false,
+    role: "Member",
+    initials: "MR",
+    color: c(3),
+    image: "https://images.unsplash.com/photo-1551288049-bebda4e38f71?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s4-sub-2",
+    type: "subspace",
+    parentId: "s4",
+    parentName: "Future Strategy",
+    name: "2026 Roadmap",
+    slug: "2026-roadmap",
+    isPrivate: false,
+    role: "Member",
+    initials: "26",
+    color: c(3),
+    image: "https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s5",
+    type: "space",
+    name: "Community Events",
+    slug: "community-events",
+    tagline: "Planning meetups, webinars, and community activity.",
+    isPrivate: true,
+    role: "Lead",
+    initials: "CE",
+    color: c(4),
+    image: "https://images.unsplash.com/photo-1768776179834-93e6cafc6d97?auto=format&fit=crop&q=80&w=1200",
+  },
+  {
+    id: "s6",
+    type: "space",
+    name: "Platform Management",
+    slug: "platform-management",
+    tagline: "Templates, governance, and platform operations.",
+    isPrivate: true,
+    role: "Admin",
+    initials: "PM",
+    color: c(5),
+    image: "https://images.unsplash.com/photo-1460925895917-afdab827c52f?auto=format&fit=crop&q=80&w=1200",
+  },
+];

--- a/prototype/src/app/components/search/SearchOverlay.tsx
+++ b/prototype/src/app/components/search/SearchOverlay.tsx
@@ -339,7 +339,7 @@ export function SearchOverlay() {
           >
             <div
             className={cn(
-              "col-span-12 lg:col-start-2 lg:col-span-10 max-md:col-start-1 max-md:col-span-12",
+              "col-span-12 lg:col-start-3 lg:col-span-8 max-md:col-start-1 max-md:col-span-12",
               "flex flex-col overflow-hidden pointer-events-auto",
             )}
             style={{

--- a/prototype/src/app/components/space/AboutThisSpaceDialog.tsx
+++ b/prototype/src/app/components/space/AboutThisSpaceDialog.tsx
@@ -1,0 +1,816 @@
+import { useState, useRef, useEffect } from "react";
+import { useNavigate } from "react-router";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from "@/app/components/ui/dialog";
+import { ScrollArea } from "@/app/components/ui/scroll-area";
+import { Button } from "@/app/components/ui/button";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/app/components/ui/avatar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/app/components/ui/tooltip";
+import {
+  X,
+  Pencil,
+  Target,
+  Users,
+  Globe,
+  MapPin,
+  Mail,
+  BookOpen,
+} from "lucide-react";
+
+/* ─── Types ──────────────────────────────────────────────── */
+
+interface SpaceLead {
+  name: string;
+  location: string;
+  avatar: string;
+  initials: string;
+}
+
+interface SpaceReference {
+  title: string;
+  url: string;
+}
+
+interface SpaceHost {
+  name: string;
+  location: string;
+  avatar: string;
+  initials: string;
+  email: string;
+}
+
+interface AboutThisSpaceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Whether the current user can edit (admin / facilitator) */
+  isAdmin?: boolean;
+  /** Space slug for settings navigation */
+  spaceSlug?: string;
+}
+
+/* ─── Mock data ──────────────────────────────────────────── */
+
+const SPACE_DATA = {
+  name: "The Sandbox",
+  tagline:
+    "To try and play around with various Alkemio features; to gain a better understanding of the platform, its flows and experience",
+  description:
+    "SANDY! A place to try and play around with various Alkemio features, to gain a better understanding of the platform, its flows, experiences, and how to improve it. To test out new features and try new things. To boldly go where no user has gone before.",
+  bannerImage:
+    "https://images.unsplash.com/photo-1690191863988-f685cddde463?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxkZXNpZ24lMjBjaGFsbGVuZ2UlMjBjcmVhdGl2ZSUyMHdvcmtzaG9wJTIwdGVhbSUyMGNvbGxhYm9yYXRpb24lMjBpbm5vdmF0aW9uJTIwc3ByaW50JTIwZGVzaWduJTIwc3ByaW50fGVufDF8fHx8MTc2OTA5NDMxMHww&ixlib=rb-4.1.0&q=80&w=1080",
+  location: "'s-gravenhage",
+  memberCount: 16,
+  whyText: "this is the description of why",
+  whoText: "this is who can join us",
+  guidelines: {
+    title: "United in Knowledge: Key Guidelines for Success",
+    body: `**Community Guidelines for The Sandbox**
+
+Introduction
+Welcome to The Sandbox!
+
+Key Guidelines
+
+**Respect and Empathy**
+Treat all community members with respect. Engage in constructive dialogue and be empathetic to differing viewpoints. Personal attacks, harassment, or discrimination of any kind will not be tolerated.
+
+**Collaboration Over Competition**
+We are here to build together. Share your knowledge generously and support other members in achieving shared goals.
+
+**Quality Contributions**
+Strive to provide thoughtful and well-researched contributions. Cite sources where possible and be transparent about assumptions.`,
+  },
+  references: [
+    {
+      title: "New reference",
+      url: "asdflasdf",
+    },
+  ],
+};
+
+const LEADS: SpaceLead[] = [
+  {
+    name: "Jeroen Nijkamp",
+    location: "'s-gravenhage",
+    avatar:
+      "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxtYW4lMjBwb3J0cmFpdCUyMHByb2Zlc3Npb25hbHxlbnwxfHx8fDE3NzIxMDQyMjl8MA&ixlib=rb-4.1.0&q=80&w=256",
+    initials: "JN",
+  },
+];
+
+const HOST: SpaceHost = {
+  name: "Jeroen Nijkamp",
+  location: "'s-gravenhage",
+  avatar:
+    "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxtYW4lMjBwb3J0cmFpdCUyMHByb2Zlc3Npb25hbHxlbnwxfHx8fDE3NzIxMDQyMjl8MA&ixlib=rb-4.1.0&q=80&w=256",
+  initials: "JN",
+  email: "jeroen@alkemio.org",
+};
+
+/* ─── Component ──────────────────────────────────────────── */
+
+export function AboutThisSpaceDialog({
+  open,
+  onOpenChange,
+  isAdmin = true,
+  spaceSlug = "default-space",
+}: AboutThisSpaceDialogProps) {
+  const navigate = useNavigate();
+  const [guidelinesOpen, setGuidelinesOpen] = useState(false);
+  const [contactOpen, setContactOpen] = useState(false);
+  const [contactMessage, setContactMessage] = useState("");
+  const guidelinesRef = useRef<HTMLDivElement>(null);
+  const [isGuidelinesTruncated, setIsGuidelinesTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = guidelinesRef.current;
+    if (el) {
+      setIsGuidelinesTruncated(el.scrollHeight > el.clientHeight);
+    }
+  }, [open]);
+
+  const goToSettings = (tab: string) => {
+    onOpenChange(false);
+    navigate(`/space/${spaceSlug}/settings/${tab}`);
+  };
+
+  return (
+    <>
+      {/* ── Main About dialog ── */}
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="w-[calc(100%-3rem)] sm:w-[50vw] sm:max-w-none p-0 gap-0 overflow-hidden rounded-xl border-0 shadow-2xl bg-background flex flex-col max-h-[85vh]">
+          {/* Fixed header */}
+          <div
+            className="px-6 pt-5 pb-4 border-b shrink-0"
+            style={{ background: "var(--background)" }}
+          >
+            <div className="flex items-start justify-between">
+              <div className="pr-8">
+                <DialogTitle
+                  className="text-xl font-semibold"
+                  style={{ color: "var(--foreground)" }}
+                >
+                  {SPACE_DATA.name}
+                </DialogTitle>
+                <DialogDescription className="mt-1 italic text-sm text-muted-foreground leading-relaxed">
+                  {SPACE_DATA.tagline}
+                </DialogDescription>
+              </div>
+              <DialogClose className="rounded-full p-2 hover:bg-muted transition-colors shrink-0 -mt-1 -mr-2">
+                <X className="w-5 h-5 text-muted-foreground" />
+              </DialogClose>
+            </div>
+          </div>
+
+          {/* Scrollable body */}
+          <ScrollArea className="flex-1 overflow-y-auto">
+            <div className="px-6 py-5 space-y-6">
+              {/* ── Space info card — description + leads ── */}
+              <div
+                className="rounded-lg overflow-hidden"
+                style={{
+                  background: "rgb(29, 56, 74)",
+                  color: "white",
+                }}
+              >
+                {/* Admin edit icons */}
+                {isAdmin && (
+                  <div className="flex justify-end gap-1 px-4 pt-3">
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 rounded-full hover:bg-white/10"
+                            style={{ color: "rgba(255,255,255,0.6)" }}
+                            onClick={() => goToSettings("about")}
+                          >
+                            <Pencil className="w-3.5 h-3.5" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Edit space profile</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 rounded-full hover:bg-white/10"
+                            style={{ color: "rgba(255,255,255,0.6)" }}
+                            onClick={() => goToSettings("community")}
+                          >
+                            <Users className="w-3.5 h-3.5" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Manage community</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                )}
+
+                {/* Description — full, not truncated, white text on dark blue */}
+                <div className={isAdmin ? "px-5 pb-5 pt-2" : "p-5"}>
+                  <p
+                    className="mb-4"
+                    style={{
+                      fontSize: "var(--text-sm)",
+                      color: "rgba(255,255,255,0.9)",
+                      lineHeight: 1.7,
+                    }}
+                  >
+                    {SPACE_DATA.description}
+                  </p>
+
+                  {/* Meta row: location + members */}
+                  <div className="flex items-center gap-4 mb-4">
+                    <span
+                      className="flex items-center gap-1"
+                      style={{
+                        fontSize: "12px",
+                        color: "rgba(255,255,255,0.7)",
+                      }}
+                    >
+                      <MapPin className="w-3 h-3" />
+                      {SPACE_DATA.location}
+                    </span>
+                    <span
+                      className="flex items-center gap-1"
+                      style={{
+                        fontSize: "12px",
+                        color: "rgba(255,255,255,0.7)",
+                      }}
+                    >
+                      <Users className="w-3 h-3" />
+                      {SPACE_DATA.memberCount} members
+                    </span>
+                  </div>
+
+                  {/* Leads — below description */}
+                  <div
+                    className="pt-4"
+                    style={{ borderTop: "1px solid rgba(255,255,255,0.15)" }}
+                  >
+                    <h4
+                      className="mb-3"
+                      style={{
+                        fontSize: "12px",
+                        fontWeight: 600,
+                        color: "rgba(255,255,255,0.6)",
+                        textTransform: "uppercase",
+                        letterSpacing: "0.04em",
+                      }}
+                    >
+                      Leads
+                    </h4>
+                    <div className="flex flex-wrap gap-4">
+                      {LEADS.map((lead) => (
+                        <div
+                          key={lead.name}
+                          className="flex items-center gap-3"
+                        >
+                          <Avatar
+                            className="w-9 h-9"
+                            style={{ border: "2px solid rgba(255,255,255,0.25)" }}
+                          >
+                            <AvatarImage
+                              src={lead.avatar}
+                              alt={lead.name}
+                            />
+                            <AvatarFallback
+                              style={{
+                                fontSize: "10px",
+                                fontWeight: 700,
+                                background: "rgba(255,255,255,0.15)",
+                                color: "white",
+                              }}
+                            >
+                              {lead.initials}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div>
+                            <p
+                              style={{
+                                fontSize: "var(--text-sm)",
+                                fontWeight: 600,
+                                color: "white",
+                              }}
+                            >
+                              {lead.name}
+                            </p>
+                            <p
+                              className="flex items-center gap-1"
+                              style={{
+                                fontSize: "12px",
+                                color: "rgba(255,255,255,0.6)",
+                              }}
+                            >
+                              <MapPin className="w-3 h-3" />
+                              {lead.location}
+                            </p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* ── Why section ── */}
+              <ContextSection
+                icon={<Target className="w-4 h-4" />}
+                title="Why"
+                isAdmin={isAdmin}
+                onEdit={() => goToSettings("about")}
+              >
+                <p
+                  style={{
+                    fontSize: "var(--text-sm)",
+                    color: "var(--muted-foreground)",
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {SPACE_DATA.whyText}
+                </p>
+              </ContextSection>
+
+              {/* ── Who section ── */}
+              <ContextSection
+                icon={<Users className="w-4 h-4" />}
+                title="Who"
+                isAdmin={isAdmin}
+                onEdit={() => goToSettings("about")}
+              >
+                <p
+                  style={{
+                    fontSize: "var(--text-sm)",
+                    color: "var(--muted-foreground)",
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {SPACE_DATA.whoText}
+                </p>
+              </ContextSection>
+
+              {/* ── Guidelines section ── */}
+              <div
+                className="rounded-lg overflow-hidden"
+                style={{
+                  border: "1px solid var(--border)",
+                  background: "var(--card)",
+                }}
+              >
+                <div className="p-5">
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center gap-2">
+                      <BookOpen
+                        className="w-4 h-4"
+                        style={{ color: "var(--muted-foreground)" }}
+                      />
+                      <h3
+                        style={{
+                          fontSize: "var(--text-sm)",
+                          fontWeight: 600,
+                          color: "var(--foreground)",
+                        }}
+                      >
+                        {SPACE_DATA.guidelines.title}
+                      </h3>
+                    </div>
+                    {isAdmin && <EditButton tooltip="Edit guidelines" onClick={() => goToSettings("about")} />}
+                  </div>
+                  <div
+                    ref={guidelinesRef}
+                    className="line-clamp-6 space-y-1"
+                    style={{
+                      fontSize: "var(--text-sm)",
+                      color: "var(--muted-foreground)",
+                      lineHeight: 1.6,
+                    }}
+                  >
+                    {SPACE_DATA.guidelines.body
+                      .split("\n")
+                      .filter(Boolean)
+                      .map((line, i) => {
+                        if (line.startsWith("**") && line.endsWith("**")) {
+                          return (
+                            <p key={i} className="font-semibold" style={{ color: "var(--foreground)" }}>
+                              {line.replace(/\*\*/g, "")}
+                            </p>
+                          );
+                        }
+                        return <p key={i}>{line.replace(/\*\*/g, "")}</p>;
+                      })}
+                  </div>
+                  {isGuidelinesTruncated && (
+                    <button
+                      onClick={() => setGuidelinesOpen(true)}
+                      className="mt-3 hover:underline"
+                      style={{
+                        fontSize: "var(--text-sm)",
+                        fontWeight: 500,
+                        color: "var(--primary)",
+                      }}
+                    >
+                      Read more
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {/* ── References section ── */}
+              <div
+                className="rounded-lg overflow-hidden"
+                style={{
+                  border: "1px solid var(--border)",
+                  background: "var(--card)",
+                }}
+              >
+                <div className="p-5">
+                  <div className="flex items-center justify-between mb-3">
+                    <h3
+                      style={{
+                        fontSize: "var(--text-sm)",
+                        fontWeight: 600,
+                        color: "var(--foreground)",
+                      }}
+                    >
+                      References
+                    </h3>
+                    {isAdmin && <EditButton tooltip="Edit references" onClick={() => goToSettings("about")} />}
+                  </div>
+                  <div className="space-y-3">
+                    {SPACE_DATA.references.map((ref, i) => (
+                      <div key={i} className="flex items-start gap-3">
+                        <div
+                          className="shrink-0 flex items-center justify-center rounded-full"
+                          style={{
+                            width: 36,
+                            height: 36,
+                            background:
+                              "color-mix(in srgb, var(--primary) 10%, transparent)",
+                          }}
+                        >
+                          <Globe
+                            className="w-4 h-4"
+                            style={{ color: "var(--primary)" }}
+                          />
+                        </div>
+                        <div>
+                          <p
+                            style={{
+                              fontSize: "var(--text-sm)",
+                              fontWeight: 500,
+                              color: "var(--foreground)",
+                            }}
+                          >
+                            {ref.title}
+                          </p>
+                          <p
+                            style={{
+                              fontSize: "12px",
+                              color: "var(--muted-foreground)",
+                            }}
+                          >
+                            {ref.url}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {/* ── Hosted by section ── */}
+              <div
+                className="rounded-lg overflow-hidden"
+                style={{
+                  border: "1px solid var(--border)",
+                  background: "var(--card)",
+                }}
+              >
+                <div className="p-5">
+                  <h3
+                    className="mb-3"
+                    style={{
+                      fontSize: "var(--text-sm)",
+                      fontWeight: 600,
+                      color: "var(--foreground)",
+                    }}
+                  >
+                    Hosted by
+                  </h3>
+                  <div className="flex items-center gap-3 mb-3">
+                    <Avatar
+                      className="w-10 h-10"
+                      style={{ border: "2px solid var(--border)" }}
+                    >
+                      <AvatarImage src={HOST.avatar} alt={HOST.name} />
+                      <AvatarFallback
+                        style={{
+                          fontSize: "11px",
+                          fontWeight: 700,
+                          background:
+                            "color-mix(in srgb, var(--primary) 15%, transparent)",
+                          color: "var(--primary)",
+                        }}
+                      >
+                        {HOST.initials}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <p
+                        style={{
+                          fontSize: "var(--text-sm)",
+                          fontWeight: 600,
+                          color: "var(--foreground)",
+                        }}
+                      >
+                        {HOST.name}
+                      </p>
+                      <p
+                        className="flex items-center gap-1"
+                        style={{
+                          fontSize: "12px",
+                          color: "var(--muted-foreground)",
+                        }}
+                      >
+                        <MapPin className="w-3 h-3" />
+                        {HOST.location}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <button
+                      onClick={() => setContactOpen(true)}
+                      className="shrink-0 mt-0.5 hover:opacity-80 transition-opacity"
+                    >
+                      <Mail
+                        className="w-4 h-4"
+                        style={{ color: "var(--muted-foreground)" }}
+                      />
+                    </button>
+                    <p
+                      style={{
+                        fontSize: "var(--text-sm)",
+                        color: "var(--muted-foreground)",
+                        lineHeight: 1.5,
+                      }}
+                    >
+                      The hosts are responsible for the content of the Space. Any
+                      questions or comments, please reach out.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Guidelines full dialog (nested) ── */}
+      <Dialog open={guidelinesOpen} onOpenChange={setGuidelinesOpen}>
+        <DialogContent className="w-[calc(100%-3rem)] sm:w-[50vw] sm:max-w-none p-0 gap-0 overflow-hidden rounded-xl border-0 shadow-2xl bg-background flex flex-col max-h-[85vh]">
+          <div
+            className="px-6 pt-5 pb-4 border-b shrink-0 flex items-center justify-between"
+            style={{ background: "var(--background)" }}
+          >
+            <DialogTitle className="text-lg font-semibold">
+              {SPACE_DATA.guidelines.title}
+            </DialogTitle>
+            <DialogClose className="rounded-full p-2 hover:bg-muted transition-colors -mr-2">
+              <X className="w-5 h-5 text-muted-foreground" />
+            </DialogClose>
+          </div>
+          <DialogDescription className="sr-only">
+            Full community guidelines for {SPACE_DATA.name}.
+          </DialogDescription>
+          <ScrollArea className="flex-1 overflow-y-auto">
+            <div
+              className="px-6 py-5 space-y-3"
+              style={{
+                fontSize: "var(--text-sm)",
+                color: "var(--muted-foreground)",
+                lineHeight: 1.7,
+              }}
+            >
+              {SPACE_DATA.guidelines.body
+                .split("\n")
+                .filter(Boolean)
+                .map((line, i) => {
+                  if (line.startsWith("**") && line.endsWith("**")) {
+                    return (
+                      <p
+                        key={i}
+                        className="font-semibold mt-2"
+                        style={{ color: "var(--foreground)" }}
+                      >
+                        {line.replace(/\*\*/g, "")}
+                      </p>
+                    );
+                  }
+                  return <p key={i}>{line.replace(/\*\*/g, "")}</p>;
+                })}
+            </div>
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Contact host dialog (nested) ── */}
+      <Dialog open={contactOpen} onOpenChange={setContactOpen}>
+        <DialogContent className="w-full sm:max-w-md p-0 gap-0 overflow-hidden rounded-xl border-0 shadow-2xl bg-background">
+          <div
+            className="px-6 pt-5 pb-4 border-b flex items-center justify-between"
+            style={{ background: "var(--background)" }}
+          >
+            <DialogTitle className="text-lg font-semibold">
+              Contact Host
+            </DialogTitle>
+            <DialogClose className="rounded-full p-2 hover:bg-muted transition-colors -mr-2">
+              <X className="w-5 h-5 text-muted-foreground" />
+            </DialogClose>
+          </div>
+          <DialogDescription className="sr-only">
+            Send a message to the space host.
+          </DialogDescription>
+          <div className="px-6 py-5 space-y-4">
+            {/* Recipient */}
+            <div className="flex items-center gap-3">
+              <Avatar className="w-8 h-8">
+                <AvatarImage src={HOST.avatar} alt={HOST.name} />
+                <AvatarFallback
+                  style={{
+                    fontSize: "9px",
+                    fontWeight: 700,
+                    background:
+                      "color-mix(in srgb, var(--primary) 15%, transparent)",
+                    color: "var(--primary)",
+                  }}
+                >
+                  {HOST.initials}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <p
+                  style={{
+                    fontSize: "var(--text-sm)",
+                    fontWeight: 600,
+                    color: "var(--foreground)",
+                  }}
+                >
+                  To: {HOST.name}
+                </p>
+                <p
+                  style={{
+                    fontSize: "12px",
+                    color: "var(--muted-foreground)",
+                  }}
+                >
+                  {HOST.email}
+                </p>
+              </div>
+            </div>
+
+            {/* Message input */}
+            <div>
+              <label
+                htmlFor="contact-message"
+                className="block mb-1.5"
+                style={{
+                  fontSize: "var(--text-sm)",
+                  fontWeight: 500,
+                  color: "var(--foreground)",
+                }}
+              >
+                Message
+              </label>
+              <textarea
+                id="contact-message"
+                rows={4}
+                value={contactMessage}
+                onChange={(e) => setContactMessage(e.target.value)}
+                placeholder="Write your message..."
+                className="w-full rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2"
+                style={{
+                  fontSize: "var(--text-sm)",
+                  border: "1px solid var(--border)",
+                  background: "var(--background)",
+                  color: "var(--foreground)",
+                  focusRingColor: "var(--ring)",
+                }}
+              />
+            </div>
+
+            {/* Actions */}
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setContactOpen(false);
+                  setContactMessage("");
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={() => {
+                  // In production this would send an in-app message
+                  setContactOpen(false);
+                  setContactMessage("");
+                }}
+              >
+                <Mail className="w-4 h-4 mr-2" />
+                Send
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+/* ─── Sub-components ─────────────────────────────────────── */
+
+interface ContextSectionProps {
+  icon: React.ReactNode;
+  title: string;
+  isAdmin?: boolean;
+  onEdit?: () => void;
+  children: React.ReactNode;
+}
+
+function ContextSection({
+  icon,
+  title,
+  isAdmin,
+  onEdit,
+  children,
+}: ContextSectionProps) {
+  return (
+    <div
+      className="rounded-lg overflow-hidden"
+      style={{
+        border: "1px solid var(--border)",
+        background: "var(--card)",
+      }}
+    >
+      <div className="p-5">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <span style={{ color: "var(--muted-foreground)" }}>{icon}</span>
+            <h3
+              style={{
+                fontSize: "var(--text-sm)",
+                fontWeight: 600,
+                color: "var(--foreground)",
+              }}
+            >
+              {title}
+            </h3>
+          </div>
+          {isAdmin && <EditButton tooltip={`Edit ${title.toLowerCase()}`} onClick={onEdit} />}
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function EditButton({ tooltip, onClick }: { tooltip: string; onClick?: () => void }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            onClick={onClick}
+          >
+            <Pencil
+              className="w-3.5 h-3.5"
+              style={{ color: "var(--muted-foreground)" }}
+            />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/prototype/src/app/components/space/ChannelTabs.tsx
+++ b/prototype/src/app/components/space/ChannelTabs.tsx
@@ -1,11 +1,19 @@
 import { cn } from "@/lib/utils";
-import { Hash } from "lucide-react";
+import { ChevronsRight } from "lucide-react";
 
 export interface CalloutTab {
   id: string;
   label: string;
+  description?: string;
   count?: number;
   pinned?: boolean;
+  linkedToNext?: boolean;
+}
+
+function FlowArrow() {
+  return (
+    <ChevronsRight className="w-3.5 h-3.5 text-muted-foreground/40 mt-[3px] -ml-[13px] mr-[7px]" />
+  );
 }
 
 interface CalloutTabsProps {
@@ -20,60 +28,57 @@ export function CalloutTabs({
   onTabChange,
 }: CalloutTabsProps) {
   return (
-    <div
-      className="flex flex-wrap items-center gap-2"
-      style={{ fontFamily: "var(--font-family, 'Inter', sans-serif)" }}
-    >
-      {tabs.map((tab) => {
-        const isActive = activeTab === tab.id;
-        return (
-          <button
-            key={tab.id}
-            onClick={() => onTabChange(tab.id)}
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded-full px-4 py-1.5 transition-all duration-200 select-none",
-              isActive
-                ? "text-primary-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-            style={{
-              fontSize: "var(--text-sm)",
-              fontWeight: isActive ? 600 : 500,
-              letterSpacing: "0.02em",
-              background: isActive
-                ? "var(--primary)"
-                : "var(--muted)",
-              border: `1px solid ${isActive ? "var(--primary)" : "var(--border)"}`,
-            }}
-          >
-            {tab.id !== "all" && (
-              <Hash
-                className="w-3 h-3"
-                style={{ opacity: isActive ? 1 : 0.6 }}
-              />
-            )}
-            {tab.label}
-            {tab.count !== undefined && tab.count > 0 && (
-              <span
-                className="rounded-full px-1.5 py-0.5"
+    <nav className="w-full">
+      <div
+        className="flex items-center gap-6 overflow-x-auto scrollbar-hide [-ms-overflow-style:none] [scrollbar-width:none] overscroll-x-contain"
+        style={{ WebkitOverflowScrolling: "touch" }}
+      >
+        {tabs.map((tab, index) => {
+          const isActive = activeTab === tab.id;
+          return (
+            <div key={tab.id} className="inline-flex items-start shrink-0">
+              {index > 0 && tabs[index - 1]?.linkedToNext && (
+                <FlowArrow />
+              )}
+              <button
+                onClick={() => onTabChange(tab.id)}
+                className={cn(
+                  "pb-2 transition-all duration-200 whitespace-nowrap border-b-2 select-none inline-flex items-center gap-1.5",
+                  isActive
+                    ? "border-primary text-primary"
+                    : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted"
+                )}
                 style={{
-                  fontSize: "10px",
-                  fontWeight: 700,
-                  lineHeight: 1,
-                  background: isActive
-                    ? "color-mix(in srgb, var(--primary-foreground) 20%, transparent)"
-                    : "color-mix(in srgb, var(--muted-foreground) 12%, transparent)",
-                  color: isActive
-                    ? "var(--primary-foreground)"
-                    : "var(--muted-foreground)",
+                  fontSize: 14,
+                  fontWeight: isActive ? 600 : 500,
+                  fontFamily: "'Inter', sans-serif",
+                  lineHeight: "20px",
                 }}
               >
-                {tab.count}
-              </span>
-            )}
-          </button>
-        );
-      })}
-    </div>
+              {tab.label}
+              {tab.count !== undefined && tab.count > 0 && (
+                <span
+                  className="rounded-full px-1.5 py-0.5"
+                  style={{
+                    fontSize: "10px",
+                    fontWeight: 700,
+                    lineHeight: 1,
+                    background: isActive
+                      ? "color-mix(in srgb, var(--primary) 12%, transparent)"
+                      : "color-mix(in srgb, var(--muted-foreground) 12%, transparent)",
+                    color: isActive
+                      ? "var(--primary)"
+                      : "var(--muted-foreground)",
+                  }}
+                >
+                  {tab.count}
+                </span>
+              )}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </nav>
   );
 }

--- a/prototype/src/app/components/space/PostCard.tsx
+++ b/prototype/src/app/components/space/PostCard.tsx
@@ -50,7 +50,7 @@ export function PostCard({ post }: { post: PostProps }) {
   };
 
   return (
-    <Card className="group hover:shadow-md transition-all duration-200 hover:-translate-y-0.5 border-border/60">
+    <Card className="group hover:shadow-md transition-all duration-300 border-border/60">
       <CardHeader className="flex flex-row items-start justify-between pb-3 pt-5 px-6 space-y-0">
         <div className="flex gap-3">
           <Avatar className="w-10 h-10 border border-border">

--- a/prototype/src/app/components/space/SpaceCard.tsx
+++ b/prototype/src/app/components/space/SpaceCard.tsx
@@ -28,6 +28,7 @@ export interface SpaceCardData {
   parent?: {
     name: string;
     slug: string;
+    bannerImage?: string;
     avatar?: string;
     initials: string;
     avatarColor: string;
@@ -120,7 +121,7 @@ export function SpaceCard({ space, className }: SpaceCardProps) {
             {space.parent ? (
               /* Stacked avatars for subspace: parent behind, subspace in front */
               <div className="relative" style={{ width: 44, height: 44 }}>
-                {/* Parent avatar (behind) */}
+                {/* Parent avatar (behind) — derived from banner */}
                 <div
                   className="absolute top-0 left-0 overflow-hidden flex items-center justify-center"
                   style={{
@@ -128,11 +129,13 @@ export function SpaceCard({ space, className }: SpaceCardProps) {
                     height: 32,
                     borderRadius: "var(--radius)",
                     border: "2px solid var(--card)",
-                    background: space.parent.avatarColor,
+                    background: space.parent.bannerImage ? undefined : space.parent.avatarColor,
                     zIndex: 1,
                   }}
                 >
-                  {space.parent.avatar ? (
+                  {space.parent.bannerImage ? (
+                    <img src={space.parent.bannerImage} alt={space.parent.name} className="w-full h-full object-cover" />
+                  ) : space.parent.avatar ? (
                     <img src={space.parent.avatar} alt={space.parent.name} className="w-full h-full object-cover" />
                   ) : (
                     <span style={{ fontSize: "9px", fontWeight: 700, color: "var(--primary-foreground)" }}>
@@ -163,7 +166,7 @@ export function SpaceCard({ space, className }: SpaceCardProps) {
                 </div>
               </div>
             ) : (
-              /* Single avatar for top-level space */
+              /* Single avatar for top-level space — derived from banner */
               <div
                 className="overflow-hidden flex items-center justify-center"
                 style={{
@@ -171,11 +174,13 @@ export function SpaceCard({ space, className }: SpaceCardProps) {
                   height: 40,
                   borderRadius: "var(--radius)",
                   border: "2.5px solid var(--card)",
-                  background: space.avatarColor,
+                  background: space.bannerImage ? undefined : space.avatarColor,
                   boxShadow: "var(--elevation-sm)",
                 }}
               >
-                {space.avatar ? (
+                {space.bannerImage ? (
+                  <img src={space.bannerImage} alt={space.name} className="w-full h-full object-cover" />
+                ) : space.avatar ? (
                   <img src={space.avatar} alt={space.name} className="w-full h-full object-cover" />
                 ) : (
                   <span style={{ fontSize: "12px", fontWeight: 700, color: "var(--primary-foreground)" }}>

--- a/prototype/src/app/components/space/SpaceFeed.tsx
+++ b/prototype/src/app/components/space/SpaceFeed.tsx
@@ -94,10 +94,18 @@ export function SpaceFeed() {
   return (
     <div className="w-full">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold text-foreground">Activity</h2>
+        <p
+          style={{
+            fontSize: "var(--text-sm)",
+            color: "var(--muted-foreground)",
+            fontFamily: "'Inter', sans-serif",
+          }}
+        >
+          The main landing page for your space, showcasing highlights and pinned content.
+        </p>
         <Button 
           size="sm" 
-          className="gap-2 shadow-sm"
+          className="shrink-0 gap-2 shadow-sm"
           onClick={() => setIsPostModalOpen(true)}
         >
           <Plus className="w-4 h-4" />

--- a/prototype/src/app/components/space/SpaceHeader.tsx
+++ b/prototype/src/app/components/space/SpaceHeader.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/app/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
 import { Badge } from "@/app/components/ui/badge";
-import { Settings, Share2, Video, FileText } from "lucide-react";
+import { Settings, Share2, Video, FileText, Activity } from "lucide-react";
 import { Link } from "react-router";
 
 interface SpaceHeaderProps {
@@ -13,7 +13,7 @@ export function SpaceHeader({ spaceSlug, spaceName = "Green Energy Space" }: Spa
   return (
     <div className="flex flex-col bg-background">
       {/* Hero Banner */}
-      <div className="relative w-full h-[320px] overflow-hidden group">
+      <div className="relative w-full h-[256px] overflow-hidden group">
         <div
           className="absolute inset-0 bg-cover bg-center transition-transform duration-700 group-hover:scale-105"
           style={{
@@ -44,14 +44,16 @@ export function SpaceHeader({ spaceSlug, spaceName = "Green Energy Space" }: Spa
               size="icon"
               className="h-9 w-9 rounded hover:opacity-100"
               style={{ color: "white" }}
+              title="Recent Activity"
             >
-              <FileText className="h-4 w-4" />
+              <Activity className="h-4 w-4" />
             </Button>
             <Button
               variant="ghost"
               size="icon"
               className="h-9 w-9 rounded hover:opacity-100"
               style={{ color: "white" }}
+              title="Video Call"
             >
               <Video className="h-4 w-4" />
             </Button>
@@ -60,6 +62,16 @@ export function SpaceHeader({ spaceSlug, spaceName = "Green Energy Space" }: Spa
               size="icon"
               className="h-9 w-9 rounded hover:opacity-100"
               style={{ color: "white" }}
+              title="Documents"
+            >
+              <FileText className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9 rounded hover:opacity-100"
+              style={{ color: "white" }}
+              title="Share"
             >
               <Share2 className="h-4 w-4" />
             </Button>
@@ -69,6 +81,7 @@ export function SpaceHeader({ spaceSlug, spaceName = "Green Energy Space" }: Spa
                 size="icon"
                 className="h-9 w-9 rounded hover:opacity-100"
                 style={{ color: "white" }}
+                title="Settings"
               >
                 <Settings className="h-4 w-4" />
               </Button>
@@ -89,7 +102,10 @@ export function SpaceHeader({ spaceSlug, spaceName = "Green Energy Space" }: Spa
             <div className="col-span-12 lg:col-start-2 lg:col-span-10">
           {/* Bottom: Title & Members */}
           <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
-            <div className="max-w-3xl" style={{ color: "var(--primary-foreground)" }}>
+            {/* Left: title */}
+            <div>
+
+            <div className="max-w-3xl pb-1" style={{ color: "var(--primary-foreground)" }}>
               <h1
                 className="mb-4"
                 style={{
@@ -116,6 +132,7 @@ export function SpaceHeader({ spaceSlug, spaceName = "Green Energy Space" }: Spa
                 Collaborating on the future of sustainable energy solutions and
                 urban transformation.
               </p>
+            </div>
             </div>
 
             <div className="flex items-center gap-4">

--- a/prototype/src/app/components/space/SpaceKnowledgeFeed.tsx
+++ b/prototype/src/app/components/space/SpaceKnowledgeFeed.tsx
@@ -126,19 +126,18 @@ export function SpaceKnowledgeFeed() {
   return (
     <div className="w-full">
       <div className="flex items-center justify-between mb-6">
-        <h2
+        <p
           style={{
-            fontSize: "var(--text-xl)",
-            fontWeight: 600,
-            color: "var(--foreground)",
+            fontSize: "var(--text-sm)",
+            color: "var(--muted-foreground)",
             fontFamily: "'Inter', sans-serif",
           }}
         >
-          Knowledge Base
-        </h2>
+          Wiki, documentation, and shared resources for members.
+        </p>
         <Button
           size="sm"
-          className="gap-2 shadow-sm"
+          className="shrink-0 gap-2 shadow-sm"
           onClick={() => setIsPostModalOpen(true)}
         >
           <Plus className="w-4 h-4" />

--- a/prototype/src/app/components/space/SpaceMembers.tsx
+++ b/prototype/src/app/components/space/SpaceMembers.tsx
@@ -237,30 +237,16 @@ export function SpaceMembers() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div>
-          <h2
-            style={{
-              fontSize: "var(--text-2xl)",
-              fontWeight: 700,
-              color: "var(--foreground)",
-              fontFamily: "'Inter', sans-serif",
-              letterSpacing: "-0.01em",
-            }}
-          >
-            Community
-          </h2>
-          <p
-            className="mt-1"
-            style={{
-              fontSize: "var(--text-sm)",
-              color: "var(--muted-foreground)",
-              fontFamily: "'Inter', sans-serif",
-            }}
-          >
-            {totalUsers} members and {totalOrgs} organizations in this space.
-          </p>
-        </div>
+      <div className="flex items-center justify-between">
+        <p
+          style={{
+            fontSize: "var(--text-sm)",
+            color: "var(--muted-foreground)",
+            fontFamily: "'Inter', sans-serif",
+          }}
+        >
+          {totalUsers} members and {totalOrgs} organizations in this space.
+        </p>
         <Button className="shrink-0">
           <UserPlus className="w-4 h-4 mr-2" />
           Invite Member
@@ -427,7 +413,7 @@ function UserCard({
   getRoleIcon: (rt: string) => React.ReactNode;
 }) {
   return (
-    <Card className="overflow-hidden hover:shadow-md transition-shadow">
+    <Card className="overflow-hidden hover:shadow-md transition-all duration-300">
       <CardContent className="p-0">
         <div className="p-4 flex items-start justify-between gap-3">
           <div className="flex items-start gap-3">
@@ -521,7 +507,7 @@ function UserCard({
 // ── Organization Card ──
 function OrgCard({ org }: { org: OrgEntry }) {
   return (
-    <Card className="overflow-hidden hover:shadow-md transition-shadow">
+    <Card className="overflow-hidden hover:shadow-md transition-all duration-300">
       <CardContent className="p-0">
         <div className="p-4 flex items-start justify-between gap-3">
           <div className="flex items-start gap-3">

--- a/prototype/src/app/components/space/SpaceSettingsAbout.tsx.bak
+++ b/prototype/src/app/components/space/SpaceSettingsAbout.tsx.bak
@@ -1,11 +1,11 @@
-import { useState, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
 import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
 import { Label } from "@/app/components/ui/label";
 import { Separator } from "@/app/components/ui/separator";
-import { Upload, X, Plus, Loader2, Check, Pencil } from "lucide-react";
+import { Upload, X, Plus, ExternalLink, Loader2, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // Mock data for initial state
@@ -43,7 +43,7 @@ function useSectionSave() {
   return { statuses, save };
 }
 
-// ─── Inline save button — bottom-right, appears when dirty ───────────────────
+// ─── Inline save button — appears only when section is dirty ─────────────────
 function InlineSaveButton({
   dirty,
   status,
@@ -80,31 +80,23 @@ function InlineSaveButton({
   );
 }
 
-// ─── Subtle pencil icon — decorative indicator inside editable fields ─────────
-function EditPencil({ className }: { className?: string }) {
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center justify-center text-muted-foreground/50 pointer-events-none",
-        className
-      )}
-      aria-hidden
-    >
-      <Pencil className="w-3.5 h-3.5" />
-    </span>
-  );
-}
-
 export function SpaceSettingsAbout() {
   const [formData, setFormData] = useState(INITIAL_DATA);
   const [savedData, setSavedData] = useState(INITIAL_DATA);
   const [tagInput, setTagInput] = useState("");
   const { statuses, save } = useSectionSave();
 
+  // Ensure formData.name is always defined to prevent crashes
+  useEffect(() => {
+    if (formData.name === undefined) {
+      setFormData(prev => ({ ...prev, name: INITIAL_DATA.name }));
+    }
+  }, [formData.name]);
+
   // ─── Per-field dirty checks ────────────────────────────────────────────────
   const dirty = {
     name: formData.name !== savedData.name,
-    branding: false,
+    branding: false, // banners are instant-upload, not tracked here
     what: formData.what !== savedData.what,
     why: formData.why !== savedData.why,
     who: formData.who !== savedData.who,
@@ -116,10 +108,6 @@ export function SpaceSettingsAbout() {
     save(id, () => {
       setSavedData(prev => ({ ...prev, [id]: (formData as any)[id] }));
     });
-  };
-
-  const discardSection = (id: SectionId) => {
-    setFormData(prev => ({ ...prev, [id]: (savedData as any)[id] }));
   };
 
   const handleQuillChange = (field: keyof typeof formData, value: string) => {
@@ -182,42 +170,41 @@ export function SpaceSettingsAbout() {
 
   return (
     <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-      {/* LEFT COLUMN - CONTENT */}
+      {/* LEFT COLUMN - CONTENT EDITOR */}
       <div className="xl:col-span-2 space-y-6">
         
         {/* Header */}
         <div>
-          <h2 className="text-2xl font-bold tracking-tight">About</h2>
-          <p className="text-muted-foreground mt-2">
+          <h2 className="text-xl font-semibold">About</h2>
+          <p className="text-sm text-muted-foreground mt-1">
             Define your space's purpose, motivation, and target audience.
           </p>
         </div>
 
         <Separator />
 
-        {/* ── Space Name ── */}
-        <section>
-          <Label className="text-xs text-muted-foreground uppercase tracking-wider">Space Name</Label>
-          <div className="mt-2 space-y-2">
-            <div className="relative max-w-md">
-              <Input
+        {/* Space Identity Section */}
+        <section className="space-y-6">
+           <div className="space-y-3">
+             <Label htmlFor="spaceName">Space Name</Label>
+             <Input 
+                id="spaceName"
                 name="name"
                 value={formData.name}
                 onChange={handleChange}
                 placeholder="e.g. Green Energy Space"
-                className="pr-8"
-              />
-              <EditPencil className="absolute right-2.5 top-1/2 -translate-y-1/2" />
-            </div>
-            <div className="flex items-center justify-end gap-2">
-              <InlineSaveButton dirty={dirty.name} status={statuses.name} onSave={() => saveSection("name")} />
-            </div>
-          </div>
+                className="max-w-md font-semibold text-lg h-11"
+             />
+             <div className="flex items-center justify-between">
+               <p className="text-xs text-muted-foreground">The public name of your space.</p>
+               <InlineSaveButton dirty={dirty.name} status={statuses.name} onSave={() => saveSection("name")} />
+             </div>
+           </div>
         </section>
 
         <Separator />
 
-        {/* ── Branding ── */}
+        {/* Branding Section */}
         <section className="space-y-6">
           <h3 className="text-lg font-medium">Space Branding</h3>
           
@@ -260,86 +247,102 @@ export function SpaceSettingsAbout() {
 
         <Separator />
 
-        {/* ── What / Why / Who — Rich text sections ── */}
-        {(["what", "why", "who"] as const).map((field) => {
-          const labels: Record<string, { title: string; hint: string }> = {
-            what: { title: "What", hint: "A clear description of the space's focus or subject matter." },
-            why: { title: "Why", hint: "Why does this space exist? What problem does it solve?" },
-            who: { title: "Who", hint: "Who should join this space? What are their roles or interests?" },
-          };
-          const { title, hint } = labels[field];
-          const htmlContent = formData[field] as string;
-
-          return (
-            <section key={field} className="space-y-1">
-              <Label className="text-base font-semibold">{title}</Label>
-
-              <div className="space-y-2">
-                <div className="prose-editor">
-                  <ReactQuill
-                    theme="snow"
-                    value={htmlContent}
-                    onChange={(val) => handleQuillChange(field, val)}
-                    modules={quillModules}
-                    placeholder={hint}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <p className="text-xs text-muted-foreground">{hint}</p>
-                  <InlineSaveButton dirty={dirty[field]} status={statuses[field]} onSave={() => saveSection(field as SectionId)} />
-                </div>
-              </div>
-              {field !== "who" && <Separator className="mt-6" />}
-            </section>
-          );
-        })}
-
-        <Separator />
-
-        {/* ── Tags ── */}
-        <section>
-          <Label>Tags</Label>
-
-          <div className="mt-2 space-y-2">
-            <div className="relative flex flex-wrap gap-2 p-3 pr-8 bg-background border border-input rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 min-h-[50px]">
-              <EditPencil className="absolute right-2.5 top-3" />
-              {formData.tags.map(tag => (
-                <span key={tag} className="inline-flex items-center gap-1 bg-secondary text-secondary-foreground px-2.5 py-0.5 rounded-full text-xs font-medium">
-                  {tag}
-                  <button onClick={() => removeTag(tag)} className="text-muted-foreground hover:text-foreground">
-                    <X className="w-3 h-3" />
-                  </button>
-                </span>
-              ))}
-              <input 
-                className="flex-1 bg-transparent border-none outline-none text-sm min-w-[120px]"
-                placeholder="Type a tag and press Enter…"
-                value={tagInput}
-                onChange={(e) => setTagInput(e.target.value)}
-                onKeyDown={handleAddTag}
+        {/* Structured Text Sections */}
+        <section className="space-y-8">
+          <div className="space-y-2">
+            <Label className="text-base">What</Label>
+            <div className="prose-editor">
+              <ReactQuill 
+                theme="snow" 
+                value={formData.what} 
+                onChange={(val) => handleQuillChange('what', val)} 
+                modules={quillModules}
+                placeholder="Describe what this space is about..."
               />
             </div>
             <div className="flex items-center justify-between">
-              <p className="text-xs text-muted-foreground">Tags help members discover your space.</p>
-              <InlineSaveButton dirty={dirty.tags} status={statuses.tags} onSave={() => saveSection("tags")} />
+              <p className="text-xs text-muted-foreground">A clear description of the space's focus or subject matter.</p>
+              <InlineSaveButton dirty={dirty.what} status={statuses.what} onSave={() => saveSection("what")} />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-base">Why</Label>
+            <div className="prose-editor">
+              <ReactQuill 
+                theme="snow" 
+                value={formData.why} 
+                onChange={(val) => handleQuillChange('why', val)} 
+                modules={quillModules}
+                placeholder="Explain the motivation or value of this space..."
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">Why does this space exist? What problem does it solve?</p>
+              <InlineSaveButton dirty={dirty.why} status={statuses.why} onSave={() => saveSection("why")} />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-base">Who</Label>
+            <div className="prose-editor">
+              <ReactQuill 
+                theme="snow" 
+                value={formData.who} 
+                onChange={(val) => handleQuillChange('who', val)} 
+                modules={quillModules}
+                placeholder="Describe the target audience or ideal members..."
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">Who should join this space? What are their roles or interests?</p>
+              <InlineSaveButton dirty={dirty.who} status={statuses.who} onSave={() => saveSection("who")} />
             </div>
           </div>
         </section>
 
         <Separator />
 
-        {/* ── References ── */}
-        <section>
+        {/* Tags Section */}
+        <section className="space-y-3">
+          <Label>Tags</Label>
+          <div className="flex flex-wrap gap-2 mb-2 p-3 bg-background border border-input rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 min-h-[50px]">
+            {formData.tags.map(tag => (
+              <span key={tag} className="inline-flex items-center gap-1 bg-secondary text-secondary-foreground px-2.5 py-0.5 rounded-full text-xs font-medium">
+                {tag}
+                <button onClick={() => removeTag(tag)} className="text-muted-foreground hover:text-foreground">
+                  <X className="w-3 h-3" />
+                </button>
+              </span>
+            ))}
+            <input 
+              className="flex-1 bg-transparent border-none outline-none text-sm min-w-[120px]"
+              placeholder="Add tags (e.g., 'Innovation')..."
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyDown={handleAddTag}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-muted-foreground">Tags help members discover your space.</p>
+            <InlineSaveButton dirty={dirty.tags} status={statuses.tags} onSave={() => saveSection("tags")} />
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* References Section */}
+        <section className="space-y-4">
           <div className="flex items-center justify-between">
             <Label>References & Links</Label>
-            <Button variant="outline" size="sm" onClick={addReference} className="gap-1 h-7 text-xs">
-              <Plus className="w-3 h-3" /> Add
+            <Button variant="outline" size="sm" onClick={addReference} className="gap-1 h-8">
+              <Plus className="w-3.5 h-3.5" /> Add Reference
             </Button>
           </div>
-
-          <div className="mt-3 space-y-3">
+          
+          <div className="space-y-3">
             {formData.references.map((ref, index) => (
-              <div key={index} className="flex gap-3 items-start">
+              <div key={index} className="flex gap-3 items-start group">
                 <div className="grid gap-2 flex-1 sm:grid-cols-2">
                   <Input 
                     placeholder="Link Title" 
@@ -360,11 +363,11 @@ export function SpaceSettingsAbout() {
               </div>
             ))}
             {formData.references.length === 0 && (
-              <p className="text-sm text-muted-foreground italic">No references added yet. Click "Add" above.</p>
+              <p className="text-sm text-muted-foreground italic">No references added yet.</p>
             )}
-            <div className="flex items-center justify-end gap-2">
-              <InlineSaveButton dirty={dirty.references} status={statuses.references} onSave={() => saveSection("references")} />
-            </div>
+          </div>
+          <div className="flex justify-end">
+            <InlineSaveButton dirty={dirty.references} status={statuses.references} onSave={() => saveSection("references")} />
           </div>
         </section>
       </div>

--- a/prototype/src/app/components/space/SpaceSettingsAccount.tsx
+++ b/prototype/src/app/components/space/SpaceSettingsAccount.tsx
@@ -44,7 +44,7 @@ export function SpaceSettingsAccount() {
   };
 
   return (
-    <div className="space-y-6 animate-in fade-in duration-500 max-w-4xl mx-auto">
+    <div className="space-y-6 animate-in fade-in duration-500">
       {/* 1. Page Title & Description */}
       <div>
         <h2 className="text-2xl font-bold tracking-tight">Account</h2>

--- a/prototype/src/app/components/space/SpaceSettingsLayout.tsx
+++ b/prototype/src/app/components/space/SpaceSettingsLayout.tsx
@@ -13,6 +13,7 @@ import {
   Save,
   Check,
   Loader2,
+  Undo2,
   MessageSquare,
   Calendar,
   FileText,
@@ -347,6 +348,7 @@ interface KanbanColumnProps {
   onRemove: (postId: string, tabId: TabId) => void;
   onMoveToTab: (postId: string, fromTab: TabId, toTab: TabId) => void;
   onRename: (id: TabId, newName: string) => void;
+  onDescriptionChange: (id: TabId, newDescription: string) => void;
   onIconChange: (id: TabId, newIcon: React.ElementType) => void;
   isEditing: boolean;
   setEditingId: (id: TabId | null) => void;
@@ -364,6 +366,7 @@ const KanbanColumn = ({
   onRemove,
   onMoveToTab,
   onRename,
+  onDescriptionChange,
   onIconChange,
   isEditing,
   setEditingId,
@@ -371,6 +374,8 @@ const KanbanColumn = ({
   const autoExpandTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [showIconPicker, setShowIconPicker] = useState(false);
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const descInputRef = useRef<HTMLInputElement>(null);
   const iconPickerRef = useRef<HTMLDivElement>(null);
   const Icon = tab.icon;
 
@@ -516,7 +521,7 @@ const KanbanColumn = ({
               {!isEditing && (
                 <button
                   onClick={() => setEditingId(tab.id)}
-                  className="opacity-0 group-hover/header:opacity-100 transition-opacity text-muted-foreground hover:text-primary"
+                  className="text-muted-foreground/50 hover:text-primary transition-colors"
                 >
                   <Pencil className="w-3 h-3" />
                 </button>
@@ -539,9 +544,40 @@ const KanbanColumn = ({
             </CollapsibleTrigger>
           </div>
 
-          <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
-            {tab.description}
-          </p>
+          {isEditingDescription ? (
+            <Input
+              ref={descInputRef}
+              value={tab.description}
+              onChange={(e) => onDescriptionChange(tab.id, e.target.value)}
+              onBlur={() => setIsEditingDescription(false)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === "Escape") setIsEditingDescription(false);
+              }}
+              className="h-6 py-0 px-1.5 text-xs w-full"
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <div className="group/desc flex items-start gap-1">
+              <p
+                className="text-xs text-muted-foreground leading-relaxed line-clamp-2 cursor-pointer hover:underline decoration-dashed underline-offset-4"
+                onClick={() => {
+                  setIsEditingDescription(true);
+                  setTimeout(() => descInputRef.current?.focus(), 0);
+                }}
+              >
+                {tab.description}
+              </p>
+              <button
+                onClick={() => {
+                  setIsEditingDescription(true);
+                  setTimeout(() => descInputRef.current?.focus(), 0);
+                }}
+                className="text-muted-foreground/50 hover:text-primary transition-colors mt-0.5 shrink-0"
+              >
+                <Pencil className="w-2.5 h-2.5" />
+              </button>
+            </div>
+          )}
         </div>
 
         <CollapsibleContent>
@@ -666,6 +702,8 @@ export function SpaceSettingsLayout() {
   const [isSaving, setIsSaving] = useState(false);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [tabPosts, setTabPosts] = useState<TabPosts>(DEFAULT_POSTS);
+  const [savedTabs, setSavedTabs] = useState<TabItem[]>(DEFAULT_TABS);
+  const [savedTabPosts, setSavedTabPosts] = useState<TabPosts>(DEFAULT_POSTS);
   const [expandedCols, setExpandedCols] = useState<Record<TabId, boolean>>({
     home: true,
     community: true,
@@ -676,19 +714,22 @@ export function SpaceSettingsLayout() {
   // ─── Change detection (tabs + posts) ───────────────────────────────────────
   const hasChanges = useMemo(() => {
     const tabsChanged = tabs.some((tab, i) => {
-      const d = DEFAULT_TABS[i];
-      return tab.id !== d.id || tab.label !== d.label || tab.icon !== d.icon;
+      const d = savedTabs[i];
+      if (!d) return true;
+      return tab.id !== d.id || tab.label !== d.label || tab.icon !== d.icon || tab.description !== d.description;
     });
     if (tabsChanged) return true;
+    if (tabs.length !== savedTabs.length) return true;
 
-    for (const tabId of Object.keys(DEFAULT_POSTS) as TabId[]) {
+    for (const tabId of Object.keys(savedTabPosts) as TabId[]) {
       const cur = tabPosts[tabId];
-      const orig = DEFAULT_POSTS[tabId];
+      const orig = savedTabPosts[tabId];
+      if (!cur || !orig) return true;
       if (cur.length !== orig.length) return true;
       if (cur.some((p, i) => p.id !== orig[i]?.id)) return true;
     }
     return false;
-  }, [tabs, tabPosts]);
+  }, [tabs, tabPosts, savedTabs, savedTabPosts]);
 
   // ─── Tab reorder ───────────────────────────────────────────────────────────
   const moveTab = useCallback(
@@ -778,37 +819,38 @@ export function SpaceSettingsLayout() {
     );
   };
 
+  const handleDescriptionChange = (id: TabId, newDescription: string) => {
+    setTabs((prev) =>
+      prev.map((tab) => (tab.id === id ? { ...tab, description: newDescription } : tab))
+    );
+  };
+
   const handleIconChange = (id: TabId, newIcon: React.ElementType) => {
     setTabs((prev) =>
       prev.map((tab) => (tab.id === id ? { ...tab, icon: newIcon } : tab))
     );
   };
 
-  // ─── Save / Reset ─────────────────────────────────────────────────────────
+  // ─── Save / Discard ─────────────────────────────────────────────────────────
   const handleSave = () => {
     setIsSaving(true);
     setTimeout(() => {
       setIsSaving(false);
+      setSavedTabs([...tabs]);
+      setSavedTabPosts({ ...tabPosts });
       setLastSaved(new Date());
     }, 1000);
   };
 
-  const handleReset = () => {
-    if (
-      confirm(
-        "Are you sure you want to reset all tabs and post assignments to defaults?"
-      )
-    ) {
-      setTabs(DEFAULT_TABS);
-      setTabPosts(DEFAULT_POSTS);
-      setExpandedCols({
-        home: true,
-        community: true,
-        subspaces: false,
-        knowledge: true,
-      });
-      setLastSaved(null);
-    }
+  const handleDiscard = () => {
+    setTabs([...savedTabs]);
+    setTabPosts({ ...savedTabPosts });
+    setExpandedCols({
+      home: true,
+      community: true,
+      subspaces: false,
+      knowledge: true,
+    });
   };
 
   // ─── Column toggle helpers ────────────────────────────────────────────────
@@ -825,8 +867,8 @@ export function SpaceSettingsLayout() {
       <div className="w-full h-full">
         <div className="flex flex-col h-full">
           <div className="mb-6">
-            <h2 className="text-xl font-semibold text-foreground">Layout</h2>
-            <p className="text-sm text-muted-foreground mt-1">
+            <h2 className="text-2xl font-bold tracking-tight text-foreground">Layout</h2>
+            <p className="text-muted-foreground mt-2">
               Customize your Space's navigation tabs. Rename, reorder, and manage post assignments.
             </p>
           </div>
@@ -851,6 +893,7 @@ export function SpaceSettingsLayout() {
                   onRemove={handleRemovePost}
                   onMoveToTab={handleMoveToTab}
                   onRename={handleRename}
+                  onDescriptionChange={handleDescriptionChange}
                   onIconChange={handleIconChange}
                   isEditing={editingId === tab.id}
                   setEditingId={setEditingId}
@@ -868,11 +911,11 @@ export function SpaceSettingsLayout() {
             <Button
               variant="ghost"
               size="sm"
-              onClick={handleReset}
-              disabled={!hasChanges && !lastSaved}
+              onClick={handleDiscard}
+              disabled={!hasChanges}
               className="text-muted-foreground hover:text-destructive"
             >
-              <RotateCcw className="w-3.5 h-3.5 mr-1.5" /> Reset
+              <Undo2 className="w-3.5 h-3.5 mr-1.5" /> Discard Changes
             </Button>
             <Button
               size="sm"

--- a/prototype/src/app/components/space/SpaceSettingsSettings.tsx
+++ b/prototype/src/app/components/space/SpaceSettingsSettings.tsx
@@ -76,12 +76,13 @@ export function SpaceSettingsSettings() {
   };
 
   return (
-    <div className="space-y-6 animate-in fade-in duration-500 max-w-4xl mx-auto">
+    <div className="space-y-6 animate-in fade-in duration-500">
       {/* 1. Page Title & Description */}
       <div>
         <h2 className="text-2xl font-bold tracking-tight">Settings</h2>
         <p className="text-muted-foreground mt-2">
           Configure your space's visibility, membership policies, and allowed member actions.
+          {" "}<span className="text-xs text-muted-foreground/70 italic">Changes are saved automatically.</span>
         </p>
       </div>
 

--- a/prototype/src/app/components/space/SpaceSettingsSubspaces.tsx
+++ b/prototype/src/app/components/space/SpaceSettingsSubspaces.tsx
@@ -511,7 +511,7 @@ export function SpaceSettingsSubspaces() {
                   <div 
                     key={subspace.id}
                     className={cn(
-                       "flex items-center gap-4 p-4 hover:bg-muted/30 transition-colors",
+                       "flex items-center gap-4 p-4 hover:bg-accent/50 transition-colors",
                        i !== filteredSubspaces.length - 1 && "border-b border-border"
                     )}
                   >

--- a/prototype/src/app/components/space/SpaceSettingsTemplates.tsx
+++ b/prototype/src/app/components/space/SpaceSettingsTemplates.tsx
@@ -171,7 +171,7 @@ function TemplateCard({ template, onAction }: {
 }) {
   return (
     <div className={cn(
-      "group relative flex flex-col border rounded-lg overflow-hidden bg-card hover:shadow-md transition-all duration-200"
+      "group relative flex flex-col border rounded-lg overflow-hidden bg-card hover:shadow-md transition-all duration-300"
     )}>
       {/* Thumbnail */}
       <div className="relative aspect-video bg-muted overflow-hidden">

--- a/prototype/src/app/components/space/SpaceSettingsUpdates.tsx
+++ b/prototype/src/app/components/space/SpaceSettingsUpdates.tsx
@@ -1,0 +1,276 @@
+import { useState } from "react";
+import ReactQuill from "react-quill";
+import "react-quill/dist/quill.snow.css";
+import { Button } from "@/app/components/ui/button";
+import { Input } from "@/app/components/ui/input";
+import { Separator } from "@/app/components/ui/separator";
+import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
+import { Badge } from "@/app/components/ui/badge";
+import {
+  Plus,
+  Megaphone,
+  Pin,
+  Trash2,
+  Calendar,
+  MoreHorizontal,
+  Send,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/app/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+interface Update {
+  id: string;
+  author: string;
+  authorInitials: string;
+  authorAvatar: string | null;
+  role: string;
+  date: string;
+  title: string;
+  body: string;
+  pinned: boolean;
+}
+
+const MOCK_UPDATES: Update[] = [
+  {
+    id: "u1",
+    author: "Elena Martinez",
+    authorInitials: "EM",
+    authorAvatar:
+      "https://images.unsplash.com/photo-1623853589874-864b1dd4d922?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    role: "Host",
+    date: "2024-02-18",
+    title: "2024 Roadmap & Community Goals",
+    body: "<p>We've finalized the 2024 roadmap for this space. Our three strategic pillars this year are:</p><ul><li><strong>Decarbonization:</strong> Accelerating the transition to net-zero energy systems</li><li><strong>Community Building:</strong> Growing from 150 to 500 active contributors</li><li><strong>Knowledge Sharing:</strong> Publishing quarterly insight reports</li></ul><p>Stay tuned for detailed challenge briefs rolling out over the next two weeks.</p>",
+    pinned: true,
+  },
+  {
+    id: "u2",
+    author: "Sarah Chen",
+    authorInitials: "SC",
+    authorAvatar:
+      "https://images.unsplash.com/photo-1757347398206-7425300ef990?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    role: "Admin",
+    date: "2024-02-10",
+    title: "New Subspaces Now Open",
+    body: "<p>We've launched three new subspaces based on community feedback:</p><ol><li>Urban Mobility Lab — focused on sustainable city transport</li><li>Green Infrastructure — planning urban green spaces</li><li>Circular Economy — reducing waste through systemic design</li></ol><p>Each subspace has dedicated leads and an innovation flow already set up. Jump in!</p>",
+    pinned: false,
+  },
+  {
+    id: "u3",
+    author: "Elena Martinez",
+    authorInitials: "EM",
+    authorAvatar:
+      "https://images.unsplash.com/photo-1623853589874-864b1dd4d922?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    role: "Host",
+    date: "2024-01-15",
+    title: "Welcome to the Green Energy Space!",
+    body: "<p>Welcome to all new members! This space is our shared home for exploring sustainable energy solutions. Check out the knowledge base for background reading, and introduce yourself in the community feed.</p>",
+    pinned: false,
+  },
+];
+
+export function SpaceSettingsUpdates() {
+  const [updates, setUpdates] = useState(MOCK_UPDATES);
+  const [composing, setComposing] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [newBody, setNewBody] = useState("");
+
+  const togglePin = (id: string) => {
+    setUpdates((prev) =>
+      prev.map((u) => (u.id === id ? { ...u, pinned: !u.pinned } : u))
+    );
+  };
+
+  const removeUpdate = (id: string) => {
+    setUpdates((prev) => prev.filter((u) => u.id !== id));
+  };
+
+  const handlePost = () => {
+    if (!newTitle.trim()) return;
+    const update: Update = {
+      id: `u-new-${Date.now()}`,
+      author: "You",
+      authorInitials: "YO",
+      authorAvatar: null,
+      role: "Host",
+      date: new Date().toISOString().slice(0, 10),
+      title: newTitle,
+      body: newBody,
+      pinned: false,
+    };
+    setUpdates((prev) => [update, ...prev]);
+    setNewTitle("");
+    setNewBody("");
+    setComposing(false);
+  };
+
+  const quillModules = {
+    toolbar: [
+      ["bold", "italic", "underline"],
+      [{ list: "ordered" }, { list: "bullet" }],
+      ["link"],
+      ["clean"],
+    ],
+  };
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-500">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Megaphone className="w-5 h-5" />
+            Updates from the Leads
+          </h2>
+          <p className="text-muted-foreground mt-2">
+            Post announcements, milestones, and progress updates visible to all
+            space members.
+          </p>
+        </div>
+        {!composing && (
+          <Button className="gap-2" size="sm" onClick={() => setComposing(true)}>
+            <Plus className="w-4 h-4" /> New Update
+          </Button>
+        )}
+      </div>
+
+      <Separator />
+
+      {/* Compose */}
+      {composing && (
+        <div
+          className="rounded-lg p-5 space-y-4"
+          style={{
+            background: "var(--muted)",
+            border: "1px solid var(--border)",
+          }}
+        >
+          <h3 className="text-sm font-semibold">New Update</h3>
+          <Input
+            placeholder="Update title"
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            className="font-semibold"
+          />
+          <div className="prose-editor">
+            <ReactQuill
+              theme="snow"
+              value={newBody}
+              onChange={setNewBody}
+              modules={quillModules}
+              placeholder="Write your update…"
+            />
+          </div>
+          <div className="flex items-center gap-3">
+            <Button size="sm" className="gap-2" onClick={handlePost}>
+              <Send className="w-4 h-4" /> Publish
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setComposing(false);
+                setNewTitle("");
+                setNewBody("");
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Update List */}
+      <div className="space-y-4">
+        {updates.length === 0 && (
+          <div className="text-center py-12 text-muted-foreground text-sm">
+            No updates yet. Click "New Update" to post the first one.
+          </div>
+        )}
+        {updates.map((update) => (
+          <div
+            key={update.id}
+            className={cn(
+              "rounded-lg p-5 space-y-3 transition-colors",
+              update.pinned && "ring-1 ring-amber-300 dark:ring-amber-700"
+            )}
+            style={{
+              background: "var(--muted)",
+              border: "1px solid var(--border)",
+            }}
+          >
+            {/* Top row — author + badges + actions */}
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <Avatar className="w-9 h-9">
+                  {update.authorAvatar && (
+                    <AvatarImage src={update.authorAvatar} />
+                  )}
+                  <AvatarFallback className="text-xs">
+                    {update.authorInitials}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{update.author}</span>
+                    <Badge
+                      variant="secondary"
+                      className="text-[10px] px-1.5 py-0"
+                    >
+                      {update.role}
+                    </Badge>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Calendar className="w-3 h-3" />
+                    {update.date}
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-1">
+                {update.pinned && (
+                  <Pin className="w-3.5 h-3.5 text-amber-500 rotate-45" />
+                )}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon" className="h-8 w-8">
+                      <MoreHorizontal className="w-4 h-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => togglePin(update.id)}>
+                      <Pin className="w-4 h-4 mr-2" />
+                      {update.pinned ? "Unpin" : "Pin to Top"}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="text-destructive"
+                      onClick={() => removeUpdate(update.id)}
+                    >
+                      <Trash2 className="w-4 h-4 mr-2" /> Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+
+            {/* Title */}
+            <h3 className="text-base font-semibold">{update.title}</h3>
+
+            {/* Body */}
+            <div
+              className="text-sm text-muted-foreground prose prose-sm max-w-none [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_strong]:text-foreground"
+              dangerouslySetInnerHTML={{ __html: update.body }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/prototype/src/app/components/space/SpaceSidebar.tsx
+++ b/prototype/src/app/components/space/SpaceSidebar.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useEffect } from "react";
 import { Button } from "@/app/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
 import {
@@ -16,6 +17,7 @@ import {
   FolderOpen,
 } from "lucide-react";
 import { Link } from "react-router";
+import { AboutThisSpaceDialog } from "@/app/components/space/AboutThisSpaceDialog";
 
 interface SpaceSidebarProps {
   spaceSlug: string;
@@ -58,6 +60,8 @@ const COMMUNITY_GUIDELINES = [
 ];
 
 export function SpaceSidebar({ spaceSlug, variant = "home" }: SpaceSidebarProps) {
+  const [aboutOpen, setAboutOpen] = useState(false);
+
   return (
     <div
       className="space-y-6 w-full"
@@ -77,10 +81,12 @@ export function SpaceSidebar({ spaceSlug, variant = "home" }: SpaceSidebarProps)
               fontSize: "var(--text-sm)",
               fontWeight: "var(--font-weight-medium)" as any,
             }}
+            onClick={() => setAboutOpen(true)}
           >
             <Info className="w-4 h-4" />
             About this Space
           </Button>
+          <AboutThisSpaceDialog open={aboutOpen} onOpenChange={setAboutOpen} spaceSlug={spaceSlug} />
 
           {/* Subspaces List */}
           {variant === "home" && <SubspacesSection spaceSlug={spaceSlug} />}
@@ -93,9 +99,6 @@ export function SpaceSidebar({ spaceSlug, variant = "home" }: SpaceSidebarProps)
 
       {variant === "community" && (
         <>
-          {/* Lead block */}
-          <LeadBlock />
-
           {/* Action buttons */}
           <div className="flex gap-2">
             <Button
@@ -142,6 +145,16 @@ export function SpaceSidebar({ spaceSlug, variant = "home" }: SpaceSidebarProps)
 /* ─── Sub-components ─────────────────────────────────────────── */
 
 function InfoBlock() {
+  const textRef = useRef<HTMLParagraphElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = textRef.current;
+    if (el) {
+      setIsTruncated(el.scrollHeight > el.clientHeight);
+    }
+  }, []);
+
   return (
     <div
       className="p-5"
@@ -152,7 +165,8 @@ function InfoBlock() {
       }}
     >
       <p
-        className="mb-3"
+        ref={textRef}
+        className="mb-3 line-clamp-4"
         style={{
           fontSize: "var(--text-sm)",
           lineHeight: 1.6,
@@ -163,92 +177,71 @@ function InfoBlock() {
         transformation. Join our community of innovators working to solve
         real-world challenges.
       </p>
-      <button
-        className="hover:underline"
-        style={{
-          fontSize: "var(--text-sm)",
-          fontWeight: "var(--font-weight-medium)" as any,
-          color: "var(--primary-foreground)",
-          opacity: 0.8,
-        }}
-      >
-        Read more
-      </button>
-    </div>
-  );
-}
-
-function LeadBlock() {
-  return (
-    <div
-      className="p-4"
-      style={{
-        background: "var(--card)",
-        border: "1px solid var(--border)",
-        borderRadius: "var(--radius)",
-      }}
-    >
-      <p
-        className="uppercase tracking-wider mb-3"
-        style={{
-          fontSize: "11px",
-          fontWeight: 600,
-          color: "var(--muted-foreground)",
-        }}
-      >
-        Space Lead
-      </p>
-      <div className="flex items-center gap-3">
-        <Avatar
-          className="w-10 h-10"
-          style={{ border: "2px solid var(--border)" }}
+      {isTruncated && (
+        <button
+          onClick={() => setAboutOpen(true)}
+          className="hover:underline mb-4"
+          style={{
+            fontSize: "var(--text-sm)",
+            fontWeight: "var(--font-weight-medium)" as any,
+            color: "var(--primary-foreground)",
+            opacity: 0.8,
+          }}
         >
-          <AvatarImage
-            src="https://images.unsplash.com/photo-1623853589874-864b1dd4d922?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx3b21hbiUyMGdsYXNzZXMlMjBibGFjayUyMGFuZCUyMHdoaXRlJTIwcG9ydHJhaXR8ZW58MXx8fHwxNzY5NDQyNTM3fDA&ixlib=rb-4.1.0&q=80&w=256"
-            alt="Elena Martinez"
-          />
-          <AvatarFallback
-            style={{
-              background: "color-mix(in srgb, var(--primary) 15%, transparent)",
-              color: "var(--primary)",
-              fontSize: "10px",
-              fontWeight: 700,
-            }}
+          Read more
+        </button>
+      )}
+
+      {/* Space Lead */}
+      <div
+        className="pt-3 mt-1"
+        style={{ borderTop: "1px solid rgba(255,255,255,0.15)" }}
+      >
+        <p
+          className="uppercase tracking-wider mb-2"
+          style={{
+            fontSize: "10px",
+            fontWeight: 700,
+            opacity: 0.6,
+            letterSpacing: "0.04em",
+          }}
+        >
+          Lead
+        </p>
+        <div className="flex items-center gap-3">
+          <Avatar
+            className="w-8 h-8"
+            style={{ border: "2px solid rgba(255,255,255,0.25)" }}
           >
-            EM
-          </AvatarFallback>
-        </Avatar>
-        <div>
-          <p
-            style={{
-              fontSize: "var(--text-sm)",
-              fontWeight: 600,
-              color: "var(--foreground)",
-            }}
-          >
-            Elena Martinez
-          </p>
-          <p
-            className="flex items-center gap-1"
-            style={{
-              fontSize: "12px",
-              color: "var(--muted-foreground)",
-            }}
-          >
-            <MapPin className="w-3 h-3" /> Amsterdam, NL
-          </p>
+            <AvatarImage
+              src="https://images.unsplash.com/photo-1623853589874-864b1dd4d922?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx3b21hbiUyMGdsYXNzZXMlMjBibGFjayUyMGFuZCUyMHdoaXRlJTIwcG9ydHJhaXR8ZW58MXx8fHwxNzY5NDQyNTM3fDA&ixlib=rb-4.1.0&q=80&w=256"
+              alt="Elena Martinez"
+            />
+            <AvatarFallback
+              style={{
+                background: "rgba(255,255,255,0.15)",
+                color: "white",
+                fontSize: "9px",
+                fontWeight: 700,
+              }}
+            >
+              EM
+            </AvatarFallback>
+          </Avatar>
+          <div>
+            <p style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+              Elena Martinez
+            </p>
+            <p
+              className="flex items-center gap-1"
+              style={{ fontSize: "11px", opacity: 0.7 }}
+            >
+              <MapPin className="w-3 h-3" />
+              Amsterdam, NL
+            </p>
+          </div>
         </div>
       </div>
-      <p
-        className="mt-3"
-        style={{
-          fontSize: "var(--text-sm)",
-          color: "var(--muted-foreground)",
-          lineHeight: 1.5,
-        }}
-      >
-        Community Host. Driving sustainable innovation in urban planning.
-      </p>
     </div>
   );
 }

--- a/prototype/src/app/components/space/SpaceSubspacesList.tsx
+++ b/prototype/src/app/components/space/SpaceSubspacesList.tsx
@@ -15,6 +15,9 @@ const SUBSPACE_COLORS = [
   "#0891b2",
 ];
 
+// Parent space banner for avatar derivation
+const PARENT_BANNER = "https://images.unsplash.com/photo-1690191863988-f685cddde463?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=400";
+
 // Mock Data — mapped to SpaceCardData format
 const SUBSPACES: (SpaceCardData & { status: string })[] = [
   {
@@ -23,6 +26,7 @@ const SUBSPACES: (SpaceCardData & { status: string })[] = [
     name: "Renewable Energy Transition",
     description: "Developing strategies for municipal energy transition to 100% renewables by 2030.",
     bannerImage: "https://images.unsplash.com/photo-1677506048377-1099738d294d?auto=format&fit=crop&w=800&q=80",
+    avatar: "https://images.unsplash.com/photo-1509391366360-2e959784a276?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
     initials: "RE",
     avatarColor: SUBSPACE_COLORS[0],
     isPrivate: false,
@@ -40,6 +44,7 @@ const SUBSPACES: (SpaceCardData & { status: string })[] = [
     name: "Urban Mobility Lab",
     description: "Reimagining city transportation networks for better accessibility and reduced carbon footprint.",
     bannerImage: "https://images.unsplash.com/photo-1743385779313-ac03bb0f997b?auto=format&fit=crop&w=800&q=80",
+    avatar: "https://images.unsplash.com/photo-1556741533-6e6a62bd8b49?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
     initials: "UM",
     avatarColor: SUBSPACE_COLORS[1],
     isPrivate: false,
@@ -56,6 +61,7 @@ const SUBSPACES: (SpaceCardData & { status: string })[] = [
     name: "Green Infrastructure",
     description: "Planning and implementation of urban green spaces, vertical gardens, and sustainable drainage.",
     bannerImage: "https://images.unsplash.com/photo-1760611656007-f767a8082758?auto=format&fit=crop&w=800&q=80",
+    avatar: "https://images.unsplash.com/photo-1518531933037-91b2f5f229cc?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
     initials: "GI",
     avatarColor: SUBSPACE_COLORS[2],
     isPrivate: false,
@@ -74,6 +80,7 @@ const SUBSPACES: (SpaceCardData & { status: string })[] = [
     name: "Policy Frameworks",
     description: "Drafting policy recommendations and regulatory frameworks to support sustainability initiatives.",
     bannerImage: "https://images.unsplash.com/photo-1769069918751-9cdb7c752fcc?auto=format&fit=crop&w=800&q=80",
+    avatar: "https://images.unsplash.com/photo-1554103210-26d928978fb5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
     initials: "PF",
     avatarColor: SUBSPACE_COLORS[3],
     isPrivate: true,
@@ -90,6 +97,7 @@ const SUBSPACES: (SpaceCardData & { status: string })[] = [
     name: "Community Engagement",
     description: "Tools and methodologies for involving local communities in decision-making processes.",
     bannerImage: "https://images.unsplash.com/photo-1554103210-26d928978fb5?auto=format&fit=crop&w=800&q=80",
+    avatar: "https://images.unsplash.com/photo-1552664730-d307ca884978?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
     initials: "CE",
     avatarColor: SUBSPACE_COLORS[4],
     isPrivate: false,
@@ -107,6 +115,7 @@ const SUBSPACES: (SpaceCardData & { status: string })[] = [
     name: "Digital Twin Project",
     description: "Creating digital replicas of urban systems to simulate and optimize performance.",
     bannerImage: "https://images.unsplash.com/photo-1683818051102-dd1199d163b9?auto=format&fit=crop&w=800&q=80",
+    avatar: "https://images.unsplash.com/photo-1620714223084-8fcacc6dfd8d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
     initials: "DT",
     avatarColor: SUBSPACE_COLORS[5],
     isPrivate: false,
@@ -133,6 +142,7 @@ export function SpaceSubspacesList() {
         .replace(/-/g, " ")
         .replace(/\b\w/g, (c) => c.toUpperCase()),
       slug,
+      bannerImage: PARENT_BANNER,
       initials: slug.substring(0, 2).toUpperCase(),
       avatarColor: "#2563eb",
     },
@@ -146,27 +156,15 @@ export function SpaceSubspacesList() {
   return (
     <div className="space-y-6" style={{ fontFamily: "'Inter', sans-serif" }}>
       {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div>
-          <h2
-            style={{
-              fontSize: "var(--text-2xl)",
-              fontWeight: 700,
-              color: "var(--foreground)",
-            }}
-          >
-            Subspaces
-          </h2>
-          <p
-            className="mt-1"
-            style={{
-              fontSize: "var(--text-sm)",
-              color: "var(--muted-foreground)",
-            }}
-          >
-            Explore focused workstreams and challenges within this space.
-          </p>
-        </div>
+      <div className="flex items-center justify-between">
+        <p
+          style={{
+            fontSize: "var(--text-sm)",
+            color: "var(--muted-foreground)",
+          }}
+        >
+          Explore focused workstreams and challenges within this space.
+        </p>
         <Button className="shrink-0 gap-2">
           <Plus className="w-4 h-4" />
           Create Subspace

--- a/prototype/src/app/components/space/SubspaceCommunityDialog.tsx
+++ b/prototype/src/app/components/space/SubspaceCommunityDialog.tsx
@@ -1,0 +1,533 @@
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/app/components/ui/dialog";
+import { Button } from "@/app/components/ui/button";
+import { Card, CardContent } from "@/app/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from "@/app/components/ui/dropdown-menu";
+import { Link } from "react-router";
+import { cn } from "@/lib/utils";
+import {
+  Search,
+  MoreHorizontal,
+  UserPlus,
+  Shield,
+  User,
+  CheckCircle2,
+  Building2,
+  ExternalLink,
+  Users,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+
+// ── Types ──
+interface MemberEntry {
+  kind: "user";
+  id: string;
+  name: string;
+  role: string;
+  roleType: string;
+  joinDate: string;
+  avatar: string | null;
+  initials: string;
+  bio: string;
+}
+
+interface OrgEntry {
+  kind: "org";
+  id: string;
+  name: string;
+  type: string;
+  description: string;
+  avatar: string;
+  initials: string;
+  members: number;
+  website: string;
+}
+
+type CommunityEntry = MemberEntry | OrgEntry;
+
+// ── Mock Data ──
+const RAW_MEMBERS: Omit<MemberEntry, "kind">[] = [
+  { id: "su1", name: "Sarah Chen", role: "Lead", roleType: "moderator", joinDate: "Nov 2023", avatar: "https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80", initials: "SC", bio: "Facilitator leading the renewable energy transition workstream." },
+  { id: "su2", name: "David Kim", role: "Member", roleType: "member", joinDate: "Jan 2024", avatar: "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80", initials: "DK", bio: "Wind energy specialist contributing research and technical analysis." },
+  { id: "su3", name: "Emily Davis", role: "Member", roleType: "member", joinDate: "Feb 2024", avatar: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80", initials: "ED", bio: "Battery storage researcher focusing on grid-scale solutions." },
+  { id: "su4", name: "Alex Torres", role: "Member", roleType: "member", joinDate: "Mar 2024", avatar: null, initials: "AT", bio: "Community solar advocate." },
+  { id: "su5", name: "Anna Martinez", role: "Lead", roleType: "moderator", joinDate: "Dec 2023", avatar: null, initials: "AM", bio: "Policy and stakeholder engagement lead." },
+  ...Array.from({ length: 11 }).map((_, i) => ({
+    id: `sm${i + 6}`,
+    name: ["James Wilson", "Emma Thompson", "Lucas Oliveira", "Sophia Li", "Oliver Smith", "Ava Patel", "William Chen", "Isabella Garcia", "Henry Wilson", "Mia Kim", "Alexander Wright"][i] || `Member ${i + 6}`,
+    role: "Member" as const,
+    roleType: "member" as const,
+    joinDate: "Apr 2024",
+    avatar: null as string | null,
+    initials: ["JW", "ET", "LO", "SL", "OS", "AP", "WC", "IG", "HW", "MK", "AW"][i] || `M${i}`,
+    bio: i % 2 === 0 ? "Contributing to the subspace community." : "",
+  })),
+];
+
+const RAW_ORGS: Omit<OrgEntry, "kind">[] = [
+  {
+    id: "sorg1",
+    name: "Green Future Labs",
+    type: "Research Institute",
+    description: "Leading research in renewable energy systems and sustainable urban planning.",
+    avatar: "https://images.unsplash.com/photo-1769697264314-28f093151bbd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    initials: "GF",
+    members: 4,
+    website: "https://greenfuturelabs.org",
+  },
+  {
+    id: "sorg2",
+    name: "Utrecht University",
+    type: "Academic",
+    description: "Faculty of Geosciences contributing research on climate adaptation and energy transition.",
+    avatar: "https://images.unsplash.com/photo-1631599143424-5bc234fbebf1?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    initials: "UU",
+    members: 3,
+    website: "https://uu.nl",
+  },
+];
+
+const ALL_ENTRIES: CommunityEntry[] = [
+  ...RAW_ORGS.map((o): OrgEntry => ({ ...o, kind: "org" })),
+  ...RAW_MEMBERS.map((m): MemberEntry => ({ ...m, kind: "user" })),
+];
+
+const FILTERS = ["All", "Lead", "Member", "Organization"];
+
+// ── Props ──
+interface SubspaceCommunityDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function SubspaceCommunityDialog({ open, onOpenChange }: SubspaceCommunityDialogProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedFilter, setSelectedFilter] = useState("All");
+  const [currentPage, setCurrentPage] = useState(1);
+  const ITEMS_PER_PAGE = 9;
+
+  const totalUsers = RAW_MEMBERS.length;
+  const totalOrgs = RAW_ORGS.length;
+
+  const filteredEntries = ALL_ENTRIES.filter((entry) => {
+    const nameMatch = entry.name.toLowerCase().includes(searchQuery.toLowerCase());
+    const extraMatch =
+      entry.kind === "user"
+        ? entry.role.toLowerCase().includes(searchQuery.toLowerCase())
+        : entry.type.toLowerCase().includes(searchQuery.toLowerCase());
+    if (!nameMatch && !extraMatch) return false;
+    if (selectedFilter === "All") return true;
+    if (selectedFilter === "Organization") return entry.kind === "org";
+    return entry.kind === "user" && entry.role === selectedFilter;
+  });
+
+  const totalPages = Math.max(1, Math.ceil(filteredEntries.length / ITEMS_PER_PAGE));
+  const safeCurrentPage = Math.min(currentPage, totalPages);
+  const paginatedEntries = filteredEntries.slice(
+    (safeCurrentPage - 1) * ITEMS_PER_PAGE,
+    safeCurrentPage * ITEMS_PER_PAGE
+  );
+
+  const handleFilterChange = (filter: string) => {
+    setSelectedFilter(filter);
+    setCurrentPage(1);
+  };
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    setCurrentPage(1);
+  };
+
+  const getRoleBadgeColor = (roleType: string) => {
+    switch (roleType) {
+      case "admin":
+        return "bg-primary/10 text-primary border-primary/20";
+      case "moderator":
+        return "bg-chart-2/10 text-chart-2 border-chart-2/20";
+      default:
+        return "bg-muted text-muted-foreground border-border";
+    }
+  };
+
+  const getRoleIcon = (roleType: string) => {
+    switch (roleType) {
+      case "admin":
+        return <Shield className="w-3 h-3 mr-1" />;
+      case "moderator":
+        return <CheckCircle2 className="w-3 h-3 mr-1" />;
+      default:
+        return <User className="w-3 h-3 mr-1" />;
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-none sm:max-w-none max-h-[85vh] overflow-y-auto"
+        style={{ width: 'calc((100vw - 2 * var(--grid-margin-desktop) - 11 * var(--grid-gutter)) / var(--grid-columns) * 8 + 7 * var(--grid-gutter))' }}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Users className="w-5 h-5" style={{ color: "var(--primary)" }} />
+            Community
+          </DialogTitle>
+          <DialogDescription>
+            {totalUsers} members and {totalOrgs} organizations in this subspace.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 mt-2">
+          {/* Search & Filters */}
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+              <input
+                type="text"
+                placeholder="Search members or organizations..."
+                value={searchQuery}
+                onChange={(e) => handleSearchChange(e.target.value)}
+                className="w-full h-10 pl-9 pr-4 transition-all"
+                style={{
+                  fontSize: "var(--text-sm)",
+                  fontFamily: "'Inter', sans-serif",
+                  borderRadius: "var(--radius)",
+                  border: "1px solid var(--border)",
+                  background: "var(--input-background)",
+                  color: "var(--foreground)",
+                  outline: "none",
+                }}
+                onFocus={(e) => {
+                  e.currentTarget.style.borderColor = "var(--primary)";
+                  e.currentTarget.style.boxShadow = "0 0 0 1px var(--ring)";
+                }}
+                onBlur={(e) => {
+                  e.currentTarget.style.borderColor = "var(--border)";
+                  e.currentTarget.style.boxShadow = "none";
+                }}
+              />
+            </div>
+
+            <div className="flex items-center gap-2 overflow-x-auto pb-2 sm:pb-0 no-scrollbar">
+              {FILTERS.map((filter) => (
+                <button
+                  key={filter}
+                  onClick={() => handleFilterChange(filter)}
+                  className="px-3 py-2 whitespace-nowrap transition-colors"
+                  style={{
+                    fontSize: "var(--text-sm)",
+                    fontWeight: "var(--font-weight-medium)" as any,
+                    fontFamily: "'Inter', sans-serif",
+                    borderRadius: "var(--radius)",
+                    border: `1px solid ${selectedFilter === filter ? "var(--primary)" : "var(--border)"}`,
+                    background: selectedFilter === filter ? "var(--primary)" : "var(--background)",
+                    color: selectedFilter === filter ? "var(--primary-foreground)" : "var(--muted-foreground)",
+                  }}
+                >
+                  {filter}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Grid */}
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {paginatedEntries.map((entry) =>
+              entry.kind === "user" ? (
+                <UserCard
+                  key={entry.id}
+                  member={entry}
+                  getRoleBadgeColor={getRoleBadgeColor}
+                  getRoleIcon={getRoleIcon}
+                />
+              ) : (
+                <OrgCard key={entry.id} org={entry} />
+              )
+            )}
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center mt-4">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground"
+                onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                disabled={currentPage === 1}
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </Button>
+              <span className="mx-2 text-sm text-muted-foreground">
+                Page {safeCurrentPage} of {totalPages}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground"
+                onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+                disabled={currentPage === totalPages}
+              >
+                <ChevronRight className="w-4 h-4" />
+              </Button>
+            </div>
+          )}
+
+          {/* Empty state */}
+          {filteredEntries.length === 0 && (
+            <div className="text-center py-12">
+              <div
+                className="inline-flex items-center justify-center w-12 h-12 mb-4"
+                style={{ borderRadius: "999px", background: "var(--muted)" }}
+              >
+                <User className="w-6 h-6" style={{ color: "var(--muted-foreground)" }} />
+              </div>
+              <h3
+                style={{
+                  fontSize: "var(--text-base)",
+                  fontWeight: "var(--font-weight-medium)" as any,
+                  color: "var(--foreground)",
+                  fontFamily: "'Inter', sans-serif",
+                }}
+              >
+                No results found
+              </h3>
+              <p className="mt-1" style={{ fontSize: "var(--text-sm)", color: "var(--muted-foreground)", fontFamily: "'Inter', sans-serif" }}>
+                Try adjusting your search or filters.
+              </p>
+              <Button
+                variant="link"
+                onClick={() => {
+                  setSearchQuery("");
+                  setSelectedFilter("All");
+                  setCurrentPage(1);
+                }}
+                className="mt-2 text-primary"
+              >
+                Clear filters
+              </Button>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── User Card ──
+function UserCard({
+  member,
+  getRoleBadgeColor,
+  getRoleIcon,
+}: {
+  member: MemberEntry;
+  getRoleBadgeColor: (rt: string) => string;
+  getRoleIcon: (rt: string) => React.ReactNode;
+}) {
+  return (
+    <Card className="overflow-hidden hover:shadow-md transition-all duration-300">
+      <CardContent className="p-0">
+        <div className="p-4 flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <Link
+              to={`/user/${member.name.toLowerCase().replace(/\s+/g, "-")}`}
+              className="transition-opacity hover:opacity-80"
+            >
+              <Avatar className="w-12 h-12" style={{ border: "1px solid var(--border)" }}>
+                {member.avatar && <AvatarImage src={member.avatar} alt={member.name} />}
+                <AvatarFallback
+                  style={{
+                    fontFamily: "'Inter', sans-serif",
+                    fontWeight: 600,
+                    fontSize: "var(--text-sm)",
+                  }}
+                >
+                  {member.initials}
+                </AvatarFallback>
+              </Avatar>
+            </Link>
+            <div>
+              <Link
+                to={`/user/${member.name.toLowerCase().replace(/\s+/g, "-")}`}
+                className="hover:text-primary transition-colors block"
+                style={{
+                  fontFamily: "'Inter', sans-serif",
+                  fontWeight: 600,
+                  fontSize: "var(--text-sm)",
+                  color: "var(--foreground)",
+                }}
+              >
+                {member.name}
+              </Link>
+              <div
+                className={cn(
+                  "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border mt-1",
+                  getRoleBadgeColor(member.roleType)
+                )}
+                style={{ fontFamily: "'Inter', sans-serif" }}
+              >
+                {getRoleIcon(member.roleType)}
+                {member.role}
+              </div>
+            </div>
+          </div>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground">
+                <MoreHorizontal className="w-4 h-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem>View Profile</DropdownMenuItem>
+              <DropdownMenuItem>Message</DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem className="text-destructive">Remove from Space</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        <div className="px-4 pb-4">
+          {member.bio && (
+            <p
+              className="line-clamp-2"
+              style={{
+                fontSize: "var(--text-sm)",
+                color: "var(--muted-foreground)",
+                fontFamily: "'Inter', sans-serif",
+              }}
+            >
+              {member.bio}
+            </p>
+          )}
+          <div
+            className={cn("flex items-center gap-1", member.bio ? "mt-4" : "mt-1")}
+            style={{
+              fontSize: "12px",
+              color: "var(--muted-foreground)",
+              fontFamily: "'Inter', sans-serif",
+            }}
+          >
+            <span>Joined {member.joinDate}</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Organization Card ──
+function OrgCard({ org }: { org: OrgEntry }) {
+  return (
+    <Card className="overflow-hidden hover:shadow-md transition-all duration-300">
+      <CardContent className="p-0">
+        <div className="p-4 flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <Link
+              to={`/organization/${org.name.toLowerCase().replace(/\s+/g, "-")}`}
+              className="transition-opacity hover:opacity-80"
+            >
+              <Avatar
+                className="w-12 h-12"
+                style={{ borderRadius: "var(--radius)", border: "1px solid var(--border)" }}
+              >
+                <AvatarImage src={org.avatar} alt={org.name} style={{ borderRadius: "var(--radius)" }} />
+                <AvatarFallback
+                  style={{
+                    borderRadius: "var(--radius)",
+                    fontFamily: "'Inter', sans-serif",
+                    fontWeight: 700,
+                    fontSize: "12px",
+                    background: "color-mix(in srgb, var(--info) 15%, transparent)",
+                    color: "var(--info)",
+                  }}
+                >
+                  {org.initials}
+                </AvatarFallback>
+              </Avatar>
+            </Link>
+            <div>
+              <Link
+                to={`/organization/${org.name.toLowerCase().replace(/\s+/g, "-")}`}
+                className="hover:text-primary transition-colors block"
+                style={{
+                  fontFamily: "'Inter', sans-serif",
+                  fontWeight: 600,
+                  fontSize: "var(--text-sm)",
+                  color: "var(--foreground)",
+                }}
+              >
+                {org.name}
+              </Link>
+              <div className="flex items-center gap-1.5 mt-1">
+                <span
+                  className="inline-flex items-center gap-1 px-2 py-0.5"
+                  style={{
+                    fontSize: "11px",
+                    fontWeight: "var(--font-weight-medium)" as any,
+                    fontFamily: "'Inter', sans-serif",
+                    color: "var(--info)",
+                    background: "color-mix(in srgb, var(--info) 10%, transparent)",
+                    border: "1px solid color-mix(in srgb, var(--info) 20%, transparent)",
+                    borderRadius: "999px",
+                  }}
+                >
+                  <Building2 className="w-3 h-3" />
+                  {org.type}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <a
+            href={org.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 p-1.5 transition-colors"
+            style={{ color: "var(--muted-foreground)", borderRadius: "var(--radius)" }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--muted)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+          </a>
+        </div>
+
+        <div className="px-4 pb-4">
+          <p
+            className="line-clamp-2 min-h-[2.5rem]"
+            style={{
+              fontSize: "var(--text-sm)",
+              color: "var(--muted-foreground)",
+              fontFamily: "'Inter', sans-serif",
+            }}
+          >
+            {org.description}
+          </p>
+          <div
+            className="flex items-center gap-1 mt-4"
+            style={{
+              fontSize: "12px",
+              color: "var(--muted-foreground)",
+              fontFamily: "'Inter', sans-serif",
+            }}
+          >
+            <Users className="w-3 h-3" />
+            <span>{org.members} members in this space</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/prototype/src/app/components/space/SubspaceHeader.tsx
+++ b/prototype/src/app/components/space/SubspaceHeader.tsx
@@ -1,11 +1,13 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
 import { Badge } from "@/app/components/ui/badge";
 import { Button } from "@/app/components/ui/button";
+import { useNavigate, Link } from "react-router";
 import {
-  Search,
+  Activity,
+  Video,
+  FileText,
   Settings,
   Share2,
-  Maximize2,
 } from "lucide-react";
 
 interface SubspaceHeaderProps {
@@ -15,161 +17,267 @@ interface SubspaceHeaderProps {
   description: string;
   parentSpaceName: string;
   imageUrl: string;
+  initials: string;
+  avatarColor: string;
+  parentInitials: string;
+  parentAvatarColor: string;
+  parentBannerImage?: string;
+  avatarImage?: string;
   memberCount?: number;
+  onCommunityClick?: () => void;
 }
 
 export function SubspaceHeader({
   spaceSlug,
+  subspaceSlug,
   title,
   description,
   parentSpaceName,
   imageUrl,
+  initials,
+  avatarColor,
+  parentInitials,
+  parentAvatarColor,
+  parentBannerImage,
+  avatarImage,
   memberCount = 16,
+  onCommunityClick,
 }: SubspaceHeaderProps) {
+  const navigate = useNavigate();
   const avatarCount = Math.min(memberCount, 5);
   const overflow = memberCount - avatarCount;
 
   return (
-    <div className="relative w-full h-[320px] overflow-hidden group">
-      {/* Background image with hover parallax */}
-      <div
-        className="absolute inset-0 bg-cover bg-center transition-transform duration-700 group-hover:scale-105"
-        style={{ backgroundImage: `url(${imageUrl})` }}
-      />
-      {/* Dark overlay for text readability */}
-      <div
-        className="absolute inset-0"
-        style={{
-          background:
-            "color-mix(in srgb, var(--foreground) 50%, transparent)",
-        }}
-      />
+    <div className="relative group">
+      {/* Banner Image */}
+      <div className="h-52 md:h-64 w-full relative overflow-hidden bg-muted">
+        <div
+          className="absolute inset-0 bg-cover bg-center transition-transform duration-700 group-hover:scale-105"
+          style={{ backgroundImage: `url(${imageUrl})` }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
 
-      {/* "SUBSPACE" badge — top-right */}
-      <Badge
-        variant="secondary"
-        className="absolute top-4 right-4 backdrop-blur-sm border-0"
-        style={{
-          background:
-            "color-mix(in srgb, var(--background) 80%, transparent)",
-          fontSize: "10px",
-          fontWeight: 700,
-          letterSpacing: "0.08em",
-          fontFamily: "var(--font-family, 'Inter', sans-serif)",
-        }}
-      >
-        SUBSPACE
-      </Badge>
-
-      {/* Content container */}
-      <div className="relative h-full px-6 md:px-8 py-8 flex flex-col justify-between pb-12">
-        {/* Top row: utility icons — aligned to grid col 2-11 */}
-        <div className="grid grid-cols-12 gap-6">
-          <div className="col-span-12 lg:col-start-2 lg:col-span-10">
-            <div className="flex items-center justify-end">
-
-              <div className="flex items-center gap-1">
-                {[
-                  { icon: Search, label: "Search" },
-                  { icon: Maximize2, label: "Open" },
-                  { icon: Settings, label: "Settings" },
-                  { icon: Share2, label: "Share" },
-                ].map(({ icon: Icon, label }) => (
+        {/* Action icons overlay — top-right of banner */}
+        <div
+          className="absolute top-0 left-0 right-0 z-10 px-6 md:px-8"
+          style={{ paddingTop: 32 }}
+        >
+          <div className="grid grid-cols-12 gap-6">
+            <div className="col-span-12 lg:col-start-2 lg:col-span-10 flex items-center justify-end">
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded hover:opacity-100"
+                  style={{ color: "white" }}
+                  title="Recent Activity"
+                >
+                  <Activity className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded hover:opacity-100"
+                  style={{ color: "white" }}
+                  title="Video Call"
+                >
+                  <Video className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded hover:opacity-100"
+                  style={{ color: "white" }}
+                  title="Documents"
+                >
+                  <FileText className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded hover:opacity-100"
+                  style={{ color: "white" }}
+                  title="Share"
+                >
+                  <Share2 className="h-4 w-4" />
+                </Button>
+                <Link to={`/space/${spaceSlug}/subspaces/${subspaceSlug}/settings/about`}>
                   <Button
-                    key={label}
                     variant="ghost"
                     size="icon"
-                    title={label}
-                    className="hover:opacity-100"
-                    style={{
-                      color: "var(--primary-foreground)",
-                      opacity: 0.8,
-                    }}
+                    className="h-9 w-9 rounded hover:opacity-100"
+                    style={{ color: "white" }}
+                    title="Settings"
                   >
-                    <Icon className="w-5 h-5" />
+                    <Settings className="h-4 w-4" />
                   </Button>
-                ))}
+                </Link>
               </div>
             </div>
           </div>
         </div>
 
-        {/* Bottom row: title + members — aligned to grid col 2-11 */}
-        <div className="grid grid-cols-12 gap-6">
-          <div className="col-span-12 lg:col-start-2 lg:col-span-10">
-            <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
-          <div
-            className="max-w-3xl"
-            style={{ color: "var(--primary-foreground)" }}
-          >
-            <h1
-              className="mb-4"
-              style={{
-                fontSize: "clamp(28px, 5vw, 44px)",
-                fontWeight: 700,
-                letterSpacing: "-0.02em",
-                lineHeight: 1.1,
-                fontFamily: "var(--font-family, 'Inter', sans-serif)",
-              }}
-            >
-              {title}
-            </h1>
-            <p
-              className="max-w-xl"
-              style={{
-                fontSize: "var(--text-base)",
-                opacity: 0.9,
-                lineHeight: 1.6,
-                fontFamily: "var(--font-family, 'Inter', sans-serif)",
-              }}
-            >
-              {description}
-            </p>
-          </div>
+        {/* "SUBSPACE" badge — top-right */}
+        <Badge
+          variant="secondary"
+          className="absolute top-4 right-4 backdrop-blur-sm border-0"
+          style={{
+            background:
+              "color-mix(in srgb, var(--background) 80%, transparent)",
+            fontSize: "10px",
+            fontWeight: 700,
+            letterSpacing: "0.08em",
+            fontFamily: "var(--font-family, 'Inter', sans-serif)",
+          }}
+        >
+          SUBSPACE
+        </Badge>
 
-          {/* Member avatars */}
-          <div className="flex items-center gap-4 shrink-0">
-            <div className="flex -space-x-2">
-              {Array.from({ length: avatarCount }).map((_, i) => (
-                <Avatar
-                  key={i}
-                  className="w-10 h-10 transition-transform hover:z-10 hover:scale-110"
-                  style={{ border: "2px solid var(--background)" }}
-                >
-                  <AvatarImage
-                    src={`https://i.pravatar.cc/150?u=sub-${i + 20}`}
-                  />
-                  <AvatarFallback
+        {/* Member avatars — bottom-right of banner */}
+        <div className="absolute bottom-6 right-6 md:right-8">
+          <div className="grid grid-cols-12 gap-6">
+            <div className="col-span-12 lg:col-start-2 lg:col-span-10 flex justify-end">
+              <button
+                onClick={onCommunityClick}
+                className="flex items-center gap-4 cursor-pointer transition-opacity hover:opacity-90"
+                title="View community"
+              >
+                <div className="flex -space-x-2">
+                  {Array.from({ length: avatarCount }).map((_, i) => (
+                    <Avatar
+                      key={i}
+                      className="w-10 h-10 transition-transform hover:z-10 hover:scale-110"
+                      style={{ border: "2px solid var(--background)" }}
+                    >
+                      <AvatarImage
+                        src={`https://i.pravatar.cc/150?u=sub-${i + 20}`}
+                      />
+                      <AvatarFallback
+                        style={{
+                          background:
+                            "color-mix(in srgb, var(--primary) 20%, transparent)",
+                          color: "var(--primary-foreground)",
+                          fontSize: "12px",
+                        }}
+                      >
+                        U{i}
+                      </AvatarFallback>
+                    </Avatar>
+                  ))}
+                  {overflow > 0 && (
+                    <div
+                      className="flex items-center justify-center w-10 h-10 rounded-full backdrop-blur-sm cursor-pointer transition-colors"
+                      style={{
+                        background:
+                          "color-mix(in srgb, var(--primary-foreground) 20%, transparent)",
+                        border: "2px solid var(--background)",
+                        color: "var(--primary-foreground)",
+                        fontSize: "12px",
+                        fontWeight: "var(--font-weight-medium)" as any,
+                        fontFamily: "var(--font-family, 'Inter', sans-serif)",
+                      }}
+                    >
+                      +{overflow}
+                    </div>
+                  )}
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Below-banner section: avatar overlaps upward, text stays below */}
+      <div className="px-6 md:px-8">
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 lg:col-start-2 lg:col-span-10 flex flex-col md:flex-row items-start gap-5">
+
+            {/* Two-layered avatar: overlaps banner via negative margin */}
+            <div className="relative shrink-0 -mt-12" style={{ width: 112, height: 112 }}>
+              {/* Parent space avatar (behind, top-left) — derived from banner */}
+              <div
+                className="absolute top-0 left-0 overflow-hidden flex items-center justify-center"
+                style={{
+                  width: 72,
+                  height: 72,
+                  borderRadius: "var(--radius-xl)",
+                  border: "3px solid var(--background)",
+                  background: parentBannerImage ? undefined : parentAvatarColor,
+                  zIndex: 1,
+                }}
+              >
+                {parentBannerImage ? (
+                  <img src={parentBannerImage} alt={parentSpaceName} className="w-full h-full object-cover" />
+                ) : (
+                  <span
                     style={{
-                      background:
-                        "color-mix(in srgb, var(--primary) 20%, transparent)",
+                      fontSize: "18px",
+                      fontWeight: 700,
                       color: "var(--primary-foreground)",
-                      fontSize: "12px",
+                      fontFamily: "'Inter', sans-serif",
                     }}
                   >
-                    U{i}
-                  </AvatarFallback>
-                </Avatar>
-              ))}
-              {overflow > 0 && (
-                <div
-                  className="flex items-center justify-center w-10 h-10 rounded-full backdrop-blur-sm cursor-pointer transition-colors"
+                    {parentInitials}
+                  </span>
+                )}
+              </div>
+
+              {/* Subspace avatar (in front, bottom-right) — picture avatar */}
+              <div
+                className="absolute overflow-hidden flex items-center justify-center"
+                style={{
+                  width: 88,
+                  height: 88,
+                  top: 24,
+                  left: 24,
+                  borderRadius: "var(--radius-xl)",
+                  border: "3px solid var(--background)",
+                  background: avatarImage ? undefined : avatarColor,
+                  zIndex: 2,
+                  boxShadow: "var(--elevation-sm)",
+                }}
+              >
+                {avatarImage ? (
+                  <img src={avatarImage} alt={title} className="w-full h-full object-cover" />
+                ) : (
+                  <span
+                    style={{
+                      fontSize: "24px",
+                      fontWeight: 700,
+                      color: "var(--primary-foreground)",
+                      fontFamily: "'Inter', sans-serif",
+                    }}
+                  >
+                    {initials}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Info — below the banner, not overlapping */}
+            <div className="flex-1 pt-4">
+              <div>
+                <h1
+                  className="text-3xl md:text-4xl font-bold text-foreground mb-1"
                   style={{
-                    background:
-                      "color-mix(in srgb, var(--primary-foreground) 20%, transparent)",
-                    border: "2px solid var(--background)",
-                    color: "var(--primary-foreground)",
-                    fontSize: "12px",
-                    fontWeight: "var(--font-weight-medium)" as any,
+                    letterSpacing: "-0.02em",
                     fontFamily: "var(--font-family, 'Inter', sans-serif)",
                   }}
                 >
-                  +{overflow}
-                </div>
-              )}
+                  {title}
+                </h1>
+                <p
+                  className="text-sm text-muted-foreground max-w-xl"
+                  style={{
+                    lineHeight: 1.5,
+                    fontFamily: "var(--font-family, 'Inter', sans-serif)",
+                  }}
+                >
+                  {description}
+                </p>
+              </div>
             </div>
-          </div>
-            </div>
+
           </div>
         </div>
       </div>

--- a/prototype/src/app/components/space/SubspaceSettingsAbout.tsx
+++ b/prototype/src/app/components/space/SubspaceSettingsAbout.tsx
@@ -1,0 +1,553 @@
+import { useState, useCallback } from "react";
+import ReactQuill from "react-quill";
+import "react-quill/dist/quill.snow.css";
+import { Button } from "@/app/components/ui/button";
+import { Input } from "@/app/components/ui/input";
+import { Label } from "@/app/components/ui/label";
+import { Separator } from "@/app/components/ui/separator";
+import { Upload, X, Plus, Loader2, Check, Pencil, Info as InfoIcon, Users } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface SubspaceSettingsAboutProps {
+  subspaceName: string;
+  initials: string;
+  avatarColor: string;
+  parentInitials: string;
+  parentAvatarColor: string;
+  memberCount: number;
+  tags?: string[];
+}
+
+const INITIAL_DATA = {
+  name: "",
+  what: "<p>This subspace focuses on developing strategies and practical solutions for this challenge area.</p>",
+  why: "<p>Because collaboration across disciplines is essential to make real progress on this challenge.</p>",
+  who: "<p>Subject matter experts, practitioners, and anyone passionate about contributing to this challenge.</p>",
+  tags: ["Innovation", "Collaboration"],
+  references: [
+    { title: "Challenge Brief", url: "https://example.com/brief" },
+  ],
+};
+
+// ─── Per-section save status ─────────────────────────────────────────────────
+type SectionId = "name" | "branding" | "what" | "why" | "who" | "tags" | "references";
+type SaveStatus = "idle" | "saving" | "saved";
+
+function useSectionSave() {
+  const [statuses, setStatuses] = useState<Record<SectionId, SaveStatus>>({
+    name: "idle", branding: "idle", what: "idle", why: "idle",
+    who: "idle", tags: "idle", references: "idle",
+  });
+
+  const save = useCallback((id: SectionId, onCommit: () => void) => {
+    setStatuses(s => ({ ...s, [id]: "saving" }));
+    setTimeout(() => {
+      onCommit();
+      setStatuses(s => ({ ...s, [id]: "saved" }));
+      setTimeout(() => setStatuses(s => ({ ...s, [id]: "idle" })), 1800);
+    }, 600);
+  }, []);
+
+  return { statuses, save };
+}
+
+// ─── Inline save button — appears when dirty ───────────────────
+function InlineSaveButton({
+  dirty,
+  status,
+  onSave,
+}: {
+  dirty: boolean;
+  status: SaveStatus;
+  onSave: () => void;
+}) {
+  if (status === "saved") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-emerald-600 animate-in fade-in slide-in-from-left-1 duration-200">
+        <Check className="w-3 h-3" /> Saved
+      </span>
+    );
+  }
+  if (status === "saving") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+        <Loader2 className="w-3 h-3 animate-spin" /> Saving…
+      </span>
+    );
+  }
+  if (!dirty) return null;
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onSave}
+      className="h-6 px-2 text-xs text-primary hover:text-primary hover:bg-primary/10 animate-in fade-in slide-in-from-left-1 duration-200"
+    >
+      Save
+    </Button>
+  );
+}
+
+// ─── Subtle pencil icon — decorative indicator inside editable fields ─────────
+function EditPencil({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center text-muted-foreground/50 pointer-events-none",
+        className
+      )}
+      aria-hidden
+    >
+      <Pencil className="w-3.5 h-3.5" />
+    </span>
+  );
+}
+
+export function SubspaceSettingsAbout({
+  subspaceName,
+  initials,
+  avatarColor,
+  parentInitials,
+  parentAvatarColor,
+  memberCount,
+}: SubspaceSettingsAboutProps) {
+  const initialFormData = { ...INITIAL_DATA, name: subspaceName };
+  const [formData, setFormData] = useState(initialFormData);
+  const [savedData, setSavedData] = useState(initialFormData);
+  const [tagInput, setTagInput] = useState("");
+  const { statuses, save } = useSectionSave();
+
+  // ─── Per-field dirty checks ────────────────────────────────────────────────
+  const dirty = {
+    name: formData.name !== savedData.name,
+    branding: false,
+    what: formData.what !== savedData.what,
+    why: formData.why !== savedData.why,
+    who: formData.who !== savedData.who,
+    tags: JSON.stringify(formData.tags) !== JSON.stringify(savedData.tags),
+    references: JSON.stringify(formData.references) !== JSON.stringify(savedData.references),
+  };
+
+  const saveSection = (id: SectionId) => {
+    save(id, () => {
+      setSavedData(prev => ({ ...prev, [id]: (formData as any)[id] }));
+    });
+  };
+
+  const handleQuillChange = (field: keyof typeof formData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleAddTag = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && tagInput.trim()) {
+      e.preventDefault();
+      if (!formData.tags.includes(tagInput.trim())) {
+        setFormData((prev) => ({ ...prev, tags: [...prev.tags, tagInput.trim()] }));
+      }
+      setTagInput("");
+    }
+  };
+
+  const removeTag = (tagToRemove: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      tags: prev.tags.filter((tag) => tag !== tagToRemove),
+    }));
+  };
+
+  const addReference = () => {
+    setFormData((prev) => ({
+      ...prev,
+      references: [...prev.references, { title: "", url: "" }],
+    }));
+  };
+
+  const updateReference = (index: number, field: "title" | "url", value: string) => {
+    const newRefs = [...formData.references];
+    newRefs[index] = { ...newRefs[index], [field]: value };
+    setFormData((prev) => ({ ...prev, references: newRefs }));
+  };
+
+  const removeReference = (index: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      references: prev.references.filter((_, i) => i !== index),
+    }));
+  };
+
+  const quillModules = {
+    toolbar: [
+      ["bold", "italic", "underline"],
+      [{ list: "ordered" }, { list: "bullet" }],
+      ["link", "blockquote", "code-block"],
+      ["clean"],
+    ],
+  };
+
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+      {/* LEFT — CONTENT */}
+      <div className="xl:col-span-2 space-y-6">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">About</h2>
+          <p className="text-muted-foreground mt-2">
+            Define this subspace's purpose, motivation, and target audience.
+          </p>
+        </div>
+
+        <Separator />
+
+        {/* ── Subspace Name ── */}
+        <section>
+          <Label className="text-xs text-muted-foreground uppercase tracking-wider">Subspace Name</Label>
+          <div className="mt-2 space-y-2">
+            <div className="relative max-w-md">
+              <Input
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+                placeholder="e.g. Renewable Energy Transition"
+                className="pr-8"
+              />
+              <EditPencil className="absolute right-2.5 top-1/2 -translate-y-1/2" />
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <InlineSaveButton dirty={dirty.name} status={statuses.name} onSave={() => saveSection("name")} />
+            </div>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* Branding */}
+        <section className="space-y-6">
+          <h3 className="text-lg font-medium">Subspace Branding</h3>
+
+          {/* Avatar */}
+          <div className="space-y-3">
+            <div className="flex items-start gap-5">
+              <div className="relative group shrink-0">
+                <div
+                  className="w-[140px] h-[140px] rounded-xl overflow-hidden flex items-center justify-center"
+                  style={{
+                    background: avatarColor,
+                    border: "2px solid var(--border)",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 36,
+                      fontWeight: 700,
+                      color: "#fff",
+                      fontFamily: "'Inter', sans-serif",
+                    }}
+                  >
+                    {initials}
+                  </span>
+                </div>
+                <div className="absolute inset-0 rounded-xl flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/30">
+                  <Button variant="secondary" size="sm" className="gap-1.5 text-xs h-7 px-2">
+                    <Upload className="w-3.5 h-3.5" /> Change
+                  </Button>
+                </div>
+              </div>
+              <div className="space-y-1 pt-1">
+                <Label className="text-base font-medium">Avatar</Label>
+                <p className="text-xs text-muted-foreground">
+                  Resolution: 410 width × 410 height (pixels)
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Card Banner */}
+          <div className="space-y-3">
+            <div className="flex items-start gap-5">
+              <div className="relative w-[200px] h-[125px] rounded-xl overflow-hidden group border border-border bg-muted/50 shrink-0">
+                <img
+                  src="https://images.unsplash.com/photo-1690191863988-f685cddde463?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxkZXNpZ24lMjBjaGFsbGVuZ2UlMjBjcmVhdGl2ZSUyMHdvcmtzaG9wJTIwdGVhbSUyMGNvbGxhYm9yYXRpb24lMjBpbm5vdmF0aW9uJTIwc3ByaW50JTIwZGVzaWduJTIwc3ByaW50fGVufDF8fHx8MTc2OTA5NDMxMHww&ixlib=rb-4.1.0&q=80&w=1080"
+                  alt="Card Banner"
+                  className="w-full h-full object-cover transition-opacity group-hover:opacity-75"
+                />
+                <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/20">
+                  <Button variant="secondary" size="sm" className="gap-1.5 text-xs h-7 px-2">
+                    <Upload className="w-3.5 h-3.5" /> Change
+                  </Button>
+                </div>
+              </div>
+              <div className="space-y-1 pt-1">
+                <Label className="text-base font-medium">Card Banner</Label>
+                <p className="text-xs text-muted-foreground">
+                  Resolution: 410 width × 256 height (pixels)
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Shown in search results and Space overviews.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* ── What / Why / Who — Rich text sections ── */}
+        {(["what", "why", "who"] as const).map((field) => {
+          const labels: Record<string, { title: string; hint: string }> = {
+            what: { title: "What", hint: "A clear description of the subspace's focus or subject matter." },
+            why: { title: "Why", hint: "Why does this subspace exist? What problem does it solve?" },
+            who: { title: "Who", hint: "Who should join this subspace? What are their roles or interests?" },
+          };
+          const { title, hint } = labels[field];
+          const htmlContent = formData[field] as string;
+
+          return (
+            <section key={field} className="space-y-1">
+              <Label className="text-base font-semibold">{title}</Label>
+
+              <div className="space-y-2">
+                <div className="prose-editor">
+                  <ReactQuill
+                    theme="snow"
+                    value={htmlContent}
+                    onChange={(val) => handleQuillChange(field, val)}
+                    modules={quillModules}
+                    placeholder={hint}
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-muted-foreground">{hint}</p>
+                  <InlineSaveButton dirty={dirty[field]} status={statuses[field]} onSave={() => saveSection(field as SectionId)} />
+                </div>
+              </div>
+              {field !== "who" && <Separator className="mt-6" />}
+            </section>
+          );
+        })}
+
+        <Separator />
+
+        {/* ── Tags ── */}
+        <section>
+          <Label>Tags</Label>
+
+          <div className="mt-2 space-y-2">
+            <div className="relative flex flex-wrap gap-2 p-3 pr-8 bg-background border border-input rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 min-h-[50px]">
+              <EditPencil className="absolute right-2.5 top-3" />
+              {formData.tags.map(tag => (
+                <span key={tag} className="inline-flex items-center gap-1 bg-secondary text-secondary-foreground px-2.5 py-0.5 rounded-full text-xs font-medium">
+                  {tag}
+                  <button onClick={() => removeTag(tag)} className="text-muted-foreground hover:text-foreground">
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              ))}
+              <input
+                className="flex-1 bg-transparent border-none outline-none text-sm min-w-[120px]"
+                placeholder="Type a tag and press Enter…"
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={handleAddTag}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">Tags help members discover your subspace.</p>
+              <InlineSaveButton dirty={dirty.tags} status={statuses.tags} onSave={() => saveSection("tags")} />
+            </div>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* ── References ── */}
+        <section>
+          <div className="flex items-center justify-between">
+            <Label>References & Links</Label>
+            <Button variant="outline" size="sm" onClick={addReference} className="gap-1 h-7 text-xs">
+              <Plus className="w-3 h-3" /> Add
+            </Button>
+          </div>
+
+          <div className="mt-3 space-y-3">
+            {formData.references.map((ref, i) => (
+              <div key={i} className="flex gap-3 items-start">
+                <div className="grid gap-2 flex-1 sm:grid-cols-2">
+                  <Input
+                    placeholder="Link Title"
+                    value={ref.title}
+                    onChange={(e) => updateReference(i, "title", e.target.value)}
+                    className="h-9"
+                  />
+                  <Input
+                    placeholder="URL (https://...)"
+                    value={ref.url}
+                    onChange={(e) => updateReference(i, "url", e.target.value)}
+                    className="h-9"
+                  />
+                </div>
+                <Button variant="ghost" size="icon" onClick={() => removeReference(i)} className="h-9 w-9 text-muted-foreground hover:text-destructive">
+                  <X className="w-4 h-4" />
+                </Button>
+              </div>
+            ))}
+            {formData.references.length === 0 && (
+              <p className="text-sm text-muted-foreground italic">No references added yet. Click "Add" above.</p>
+            )}
+            <div className="flex items-center justify-end gap-2">
+              <InlineSaveButton dirty={dirty.references} status={statuses.references} onSave={() => saveSection("references")} />
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {/* RIGHT COLUMN — PREVIEW */}
+      <div className="hidden xl:block">
+        <div className="sticky top-6 space-y-6">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="font-semibold text-sm text-muted-foreground uppercase tracking-wider">
+              Preview
+            </h3>
+            {Object.values(dirty).some(Boolean) ? (
+              <span className="text-xs text-amber-500 flex items-center gap-1.5">
+                Unsaved changes
+              </span>
+            ) : Object.values(statuses).some(s => s === "saved") ? (
+              <span className="text-xs text-success flex items-center gap-1.5">
+                <Check className="w-3 h-3" /> Saved
+              </span>
+            ) : null}
+          </div>
+
+          {/* Subspace Card Preview */}
+          <div
+            className="bg-card border border-border rounded-xl shadow-sm"
+          >
+            {/* Card banner */}
+            <div className="h-28 relative bg-muted rounded-t-xl overflow-hidden">
+              <div
+                className="absolute inset-0"
+                style={{
+                  background: `linear-gradient(135deg, ${avatarColor}44 0%, ${parentAvatarColor}44 100%)`,
+                }}
+              />
+            </div>
+
+            {/* Two-layered avatar — overlaps banner, NOT clipped */}
+            <div className="relative px-4" style={{ height: 0 }}>
+              <div className="absolute bottom-0 left-4" style={{ width: 48, height: 48 }}>
+                {/* Parent (behind, top-left) */}
+                <div
+                  className="absolute top-0 left-0 flex items-center justify-center"
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: 7,
+                    border: "2px solid var(--card)",
+                    background: parentAvatarColor,
+                    zIndex: 1,
+                  }}
+                >
+                  <span style={{ fontSize: 9, fontWeight: 700, color: "#fff", fontFamily: "'Inter', sans-serif" }}>
+                    {parentInitials}
+                  </span>
+                </div>
+                {/* Subspace (front, bottom-right) */}
+                <div
+                  className="absolute flex items-center justify-center"
+                  style={{
+                    width: 38,
+                    height: 38,
+                    top: 10,
+                    left: 10,
+                    borderRadius: 8,
+                    border: "2px solid var(--card)",
+                    background: avatarColor,
+                    zIndex: 2,
+                    boxShadow: "0 1px 3px rgba(0,0,0,.12)",
+                  }}
+                >
+                  <span style={{ fontSize: 11, fontWeight: 700, color: "#fff", fontFamily: "'Inter', sans-serif" }}>
+                    {initials}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-4 pt-8 space-y-3">
+              <div>
+                <h4 className="font-semibold text-sm">
+                  {formData.name || "Untitled Subspace"}
+                </h4>
+                <p className="text-xs text-muted-foreground mt-0.5">Last active just now</p>
+              </div>
+
+              <div className="space-y-1">
+                <p className="text-xs font-medium text-muted-foreground uppercase">What</p>
+                <div
+                  className="text-sm text-card-foreground line-clamp-3 prose prose-sm max-w-none"
+                  dangerouslySetInnerHTML={{
+                    __html:
+                      formData.what ||
+                      "<p class='text-muted-foreground italic'>No description yet…</p>",
+                  }}
+                />
+              </div>
+
+              {/* Tags */}
+              <div className="flex flex-wrap gap-1.5">
+                {formData.tags.length > 0 ? (
+                  formData.tags.slice(0, 3).map((tag) => (
+                    <span
+                      key={tag}
+                      className="bg-secondary px-2 py-0.5 rounded text-[10px] text-secondary-foreground"
+                    >
+                      {tag}
+                    </span>
+                  ))
+                ) : (
+                  <span className="bg-muted px-2 py-0.5 rounded text-[10px] text-muted-foreground">
+                    No Tags
+                  </span>
+                )}
+                {formData.tags.length > 3 && (
+                  <span className="bg-muted px-2 py-0.5 rounded text-[10px] text-muted-foreground">
+                    +{formData.tags.length - 3}
+                  </span>
+                )}
+              </div>
+
+              {/* Members */}
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground pt-1">
+                <Users className="w-3.5 h-3.5" />
+                <span>{memberCount} members</span>
+              </div>
+            </div>
+          </div>
+
+          <div
+            className="rounded-lg p-4 text-xs space-y-2"
+            style={{
+              background: "color-mix(in srgb, var(--primary) 5%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--primary) 10%, transparent)",
+              color: "color-mix(in srgb, var(--primary) 80%, var(--foreground))",
+            }}
+          >
+            <p className="font-semibold flex items-center gap-2">
+              <InfoIcon className="w-3.5 h-3.5" />
+              Live Preview
+            </p>
+            <p>
+              This preview shows how this subspace card will appear in space
+              overviews and search results.
+            </p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  );
+}

--- a/prototype/src/app/components/space/SubspaceSettingsCommunity.tsx
+++ b/prototype/src/app/components/space/SubspaceSettingsCommunity.tsx
@@ -1,188 +1,150 @@
 import { useState } from "react";
-import { 
-  Search, 
-  Filter, 
-  MoreHorizontal, 
-  Check, 
-  X, 
-  ChevronDown, 
-  ChevronUp, 
-  Plus, 
-  FileText, 
-  Shield, 
-  Building, 
-  Bot, 
-  Users, 
-  Clock, 
+import {
+  Search,
+  Filter,
+  MoreHorizontal,
+  Check,
+  X,
+  ChevronDown,
+  ChevronUp,
+  Plus,
+  FileText,
+  Shield,
+  Building,
+  Bot,
+  Users,
+  Clock,
   Mail,
   Trash2,
-  ExternalLink,
-  AlertCircle,
   UserPlus,
   ChevronLeft,
   ChevronRight,
   ArrowUpDown,
   ArrowUp,
-  ArrowDown
+  ArrowDown,
 } from "lucide-react";
 import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
 import { Badge } from "@/app/components/ui/badge";
-import { 
-  Table, 
-  TableBody, 
-  TableCell, 
-  TableHead, 
-  TableHeader, 
-  TableRow 
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/app/components/ui/table";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  DropdownMenuSeparator
+  DropdownMenuSeparator,
 } from "@/app/components/ui/dropdown-menu";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/app/components/ui/collapsible";
-import { cn } from "@/lib/utils";
 import { Separator } from "@/app/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
+import { cn } from "@/lib/utils";
 
-// --- Mock Data ---
+type MemberRole = "Lead" | "Admin" | "Member";
+type MemberStatus = "Active" | "Pending" | "Invited";
 
-type MemberStatus = 'Active' | 'Pending' | 'Invited';
-type MemberRole = 'Host' | 'Admin' | 'Lead' | 'Member';
-
-interface CommunityMember {
+interface Member {
   id: string;
   name: string;
   email: string;
-  date: string; // ISO date or joined string
-  status: MemberStatus;
   role: MemberRole;
+  status: MemberStatus;
   avatar: string | null;
   initials: string;
+  date: string;
 }
 
-const MOCK_MEMBERS: CommunityMember[] = [
-  // 5 Key Users (Matching SpaceMembers.tsx)
+const MOCK_MEMBERS: Member[] = [
   {
-    id: 'u1',
+    id: "1",
     name: "Elena Martinez",
     email: "elena@alkemio.org",
-    date: "2023-10-15",
+    role: "Lead",
     status: "Active",
-    role: "Host",
-    avatar: "https://images.unsplash.com/photo-1623853589874-864b1dd4d922?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx3b21hbiUyMGdsYXNzZXMlMjBibGFjayUyMGFuZCUyMHdoaXRlJTIwcG9ydHJhaXR8ZW58MXx8fHwxNzY5NDQyNTM3fDA&ixlib=rb-4.1.0&q=80&w=256",
-    initials: "EM"
+    avatar: "https://images.unsplash.com/photo-1623853589874-864b1dd4d922?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    initials: "EM",
+    date: "2023-10-15",
   },
   {
-    id: 'u2',
+    id: "2",
     name: "Sarah Chen",
     email: "sarah.chen@example.com",
-    date: "2023-11-02",
-    status: "Active",
     role: "Admin",
-    avatar: "https://images.unsplash.com/photo-1757347398206-7425300ef990?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx3b21hbiUyMHNtaWxpbmclMjBkYXJrJTIwaGFpciUyMHBvcnRyYWl0fGVufDF8fHx8MTc2OTQ0MjUzN3ww&ixlib=rb-4.1.0&q=80&w=256",
-    initials: "SC"
-  },
-  {
-    id: 'u3',
-    name: "Maya Ross",
-    email: "maya.r@example.com",
-    date: "2023-12-10",
     status: "Active",
-    role: "Lead",
-    avatar: "https://images.unsplash.com/photo-1589332911105-a6b59f2e4c4b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx3b21hbiUyMHNtaWxpbmclMjBkYXJrJTIwaGFpciUyMHBvcnRyYWl0fGVufDF8fHx8MTc2OTQ0MjUzN3ww&ixlib=rb-4.1.0&q=80&w=256",
-    initials: "MR"
+    avatar: "https://images.unsplash.com/photo-1757347398206-7425300ef990?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    initials: "SC",
+    date: "2023-11-02",
   },
   {
-    id: 'u4',
+    id: "3",
     name: "David Kim",
     email: "dkim@design.co",
-    date: "2024-01-05",
-    status: "Active",
     role: "Member",
-    avatar: "https://images.unsplash.com/photo-1651634099348-e4c38cfaa6d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxtYW4lMjBiZWFyZCUyMHN1bnNldCUyMHBvcnRyYWl0fGVufDF8fHx8MTc2OTQ0MjUzN3ww&ixlib=rb-4.1.0&q=80&w=256",
-    initials: "DK"
+    status: "Active",
+    avatar: null,
+    initials: "DK",
+    date: "2024-01-05",
   },
   {
-    id: 'u5',
+    id: "4",
+    name: "Maya Ross",
+    email: "maya.r@example.com",
+    role: "Member",
+    status: "Active",
+    avatar: null,
+    initials: "MR",
+    date: "2023-12-10",
+  },
+  {
+    id: "5",
     name: "Robert Fox",
     email: "robert.fox@example.com",
-    date: "2024-01-12",
-    status: "Active",
     role: "Member",
-    avatar: "https://images.unsplash.com/photo-1651097681268-851acda33b18?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxvbGRlciUyMG1hbiUyMHdoaXRlJTIwYmVhcmQlMjBnbGFzc2VzJTIwcG9ydHJhaXR8ZW58MXx8fHwxNzY5NDQyNTM3fDA&ixlib=rb-4.1.0&q=80&w=256",
-    initials: "RF"
+    status: "Active",
+    avatar: null,
+    initials: "RF",
+    date: "2024-01-12",
   },
-  // Pending Members (Requested to join)
   {
-    id: 'p1',
+    id: "6",
     name: "Michael Chen",
     email: "m.chen@university.edu",
-    date: "2024-02-20",
-    status: "Pending",
     role: "Member",
+    status: "Pending",
     avatar: null,
-    initials: "MC"
+    initials: "MC",
+    date: "2024-02-20",
   },
   {
-    id: 'p2',
+    id: "7",
     name: "Jessica Alverez",
     email: "jess.alverez@studio.com",
+    role: "Member",
+    status: "Invited",
+    avatar: null,
+    initials: "JA",
     date: "2024-02-21",
-    status: "Pending",
-    role: "Member",
-    avatar: null,
-    initials: "JA"
   },
-  // Invited Members (No response yet)
-  {
-    id: 'i1',
-    name: "Thomas Wright",
-    email: "tom.wright@construction.com",
-    date: "2024-02-18",
-    status: "Invited",
-    role: "Member",
-    avatar: null,
-    initials: "TW"
-  },
-  {
-    id: 'i2',
-    name: "Emily Zhang",
-    email: "emily.z@tech.io",
-    date: "2024-02-19",
-    status: "Invited",
-    role: "Lead",
-    avatar: null,
-    initials: "EZ"
-  },
-  // Generated Members (20 more)
-  ...Array.from({ length: 20 }).map((_, i) => ({
-    id: `m${i+6}`,
-    name: [
-      "James Wilson", "Emma Thompson", "Lucas Oliveira", "Sophia Li", "Oliver Smith", 
-      "Ava Patel", "William Chen", "Isabella Garcia", "Henry Wilson", "Mia Kim",
-      "Alexander Wright", "Charlotte Davis", "Daniel Lee", "Amelia White", "Matthew Clark",
-      "Harper Lewis", "Joseph Hall", "Evelyn Young", "Samuel Allen", "Abigail King",
-      "Benjamin Scott", "Elizabeth Green", "Jack Baker", "Victoria Adams"
-    ][i] || `Member ${i+6}`,
-    email: `member${i+6}@example.com`,
+  ...Array.from({ length: 8 }).map((_, i) => ({
+    id: `m${i + 8}`,
+    name: ["James Wilson", "Emma Thompson", "Lucas Oliveira", "Sophia Li", "Oliver Smith", "Ava Patel", "William Chen", "Isabella Garcia"][i] || `Member ${i + 8}`,
+    email: `member${i + 8}@example.com`,
     date: "2024-02-15",
     status: "Active" as MemberStatus,
-    role: (i < 3 ? "Lead" : "Member") as MemberRole,
+    role: (i < 1 ? "Lead" : "Member") as MemberRole,
     avatar: null,
-    initials: [
-      "JW", "ET", "LO", "SL", "OS", "AP", "WC", "IG", "HW", "MK",
-      "AW", "CD", "DL", "AW", "MC", "HL", "JH", "EY", "SA", "AK",
-      "BS", "EG", "JB", "VA"
-    ][i] || `M${i+6}`,
-  }))
+    initials: ["JW", "ET", "LO", "SL", "OS", "AP", "WC", "IG"][i] || `M${i + 8}`,
+  })),
 ];
 
 interface Organization {
@@ -193,48 +155,44 @@ interface Organization {
 }
 
 const MOCK_ORGS: Organization[] = [
-  { id: 'org1', name: 'Acme Corp', logo: 'AC', memberCount: 15 },
-  { id: 'org2', name: 'Global Tech', logo: 'GT', memberCount: 42 },
+  { id: "org1", name: "Partner Org", logo: "PO", memberCount: 5 },
 ];
 
 interface VirtualContributor {
   id: string;
   name: string;
-  status: 'Active' | 'Inactive';
+  status: "Active" | "Inactive";
 }
 
 const MOCK_VCS: VirtualContributor[] = [
-  { id: 'vc1', name: 'Summarizer Bot', status: 'Active' },
-  { id: 'vc2', name: 'Translation Assistant', status: 'Inactive' },
+  { id: "vc1", name: "Summarizer Bot", status: "Active" },
 ];
-
-// --- Components ---
 
 function StatusBadge({ status }: { status: MemberStatus }) {
   switch (status) {
-    case 'Pending':
+    case "Pending":
       return <Badge variant="outline" className="bg-muted text-muted-foreground border-border">Pending</Badge>;
-    case 'Invited':
+    case "Invited":
       return <Badge variant="outline" className="bg-primary/10 text-primary border-primary/20">Invited</Badge>;
-    case 'Active':
+    case "Active":
       return <Badge variant="outline" className="bg-chart-1/10 text-chart-1 border-chart-1/20">Active</Badge>;
     default:
       return <Badge variant="outline">{status}</Badge>;
   }
 }
 
-function SectionHeader({ 
-  icon: Icon, 
-  title, 
-  description, 
-  isOpen, 
-  onToggle 
-}: { 
-  icon: React.ElementType, 
-  title: string, 
-  description: string, 
-  isOpen: boolean, 
-  onToggle: () => void 
+function SectionHeader({
+  icon: Icon,
+  title,
+  description,
+  isOpen,
+  onToggle,
+}: {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+  isOpen: boolean;
+  onToggle: () => void;
 }) {
   return (
     <div className="flex items-start gap-4 cursor-pointer group" onClick={onToggle}>
@@ -243,37 +201,27 @@ function SectionHeader({
       </div>
       <div className="flex-1">
         <div className="flex items-center justify-between">
-          <h3 className="font-semibold text-base flex items-center gap-2">
-            {title}
-          </h3>
+          <h3 className="font-semibold text-base flex items-center gap-2">{title}</h3>
           <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
             {isOpen ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
           </Button>
         </div>
-        <p className="text-sm text-muted-foreground mt-1 pr-8">
-          {description}
-        </p>
+        <p className="text-sm text-muted-foreground mt-1 pr-8">{description}</p>
       </div>
     </div>
   );
 }
 
-export function SpaceSettingsCommunity() {
-  const [members, setMembers] = useState<CommunityMember[]>(MOCK_MEMBERS);
-  const [filter, setFilter] = useState<'All' | 'Active' | 'Pending' | 'Invited'>('All');
-  const [searchQuery, setSearchQuery] = useState('');
-  
-  // Pagination State
+export function SubspaceSettingsCommunity() {
+  const [members, setMembers] = useState<Member[]>(MOCK_MEMBERS);
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<"All" | "Active" | "Pending" | "Invited">("All");
   const [page, setPage] = useState(1);
   const pageSize = 10;
-
-  // Sort State
-  const [sortConfig, setSortConfig] = useState<{ key: keyof CommunityMember | null; direction: 'asc' | 'desc' }>({ 
-    key: null, 
-    direction: 'asc' 
+  const [sortConfig, setSortConfig] = useState<{ key: keyof Member | null; direction: "asc" | "desc" }>({
+    key: null,
+    direction: "asc",
   });
-  
-  // Sections State
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({
     form: false,
     guidelines: false,
@@ -282,101 +230,116 @@ export function SpaceSettingsCommunity() {
   });
 
   const toggleSection = (section: string) => {
-    setOpenSections(prev => ({ ...prev, [section]: !prev[section] }));
+    setOpenSections((prev) => ({ ...prev, [section]: !prev[section] }));
   };
 
-  const handleSort = (key: keyof CommunityMember) => {
-    setSortConfig(current => ({
+  const handleSort = (key: keyof Member) => {
+    setSortConfig((current) => ({
       key,
-      direction: current.key === key && current.direction === 'asc' ? 'desc' : 'asc',
+      direction: current.key === key && current.direction === "asc" ? "desc" : "asc",
     }));
   };
 
-  // Filter & Sort Logic
-  const filteredMembers = members.filter(member => {
-    const matchesSearch = member.name.toLowerCase().includes(searchQuery.toLowerCase()) || 
-                          member.email.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesFilter = filter === 'All' || member.status === filter;
-    return matchesSearch && matchesFilter;
-  }).sort((a, b) => {
-    // If a custom sort is active
-    if (sortConfig.key) {
-      const aValue = a[sortConfig.key];
-      const bValue = b[sortConfig.key];
-
-      if (aValue === null && bValue === null) return 0;
-      if (aValue === null) return 1;
-      if (bValue === null) return -1;
-
-      if (aValue! < bValue!) {
-        return sortConfig.direction === 'asc' ? -1 : 1;
+  const filteredMembers = members
+    .filter((m) => {
+      const matchSearch =
+        m.name.toLowerCase().includes(search.toLowerCase()) ||
+        m.email.toLowerCase().includes(search.toLowerCase());
+      const matchFilter = filter === "All" || m.status === filter;
+      return matchSearch && matchFilter;
+    })
+    .sort((a, b) => {
+      if (sortConfig.key) {
+        const aValue = a[sortConfig.key];
+        const bValue = b[sortConfig.key];
+        if (aValue === null && bValue === null) return 0;
+        if (aValue === null) return 1;
+        if (bValue === null) return -1;
+        if (aValue! < bValue!) return sortConfig.direction === "asc" ? -1 : 1;
+        if (aValue! > bValue!) return sortConfig.direction === "asc" ? 1 : -1;
+        return 0;
       }
-      if (aValue! > bValue!) {
-        return sortConfig.direction === 'asc' ? 1 : -1;
-      }
+      // Default: Pending > Invited > Active
+      if (a.status === b.status) return 0;
+      if (a.status === "Pending") return -1;
+      if (b.status === "Pending") return 1;
+      if (a.status === "Invited") return -1;
+      if (b.status === "Invited") return 1;
       return 0;
-    }
-
-    // Default Priority Sort: Pending > Invited > Others
-    if (a.status === b.status) return 0;
-    if (a.status === 'Pending') return -1;
-    if (b.status === 'Pending') return 1;
-    if (a.status === 'Invited') return -1;
-    if (b.status === 'Invited') return 1;
-    return 0;
-  });
+    });
 
   const totalPages = Math.ceil(filteredMembers.length / pageSize);
   const paginatedMembers = filteredMembers.slice((page - 1) * pageSize, page * pageSize);
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(e.target.value);
-    setPage(1); // Reset to first page on search
+    setSearch(e.target.value);
+    setPage(1);
   };
 
-  const handleFilterChange = (newFilter: 'All' | 'Active' | 'Pending' | 'Invited') => {
+  const handleFilterChange = (newFilter: typeof filter) => {
     setFilter(newFilter);
-    setPage(1); // Reset to first page on filter change
+    setPage(1);
   };
 
   const handleRemove = (id: string) => {
-    setMembers(members.filter(m => m.id !== id));
+    setMembers(members.filter((m) => m.id !== id));
   };
 
   return (
     <div className="space-y-8 animate-in fade-in duration-500">
-      
-      {/* 1. Header */}
+      {/* Header */}
       <div>
         <h2 className="text-2xl font-bold tracking-tight">Community</h2>
         <p className="text-muted-foreground mt-2">
-          Manage your space members, review applications, and configure community settings.
+          Manage your subspace members, review applications, and configure community settings.
         </p>
       </div>
 
       <Separator />
 
-      {/* 2. Members Management Table */}
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        {[
+          { label: "Total Members", value: members.filter((m) => m.status === "Active").length, icon: Users },
+          { label: "Leads", value: members.filter((m) => m.role === "Lead").length, icon: Shield },
+          { label: "Pending", value: members.filter((m) => m.status === "Pending").length, icon: Clock },
+          { label: "Invited", value: members.filter((m) => m.status === "Invited").length, icon: Mail },
+        ].map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-lg p-4 space-y-1"
+            style={{ background: "var(--muted)", border: "1px solid var(--border)" }}
+          >
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <stat.icon className="w-4 h-4" />
+              <span className="text-xs font-medium">{stat.label}</span>
+            </div>
+            <p className="text-2xl font-bold">{stat.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Members Table Section */}
       <div className="space-y-4">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <h3 className="text-lg font-semibold flex items-center gap-2">
-            Space Members
+            Subspace Members
             <Badge variant="secondary" className="rounded-full px-2 py-0.5 ml-2">
               {filteredMembers.length}
             </Badge>
           </h3>
-          
+
           <div className="flex items-center gap-2 flex-wrap">
-             <div className="relative">
+            <div className="relative">
               <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-              <Input 
-                 placeholder="Search members..." 
-                 className="pl-9 h-9 w-[200px]" 
-                 value={searchQuery}
-                 onChange={handleSearchChange}
+              <Input
+                placeholder="Search members..."
+                className="pl-9 h-9 w-[200px]"
+                value={search}
+                onChange={handleSearchChange}
               />
             </div>
-            
+
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="outline" size="sm" className="h-9 gap-2">
@@ -385,24 +348,24 @@ export function SpaceSettingsCommunity() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => handleFilterChange('All')}>
+                <DropdownMenuItem onClick={() => handleFilterChange("All")}>
                   All Members
-                  {filter === 'All' && <Check className="w-4 h-4 ml-auto" />}
+                  {filter === "All" && <Check className="w-4 h-4 ml-auto" />}
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => handleFilterChange('Active')}>
+                <DropdownMenuItem onClick={() => handleFilterChange("Active")}>
                   Active Only
-                  {filter === 'Active' && <Check className="w-4 h-4 ml-auto" />}
+                  {filter === "Active" && <Check className="w-4 h-4 ml-auto" />}
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => handleFilterChange('Pending')}>
+                <DropdownMenuItem onClick={() => handleFilterChange("Pending")}>
                   Pending
-                  {filter === 'Pending' && <Check className="w-4 h-4 ml-auto" />}
+                  {filter === "Pending" && <Check className="w-4 h-4 ml-auto" />}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
 
             <Button size="sm" className="h-9 gap-2">
-               <UserPlus className="w-4 h-4" />
-               Invite
+              <UserPlus className="w-4 h-4" />
+              Invite
             </Button>
           </div>
         </div>
@@ -412,56 +375,56 @@ export function SpaceSettingsCommunity() {
             <TableHeader>
               <TableRow>
                 <TableHead className="w-[300px]">
-                  <Button 
-                    variant="ghost" 
+                  <Button
+                    variant="ghost"
                     className="p-0 hover:bg-transparent font-medium text-muted-foreground h-auto"
-                    onClick={() => handleSort('name')}
+                    onClick={() => handleSort("name")}
                   >
                     Name
-                    {sortConfig.key === 'name' ? (
-                      sortConfig.direction === 'asc' ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />
+                    {sortConfig.key === "name" ? (
+                      sortConfig.direction === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />
                     ) : (
                       <ArrowUpDown className="ml-2 h-4 w-4 opacity-50" />
                     )}
                   </Button>
                 </TableHead>
                 <TableHead>
-                  <Button 
-                    variant="ghost" 
+                  <Button
+                    variant="ghost"
                     className="p-0 hover:bg-transparent font-medium text-muted-foreground h-auto"
-                    onClick={() => handleSort('role')}
+                    onClick={() => handleSort("role")}
                   >
                     Role
-                    {sortConfig.key === 'role' ? (
-                      sortConfig.direction === 'asc' ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />
+                    {sortConfig.key === "role" ? (
+                      sortConfig.direction === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />
                     ) : (
                       <ArrowUpDown className="ml-2 h-4 w-4 opacity-50" />
                     )}
                   </Button>
                 </TableHead>
                 <TableHead>
-                  <Button 
-                    variant="ghost" 
+                  <Button
+                    variant="ghost"
                     className="p-0 hover:bg-transparent font-medium text-muted-foreground h-auto"
-                    onClick={() => handleSort('date')}
+                    onClick={() => handleSort("date")}
                   >
                     Joined
-                    {sortConfig.key === 'date' ? (
-                      sortConfig.direction === 'asc' ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />
+                    {sortConfig.key === "date" ? (
+                      sortConfig.direction === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />
                     ) : (
                       <ArrowUpDown className="ml-2 h-4 w-4 opacity-50" />
                     )}
                   </Button>
                 </TableHead>
                 <TableHead>
-                  <Button 
-                    variant="ghost" 
+                  <Button
+                    variant="ghost"
                     className="p-0 hover:bg-transparent font-medium text-muted-foreground h-auto"
-                    onClick={() => handleSort('status')}
+                    onClick={() => handleSort("status")}
                   >
                     Status
-                    {sortConfig.key === 'status' ? (
-                      sortConfig.direction === 'asc' ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />
+                    {sortConfig.key === "status" ? (
+                      sortConfig.direction === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />
                     ) : (
                       <ArrowUpDown className="ml-2 h-4 w-4 opacity-50" />
                     )}
@@ -477,7 +440,12 @@ export function SpaceSettingsCommunity() {
                     <div className="flex flex-col items-center justify-center text-muted-foreground">
                       <Users className="w-8 h-8 mb-2 opacity-20" />
                       <p>No members found matching your criteria.</p>
-                      <Button variant="link" size="sm" className="mt-1" onClick={() => {setFilter('All'); setSearchQuery('');}}>
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="mt-1"
+                        onClick={() => { setFilter("All"); setSearch(""); }}
+                      >
                         Clear filters
                       </Button>
                     </div>
@@ -489,8 +457,8 @@ export function SpaceSettingsCommunity() {
                     <TableCell>
                       <div className="flex items-center gap-3">
                         <Avatar className="w-8 h-8 border border-border">
-                           {member.avatar && <AvatarImage src={member.avatar} />}
-                           <AvatarFallback className="text-xs">{member.initials}</AvatarFallback>
+                          {member.avatar && <AvatarImage src={member.avatar} />}
+                          <AvatarFallback className="text-xs">{member.initials}</AvatarFallback>
                         </Avatar>
                         <div>
                           <div className="font-medium text-sm">{member.name}</div>
@@ -499,9 +467,7 @@ export function SpaceSettingsCommunity() {
                       </div>
                     </TableCell>
                     <TableCell>
-                      <span className="font-medium text-sm text-foreground">
-                        {member.role}
-                      </span>
+                      <span className="font-medium text-sm text-foreground">{member.role}</span>
                     </TableCell>
                     <TableCell className="text-muted-foreground text-sm">
                       {new Date(member.date).toLocaleDateString()}
@@ -511,19 +477,19 @@ export function SpaceSettingsCommunity() {
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex items-center justify-end gap-2">
-                        {member.status === 'Pending' && (
+                        {member.status === "Pending" && (
                           <>
-                            <Button 
-                              size="sm" 
-                              variant="outline" 
+                            <Button
+                              size="sm"
+                              variant="outline"
                               className="h-8 w-8 p-0 text-primary border-primary/20 hover:bg-primary/10 hover:text-primary hover:border-primary/30"
                               title="Approve Request"
                             >
                               <Check className="h-4 w-4" />
                             </Button>
-                            <Button 
-                              size="sm" 
-                              variant="outline" 
+                            <Button
+                              size="sm"
+                              variant="outline"
                               className="h-8 w-8 p-0 text-destructive border-destructive/20 hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30"
                               title="Reject Request"
                             >
@@ -540,23 +506,23 @@ export function SpaceSettingsCommunity() {
                           <DropdownMenuContent align="end">
                             <DropdownMenuItem>View Profile</DropdownMenuItem>
                             <DropdownMenuItem>Change Role</DropdownMenuItem>
-                            {member.status === 'Pending' && (
-                               <>
+                            {member.status === "Pending" && (
+                              <>
                                 <DropdownMenuSeparator />
                                 <DropdownMenuItem className="text-success font-medium">Approve Request</DropdownMenuItem>
                                 <DropdownMenuItem className="text-destructive">Reject Request</DropdownMenuItem>
-                               </>
+                              </>
                             )}
-                            {member.status === 'Invited' && (
-                               <>
+                            {member.status === "Invited" && (
+                              <>
                                 <DropdownMenuSeparator />
                                 <DropdownMenuItem>Resend Invitation</DropdownMenuItem>
                                 <DropdownMenuItem className="text-destructive">Revoke Invitation</DropdownMenuItem>
-                               </>
+                              </>
                             )}
                             <DropdownMenuSeparator />
                             <DropdownMenuItem className="text-destructive" onClick={() => handleRemove(member.id)}>
-                              Remove from Space
+                              Remove from Subspace
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>
@@ -569,21 +535,19 @@ export function SpaceSettingsCommunity() {
           </Table>
         </div>
 
-        {/* Pagination Controls */}
+        {/* Pagination */}
         {filteredMembers.length > pageSize && (
           <div className="flex items-center justify-between py-2">
             <div className="text-sm text-muted-foreground">
               Showing <span className="font-medium">{(page - 1) * pageSize + 1}</span> to{" "}
-              <span className="font-medium">
-                {Math.min(page * pageSize, filteredMembers.length)}
-              </span>{" "}
+              <span className="font-medium">{Math.min(page * pageSize, filteredMembers.length)}</span>{" "}
               of <span className="font-medium">{filteredMembers.length}</span> members
             </div>
             <div className="flex items-center space-x-2">
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => setPage(p => Math.max(1, p - 1))}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page === 1}
                 className="h-8 w-8 p-0"
               >
@@ -595,7 +559,7 @@ export function SpaceSettingsCommunity() {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page === totalPages}
                 className="h-8 w-8 p-0"
               >
@@ -608,108 +572,96 @@ export function SpaceSettingsCommunity() {
 
       <Separator />
 
-      {/* 3. Application Form */}
-      <Collapsible 
-        open={openSections.form} 
-        onOpenChange={() => toggleSection('form')}
+      {/* Application Form */}
+      <Collapsible
+        open={openSections.form}
+        onOpenChange={() => toggleSection("form")}
         className="bg-card border rounded-lg p-6"
       >
         <CollapsibleTrigger asChild>
           <div>
-            <SectionHeader 
-              icon={FileText} 
-              title="Application Form" 
-              description="Customize the questions users must answer when applying to join this space."
+            <SectionHeader
+              icon={FileText}
+              title="Application Form"
+              description="Customize the questions users must answer when applying to join this subspace."
               isOpen={openSections.form}
-              onToggle={() => toggleSection('form')}
+              onToggle={() => toggleSection("form")}
             />
           </div>
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-6 pl-[52px]">
           <div className="bg-muted/30 rounded-lg p-4 border border-border space-y-3">
-             <div className="flex items-center justify-between p-3 bg-background border rounded-md">
-                <div className="flex items-center gap-3">
-                   <div className="bg-primary/10 p-2 rounded text-primary">
-                      <span className="font-bold text-xs">Q1</span>
-                   </div>
-                   <span className="text-sm font-medium">Why do you want to join this space?</span>
+            <div className="flex items-center justify-between p-3 bg-background border rounded-md">
+              <div className="flex items-center gap-3">
+                <div className="bg-primary/10 p-2 rounded text-primary">
+                  <span className="font-bold text-xs">Q1</span>
                 </div>
-                <Badge variant="secondary">Required</Badge>
-             </div>
-             <div className="flex items-center justify-between p-3 bg-background border rounded-md">
-                <div className="flex items-center gap-3">
-                   <div className="bg-primary/10 p-2 rounded text-primary">
-                      <span className="font-bold text-xs">Q2</span>
-                   </div>
-                   <span className="text-sm font-medium">Link to your portfolio or LinkedIn profile</span>
-                </div>
-                <Badge variant="outline">Optional</Badge>
-             </div>
+                <span className="text-sm font-medium">Why do you want to join this subspace?</span>
+              </div>
+              <Badge variant="secondary">Required</Badge>
+            </div>
           </div>
           <div className="mt-4">
-             <Button variant="outline" size="sm" className="gap-2">
-                <ExternalLink className="w-4 h-4" />
-                Edit Application Form
-             </Button>
-             <p className="text-xs text-muted-foreground mt-2">
-               This form is shown to users when they apply to join.
-             </p>
+            <Button variant="outline" size="sm">Edit Application Form</Button>
+            <p className="text-xs text-muted-foreground mt-2">
+              This form is shown to users when they apply to join.
+            </p>
           </div>
         </CollapsibleContent>
       </Collapsible>
 
-      {/* 4. Community Guidelines */}
-      <Collapsible 
-        open={openSections.guidelines} 
-        onOpenChange={() => toggleSection('guidelines')}
+      {/* Community Guidelines */}
+      <Collapsible
+        open={openSections.guidelines}
+        onOpenChange={() => toggleSection("guidelines")}
         className="bg-card border rounded-lg p-6"
       >
         <CollapsibleTrigger asChild>
-           <div>
-            <SectionHeader 
-              icon={Shield} 
-              title="Community Guidelines" 
+          <div>
+            <SectionHeader
+              icon={Shield}
+              title="Community Guidelines"
               description="Establish rules and expectations for member behavior."
               isOpen={openSections.guidelines}
-              onToggle={() => toggleSection('guidelines')}
+              onToggle={() => toggleSection("guidelines")}
             />
-           </div>
+          </div>
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-6 pl-[52px]">
           <div className="bg-muted/30 rounded-lg p-4 border border-border">
-             <p className="text-sm text-muted-foreground italic">
-                "Be respectful, share openly, and contribute constructively..."
-             </p>
+            <p className="text-sm text-muted-foreground italic">
+              "Be respectful, share openly, and contribute constructively..."
+            </p>
           </div>
           <div className="mt-4">
-             <Button variant="outline" size="sm">Edit Guidelines</Button>
-             <p className="text-xs text-muted-foreground mt-2">
-               Displayed to new members upon joining.
-             </p>
+            <Button variant="outline" size="sm">Edit Guidelines</Button>
+            <p className="text-xs text-muted-foreground mt-2">
+              Displayed to new members upon joining.
+            </p>
           </div>
         </CollapsibleContent>
       </Collapsible>
 
-      {/* 5. Member Organizations */}
-      <Collapsible 
-        open={openSections.orgs} 
-        onOpenChange={() => toggleSection('orgs')}
+      {/* Member Organizations */}
+      <Collapsible
+        open={openSections.orgs}
+        onOpenChange={() => toggleSection("orgs")}
         className="bg-card border rounded-lg p-6"
       >
         <CollapsibleTrigger asChild>
-           <div>
-            <SectionHeader 
-              icon={Building} 
-              title="Member Organizations" 
+          <div>
+            <SectionHeader
+              icon={Building}
+              title="Member Organizations"
               description="Allow members from specific organizations to join automatically."
               isOpen={openSections.orgs}
-              onToggle={() => toggleSection('orgs')}
+              onToggle={() => toggleSection("orgs")}
             />
-           </div>
+          </div>
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-6 pl-[52px]">
           <div className="space-y-3">
-            {MOCK_ORGS.map(org => (
+            {MOCK_ORGS.map((org) => (
               <div key={org.id} className="flex items-center justify-between p-3 bg-background border rounded-md">
                 <div className="flex items-center gap-3">
                   <div className="w-10 h-10 bg-muted rounded-md flex items-center justify-center font-bold text-muted-foreground">
@@ -717,75 +669,83 @@ export function SpaceSettingsCommunity() {
                   </div>
                   <div>
                     <div className="font-medium text-sm">{org.name}</div>
-                    <div className="text-xs text-muted-foreground">{org.memberCount} members in space</div>
+                    <div className="text-xs text-muted-foreground">{org.memberCount} members in subspace</div>
                   </div>
                 </div>
                 <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-destructive">
-                   <X className="w-4 h-4" />
+                  <X className="w-4 h-4" />
                 </Button>
               </div>
             ))}
           </div>
           <div className="mt-4">
-             <Button variant="outline" size="sm" className="gap-2">
-                <Plus className="w-4 h-4" /> Add Organization
-             </Button>
-             <p className="text-xs text-muted-foreground mt-2">
-               Users from these organizations can join without admin approval.
-             </p>
+            <Button variant="outline" size="sm" className="gap-2">
+              <Plus className="w-4 h-4" /> Add Organization
+            </Button>
+            <p className="text-xs text-muted-foreground mt-2">
+              Users from these organizations can join without admin approval.
+            </p>
           </div>
         </CollapsibleContent>
       </Collapsible>
 
-      {/* 6. Virtual Contributors */}
-      <Collapsible 
-        open={openSections.vcs} 
-        onOpenChange={() => toggleSection('vcs')}
+      {/* Virtual Contributors */}
+      <Collapsible
+        open={openSections.vcs}
+        onOpenChange={() => toggleSection("vcs")}
         className="bg-card border rounded-lg p-6"
       >
         <CollapsibleTrigger asChild>
-           <div>
-            <SectionHeader 
-              icon={Bot} 
-              title="Virtual Contributors" 
-              description="Manage AI agents and bots participating in this space."
+          <div>
+            <SectionHeader
+              icon={Bot}
+              title="Virtual Contributors"
+              description="Manage AI agents and bots participating in this subspace."
               isOpen={openSections.vcs}
-              onToggle={() => toggleSection('vcs')}
+              onToggle={() => toggleSection("vcs")}
             />
-           </div>
+          </div>
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-6 pl-[52px]">
           <div className="space-y-3">
-            {MOCK_VCS.map(vc => (
+            {MOCK_VCS.map((vc) => (
               <div key={vc.id} className="flex items-center justify-between p-3 bg-background border rounded-md">
                 <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-md flex items-center justify-center" style={{ background: 'color-mix(in srgb, var(--primary) 10%, transparent)', color: 'var(--primary)' }}>
+                  <div
+                    className="w-10 h-10 rounded-md flex items-center justify-center"
+                    style={{
+                      background: "color-mix(in srgb, var(--primary) 10%, transparent)",
+                      color: "var(--primary)",
+                    }}
+                  >
                     <Bot className="w-5 h-5" />
                   </div>
                   <div>
                     <div className="font-medium text-sm">{vc.name}</div>
                     <div className="flex items-center gap-2 mt-0.5">
-                       <span className={cn(
-                         "w-1.5 h-1.5 rounded-full",
-                         vc.status === 'Active' ? "bg-primary" : "bg-muted-foreground/30"
-                       )} />
-                       <span className="text-xs text-muted-foreground">{vc.status}</span>
+                      <span
+                        className={cn(
+                          "w-1.5 h-1.5 rounded-full",
+                          vc.status === "Active" ? "bg-primary" : "bg-muted-foreground/30"
+                        )}
+                      />
+                      <span className="text-xs text-muted-foreground">{vc.status}</span>
                     </div>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                   <Button variant="ghost" size="sm">Edit</Button>
-                   <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-destructive">
-                      <Trash2 className="w-4 h-4" />
-                   </Button>
+                  <Button variant="ghost" size="sm">Edit</Button>
+                  <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-destructive">
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
                 </div>
               </div>
             ))}
           </div>
           <div className="mt-4">
-             <Button variant="outline" size="sm" className="gap-2">
-                <Plus className="w-4 h-4" /> Add Virtual Contributor
-             </Button>
+            <Button variant="outline" size="sm" className="gap-2">
+              <Plus className="w-4 h-4" /> Add Virtual Contributor
+            </Button>
           </div>
         </CollapsibleContent>
       </Collapsible>

--- a/prototype/src/app/components/space/SubspaceSettingsLayout.tsx
+++ b/prototype/src/app/components/space/SubspaceSettingsLayout.tsx
@@ -1,0 +1,1096 @@
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import { DndProvider, useDrag, useDrop } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { motion, AnimatePresence } from "motion/react";
+import {
+  GripVertical,
+  Pencil,
+  RotateCcw,
+  Save,
+  Check,
+  Loader2,
+  Undo2,
+  Plus,
+  Trash2,
+
+  ChevronDown,
+  ChevronsRight,
+  MoreHorizontal,
+  ArrowRight,
+  Eye,
+  XCircle,
+  Download,
+  Upload,
+  FileText,
+} from "lucide-react";
+import { Button } from "@/app/components/ui/button";
+import { Input } from "@/app/components/ui/input";
+import { Badge } from "@/app/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@/app/components/ui/collapsible";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuSeparator,
+} from "@/app/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/app/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+interface PhaseItem {
+  id: string;
+  label: string;
+  description: string;
+  linkedToNext: boolean; // arrow → to the next phase
+}
+
+interface PostEntry {
+  id: string;
+  title: string;
+  responses?: number;
+}
+
+type PhasePosts = Record<string, PostEntry[]>;
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+const DEFAULT_PHASES: PhaseItem[] = [
+  {
+    id: "explore",
+    label: "Explore",
+    description: "Diverge — gather ideas, research, and inspiration.",
+    linkedToNext: true,
+  },
+  {
+    id: "define",
+    label: "Define",
+    description: "Converge — synthesise insights into a clear problem statement.",
+    linkedToNext: true,
+  },
+  {
+    id: "ideate",
+    label: "Ideate",
+    description: "Diverge — brainstorm and generate creative solutions.",
+    linkedToNext: true,
+  },
+  {
+    id: "prototype",
+    label: "Prototype",
+    description: "Converge — build and test low-fidelity prototypes.",
+    linkedToNext: false,
+  },
+];
+
+const DEFAULT_POSTS: PhasePosts = {
+  explore: [
+    { id: "p-e1", title: "Research: Stakeholder Interviews", responses: 3 },
+    { id: "p-e2", title: "Desk Research Summary" },
+  ],
+  define: [
+    { id: "p-d1", title: "Problem Statement v1", responses: 5 },
+  ],
+  ideate: [
+    { id: "p-i1", title: "Brainstorm: Solar Integration" },
+    { id: "p-i2", title: "Concept Map: Grid Modernisation", responses: 2 },
+  ],
+  prototype: [],
+};
+
+// Innovation flow templates
+interface FlowTemplate {
+  id: string;
+  name: string;
+  description: string;
+  phases: Omit<PhaseItem, "id">[];
+}
+
+const FLOW_TEMPLATES: FlowTemplate[] = [
+  {
+    id: "double-diamond",
+    name: "Double Diamond",
+    description: "Discover → Define → Develop → Deliver",
+    phases: [
+      { label: "Discover", description: "Research and explore the problem space.", linkedToNext: true },
+      { label: "Define", description: "Narrow down to a clear problem definition.", linkedToNext: true },
+      { label: "Develop", description: "Co-create and iterate on possible solutions.", linkedToNext: true },
+      { label: "Deliver", description: "Finalise and implement the solution.", linkedToNext: false },
+    ],
+  },
+  {
+    id: "design-thinking",
+    name: "Design Thinking (Stanford d.school)",
+    description: "Empathize → Define → Ideate → Prototype → Test",
+    phases: [
+      { label: "Empathize", description: "Understand users through observation and engagement.", linkedToNext: true },
+      { label: "Define", description: "Frame the core problem to solve.", linkedToNext: true },
+      { label: "Ideate", description: "Brainstorm a broad set of solutions.", linkedToNext: true },
+      { label: "Prototype", description: "Build quick, low-cost prototypes.", linkedToNext: true },
+      { label: "Test", description: "Gather feedback and refine.", linkedToNext: false },
+    ],
+  },
+  {
+    id: "lean-startup",
+    name: "Lean Startup",
+    description: "Build → Measure → Learn",
+    phases: [
+      { label: "Build", description: "Create a minimum viable product (MVP).", linkedToNext: true },
+      { label: "Measure", description: "Collect data on how users interact.", linkedToNext: true },
+      { label: "Learn", description: "Analyse results and decide on next steps.", linkedToNext: false },
+    ],
+  },
+  {
+    id: "challenge-driven",
+    name: "Challenge-Driven Innovation",
+    description: "Challenge → Knowledge → Propose → Pilot → Scale",
+    phases: [
+      { label: "Challenge", description: "Frame the challenge statement.", linkedToNext: true },
+      { label: "Knowledge", description: "Gather relevant knowledge and research.", linkedToNext: true },
+      { label: "Propose", description: "Generate and evaluate proposals.", linkedToNext: true },
+      { label: "Pilot", description: "Run small-scale pilots.", linkedToNext: true },
+      { label: "Scale", description: "Expand successful pilots.", linkedToNext: false },
+    ],
+  },
+];
+
+// ─── DnD Item Types ───────────────────────────────────────────────────────────
+const POST_CARD = "SUBSPACE_POST_CARD";
+const PHASE_COLUMN = "PHASE_COLUMN";
+
+interface PostDragItem {
+  id: string;
+  index: number;
+  sourcePhaseId: string;
+}
+
+interface ColumnDragItem {
+  id: string;
+  index: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Post Card (draggable)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface PostCardProps {
+  post: PostEntry;
+  index: number;
+  phaseId: string;
+  allPhases: PhaseItem[];
+  movePostInPhase: (phaseId: string, dragIdx: number, hoverIdx: number) => void;
+  movePostBetweenPhases: (
+    sourcePhaseId: string,
+    dragIdx: number,
+    targetPhaseId: string,
+    targetIdx: number
+  ) => void;
+  onRemove: (postId: string, phaseId: string) => void;
+  onMoveToPhase: (postId: string, fromPhase: string, toPhase: string) => void;
+}
+
+const PhasePostCard = ({
+  post,
+  index,
+  phaseId,
+  allPhases,
+  movePostInPhase,
+  movePostBetweenPhases,
+  onRemove,
+  onMoveToPhase,
+}: PostCardProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const [{ handlerId }, drop] = useDrop<
+    PostDragItem,
+    void,
+    { handlerId: string | symbol | null }
+  >({
+    accept: POST_CARD,
+    collect: (monitor) => ({ handlerId: monitor.getHandlerId() }),
+    hover(item, monitor) {
+      if (!ref.current) return;
+      const dragIndex = item.index;
+      const hoverIndex = index;
+      if (item.sourcePhaseId === phaseId && dragIndex === hoverIndex) return;
+      const rect = ref.current.getBoundingClientRect();
+      const midY = (rect.bottom - rect.top) / 2;
+      const clientOffset = monitor.getClientOffset();
+      if (!clientOffset) return;
+      const hoverY = clientOffset.y - rect.top;
+      if (item.sourcePhaseId === phaseId) {
+        if (dragIndex < hoverIndex && hoverY < midY) return;
+        if (dragIndex > hoverIndex && hoverY > midY) return;
+        movePostInPhase(phaseId, dragIndex, hoverIndex);
+        item.index = hoverIndex;
+        return;
+      }
+      movePostBetweenPhases(item.sourcePhaseId, dragIndex, phaseId, hoverIndex);
+      item.sourcePhaseId = phaseId;
+      item.index = hoverIndex;
+    },
+  });
+
+  const [{ isDragging }, drag] = useDrag({
+    type: POST_CARD,
+    item: (): PostDragItem => ({ id: post.id, index, sourcePhaseId: phaseId }),
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  });
+
+  drag(drop(ref));
+
+  const otherPhases = allPhases.filter((p) => p.id !== phaseId);
+
+  return (
+    <motion.div
+      ref={ref}
+      data-handler-id={handlerId}
+      layout
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95, height: 0 }}
+      transition={{ duration: 0.15 }}
+      className={cn(
+        "flex items-center gap-2 px-2.5 py-2 bg-background border border-border rounded-lg",
+        "cursor-grab active:cursor-grabbing group/post",
+        "hover:border-primary/30 transition-all",
+        isDragging && "opacity-30 border-dashed"
+      )}
+    >
+      <GripVertical className="w-3.5 h-3.5 text-muted-foreground/30 group-hover/post:text-muted-foreground/60 shrink-0" />
+      <span className="flex-1 min-w-0 text-xs font-medium leading-snug line-clamp-2 text-foreground">
+        {post.title}
+      </span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="w-6 h-6 shrink-0 opacity-0 group-hover/post:opacity-100 transition-opacity"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <MoreHorizontal className="w-3.5 h-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <ArrowRight className="w-4 h-4 mr-2" />
+              Move to
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {otherPhases.map((p) => (
+                <DropdownMenuItem
+                  key={p.id}
+                  onClick={() => onMoveToPhase(post.id, phaseId, p.id)}
+                >
+                  {p.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuItem>
+            <Eye className="w-4 h-4 mr-2" />
+            View Post
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => onRemove(post.id, phaseId)}
+          >
+            <XCircle className="w-4 h-4 mr-2" />
+            Remove from Phase
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </motion.div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Phase Column (collapsible, drop target, editable)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface PhaseColumnProps {
+  phase: PhaseItem;
+  phaseIndex: number;
+  posts: PostEntry[];
+  allPhases: PhaseItem[];
+  isOpen: boolean;
+  onToggle: () => void;
+  onAutoExpand: () => void;
+  movePostInPhase: (phaseId: string, dragIdx: number, hoverIdx: number) => void;
+  movePostBetweenPhases: (
+    sourcePhaseId: string,
+    dragIdx: number,
+    targetPhaseId: string,
+    targetIdx: number
+  ) => void;
+  onRemove: (postId: string, phaseId: string) => void;
+  onMoveToPhase: (postId: string, fromPhase: string, toPhase: string) => void;
+  onRename: (id: string, newName: string) => void;
+  onDescriptionChange: (id: string, newDescription: string) => void;
+  onDeletePhase: (id: string) => void;
+  isEditing: boolean;
+  setEditingId: (id: string | null) => void;
+  isLast: boolean;
+}
+
+const PhaseColumn = ({
+  phase,
+  phaseIndex,
+  posts,
+  allPhases,
+  isOpen,
+  onToggle,
+  onAutoExpand,
+  movePostInPhase,
+  movePostBetweenPhases,
+  onRemove,
+  onMoveToPhase,
+  onRename,
+  onDescriptionChange,
+  onDeletePhase,
+  isEditing,
+  setEditingId,
+  isLast,
+}: PhaseColumnProps) => {
+  const autoExpandTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const descInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) inputRef.current.focus();
+  }, [isEditing]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === "Escape") setEditingId(null);
+  };
+
+  const [{ isOverColumn, canDropHere }, dropRef] = useDrop<
+    PostDragItem,
+    void,
+    { isOverColumn: boolean; canDropHere: boolean }
+  >({
+    accept: POST_CARD,
+    collect: (monitor) => ({
+      isOverColumn: monitor.isOver({ shallow: true }),
+      canDropHere: monitor.canDrop(),
+    }),
+    hover(item) {
+      if (!isOpen && autoExpandTimer.current === null) {
+        autoExpandTimer.current = setTimeout(() => {
+          onAutoExpand();
+          autoExpandTimer.current = null;
+        }, 500);
+      }
+      if (item.sourcePhaseId !== phase.id && posts.length === 0) {
+        movePostBetweenPhases(item.sourcePhaseId, item.index, phase.id, 0);
+        item.sourcePhaseId = phase.id;
+        item.index = 0;
+      }
+    },
+    drop(item) {
+      if (item.sourcePhaseId !== phase.id) {
+        movePostBetweenPhases(
+          item.sourcePhaseId,
+          item.index,
+          phase.id,
+          posts.length
+        );
+        item.sourcePhaseId = phase.id;
+        item.index = posts.length;
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (!isOverColumn && autoExpandTimer.current) {
+      clearTimeout(autoExpandTimer.current);
+      autoExpandTimer.current = null;
+    }
+  }, [isOverColumn]);
+
+  useEffect(() => {
+    return () => {
+      if (autoExpandTimer.current) clearTimeout(autoExpandTimer.current);
+    };
+  }, []);
+
+  return (
+      <Collapsible open={isOpen} onOpenChange={onToggle}>
+        <div
+          className={cn(
+            "border border-border rounded-xl bg-card overflow-hidden transition-all",
+            isOverColumn && canDropHere && "ring-2 ring-primary/30 ring-inset"
+          )}
+        >
+          <div className="px-3 py-3 bg-muted/30 space-y-2">
+            <div className="flex items-center gap-2">
+              {/* Phase number badge */}
+              <div className="w-6 h-6 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-bold shrink-0">
+                {phaseIndex + 1}
+              </div>
+
+              <div className="flex-1 min-w-0 flex items-center gap-1.5 group/header">
+                {isEditing ? (
+                  <Input
+                    ref={inputRef}
+                    value={phase.label}
+                    onChange={(e) => onRename(phase.id, e.target.value)}
+                    onBlur={() => setEditingId(null)}
+                    onKeyDown={handleKeyDown}
+                    className="h-6 py-0 px-1.5 text-sm font-semibold w-full max-w-[140px]"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                ) : (
+                  <span
+                    className="text-sm font-semibold text-foreground truncate cursor-pointer hover:underline decoration-dashed underline-offset-4"
+                    onClick={() => setEditingId(phase.id)}
+                  >
+                    {phase.label}
+                  </span>
+                )}
+                {!isEditing && (
+                  <button
+                    onClick={() => setEditingId(phase.id)}
+                    className="opacity-0 group-hover/header:opacity-100 transition-opacity text-muted-foreground hover:text-primary"
+                  >
+                    <Pencil className="w-3 h-3" />
+                  </button>
+                )}
+              </div>
+
+              <Badge variant="secondary" className="text-xs tabular-nums shrink-0">
+                {posts.length}
+              </Badge>
+
+              {/* Phase actions */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button className="p-0.5 rounded hover:bg-muted/50 transition-colors">
+                    <MoreHorizontal className="w-3.5 h-3.5 text-muted-foreground" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-48">
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => onDeletePhase(phase.id)}
+                  >
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Delete Phase
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <CollapsibleTrigger asChild>
+                <button className="p-0.5 rounded hover:bg-muted/50 transition-colors">
+                  <ChevronDown
+                    className={cn(
+                      "w-3.5 h-3.5 text-muted-foreground transition-transform duration-200",
+                      !isOpen && "-rotate-90"
+                    )}
+                  />
+                </button>
+              </CollapsibleTrigger>
+            </div>
+
+            {/* Description — editable */}
+            {isEditingDescription ? (
+              <Input
+                ref={descInputRef}
+                value={phase.description}
+                onChange={(e) => onDescriptionChange(phase.id, e.target.value)}
+                onBlur={() => setIsEditingDescription(false)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === "Escape") setIsEditingDescription(false);
+                }}
+                className="h-6 py-0 px-1.5 text-xs w-full"
+                onClick={(e) => e.stopPropagation()}
+              />
+            ) : (
+              <div className="group/desc flex items-start gap-1">
+                <p
+                  className="text-xs text-muted-foreground leading-relaxed line-clamp-2 cursor-pointer hover:underline decoration-dashed underline-offset-4"
+                  onClick={() => {
+                    setIsEditingDescription(true);
+                    setTimeout(() => descInputRef.current?.focus(), 0);
+                  }}
+                >
+                  {phase.description}
+                </p>
+                <button
+                  onClick={() => {
+                    setIsEditingDescription(true);
+                    setTimeout(() => descInputRef.current?.focus(), 0);
+                  }}
+                  className="opacity-0 group-hover/desc:opacity-100 transition-opacity text-muted-foreground hover:text-primary mt-0.5 shrink-0"
+                >
+                  <Pencil className="w-2.5 h-2.5" />
+                </button>
+              </div>
+            )}
+          </div>
+
+          <CollapsibleContent>
+            <div
+              ref={(node) => { dropRef(node); }}
+              className={cn(
+                "p-1.5 space-y-1.5 min-h-[60px] transition-colors",
+                isOverColumn && canDropHere && "bg-primary/5"
+              )}
+            >
+              {posts.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-4">
+                  <span className="text-xs text-muted-foreground/50">
+                    No posts assigned
+                  </span>
+                </div>
+              ) : (
+                <AnimatePresence initial={false}>
+                  {posts.map((post, idx) => (
+                    <PhasePostCard
+                      key={post.id}
+                      post={post}
+                      index={idx}
+                      phaseId={phase.id}
+                      allPhases={allPhases}
+                      movePostInPhase={movePostInPhase}
+                      movePostBetweenPhases={movePostBetweenPhases}
+                      onRemove={onRemove}
+                      onMoveToPhase={onMoveToPhase}
+                    />
+                  ))}
+                </AnimatePresence>
+              )}
+            </div>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Draggable Phase Wrapper (for reordering columns)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface DraggablePhaseWrapperProps {
+  phaseId: string;
+  index: number;
+  movePhase: (dragIndex: number, hoverIndex: number) => void;
+  children: React.ReactNode;
+}
+
+const DraggablePhaseWrapper = ({
+  phaseId,
+  index,
+  movePhase,
+  children,
+}: DraggablePhaseWrapperProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const [{ handlerId }, drop] = useDrop<
+    ColumnDragItem,
+    void,
+    { handlerId: string | symbol | null }
+  >({
+    accept: PHASE_COLUMN,
+    collect: (monitor) => ({ handlerId: monitor.getHandlerId() }),
+    hover(item, monitor) {
+      if (!ref.current) return;
+      const dragIndex = item.index;
+      const hoverIndex = index;
+      if (dragIndex === hoverIndex) return;
+      const rect = ref.current.getBoundingClientRect();
+      const midX = (rect.right - rect.left) / 2;
+      const clientOffset = monitor.getClientOffset();
+      if (!clientOffset) return;
+      const hoverX = clientOffset.x - rect.left;
+      if (dragIndex < hoverIndex && hoverX < midX) return;
+      if (dragIndex > hoverIndex && hoverX > midX) return;
+      movePhase(dragIndex, hoverIndex);
+      item.index = hoverIndex;
+    },
+  });
+
+  const [{ isDragging }, drag, preview] = useDrag({
+    type: PHASE_COLUMN,
+    item: (): ColumnDragItem => ({ id: phaseId, index }),
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  });
+
+  drop(ref);
+  preview(ref);
+  drag(ref);
+
+  return (
+    <div
+      ref={ref}
+      data-handler-id={handlerId}
+      className={cn("transition-opacity min-w-[220px]", isDragging && "opacity-40")}
+    >
+      {children}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Main Layout Component
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function SubspaceSettingsLayout() {
+  const [phases, setPhases] = useState<PhaseItem[]>(DEFAULT_PHASES);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSaved, setLastSaved] = useState<Date | null>(null);
+  const [phasePosts, setPhasePosts] = useState<PhasePosts>(DEFAULT_POSTS);
+  const [expandedCols, setExpandedCols] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    DEFAULT_PHASES.forEach((p) => {
+      initial[p.id] = (DEFAULT_POSTS[p.id]?.length ?? 0) > 0;
+    });
+    return initial;
+  });
+  const [showTemplates, setShowTemplates] = useState(false);
+  const [showSaveTemplate, setShowSaveTemplate] = useState(false);
+  const [templateName, setTemplateName] = useState("");
+
+  // ─── Change detection ──────────────────────────────────────────────────────
+  const hasChanges = useMemo(() => {
+    if (phases.length !== DEFAULT_PHASES.length) return true;
+    const phasesChanged = phases.some((phase, i) => {
+      const d = DEFAULT_PHASES[i];
+      return (
+        phase.id !== d.id ||
+        phase.label !== d.label ||
+        phase.description !== d.description ||
+        phase.linkedToNext !== d.linkedToNext
+      );
+    });
+    if (phasesChanged) return true;
+
+    for (const phaseId of Object.keys(DEFAULT_POSTS)) {
+      const cur = phasePosts[phaseId] ?? [];
+      const orig = DEFAULT_POSTS[phaseId] ?? [];
+      if (cur.length !== orig.length) return true;
+      if (cur.some((p, i) => p.id !== orig[i]?.id)) return true;
+    }
+    return false;
+  }, [phases, phasePosts]);
+
+  // ─── Phase reorder ─────────────────────────────────────────────────────────
+  const movePhase = useCallback(
+    (dragIndex: number, hoverIndex: number) => {
+      setPhases((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(dragIndex, 1);
+        next.splice(hoverIndex, 0, moved);
+        return next;
+      });
+    },
+    []
+  );
+
+  // ─── Post reorder within a phase ──────────────────────────────────────────
+  const movePostInPhase = useCallback(
+    (phaseId: string, dragIdx: number, hoverIdx: number) => {
+      setPhasePosts((prev) => {
+        const list = [...(prev[phaseId] || [])];
+        const [moved] = list.splice(dragIdx, 1);
+        list.splice(hoverIdx, 0, moved);
+        return { ...prev, [phaseId]: list };
+      });
+    },
+    []
+  );
+
+  // ─── Cross-phase move ─────────────────────────────────────────────────────
+  const movePostBetweenPhases = useCallback(
+    (sourceId: string, dragIdx: number, targetId: string, targetIdx: number) => {
+      setPhasePosts((prev) => {
+        const source = [...(prev[sourceId] || [])];
+        const target = sourceId === targetId ? source : [...(prev[targetId] || [])];
+        const [moved] = source.splice(dragIdx, 1);
+        if (sourceId === targetId) {
+          source.splice(targetIdx, 0, moved);
+          return { ...prev, [sourceId]: source };
+        }
+        target.splice(targetIdx, 0, moved);
+        return { ...prev, [sourceId]: source, [targetId]: target };
+      });
+    },
+    []
+  );
+
+  // ─── Menu-based move ──────────────────────────────────────────────────────
+  const handleMoveToPhase = useCallback(
+    (postId: string, fromPhase: string, toPhase: string) => {
+      setPhasePosts((prev) => {
+        const source = [...(prev[fromPhase] || [])];
+        const idx = source.findIndex((p) => p.id === postId);
+        if (idx === -1) return prev;
+        const [moved] = source.splice(idx, 1);
+        return {
+          ...prev,
+          [fromPhase]: source,
+          [toPhase]: [...(prev[toPhase] || []), moved],
+        };
+      });
+      setExpandedCols((prev) => ({ ...prev, [toPhase]: true }));
+    },
+    []
+  );
+
+  // ─── Remove post ──────────────────────────────────────────────────────────
+  const handleRemovePost = useCallback(
+    (postId: string, phaseId: string) => {
+      setPhasePosts((prev) => ({
+        ...prev,
+        [phaseId]: (prev[phaseId] || []).filter((p) => p.id !== postId),
+      }));
+    },
+    []
+  );
+
+  // ─── Phase operations ─────────────────────────────────────────────────────
+  const handleRename = (id: string, newName: string) => {
+    if (newName.length > 30) return;
+    setPhases((prev) => prev.map((p) => (p.id === id ? { ...p, label: newName } : p)));
+  };
+
+  const handleDescriptionChange = (id: string, newDescription: string) => {
+    setPhases((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, description: newDescription } : p))
+    );
+  };
+
+
+
+  const handleDeletePhase = (id: string) => {
+    if (phases.length <= 1) return;
+    setPhases((prev) => prev.filter((p) => p.id !== id));
+    setPhasePosts((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  };
+
+  const handleAddPhase = () => {
+    const newId = `phase-${Date.now()}`;
+    // Set the previous last phase to link to this one
+    setPhases((prev) => {
+      const updated = prev.map((p, i) =>
+        i === prev.length - 1 ? { ...p, linkedToNext: true } : p
+      );
+      return [
+        ...updated,
+        {
+          id: newId,
+          label: "New Phase",
+          description: "Describe this phase's purpose.",
+          linkedToNext: false,
+        },
+      ];
+    });
+    setPhasePosts((prev) => ({ ...prev, [newId]: [] }));
+    setExpandedCols((prev) => ({ ...prev, [newId]: true }));
+    setEditingId(newId);
+  };
+
+  const handleLoadTemplate = (template: FlowTemplate) => {
+    const newPhases: PhaseItem[] = template.phases.map((p, i) => ({
+      ...p,
+      id: `${template.id}-${i}-${Date.now()}`,
+    }));
+    setPhases(newPhases);
+    const newPosts: PhasePosts = {};
+    newPhases.forEach((p) => {
+      newPosts[p.id] = [];
+    });
+    setPhasePosts(newPosts);
+    const newExpanded: Record<string, boolean> = {};
+    newPhases.forEach((p) => {
+      newExpanded[p.id] = true;
+    });
+    setExpandedCols(newExpanded);
+    setShowTemplates(false);
+  };
+
+  // ─── Save / Discard ─────────────────────────────────────────────────────────
+  const handleSave = () => {
+    setIsSaving(true);
+    setTimeout(() => {
+      setIsSaving(false);
+      setSavedPhases([...phases]);
+      setSavedPhasePosts({ ...phasePosts });
+      setLastSaved(new Date());
+    }, 1000);
+  };
+
+  const handleDiscard = () => {
+    setPhases([...savedPhases]);
+    setPhasePosts({ ...savedPhasePosts });
+    const newExpanded: Record<string, boolean> = {};
+    savedPhases.forEach((p) => {
+      newExpanded[p.id] = (savedPhasePosts[p.id]?.length ?? 0) > 0;
+    });
+    setExpandedCols(newExpanded);
+  };
+
+  // ─── Column toggle helpers ────────────────────────────────────────────────
+  const toggleColumn = useCallback((phaseId: string) => {
+    setExpandedCols((prev) => ({ ...prev, [phaseId]: !prev[phaseId] }));
+  }, []);
+
+  const autoExpandColumn = useCallback((phaseId: string) => {
+    setExpandedCols((prev) => ({ ...prev, [phaseId]: true }));
+  }, []);
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <div className="w-full h-full">
+        <div className="flex flex-col h-full">
+          {/* Header */}
+          <div className="mb-6">
+            <h2 className="text-2xl font-bold tracking-tight text-foreground">Innovation Flow</h2>
+            <p className="text-muted-foreground mt-2">
+              Design your subspace's innovation flow. Add, remove, and reorder phases. Drag posts between phases.
+            </p>
+          </div>
+
+          {/* Flow visualisation bar */}
+          <div className="mb-4 flex items-center gap-1.5 overflow-x-auto pb-2">
+            {phases.map((phase, i) => (
+              <div key={phase.id} className="flex items-center gap-1.5 shrink-0">
+                <div
+                  className={cn(
+                    "px-3 py-1 rounded-full text-xs font-medium border transition-colors",
+                    "bg-primary/10 text-primary border-primary/20"
+                  )}
+                >
+                  {phase.label}
+                </div>
+                {i < phases.length - 1 && (
+                  <ChevronsRight className="w-4 h-4 text-primary" />
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Template & Add actions */}
+          <div className="mb-4 flex items-center gap-2 flex-wrap">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={() => setShowTemplates(true)}
+            >
+              <Download className="w-3.5 h-3.5" />
+              Load Template
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={() => setShowSaveTemplate(true)}
+            >
+              <Upload className="w-3.5 h-3.5" />
+              Save as Template
+            </Button>
+            <div className="flex-1" />
+            <Button
+              size="sm"
+              className="gap-2"
+              onClick={handleAddPhase}
+            >
+              <Plus className="w-3.5 h-3.5" />
+              Add Phase
+            </Button>
+          </div>
+
+          {/* Phase columns */}
+          <div className="flex items-start gap-3 overflow-x-auto pb-2">
+            {phases.map((phase, i) => (
+              <DraggablePhaseWrapper
+                key={phase.id}
+                phaseId={phase.id}
+                index={i}
+                movePhase={movePhase}
+              >
+                <PhaseColumn
+                  phase={phase}
+                  phaseIndex={i}
+                  posts={phasePosts[phase.id] || []}
+                  allPhases={phases}
+                  isOpen={!!expandedCols[phase.id]}
+                  onToggle={() => toggleColumn(phase.id)}
+                  onAutoExpand={() => autoExpandColumn(phase.id)}
+                  movePostInPhase={movePostInPhase}
+                  movePostBetweenPhases={movePostBetweenPhases}
+                  onRemove={handleRemovePost}
+                  onMoveToPhase={handleMoveToPhase}
+                  onRename={handleRename}
+                  onDescriptionChange={handleDescriptionChange}
+                  onDeletePhase={handleDeletePhase}
+                  isEditing={editingId === phase.id}
+                  setEditingId={setEditingId}
+                  isLast={i === phases.length - 1}
+                />
+              </DraggablePhaseWrapper>
+            ))}
+          </div>
+
+          {/* Save / Reset bar */}
+          <div className="mt-10 flex items-center justify-end gap-3">
+            {lastSaved && (
+              <span className="text-sm text-muted-foreground flex items-center gap-1.5 mr-auto">
+                <Check className="w-4 h-4 text-success" /> Saved
+              </span>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleDiscard}
+              disabled={!hasChanges}
+              className="text-muted-foreground hover:text-destructive"
+            >
+              <Undo2 className="w-3.5 h-3.5 mr-1.5" /> Discard Changes
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={!hasChanges || isSaving}
+            >
+              {isSaving ? (
+                <>
+                  <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" /> Saving...
+                </>
+              ) : (
+                <>
+                  <Save className="w-3.5 h-3.5 mr-1.5" /> Save Changes
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Load Template Dialog ── */}
+      <Dialog open={showTemplates} onOpenChange={setShowTemplates}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Load Innovation Flow Template</DialogTitle>
+            <DialogDescription>
+              Choose a template to replace the current flow. Existing post assignments will be cleared.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 mt-4">
+            {FLOW_TEMPLATES.map((template) => (
+              <button
+                key={template.id}
+                onClick={() => handleLoadTemplate(template)}
+                className="w-full text-left p-4 rounded-lg border border-border hover:border-primary/40 hover:bg-primary/5 transition-all group"
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <span className="font-semibold text-sm text-foreground group-hover:text-primary transition-colors">
+                    {template.name}
+                  </span>
+                  <Badge variant="secondary" className="text-xs">
+                    {template.phases.length} phases
+                  </Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">{template.description}</p>
+                <div className="flex items-center gap-1.5 mt-2">
+                  {template.phases.map((p, i) => (
+                    <div key={i} className="flex items-center gap-1 shrink-0">
+                      <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground">
+                        {p.label}
+                      </span>
+                      {i < template.phases.length - 1 && p.linkedToNext && (
+                        <ChevronsRight className="w-3 h-3 text-muted-foreground" />
+                      )}
+                      {i < template.phases.length - 1 && !p.linkedToNext && (
+                        <span className="inline-block w-2 h-[1px] bg-border" />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Save as Template Dialog ── */}
+      <Dialog open={showSaveTemplate} onOpenChange={setShowSaveTemplate}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Save Flow as Template</DialogTitle>
+            <DialogDescription>
+              Save your current innovation flow for reuse in other subspaces.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 mt-4">
+            <div>
+              <label className="text-sm font-medium text-foreground">Template Name</label>
+              <Input
+                className="mt-1.5"
+                placeholder="e.g. My Custom Innovation Flow"
+                value={templateName}
+                onChange={(e) => setTemplateName(e.target.value)}
+              />
+            </div>
+            <div className="flex items-center gap-1.5 overflow-x-auto pb-1">
+              {phases.map((phase, i) => (
+                <div key={phase.id} className="flex items-center gap-1 shrink-0">
+                  <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary">
+                    {phase.label}
+                  </span>
+                  {i < phases.length - 1 && (
+                    <span>
+                      {phase.linkedToNext ? (
+                        <ChevronsRight className="w-3 h-3 text-primary" />
+                      ) : (
+                        <span className="inline-block w-2 h-[1px] bg-border" />
+                      )}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" size="sm" onClick={() => setShowSaveTemplate(false)}>
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                disabled={!templateName.trim()}
+                onClick={() => {
+                  // Mock save
+                  setShowSaveTemplate(false);
+                  setTemplateName("");
+                }}
+              >
+                <FileText className="w-3.5 h-3.5 mr-1.5" />
+                Save Template
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </DndProvider>
+  );
+}

--- a/prototype/src/app/components/space/SubspaceSettingsSettings.tsx
+++ b/prototype/src/app/components/space/SubspaceSettingsSettings.tsx
@@ -1,0 +1,465 @@
+import { useState } from "react";
+import {
+  Globe,
+  Lock,
+  UserPlus,
+  Mail,
+  AlertTriangle,
+  Video,
+  Edit3,
+  Share2,
+  Shield,
+  Layout,
+  Copy,
+  FileBox,
+  Users2,
+} from "lucide-react";
+import { Button } from "@/app/components/ui/button";
+import { Switch } from "@/app/components/ui/switch";
+import { Label } from "@/app/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/app/components/ui/radio-group";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/app/components/ui/accordion";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/app/components/ui/dialog";
+import { Separator } from "@/app/components/ui/separator";
+
+// Icon helper
+function FileTextIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+      <polyline points="14 2 14 8 20 8" />
+      <line x1="16" x2="8" y1="13" y2="13" />
+      <line x1="16" x2="8" y1="17" y2="17" />
+      <line x1="10" x2="8" y1="9" y2="9" />
+    </svg>
+  );
+}
+
+interface SubspaceSettingsSettingsProps {
+  subspaceName: string;
+}
+
+export function SubspaceSettingsSettings({ subspaceName }: SubspaceSettingsSettingsProps) {
+  const [visibility, setVisibility] = useState("public");
+  const [membershipMode, setMembershipMode] = useState("application");
+  const [allowedActions, setAllowedActions] = useState({
+    spaceInvitations: true,
+    createPosts: true,
+    videoCalls: true,
+    guestContributions: false,
+    createSubSubspaces: false,
+    parentContribute: true,
+  });
+  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
+
+  const handleActionToggle = (key: keyof typeof allowedActions) => {
+    setAllowedActions((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-500">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Settings</h2>
+        <p className="text-muted-foreground mt-2">
+          Configure this subspace's visibility, membership policies, and allowed
+          member actions.
+          {" "}<span className="text-xs text-muted-foreground/70 italic">Changes are saved automatically.</span>
+        </p>
+      </div>
+
+      <Separator />
+
+      <Accordion
+        type="multiple"
+        defaultValue={["visibility", "membership", "actions"]}
+        className="w-full space-y-4"
+      >
+        {/* Visibility */}
+        <AccordionItem
+          value="visibility"
+          className="border rounded-lg bg-card px-6"
+        >
+          <AccordionTrigger className="hover:no-underline py-6">
+            <div className="flex flex-col items-start gap-1">
+              <h3 className="text-lg font-semibold flex items-center gap-2">
+                Visibility
+              </h3>
+              <p className="text-sm text-muted-foreground font-normal text-left">
+                Control who can see and access this subspace
+              </p>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent className="pb-6 pt-0">
+            <RadioGroup
+              value={visibility}
+              onValueChange={setVisibility}
+              className="space-y-4"
+            >
+              <div
+                className="flex items-start space-x-3 p-4 rounded-md border bg-muted/20 hover:bg-muted/40 transition-colors cursor-pointer"
+                onClick={() => setVisibility("public")}
+              >
+                <RadioGroupItem value="public" id="v-public" className="mt-1" />
+                <div className="space-y-1">
+                  <Label
+                    htmlFor="v-public"
+                    className="text-base font-medium flex items-center gap-2 cursor-pointer"
+                  >
+                    <Globe className="w-4 h-4 text-info" /> Public
+                  </Label>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    This subspace and its contents are visible to all members of
+                    the parent space.
+                  </p>
+                </div>
+              </div>
+              <div
+                className="flex items-start space-x-3 p-4 rounded-md border bg-muted/20 hover:bg-muted/40 transition-colors cursor-pointer"
+                onClick={() => setVisibility("private")}
+              >
+                <RadioGroupItem value="private" id="v-private" className="mt-1" />
+                <div className="space-y-1">
+                  <Label
+                    htmlFor="v-private"
+                    className="text-base font-medium flex items-center gap-2 cursor-pointer"
+                  >
+                    <Lock className="w-4 h-4 text-warning" /> Private
+                  </Label>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    Only subspace members can see this subspace and its contents.
+                  </p>
+                </div>
+              </div>
+            </RadioGroup>
+            <p className="text-xs text-muted-foreground mt-4 italic">
+              Consider your subspace's purpose and audience when choosing visibility.
+            </p>
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* Membership */}
+        <AccordionItem
+          value="membership"
+          className="border rounded-lg bg-card px-6"
+        >
+          <AccordionTrigger className="hover:no-underline py-6">
+            <div className="flex flex-col items-start gap-1">
+              <h3 className="text-lg font-semibold flex items-center gap-2">
+                Membership
+              </h3>
+              <p className="text-sm text-muted-foreground font-normal text-left">
+                Choose how users join this subspace
+              </p>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent className="pb-6 pt-0">
+            <RadioGroup
+              value={membershipMode}
+              onValueChange={setMembershipMode}
+              className="space-y-4"
+            >
+              <div
+                className="flex items-start space-x-3 p-4 rounded-md border bg-muted/20 hover:bg-muted/40 transition-colors cursor-pointer"
+                onClick={() => setMembershipMode("none")}
+              >
+                <RadioGroupItem value="none" id="m-none" className="mt-1" />
+                <div className="space-y-1">
+                  <Label
+                    htmlFor="m-none"
+                    className="text-base font-medium flex items-center gap-2 cursor-pointer"
+                  >
+                    <UserPlus className="w-4 h-4 text-success" /> No Application
+                    Required
+                  </Label>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    All parent space members can join directly without approval.
+                  </p>
+                  <p className="text-xs text-muted-foreground italic mt-1">Best for public, open collaboration spaces</p>
+                </div>
+              </div>
+              <div
+                className="flex items-start space-x-3 p-4 rounded-md border bg-muted/20 hover:bg-muted/40 transition-colors cursor-pointer"
+                onClick={() => setMembershipMode("application")}
+              >
+                <RadioGroupItem value="application" id="m-application" className="mt-1" />
+                <div className="space-y-1">
+                  <Label
+                    htmlFor="m-application"
+                    className="text-base font-medium flex items-center gap-2 cursor-pointer"
+                  >
+                    <FileTextIcon className="w-4 h-4 text-info" /> Application Required
+                  </Label>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    Members must submit an application that leads can approve or
+                    reject.
+                  </p>
+                  <p className="text-xs text-muted-foreground italic mt-1">Best for curated spaces with specific requirements</p>
+                </div>
+              </div>
+              <div
+                className="flex items-start space-x-3 p-4 rounded-md border bg-muted/20 hover:bg-muted/40 transition-colors cursor-pointer"
+                onClick={() => setMembershipMode("invitation")}
+              >
+                <RadioGroupItem value="invitation" id="m-invitation" className="mt-1" />
+                <div className="space-y-1">
+                  <Label
+                    htmlFor="m-invitation"
+                    className="text-base font-medium flex items-center gap-2 cursor-pointer"
+                  >
+                    <Mail className="w-4 h-4 text-primary" /> Invitation Only
+                  </Label>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    Members can only join after being invited by a lead.
+                  </p>
+                  <p className="text-xs text-muted-foreground italic mt-1">Best for private, restricted collaboration teams</p>
+                </div>
+              </div>
+            </RadioGroup>
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* Allowed Actions */}
+        <AccordionItem
+          value="actions"
+          className="border rounded-lg bg-card px-6"
+        >
+          <AccordionTrigger className="hover:no-underline py-6">
+            <div className="flex flex-col items-start gap-1">
+              <h3 className="text-lg font-semibold flex items-center gap-2">
+                Allowed Actions
+              </h3>
+              <p className="text-sm text-muted-foreground font-normal text-left">
+                Configure what members can do in this subspace
+              </p>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent className="pb-6 pt-0">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <ActionToggle
+                id="spaceInvitations"
+                label="Space Invitations"
+                description="Allow admins of Subspaces within this Subspace to invite users directly to their own Subspace. If a user is not yet a member of this Subspace, they will automatically become one upon accepting the invitation. Note: Only users who are already members of the Space can be invited this way."
+                checked={allowedActions.spaceInvitations}
+                onCheckedChange={() => handleActionToggle('spaceInvitations')}
+                icon={UserPlus}
+              />
+              <ActionToggle
+                id="createPosts"
+                label="Create Posts"
+                description="Allow members to create posts. If you deactivate this, members will still be able to contribute to existing posts, but will not be able to create new posts."
+                checked={allowedActions.createPosts}
+                onCheckedChange={() => handleActionToggle('createPosts')}
+                icon={Edit3}
+              />
+              <ActionToggle
+                id="videoCalls"
+                label="Video Call"
+                description="Show video call button in the tab menu. All members of this Space can use this button to start a Jitsi video conference."
+                checked={allowedActions.videoCalls}
+                onCheckedChange={() => handleActionToggle('videoCalls')}
+                icon={Video}
+              />
+              <ActionToggle
+                id="guestContributions"
+                label="Guest Contributions"
+                description="Allow whiteboards in this Space to be shared with guest users (non-members) for collaborative contributions."
+                checked={allowedActions.guestContributions}
+                onCheckedChange={() => handleActionToggle('guestContributions')}
+                icon={Share2}
+              />
+              <ActionToggle
+                id="createSubSubspaces"
+                label="Create Subspaces"
+                description="Allow members to create Subspaces in this Space. If you deactivate this, you can still create Subspaces yourself and add other people as an admin inside the Subspace."
+                checked={allowedActions.createSubSubspaces}
+                onCheckedChange={() => handleActionToggle('createSubSubspaces')}
+                icon={Layout}
+              />
+              <ActionToggle
+                id="parentContribute"
+                label="Parent Community Contributions"
+                description="Allow members of the parent community to contribute without needing to join first."
+                checked={allowedActions.parentContribute}
+                onCheckedChange={() => handleActionToggle('parentContribute')}
+                icon={Users2}
+              />
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* Save as Template / Duplicate */}
+        <AccordionItem value="template" className="border rounded-lg bg-card px-6">
+          <AccordionTrigger className="hover:no-underline py-6">
+            <div className="flex flex-col items-start gap-1">
+              <h3 className="text-lg font-semibold flex items-center gap-2">
+                Template & Duplication
+              </h3>
+              <p className="text-sm text-muted-foreground font-normal text-left">
+                Save this subspace as a reusable template or create a copy
+              </p>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent className="pb-6 pt-0">
+            <div className="space-y-4">
+              <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 p-4 border rounded-md bg-muted/20">
+                <div className="flex items-start gap-3">
+                  <FileBox className="w-5 h-5 mt-0.5 text-muted-foreground" />
+                  <div>
+                    <h4 className="font-semibold text-foreground">Save as Template</h4>
+                    <p className="text-sm text-muted-foreground mt-1 max-w-xl">
+                      Turn this subspace into a template that can be used to create new subspaces with the same structure, innovation flow, and settings.
+                    </p>
+                  </div>
+                </div>
+                <Button variant="outline" className="shrink-0">
+                  Save as Template
+                </Button>
+              </div>
+              <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 p-4 border rounded-md bg-muted/20 opacity-50">
+                <div className="flex items-start gap-3">
+                  <Copy className="w-5 h-5 mt-0.5 text-muted-foreground" />
+                  <div>
+                    <h4 className="font-semibold text-foreground">Duplicate Subspace</h4>
+                    <p className="text-sm text-muted-foreground mt-1 max-w-xl">
+                      Create a copy of this subspace including its structure, posts, and settings. Members will not be copied.
+                    </p>
+                  </div>
+                </div>
+                <Button variant="outline" className="shrink-0" disabled>
+                  Duplicate
+                </Button>
+              </div>
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* Danger Zone */}
+        <AccordionItem value="danger" className="border border-destructive/20 rounded-lg bg-destructive/5 px-6">
+          <AccordionTrigger className="hover:no-underline py-6">
+            <div className="flex flex-col items-start gap-1">
+              <h3 className="text-lg font-semibold flex items-center gap-2 text-destructive">
+                <AlertTriangle className="w-5 h-5" />
+                Danger Zone
+              </h3>
+              <p className="text-sm text-destructive/80 font-normal text-left">
+                Irreversible actions for this subspace
+              </p>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent className="pb-6 pt-0">
+            <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 p-4 border border-destructive/20 rounded-md bg-background">
+              <div>
+                <h4 className="font-semibold text-foreground">Delete this Subspace</h4>
+                <p className="text-sm text-muted-foreground mt-1 max-w-xl">
+                  Deleting this subspace is permanent. All posts, content, and membership data will be permanently removed. Be careful, this action cannot be undone.
+                </p>
+              </div>
+              <Dialog
+                open={deleteConfirmationOpen}
+                onOpenChange={setDeleteConfirmationOpen}
+              >
+                <DialogTrigger asChild>
+                  <Button variant="destructive">
+                    Delete Subspace
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2 text-destructive">
+                      <AlertTriangle className="w-5 h-5" />
+                      Delete "{subspaceName}"?
+                    </DialogTitle>
+                    <DialogDescription className="pt-2">
+                      This action cannot be undone. This will permanently delete the subspace <strong>{subspaceName}</strong> and remove all associated data including:
+                      <ul className="list-disc ml-6 mt-2 mb-2 space-y-1">
+                        <li>All member associations</li>
+                        <li>All document and file storage</li>
+                        <li>All community posts and threads</li>
+                        <li>All nested subspaces and their content</li>
+                      </ul>
+                      Please contact Alkemio support to proceed with deletion if you are sure.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <DialogFooter className="gap-2 sm:justify-between">
+                    <Button variant="ghost" onClick={() => setDeleteConfirmationOpen(false)}>
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      onClick={() => {
+                        setDeleteConfirmationOpen(false);
+                        alert("Please contact support@alkemio.org to complete this request.");
+                      }}
+                    >
+                      I understand, delete this subspace
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </div>
+            <p className="text-xs text-muted-foreground mt-3 italic">
+              Please contact the Alkemio team if you need assistance with subspace deletion.
+            </p>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+}
+
+function ActionToggle({
+  id,
+  label,
+  description,
+  checked,
+  onCheckedChange,
+  icon: Icon,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  icon: any;
+}) {
+  return (
+    <div className="flex items-start justify-between space-x-4 p-3 rounded-lg border bg-muted/20">
+      <div className="flex items-start gap-3">
+        <div className="mt-1 text-muted-foreground">
+          <Icon className="w-5 h-5" />
+        </div>
+        <div className="space-y-0.5">
+          <Label htmlFor={id} className="text-base font-medium cursor-pointer">{label}</Label>
+          <p className="text-xs text-muted-foreground leading-snug max-w-[200px] sm:max-w-xs">
+            {description}
+          </p>
+        </div>
+      </div>
+      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}

--- a/prototype/src/app/components/space/SubspaceSettingsSubspaces.tsx
+++ b/prototype/src/app/components/space/SubspaceSettingsSubspaces.tsx
@@ -1,0 +1,376 @@
+import { useState } from "react";
+import {
+  Search,
+  Plus,
+  MoreVertical,
+  Users,
+  Calendar,
+  Archive,
+  Eye,
+  Trash2,
+  Edit,
+  Grid,
+  List as ListIcon,
+  LayoutTemplate,
+  Filter,
+} from "lucide-react";
+import { Button } from "@/app/components/ui/button";
+import { Input } from "@/app/components/ui/input";
+import { Badge } from "@/app/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from "@/app/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/app/components/ui/dialog";
+import { Separator } from "@/app/components/ui/separator";
+import { cn } from "@/lib/utils";
+import { ImageWithFallback } from "@/app/components/figma/ImageWithFallback";
+
+interface SubSubspace {
+  id: string;
+  name: string;
+  description: string;
+  image: string;
+  memberCount: number;
+  status: "Active" | "Archived";
+  lastActive: string;
+}
+
+const MOCK_SUBSUBSPACES: SubSubspace[] = [
+  {
+    id: "1",
+    name: "Solar Panel Research",
+    description: "Exploring next-gen photovoltaic technologies and materials.",
+    image: "https://images.unsplash.com/photo-1509391366360-2e959784a276?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxzb2xhciUyMHBhbmVsfGVufDF8fHx8MTc2OTQ0MTk1MHww&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
+    memberCount: 8,
+    status: "Active",
+    lastActive: "3 hours ago",
+  },
+  {
+    id: "2",
+    name: "Wind Energy Models",
+    description: "Computational fluid dynamics models for wind turbine placement.",
+    image: "https://images.unsplash.com/photo-1532601224476-15c79f2f7a51?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx3aW5kJTIwdHVyYmluZXxlbnwxfHx8fDE3Njk0NDE5NTB8MA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
+    memberCount: 5,
+    status: "Active",
+    lastActive: "1 day ago",
+  },
+  {
+    id: "3",
+    name: "Policy Analysis",
+    description: "Reviewing legislative frameworks for renewable energy subsidies.",
+    image: "https://images.unsplash.com/photo-1589829545856-d10d557cf95f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwb2xpY3klMjBkb2N1bWVudHxlbnwxfHx8fDE3Njk0NDE5NTB8MA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
+    memberCount: 4,
+    status: "Archived",
+    lastActive: "2 weeks ago",
+  },
+];
+
+export function SubspaceSettingsSubspaces() {
+  const [subspaces, setSubspaces] = useState<SubSubspace[]>(MOCK_SUBSUBSPACES);
+  const [search, setSearch] = useState("");
+  const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+  const [statusFilter, setStatusFilter] = useState<"All" | "Active" | "Archived">("All");
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newDesc, setNewDesc] = useState("");
+
+  const filtered = subspaces.filter((s) => {
+    const matchSearch = s.name.toLowerCase().includes(search.toLowerCase()) ||
+                        s.description.toLowerCase().includes(search.toLowerCase());
+    const matchStatus = statusFilter === "All" || s.status === statusFilter;
+    return matchSearch && matchStatus;
+  });
+
+  const handleCreate = () => {
+    const newSubspace: SubSubspace = {
+      id: Math.random().toString(36).substr(2, 9),
+      name: newName,
+      description: newDesc,
+      image: "https://images.unsplash.com/photo-1509391366360-2e959784a276?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxzb2xhciUyMHBhbmVsfGVufDF8fHx8MTc2OTQ0MTk1MHww&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
+      memberCount: 1,
+      status: "Active",
+      lastActive: "Just now",
+    };
+    setSubspaces([newSubspace, ...subspaces]);
+    setIsCreateModalOpen(false);
+    setNewName("");
+    setNewDesc("");
+  };
+
+  const handleDelete = (id: string) => {
+    setSubspaces(subspaces.filter((s) => s.id !== id));
+  };
+
+  const handleArchive = (id: string) => {
+    setSubspaces(subspaces.map((s) => (s.id === id ? { ...s, status: "Archived" as const } : s)));
+  };
+
+  return (
+    <div className="space-y-8 animate-in fade-in duration-500">
+      {/* Header */}
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Subspaces</h2>
+        <p className="text-muted-foreground mt-2">
+          Manage child subspaces within this subspace.
+        </p>
+      </div>
+
+      <Separator />
+
+      {/* Subspaces List */}
+      <div className="space-y-4">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <h3 className="text-lg font-semibold flex items-center gap-2">
+            Subspaces
+            <Badge variant="secondary" className="rounded-full">
+              {filtered.length}
+            </Badge>
+          </h3>
+
+          <div className="flex flex-col sm:flex-row gap-2 w-full md:w-auto">
+            <div className="relative flex-1 sm:w-64">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search subspaces..."
+                className="pl-9 h-9"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" className="h-9 gap-2">
+                  <Filter className="w-4 h-4" />
+                  Filter: {statusFilter}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setStatusFilter("All")}>All</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setStatusFilter("Active")}>Active Only</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setStatusFilter("Archived")}>Archived Only</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <div className="border rounded-md flex items-center h-9 p-0.5 bg-muted/20">
+              <Button
+                variant={viewMode === "grid" ? "secondary" : "ghost"}
+                size="icon"
+                className="h-8 w-8 rounded-sm"
+                onClick={() => setViewMode("grid")}
+              >
+                <Grid className="w-4 h-4" />
+              </Button>
+              <Button
+                variant={viewMode === "list" ? "secondary" : "ghost"}
+                size="icon"
+                className="h-8 w-8 rounded-sm"
+                onClick={() => setViewMode("list")}
+              >
+                <ListIcon className="w-4 h-4" />
+              </Button>
+            </div>
+
+            <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>
+              <DialogTrigger asChild>
+                <Button size="sm" className="h-9 gap-2">
+                  <Plus className="w-4 h-4" />
+                  Create Subspace
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Create New Subspace</DialogTitle>
+                  <DialogDescription>
+                    Set up a new workspace within this subspace.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4 py-4">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Subspace Name</label>
+                    <Input
+                      placeholder="e.g. Solar Panel Research"
+                      value={newName}
+                      onChange={(e) => setNewName(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Description</label>
+                    <Input
+                      placeholder="What is this subspace for?"
+                      value={newDesc}
+                      onChange={(e) => setNewDesc(e.target.value)}
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setIsCreateModalOpen(false)}>Cancel</Button>
+                  <Button onClick={handleCreate} disabled={!newName}>Create Subspace</Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </div>
+
+        {/* Grid View */}
+        {viewMode === "grid" && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filtered.map((s) => (
+              <div
+                key={s.id}
+                className="group bg-card border border-border rounded-xl overflow-hidden hover:shadow-md transition-all flex flex-col"
+              >
+                <div className="h-32 bg-muted relative overflow-hidden">
+                  <ImageWithFallback
+                    src={s.image}
+                    alt={s.name}
+                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                  />
+                  <div className="absolute top-2 right-2">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="secondary" size="icon" className="h-7 w-7 rounded-full bg-background/80 backdrop-blur-sm border border-black/5 hover:bg-background">
+                          <MoreVertical className="w-3.5 h-3.5" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem><Eye className="w-4 h-4 mr-2" /> View</DropdownMenuItem>
+                        <DropdownMenuItem><Edit className="w-4 h-4 mr-2" /> Edit Details</DropdownMenuItem>
+                        {s.status !== "Archived" && (
+                          <DropdownMenuItem onClick={() => handleArchive(s.id)}>
+                            <Archive className="w-4 h-4 mr-2" /> Archive
+                          </DropdownMenuItem>
+                        )}
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem className="text-destructive" onClick={() => handleDelete(s.id)}>
+                          <Trash2 className="w-4 h-4 mr-2" /> Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                  {s.status === "Archived" && (
+                    <div className="absolute inset-0 bg-background/60 backdrop-blur-[1px] flex items-center justify-center">
+                      <Badge variant="secondary" className="gap-1">
+                        <Archive className="w-3 h-3" /> Archived
+                      </Badge>
+                    </div>
+                  )}
+                </div>
+
+                <div className="p-4 flex flex-col flex-1">
+                  <div className="flex-1">
+                    <h4 className="font-semibold text-lg line-clamp-1 group-hover:text-primary transition-colors cursor-pointer">
+                      {s.name}
+                    </h4>
+                    <p className="text-sm text-muted-foreground mt-1 line-clamp-2 min-h-[40px]">
+                      {s.description}
+                    </p>
+                  </div>
+
+                  <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground pt-4 border-t border-border">
+                    <div className="flex items-center gap-1.5" title={`${s.memberCount} members`}>
+                      <Users className="w-3.5 h-3.5" /> {s.memberCount}
+                    </div>
+                    <div className="flex items-center gap-1.5" title="Last active">
+                      <Calendar className="w-3.5 h-3.5" /> {s.lastActive}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+
+            {filtered.length === 0 && (
+              <div className="col-span-full py-12 flex flex-col items-center justify-center text-muted-foreground border-2 border-dashed border-border rounded-xl bg-muted/10">
+                <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center mb-4">
+                  <Search className="w-6 h-6 opacity-50" />
+                </div>
+                <h3 className="font-medium text-lg text-foreground">No subspaces found</h3>
+                <p className="text-sm mt-1 mb-4">Try adjusting your search or filters.</p>
+                <Button variant="outline" onClick={() => { setSearch(""); setStatusFilter("All"); }}>
+                  Clear Filters
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* List View */}
+        {viewMode === "list" && (
+          <div className="border border-border rounded-xl overflow-hidden bg-card">
+            {filtered.map((s, i) => (
+              <div
+                key={s.id}
+                className={cn(
+                  "flex items-center gap-4 p-4 hover:bg-accent/50 transition-colors",
+                  i !== filtered.length - 1 && "border-b border-border"
+                )}
+              >
+                <div className="w-16 h-12 rounded bg-muted overflow-hidden shrink-0">
+                  <ImageWithFallback
+                    src={s.image}
+                    alt={s.name}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h4 className="font-medium text-sm text-foreground truncate">{s.name}</h4>
+                    {s.status === "Archived" && (
+                      <Badge variant="secondary" className="text-[10px] py-0 h-5">Archived</Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground truncate max-w-md">{s.description}</p>
+                </div>
+                <div className="hidden sm:flex items-center gap-6 text-xs text-muted-foreground shrink-0">
+                  <div className="flex items-center gap-1.5 w-20">
+                    <Users className="w-3.5 h-3.5" /> {s.memberCount}
+                  </div>
+                  <div className="flex items-center gap-1.5 w-24">
+                    <Calendar className="w-3.5 h-3.5" /> {s.lastActive}
+                  </div>
+                </div>
+                <div className="shrink-0">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                        <MoreVertical className="w-4 h-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem><Edit className="w-4 h-4 mr-2" /> Edit</DropdownMenuItem>
+                      <DropdownMenuItem>
+                        <Archive className="w-4 h-4 mr-2" />
+                        {s.status === "Active" ? "Archive" : "Unarchive"}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem className="text-destructive" onClick={() => handleDelete(s.id)}>
+                        <Trash2 className="w-4 h-4 mr-2" /> Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </div>
+            ))}
+            {filtered.length === 0 && (
+              <div className="p-8 text-center text-muted-foreground text-sm">
+                No subspaces found matching criteria.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/prototype/src/app/components/space/SubspaceSettingsUpdates.tsx
+++ b/prototype/src/app/components/space/SubspaceSettingsUpdates.tsx
@@ -1,0 +1,282 @@
+import { useState } from "react";
+import ReactQuill from "react-quill";
+import "react-quill/dist/quill.snow.css";
+import { Button } from "@/app/components/ui/button";
+import { Input } from "@/app/components/ui/input";
+import { Label } from "@/app/components/ui/label";
+import { Separator } from "@/app/components/ui/separator";
+import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
+import { Badge } from "@/app/components/ui/badge";
+import {
+  Plus,
+  Megaphone,
+  Pin,
+  Trash2,
+  Calendar,
+  MoreHorizontal,
+  Send,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/app/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+interface Update {
+  id: string;
+  author: string;
+  authorInitials: string;
+  authorAvatar: string | null;
+  role: string;
+  date: string;
+  title: string;
+  body: string;
+  pinned: boolean;
+}
+
+const MOCK_UPDATES: Update[] = [
+  {
+    id: "u1",
+    author: "Elena Martinez",
+    authorInitials: "EM",
+    authorAvatar:
+      "https://images.unsplash.com/photo-1623853589874-864b1dd4d922?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    role: "Lead",
+    date: "2024-02-18",
+    title: "Phase 2 Kickoff — What to Expect",
+    body: "<p>We're excited to announce that Phase 2 of this challenge is now officially underway. Over the next four weeks, we'll be focusing on prototyping and testing the top 5 ideas that emerged from Phase 1.</p><p><strong>Key milestones:</strong></p><ul><li>Week 1–2: Rapid prototyping sessions</li><li>Week 3: Community voting on prototypes</li><li>Week 4: Final selection &amp; Phase 3 planning</li></ul>",
+    pinned: true,
+  },
+  {
+    id: "u2",
+    author: "Sarah Chen",
+    authorInitials: "SC",
+    authorAvatar:
+      "https://images.unsplash.com/photo-1757347398206-7425300ef990?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    role: "Admin",
+    date: "2024-02-10",
+    title: "Community Survey Results",
+    body: "<p>Thank you to everyone who participated in our community survey! We received 47 responses and the results are in. The top priorities identified by the community are:</p><ol><li>More structured collaboration workshops</li><li>Regular progress updates from leads</li><li>Dedicated Q&A sessions with experts</li></ol>",
+    pinned: false,
+
+  },
+  {
+    id: "u3",
+    author: "Elena Martinez",
+    authorInitials: "EM",
+    authorAvatar:
+      "https://images.unsplash.com/photo-1623853589874-864b1dd4d922?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
+    role: "Lead",
+    date: "2024-02-05",
+    title: "Welcome & Phase 1 Recap",
+    body: "<p>A warm welcome to all new members who joined this month! Here's a quick recap of what we accomplished in Phase 1...</p>",
+    pinned: false,
+  },
+];
+
+export function SubspaceSettingsUpdates() {
+  const [updates, setUpdates] = useState(MOCK_UPDATES);
+  const [composing, setComposing] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [newBody, setNewBody] = useState("");
+  const filtered = updates;
+
+  const togglePin = (id: string) => {
+    setUpdates((prev) =>
+      prev.map((u) => (u.id === id ? { ...u, pinned: !u.pinned } : u))
+    );
+  };
+
+  const removeUpdate = (id: string) => {
+    setUpdates((prev) => prev.filter((u) => u.id !== id));
+  };
+
+  const handlePost = () => {
+    if (!newTitle.trim()) return;
+    const update: Update = {
+      id: `u-new-${Date.now()}`,
+      author: "You",
+      authorInitials: "YO",
+      authorAvatar: null,
+      role: "Lead",
+      date: new Date().toISOString().slice(0, 10),
+      title: newTitle,
+      body: newBody,
+      pinned: false,
+    };
+    setUpdates((prev) => [update, ...prev]);
+    setNewTitle("");
+    setNewBody("");
+    setComposing(false);
+  };
+
+  const quillModules = {
+    toolbar: [
+      ["bold", "italic", "underline"],
+      [{ list: "ordered" }, { list: "bullet" }],
+      ["link"],
+      ["clean"],
+    ],
+  };
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-500">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Megaphone className="w-5 h-5" />
+            Updates from the Leads
+          </h2>
+          <p className="text-muted-foreground mt-2">
+            Post announcements, milestones, and progress updates visible to all
+            subspace members.
+          </p>
+        </div>
+        {!composing && (
+          <Button className="gap-2" size="sm" onClick={() => setComposing(true)}>
+            <Plus className="w-4 h-4" /> New Update
+          </Button>
+        )}
+      </div>
+
+      <Separator />
+
+      {/* Compose */}
+      {composing && (
+        <div
+          className="rounded-lg p-5 space-y-4"
+          style={{
+            background: "var(--muted)",
+            border: "1px solid var(--border)",
+          }}
+        >
+          <h3 className="text-sm font-semibold">New Update</h3>
+          <Input
+            placeholder="Update title"
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            className="font-semibold"
+          />
+          <div className="prose-editor">
+            <ReactQuill
+              theme="snow"
+              value={newBody}
+              onChange={setNewBody}
+              modules={quillModules}
+              placeholder="Write your update…"
+            />
+          </div>
+          <div className="flex items-center gap-3">
+            <Button size="sm" className="gap-2" onClick={handlePost}>
+              <Send className="w-4 h-4" /> Publish
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setComposing(false);
+                setNewTitle("");
+                setNewBody("");
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+
+
+      {/* Update List */}
+      <div className="space-y-4">
+        {filtered.length === 0 && (
+          <div className="text-center py-12 text-muted-foreground text-sm">
+            No updates yet. Click "New Update" to post the first one.
+          </div>
+        )}
+        {filtered.map((update) => (
+          <div
+            key={update.id}
+            className={cn(
+              "rounded-lg p-5 space-y-3 transition-colors",
+              update.pinned && "ring-1 ring-amber-300 dark:ring-amber-700"
+            )}
+            style={{
+              background: "var(--muted)",
+              border: "1px solid var(--border)",
+            }}
+          >
+            {/* Top row — author + badges + actions */}
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <Avatar className="w-9 h-9">
+                  {update.authorAvatar && (
+                    <AvatarImage src={update.authorAvatar} />
+                  )}
+                  <AvatarFallback className="text-xs">
+                    {update.authorInitials}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{update.author}</span>
+                    <Badge
+                      variant="secondary"
+                      className="text-[10px] px-1.5 py-0"
+                    >
+                      {update.role}
+                    </Badge>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Calendar className="w-3 h-3" />
+                    {update.date}
+
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-1">
+                {update.pinned && (
+                  <Pin className="w-3.5 h-3.5 text-amber-500 rotate-45" />
+                )}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon" className="h-8 w-8">
+                      <MoreHorizontal className="w-4 h-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => togglePin(update.id)}>
+                      <Pin className="w-4 h-4 mr-2" />
+                      {update.pinned ? "Unpin" : "Pin to Top"}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="text-destructive"
+                      onClick={() => removeUpdate(update.id)}
+                    >
+                      <Trash2 className="w-4 h-4 mr-2" /> Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+
+            {/* Title */}
+            <h3 className="text-base font-semibold">{update.title}</h3>
+
+            {/* Body */}
+            <div
+              className="text-sm text-muted-foreground prose prose-sm max-w-none [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_strong]:text-foreground"
+              dangerouslySetInnerHTML={{ __html: update.body }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/prototype/src/app/components/space/SubspaceSidebar.tsx
+++ b/prototype/src/app/components/space/SubspaceSidebar.tsx
@@ -1,15 +1,33 @@
+import { useState, useRef, useEffect } from "react";
 import { Button } from "@/app/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
+import { SpaceCard, type SpaceCardData } from "@/app/components/space/SpaceCard";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/app/components/ui/dialog";
+import { Separator } from "@/app/components/ui/separator";
 import {
   Info,
   ChevronLeft,
-  FileText,
-  Users,
-  Calendar,
+  Activity,
+  CalendarDays,
+  List,
+  Layers,
   MapPin,
   Bot,
   ExternalLink,
+  Clock,
+  MessageSquare,
+  FileText,
+  Users,
+  Plus,
+  Folder,
 } from "lucide-react";
+import { SubspaceCommunityDialog } from "@/app/components/space/SubspaceCommunityDialog";
 import { cn } from "@/lib/utils";
 
 interface SubspaceSidebarProps {
@@ -18,12 +36,12 @@ interface SubspaceSidebarProps {
   className?: string;
 }
 
-const FACILITATOR = {
-  name: "Sarah Chen",
-  role: "Facilitator",
-  location: "Amsterdam, NL",
+const SUBSPACE_LEAD = {
+  name: "David Kim",
+  location: "Berlin, DE",
   avatar:
-    "https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80",
+    "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80",
+  initials: "DK",
 };
 
 const VIRTUAL_CONTRIBUTOR = {
@@ -33,11 +51,77 @@ const VIRTUAL_CONTRIBUTOR = {
     "https://images.unsplash.com/photo-1641312874336-6279a832a3dc?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=256",
 };
 
+const SUB_SUBSPACES: (SpaceCardData & { status: string })[] = [
+  {
+    id: "ss-1",
+    slug: "solar-panel-deployment",
+    name: "Solar Panel Deployment",
+    description: "Planning and rollout of residential solar panel installations across participating municipalities.",
+    bannerImage: "https://images.unsplash.com/photo-1509391366360-2e959784a276?auto=format&fit=crop&w=800&q=80",
+    initials: "SP",
+    avatarColor: "#f59e0b",
+    isPrivate: false,
+    tags: ["Solar", "Deployment"],
+    memberCount: 8,
+    status: "Active",
+    leads: [
+      { name: "Sarah Chen", avatar: "https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80", type: "person" },
+    ],
+    parent: { name: "Renewable Energy Transition", slug: "renewable-energy-transition", initials: "RE", avatarColor: "#22c55e" },
+  },
+  {
+    id: "ss-2",
+    slug: "wind-farm-feasibility",
+    name: "Wind Farm Feasibility",
+    description: "Feasibility studies for offshore and onshore wind projects in the northern corridor.",
+    bannerImage: "https://images.unsplash.com/photo-1532601224476-15c79f2f7a51?auto=format&fit=crop&w=800&q=80",
+    initials: "WF",
+    avatarColor: "#0ea5e9",
+    isPrivate: false,
+    tags: ["Wind", "Feasibility"],
+    memberCount: 6,
+    status: "Active",
+    leads: [
+      { name: "David Kim", avatar: "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80", type: "person" },
+    ],
+    parent: { name: "Renewable Energy Transition", slug: "renewable-energy-transition", initials: "RE", avatarColor: "#22c55e" },
+  },
+  {
+    id: "ss-3",
+    slug: "battery-storage-research",
+    name: "Battery Storage Research",
+    description: "Research on grid-scale battery storage solutions and next-gen energy storage tech.",
+    bannerImage: "https://images.unsplash.com/photo-1620714223084-8fcacc6dfd8d?auto=format&fit=crop&w=800&q=80",
+    initials: "BS",
+    avatarColor: "#8b5cf6",
+    isPrivate: false,
+    tags: ["Battery", "Research"],
+    memberCount: 5,
+    status: "Active",
+    leads: [
+      { name: "Emily Davis", avatar: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80", type: "person" },
+      { name: "Tech Innovations", avatar: "https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?ixlib=rb-1.2.1&auto=format&fit=crop&w=256&q=80", type: "org" },
+    ],
+    parent: { name: "Renewable Energy Transition", slug: "renewable-energy-transition", initials: "RE", avatarColor: "#22c55e" },
+  },
+];
+
 export function SubspaceSidebar({
   isCollapsed,
   onToggleCollapse,
   className,
 }: SubspaceSidebarProps) {
+  const [openDialog, setOpenDialog] = useState<string | null>(null);
+  const challengeRef = useRef<HTMLParagraphElement>(null);
+  const [isChallengesTruncated, setIsChallengesTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = challengeRef.current;
+    if (el) {
+      setIsChallengesTruncated(el.scrollHeight > el.clientHeight);
+    }
+  }, []);
+
   return (
     <div
       className={cn(
@@ -96,6 +180,8 @@ export function SubspaceSidebar({
             </span>
           </div>
           <p
+            ref={challengeRef}
+            className="line-clamp-4"
             style={{
               fontSize: "var(--text-sm)",
               lineHeight: 1.6,
@@ -106,93 +192,73 @@ export function SubspaceSidebar({
             distributed teams to innovate effectively while maintaining social
             connection?
           </p>
-          <Button
-            variant="secondary"
-            size="sm"
-            className="w-full mt-4 gap-2"
-            style={{
-              fontSize: "var(--text-sm)",
-              fontWeight: "var(--font-weight-medium)" as any,
-              background:
-                "color-mix(in srgb, var(--primary-foreground) 15%, transparent)",
-              color: "var(--primary-foreground)",
-              border: "none",
-            }}
-          >
-            <ExternalLink className="w-3.5 h-3.5" />
-            Read Full Brief
-          </Button>
-        </div>
-
-        {/* ── Facilitator ── */}
-        <div
-          className="p-4"
-          style={{
-            background: "var(--card)",
-            border: "1px solid var(--border)",
-            borderRadius: "var(--radius)",
-          }}
-        >
-          <p
-            className="uppercase tracking-wider mb-3"
-            style={{
-              fontSize: "11px",
-              fontWeight: 600,
-              color: "var(--muted-foreground)",
-            }}
-          >
-            Facilitator
-          </p>
-          <div className="flex items-center gap-3">
-            <Avatar
-              className="w-10 h-10"
-              style={{ border: "2px solid var(--border)" }}
+          {isChallengesTruncated && (
+            <Button
+              variant="secondary"
+              size="sm"
+              className="w-full mt-4 gap-2"
+              onClick={() => setOpenDialog("activity")}
+              style={{
+                fontSize: "var(--text-sm)",
+                fontWeight: "var(--font-weight-medium)" as any,
+                background:
+                  "color-mix(in srgb, var(--primary-foreground) 15%, transparent)",
+                color: "var(--primary-foreground)",
+                border: "none",
+              }}
             >
-              <AvatarImage src={FACILITATOR.avatar} alt={FACILITATOR.name} />
-              <AvatarFallback
-                style={{
-                  background:
-                    "color-mix(in srgb, var(--primary) 15%, transparent)",
-                  color: "var(--primary)",
-                  fontSize: "10px",
-                  fontWeight: 700,
-                }}
+              <ExternalLink className="w-3.5 h-3.5" />
+              Read Full Brief
+            </Button>
+          )}
+
+          {/* Subspace Lead */}
+          <div
+            className="pt-3 mt-3"
+            style={{ borderTop: "1px solid rgba(255,255,255,0.15)" }}
+          >
+            <p
+              className="uppercase tracking-wider mb-2"
+              style={{
+                fontSize: "10px",
+                fontWeight: 700,
+                opacity: 0.6,
+                letterSpacing: "0.04em",
+              }}
+            >
+              Lead
+            </p>
+            <div className="flex items-center gap-3">
+              <Avatar
+                className="w-8 h-8"
+                style={{ border: "2px solid rgba(255,255,255,0.25)" }}
               >
-                SC
-              </AvatarFallback>
-            </Avatar>
-            <div>
-              <p
-                style={{
-                  fontSize: "var(--text-sm)",
-                  fontWeight: 600,
-                  color: "var(--foreground)",
-                }}
-              >
-                {FACILITATOR.name}
-              </p>
-              <p
-                className="flex items-center gap-1"
-                style={{
-                  fontSize: "12px",
-                  color: "var(--muted-foreground)",
-                }}
-              >
-                <MapPin className="w-3 h-3" />
-                {FACILITATOR.location}
-              </p>
+                <AvatarImage src={SUBSPACE_LEAD.avatar} alt={SUBSPACE_LEAD.name} />
+                <AvatarFallback
+                  style={{
+                    background: "rgba(255,255,255,0.15)",
+                    color: "white",
+                    fontSize: "9px",
+                    fontWeight: 700,
+                  }}
+                >
+                  {SUBSPACE_LEAD.initials}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <p style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                  {SUBSPACE_LEAD.name}
+                </p>
+                <p
+                  className="flex items-center gap-1"
+                  style={{ fontSize: "11px", opacity: 0.7 }}
+                >
+                  <MapPin className="w-3 h-3" />
+                  {SUBSPACE_LEAD.location}
+                </p>
+              </div>
             </div>
           </div>
-          <p
-            className="mt-3"
-            style={{
-              fontSize: "var(--text-sm)",
-              color: "var(--muted-foreground)",
-              lineHeight: 1.5,
-            }}
-          >
-            {FACILITATOR.role} · Leading collaboration and workshop facilitation.
-          </p>
         </div>
 
         {/* ── Quick Actions ── */}
@@ -209,12 +275,15 @@ export function SubspaceSidebar({
           </p>
           <div className="space-y-1">
             {[
-              { icon: FileText, label: "Project Docs" },
-              { icon: Users, label: "Team Roster" },
-              { icon: Calendar, label: "Schedule" },
-            ].map(({ icon: Icon, label }) => (
+              { icon: Activity, label: "Recent Activity", key: "activity" },
+              { icon: Users, label: "Community", key: "community" },
+              { icon: CalendarDays, label: "Events", key: "events" },
+              { icon: List, label: "Index", key: "index" },
+              { icon: Layers, label: "Subspaces", key: "subspaces" },
+            ].map(({ icon: Icon, label, key }) => (
               <button
-                key={label}
+                key={key}
+                onClick={() => setOpenDialog(key)}
                 className="flex items-center gap-3 w-full text-left px-3 py-2.5 rounded-md transition-colors hover:bg-muted/50"
                 style={{
                   background:
@@ -305,48 +374,214 @@ export function SubspaceSidebar({
             </div>
           </div>
         </div>
-
-        {/* ── About this Subspace ── */}
-        <div
-          className="p-4"
-          style={{
-            background: "var(--muted)",
-            borderRadius: "var(--radius)",
-          }}
-        >
-          <p
-            style={{
-              fontSize: "var(--text-sm)",
-              fontWeight: "var(--font-weight-medium)" as any,
-              color: "var(--foreground)",
-              marginBottom: 4,
-            }}
-          >
-            About this Subspace
-          </p>
-          <p
-            style={{
-              fontSize: "12px",
-              color: "var(--muted-foreground)",
-              lineHeight: 1.5,
-            }}
-          >
-            Created on Jan 12, 2024 by Sarah Chen. Part of the Green Energy Space space.
-          </p>
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full mt-3 gap-2"
-            style={{
-              fontSize: "var(--text-sm)",
-              fontWeight: "var(--font-weight-medium)" as any,
-            }}
-          >
-            <Info className="w-3.5 h-3.5" />
-            More Info
-          </Button>
-        </div>
       </div>
+
+      {/* ── Quick Action Dialogs ── */}
+
+      {/* Community Dialog */}
+      <SubspaceCommunityDialog
+        open={openDialog === "community"}
+        onOpenChange={(open) => setOpenDialog(open ? "community" : null)}
+      />
+
+      {/* Recent Activity Dialog */}
+      <Dialog open={openDialog === "activity"} onOpenChange={(open) => setOpenDialog(open ? "activity" : null)}>
+        <DialogContent
+          className="max-w-none sm:max-w-none max-h-[85vh] overflow-y-auto"
+          style={{ width: 'calc((100vw - 2 * var(--grid-margin-desktop) - 11 * var(--grid-gutter)) / var(--grid-columns) * 6 + 5 * var(--grid-gutter))' }}
+        >
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Activity className="w-5 h-5" style={{ color: "var(--primary)" }} />
+              Recent Activity
+            </DialogTitle>
+            <DialogDescription>Latest updates and contributions in this subspace.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 mt-2">
+            {[
+              { user: "Sarah Chen", action: "posted", target: "Kickoff: Municipal Transition Strategy", time: "2 hours ago", icon: FileText },
+              { user: "David Kim", action: "added a whiteboard to", target: "Renewable Grid Architecture", time: "5 hours ago", icon: FileText },
+              { user: "Emily Davis", action: "commented on", target: "Draft: Incentive Framework", time: "1 day ago", icon: MessageSquare },
+              { user: "Alex Torres", action: "created", target: "Call for Ideas: Community Solar", time: "2 days ago", icon: FileText },
+              { user: "Anna Martinez", action: "updated", target: "Stakeholder Contact Directory", time: "3 days ago", icon: FileText },
+            ].map((item, i) => (
+              <div key={i}>
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5 p-1.5 rounded-md" style={{ background: "color-mix(in srgb, var(--primary) 10%, transparent)" }}>
+                    <item.icon className="w-3.5 h-3.5" style={{ color: "var(--primary)" }} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p style={{ fontSize: "var(--text-sm)", color: "var(--foreground)" }}>
+                      <span style={{ fontWeight: 600 }}>{item.user}</span>{" "}
+                      <span style={{ color: "var(--muted-foreground)" }}>{item.action}</span>{" "}
+                      <span style={{ fontWeight: 500 }}>{item.target}</span>
+                    </p>
+                    <p className="flex items-center gap-1 mt-0.5" style={{ fontSize: "12px", color: "var(--muted-foreground)" }}>
+                      <Clock className="w-3 h-3" />
+                      {item.time}
+                    </p>
+                  </div>
+                </div>
+                {i < 4 && <Separator className="mt-3" />}
+              </div>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Events Dialog */}
+      <Dialog open={openDialog === "events"} onOpenChange={(open) => setOpenDialog(open ? "events" : null)}>
+        <DialogContent
+          className="max-w-none sm:max-w-none max-h-[85vh] overflow-y-auto"
+          style={{ width: 'calc((100vw - 2 * var(--grid-margin-desktop) - 11 * var(--grid-gutter)) / var(--grid-columns) * 6 + 5 * var(--grid-gutter))' }}
+        >
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <CalendarDays className="w-5 h-5" style={{ color: "var(--primary)" }} />
+              Events
+            </DialogTitle>
+            <DialogDescription>Upcoming and past events for this subspace.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 mt-2">
+            {[
+              { title: "Strategy Workshop", date: "Apr 25, 2026", time: "10:00 – 12:00 CET", status: "upcoming", attendees: 14 },
+              { title: "Stakeholder Review Meeting", date: "Apr 28, 2026", time: "14:00 – 15:30 CET", status: "upcoming", attendees: 8 },
+              { title: "Policy Framework Feedback Session", date: "May 2, 2026", time: "09:00 – 11:00 CET", status: "upcoming", attendees: 22 },
+              { title: "Community Solar Ideation Sprint", date: "Apr 15, 2026", time: "13:00 – 17:00 CET", status: "past", attendees: 18 },
+              { title: "Monthly Progress Sync", date: "Apr 10, 2026", time: "11:00 – 12:00 CET", status: "past", attendees: 12 },
+            ].map((event, i) => (
+              <div
+                key={i}
+                className="p-3 rounded-lg"
+                style={{
+                  border: "1px solid var(--border)",
+                  background: event.status === "upcoming" ? "var(--card)" : "var(--muted)",
+                }}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p style={{ fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--foreground)" }}>{event.title}</p>
+                    <p className="mt-1 flex items-center gap-1.5" style={{ fontSize: "12px", color: "var(--muted-foreground)" }}>
+                      <CalendarDays className="w-3 h-3" />
+                      {event.date} · {event.time}
+                    </p>
+                  </div>
+                  <span
+                    className="shrink-0 px-2 py-0.5 rounded-full text-[11px] font-medium"
+                    style={{
+                      background: event.status === "upcoming"
+                        ? "color-mix(in srgb, var(--primary) 12%, transparent)"
+                        : "color-mix(in srgb, var(--muted-foreground) 12%, transparent)",
+                      color: event.status === "upcoming" ? "var(--primary)" : "var(--muted-foreground)",
+                    }}
+                  >
+                    {event.status === "upcoming" ? "Upcoming" : "Past"}
+                  </span>
+                </div>
+                <p className="mt-1.5 flex items-center gap-1" style={{ fontSize: "12px", color: "var(--muted-foreground)" }}>
+                  <Users className="w-3 h-3" />
+                  {event.attendees} attendees
+                </p>
+              </div>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Index Dialog */}
+      <Dialog open={openDialog === "index"} onOpenChange={(open) => setOpenDialog(open ? "index" : null)}>
+        <DialogContent
+          className="max-w-none sm:max-w-none max-h-[85vh] overflow-y-auto"
+          style={{ width: 'calc((100vw - 2 * var(--grid-margin-desktop) - 11 * var(--grid-gutter)) / var(--grid-columns) * 6 + 5 * var(--grid-gutter))' }}
+        >
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <List className="w-5 h-5" style={{ color: "var(--primary)" }} />
+              Index
+            </DialogTitle>
+            <DialogDescription>All posts and content organized in this subspace.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1 mt-2">
+            {[
+              { title: "Kickoff: Municipal Transition Strategy", type: "Post", channel: "Strategy Docs", author: "Sarah Chen" },
+              { title: "Renewable Grid Architecture — Visual Mapping", type: "Whiteboard", channel: "Strategy Docs", author: "David Kim" },
+              { title: "Draft: Incentive Framework for Early Adopters", type: "Post", channel: "Policy Drafts", author: "Emily Davis" },
+              { title: "Call for Ideas: Community Solar Projects", type: "Call for Whiteboards", channel: "Municipal Data", author: "Alex Torres" },
+              { title: "Stakeholder Contact Directory", type: "Collection", channel: "Stakeholders", author: "Anna Martinez" },
+              { title: "Comparative Analysis: EU Renewable Directives", type: "Post", channel: "Policy Drafts", author: "Robert Fox" },
+            ].map((item, i) => (
+              <button
+                key={i}
+                className="flex items-start gap-3 w-full text-left px-3 py-2.5 rounded-md transition-colors hover:bg-muted/50"
+              >
+                <FileText className="w-4 h-4 shrink-0 mt-0.5" style={{ color: "var(--primary)" }} />
+                <div className="flex-1 min-w-0">
+                  <p className="truncate" style={{ fontSize: "var(--text-sm)", fontWeight: 500, color: "var(--foreground)" }}>
+                    {item.title}
+                  </p>
+                  <p style={{ fontSize: "12px", color: "var(--muted-foreground)" }}>
+                    {item.type} · {item.channel} · {item.author}
+                  </p>
+                </div>
+              </button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Subspaces Dialog */}
+      <Dialog open={openDialog === "subspaces"} onOpenChange={(open) => setOpenDialog(open ? "subspaces" : null)}>
+        <DialogContent
+          className="max-w-none sm:max-w-none max-h-[85vh] overflow-y-auto"
+          style={{ width: 'calc((100vw - 2 * var(--grid-margin-desktop) - 11 * var(--grid-gutter)) / var(--grid-columns) * 6 + 5 * var(--grid-gutter))' }}
+        >
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Layers className="w-5 h-5" style={{ color: "var(--primary)" }} />
+              Subspaces
+            </DialogTitle>
+            <DialogDescription>Explore focused workstreams and challenges within this subspace.</DialogDescription>
+          </DialogHeader>
+
+          {/* Header row with filter + create */}
+          <div className="flex items-center justify-between mt-1">
+            <div className="flex items-center gap-2">
+              {["All", "Active", "Archived"].map((status) => (
+                <button
+                  key={status}
+                  className={cn(
+                    "px-3 py-1.5 rounded-full transition-colors",
+                    status === "All"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-background text-muted-foreground hover:bg-muted hover:text-foreground"
+                  )}
+                  style={{
+                    fontSize: "var(--text-sm)",
+                    fontWeight: 500,
+                    border: `1px solid ${status === "All" ? "var(--primary)" : "var(--border)"}`,
+                  }}
+                >
+                  {status}
+                </button>
+              ))}
+            </div>
+            <Button size="sm" className="shrink-0 gap-2">
+              <Plus className="w-4 h-4" />
+              Create Subspace
+            </Button>
+          </div>
+
+          {/* Card Grid — mirrors SpaceSubspacesList layout */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
+            {(SUB_SUBSPACES as (SpaceCardData & { status: string })[]).map((subspace) => (
+              <SpaceCard
+                key={subspace.id}
+                space={subspace}
+              />
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/prototype/src/app/components/template-library/TemplateDetail.tsx
+++ b/prototype/src/app/components/template-library/TemplateDetail.tsx
@@ -520,7 +520,7 @@ function RenderWhiteboardContent({ template }: { template: any }) {
               </div>
               
               {/* Mock Content on Canvas */}
-              <div className="absolute inset-0 flex items-center justify-center transform group-hover:scale-105 transition-transform duration-700 ease-out">
+              <div className="absolute inset-0 flex items-center justify-center transform group-hover:scale-105 transition-transform duration-500 ease-out">
                  {/* Zone 1 */}
                  <div className="absolute top-1/4 left-1/4 transform -translate-x-1/2 -translate-y-1/2">
                      <div className="w-48 h-48 border-2 border-dashed border-border rounded-xl flex items-center justify-center bg-background/50">

--- a/prototype/src/app/components/template-library/TemplateLibrary.tsx
+++ b/prototype/src/app/components/template-library/TemplateLibrary.tsx
@@ -19,7 +19,7 @@ function PackCard({ pack, onClick }: { pack: typeof TEMPLATE_PACKS[0], onClick: 
   return (
     <div 
         onClick={onClick}
-        className="group relative flex flex-col bg-card border border-border rounded-xl overflow-hidden hover:shadow-md transition-all cursor-pointer"
+        className="group relative flex flex-col bg-card border border-border rounded-xl overflow-hidden hover:shadow-md transition-all duration-300 cursor-pointer"
     >
       <div className="relative h-40 w-full overflow-hidden bg-muted">
         <img 
@@ -85,7 +85,7 @@ function TemplatePreview({ type, content, structure }: { type: string, content?:
                  <img 
                     src={content} 
                     alt="Space Banner" 
-                    className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105" 
+                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" 
                  />
              ) : (
                  <div className="w-full h-full flex items-center justify-center bg-muted text-muted-foreground/50">
@@ -117,7 +117,7 @@ function TemplatePreview({ type, content, structure }: { type: string, content?:
                  <img 
                     src={content} 
                     alt="Subspace Banner" 
-                    className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105" 
+                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" 
                  />
              ) : (
                  <div className="w-full h-full flex items-center justify-center bg-muted text-muted-foreground/50">
@@ -207,7 +207,7 @@ function TemplateCard({ template }: { template: typeof INDIVIDUAL_TEMPLATES[0] }
   return (
     <div 
         onClick={() => navigate(`/templates/${template.id}`)}
-        className="group relative flex flex-col bg-card border border-border rounded-xl overflow-hidden hover:shadow-md transition-all cursor-pointer h-full"
+        className="group relative flex flex-col bg-card border border-border rounded-xl overflow-hidden hover:shadow-md transition-all duration-300 cursor-pointer h-full"
     >
       {/* Preview Section - Expanded to match PackCard style */}
       <div className="relative h-44 w-full overflow-hidden bg-muted border-b border-border/50">

--- a/prototype/src/app/components/template-library/TemplatePackDetail.tsx
+++ b/prototype/src/app/components/template-library/TemplatePackDetail.tsx
@@ -90,7 +90,7 @@ function TemplatePreview({ type, content, structure }: { type: string, content?:
                  <img 
                     src={content} 
                     alt="Space Banner" 
-                    className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105" 
+                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" 
                  />
              ) : (
                  <div className="w-full h-full flex items-center justify-center bg-muted text-muted-foreground/40">
@@ -117,7 +117,7 @@ function TemplatePreview({ type, content, structure }: { type: string, content?:
                  <img 
                     src={content} 
                     alt="Subspace Banner" 
-                    className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105" 
+                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" 
                  />
              ) : (
                  <div className="w-full h-full flex items-center justify-center bg-muted text-muted-foreground/40">
@@ -209,7 +209,7 @@ function TemplateCard({ template, onApply }: { template: typeof PACK_TEMPLATES[0
   return (
     <div 
         onClick={handleViewDetails}
-        className="group relative flex flex-col bg-card border border-border rounded-xl overflow-hidden hover:shadow-md transition-all cursor-pointer h-full"
+        className="group relative flex flex-col bg-card border border-border rounded-xl overflow-hidden hover:shadow-md transition-all duration-300 cursor-pointer h-full"
     >
       <div className="relative h-32 w-full overflow-hidden bg-muted border-b border-border/50">
         <TemplatePreview type={template.type} content={template.previewContent} structure={template.structure} />

--- a/prototype/src/app/components/user/OrganizationCard.tsx
+++ b/prototype/src/app/components/user/OrganizationCard.tsx
@@ -12,7 +12,7 @@ interface OrganizationCardProps {
 
 export function OrganizationCard({ name, role, memberCount, imageUrl }: OrganizationCardProps) {
   return (
-    <Card className="overflow-hidden hover:shadow-md transition-shadow group cursor-pointer border-border/50">
+    <Card className="overflow-hidden hover:shadow-md transition-all duration-300 group cursor-pointer border-border/50">
       <CardContent className="p-4 flex items-center gap-4">
         <Avatar className="h-12 w-12 rounded-lg border border-border">
           <AvatarImage src={imageUrl} alt={name} className="object-cover" />

--- a/prototype/src/app/components/user/SpaceGridCard.tsx
+++ b/prototype/src/app/components/user/SpaceGridCard.tsx
@@ -24,7 +24,7 @@ export function SpaceGridCard({
   className,
 }: SpaceGridCardProps) {
   return (
-    <Card className={cn("overflow-hidden hover:shadow-md transition-all group cursor-pointer h-full flex flex-col", className)}>
+    <Card className={cn("overflow-hidden hover:shadow-md transition-all duration-300 group cursor-pointer h-full flex flex-col", className)}>
       <div className="relative h-32 w-full bg-muted overflow-hidden">
         {imageUrl ? (
           <div 

--- a/prototype/src/app/contexts/SearchContext.tsx
+++ b/prototype/src/app/contexts/SearchContext.tsx
@@ -6,7 +6,7 @@ interface SearchContextValue {
   isOpen: boolean;
   /** The query term passed from the Header input when opening */
   initialQuery: string;
-  /** The scope passed from the Header when opening ("all" or a space slug) TODO: Not used yet */
+  /** The scope passed from the Header when opening ("all" or a space slug) */
   initialScope: SearchScope;
   /** Open with an initial search term and optional scope */
   openSearch: (query?: string, scope?: SearchScope) => void;

--- a/prototype/src/app/hooks/useBreadcrumbs.ts
+++ b/prototype/src/app/hooks/useBreadcrumbs.ts
@@ -15,22 +15,24 @@ export interface BreadcrumbSegment {
 
 // ─── Mock data lookups ───
 
-const SPACE_MAP: Record<string, { name: string; avatar?: string; initials: string }> = {
-  "green-energy": { name: "Green Energy Space", initials: "GE" },
-  "sustainable-futures": { name: "Sustainable Futures", initials: "SF" },
-  "sustainability-lab": { name: "Sustainability Lab", initials: "SL" },
-  "urban-mobility": { name: "Urban Mobility Lab", initials: "UM" },
-  "community-garden": { name: "Community Garden", initials: "CG" },
+const SPACE_MAP: Record<string, { name: string; bannerImage?: string; initials: string }> = {
+  "green-energy": { name: "Green Energy Space", initials: "GE", bannerImage: "https://images.unsplash.com/photo-1690191863988-f685cddde463?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100" },
+  "sustainable-futures": { name: "Sustainable Futures", initials: "SF", bannerImage: "https://images.unsplash.com/photo-1623652554515-91c833e3080e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100" },
+  "sustainability-lab": { name: "Sustainability Lab", initials: "SL", bannerImage: "https://images.unsplash.com/photo-1623652554515-91c833e3080e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100" },
+  "urban-mobility": { name: "Urban Mobility Lab", initials: "UM", bannerImage: "https://images.unsplash.com/photo-1735639013995-086e648eaa38?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100" },
+  "community-garden": { name: "Community Garden", initials: "CG", bannerImage: "https://images.unsplash.com/photo-1768659347532-74d3b1efb0ae?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100" },
+  "innovation-lab": { name: "Innovation Lab", initials: "IL", bannerImage: "https://images.unsplash.com/photo-1676276376052-dc9c9c0b6917?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100" },
 };
 
-const SUBSPACE_MAP: Record<string, { name: string; initials: string; parentSlug: string }> = {
-  "renewable-energy-transition": { name: "Renewable Energy Transition", initials: "RE", parentSlug: "green-energy" },
-  "urban-mobility-lab": { name: "Urban Mobility Lab", initials: "UM", parentSlug: "green-energy" },
-  "green-infrastructure": { name: "Green Infrastructure", initials: "GI", parentSlug: "green-energy" },
+const SUBSPACE_MAP: Record<string, { name: string; initials: string; avatar?: string; parentSlug: string }> = {
+  "renewable-energy-transition": { name: "Renewable Energy Transition", initials: "RE", avatar: "https://images.unsplash.com/photo-1509391366360-2e959784a276?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100", parentSlug: "green-energy" },
+  "urban-mobility-lab": { name: "Urban Mobility Lab", initials: "UM", avatar: "https://images.unsplash.com/photo-1556741533-6e6a62bd8b49?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100", parentSlug: "green-energy" },
+  "green-infrastructure": { name: "Green Infrastructure", initials: "GI", avatar: "https://images.unsplash.com/photo-1518531933037-91b2f5f229cc?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=100", parentSlug: "green-energy" },
 };
 
 const SETTINGS_TAB_NAMES: Record<string, string> = {
   about: "About",
+  layout: "Layout",
   community: "Community",
   subspaces: "Subspaces",
   templates: "Templates",
@@ -38,6 +40,7 @@ const SETTINGS_TAB_NAMES: Record<string, string> = {
   settings: "Settings",
   account: "Account",
   profile: "Profile",
+  updates: "Updates",
 };
 
 function slugToName(slug: string): string {
@@ -47,9 +50,13 @@ function slugToName(slug: string): string {
 function spaceAvatar(slug: string): React.ReactNode {
   const space = SPACE_MAP[slug];
   const initials = space?.initials ?? slug.substring(0, 2).toUpperCase();
+  const bannerImage = space?.bannerImage;
   return React.createElement(
     Avatar,
     { className: "w-5 h-5", style: { border: "1px solid var(--border)" } },
+    bannerImage
+      ? React.createElement(AvatarImage, { src: bannerImage, alt: space?.name ?? slug, className: "object-cover" })
+      : null,
     React.createElement(AvatarFallback, {
       className: "text-[9px] font-semibold",
       style: { background: "color-mix(in srgb, var(--primary) 15%, transparent)", color: "var(--primary)" },
@@ -60,9 +67,13 @@ function spaceAvatar(slug: string): React.ReactNode {
 function subspaceAvatar(slug: string): React.ReactNode {
   const sub = SUBSPACE_MAP[slug];
   const initials = sub?.initials ?? slug.substring(0, 2).toUpperCase();
+  const avatarUrl = sub?.avatar;
   return React.createElement(
     Avatar,
     { className: "w-5 h-5", style: { border: "1px solid var(--border)" } },
+    avatarUrl
+      ? React.createElement(AvatarImage, { src: avatarUrl, alt: sub?.name ?? slug, className: "object-cover" })
+      : null,
     React.createElement(AvatarFallback, {
       className: "text-[9px] font-semibold",
       style: { background: "color-mix(in srgb, var(--primary) 15%, transparent)", color: "var(--primary)" },
@@ -262,8 +273,36 @@ export function useBreadcrumbs(): BreadcrumbSegment[] {
       ];
     }
 
-    // Subspace
+    // Subspace settings: /space/:spaceSlug/subspaces/:subspaceSlug/settings/:tab
     const subspaceSlug = params.subspaceSlug;
+    if (subspaceSlug && path.includes(`/subspaces/${subspaceSlug}/settings`)) {
+      const subInfo = SUBSPACE_MAP[subspaceSlug];
+      const subspaceName = subInfo?.name ?? subspaceSlug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+      const subspaceHref = `${spaceHref}/subspaces/${subspaceSlug}`;
+      const subspaceSegment: BreadcrumbSegment = {
+        label: subspaceName,
+        href: subspaceHref,
+        isCurrentPage: false,
+        icon: subspaceAvatar(subspaceSlug),
+      };
+      const tab = params.tab;
+      if (tab) {
+        const tabName = SETTINGS_TAB_NAMES[tab] ?? tab.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+        return [
+          spaceSegment,
+          subspaceSegment,
+          { label: "Settings", href: `${subspaceHref}/settings`, isCurrentPage: false },
+          { label: tabName, href: `${subspaceHref}/settings/${tab}`, isCurrentPage: true },
+        ];
+      }
+      return [
+        spaceSegment,
+        subspaceSegment,
+        { label: "Settings", href: `${subspaceHref}/settings`, isCurrentPage: true },
+      ];
+    }
+
+    // Subspace page: /space/:spaceSlug/subspaces/:subspaceSlug
     if (subspaceSlug) {
       const subInfo = SUBSPACE_MAP[subspaceSlug];
       const subspaceName = subInfo?.name ?? subspaceSlug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());

--- a/prototype/src/app/pages/SpaceSettingsPage.tsx
+++ b/prototype/src/app/pages/SpaceSettingsPage.tsx
@@ -1,113 +1,120 @@
 import { useParams, Link, useLocation, Navigate } from "react-router";
-import { SpaceHeader } from "@/app/components/space/SpaceHeader";
 import { SpaceSettingsAbout } from "@/app/components/space/SpaceSettingsAbout";
 import { SpaceSettingsLayout } from "@/app/components/space/SpaceSettingsLayout";
 import { SpaceSettingsCommunity } from "@/app/components/space/SpaceSettingsCommunity";
+import { SpaceSettingsUpdates } from "@/app/components/space/SpaceSettingsUpdates";
 import { SpaceSettingsSubspaces } from "@/app/components/space/SpaceSettingsSubspaces";
 import { SpaceSettingsTemplates } from "@/app/components/space/SpaceSettingsTemplates";
 import { SpaceSettingsStorage } from "@/app/components/space/SpaceSettingsStorage";
 import { SpaceSettingsSettings } from "@/app/components/space/SpaceSettingsSettings";
 import { SpaceSettingsAccount } from "@/app/components/space/SpaceSettingsAccount";
-import { Info, Layout, Users, Layers, FileText, HardDrive, Settings, User } from "lucide-react";
+import { Info, Layout, Users, Megaphone, Layers, FileText, HardDrive, Settings, User } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-// Simple slug-to-name mapping (shared with SpaceLayout)
-function slugToName(slug: string): string {
-  const map: Record<string, string> = {
-    "green-energy": "Green Energy Space",
-    "sustainability-lab": "Sustainability Lab",
-    "urban-mobility": "Urban Mobility Lab",
-    "community-garden": "Community Garden",
+interface SpaceData {
+  name: string;
+  initials: string;
+  avatarColor: string;
+  bannerImage: string;
+  description: string;
+}
+
+const SPACE_DATA: Record<string, SpaceData> = {
+  "green-energy": { name: "Green Energy Space", initials: "GE", avatarColor: "#2563eb", bannerImage: "https://images.unsplash.com/photo-1690191863988-f685cddde463?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxkZXNpZ24lMjBjaGFsbGVuZ2UlMjBjcmVhdGl2ZSUyMHdvcmtzaG9wJTIwdGVhbSUyMGNvbGxhYm9yYXRpb24lMjBpbm5vdmF0aW9uJTIwc3ByaW50JTIwZGVzaWduJTIwc3ByaW50fGVufDF8fHx8MTc2OTA5NDMxMHww&ixlib=rb-4.1.0&q=80&w=400", description: "Accelerating the transition to sustainable energy systems worldwide." },
+  "sustainability-lab": { name: "Sustainability Lab", initials: "SL", avatarColor: "#16a34a", bannerImage: "https://images.unsplash.com/photo-1623652554515-91c833e3080e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb2xsYWJvcmF0aW9uJTIwdGVhbXdvcmslMjBpbm5vdmF0aW9uJTIwZGVzaWduJTIwdGhpbmtpbmclMjB3b3Jrc2hvcHxlbnwxfHx8fDE3NjkwODc1ODd8MA&ixlib=rb-4.1.0&q=80&w=400", description: "Experimenting with innovative approaches to environmental sustainability." },
+  "urban-mobility": { name: "Urban Mobility Lab", initials: "UM", avatarColor: "#0891b2", bannerImage: "https://images.unsplash.com/photo-1735639013995-086e648eaa38?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxicmFpbnN0b3JtaW5nJTIwY3JlYXRpdmUlMjB3b3Jrc2hvcCUyMHRlYW18ZW58MXx8fHwxNzY5MDg3NTg3fDA&ixlib=rb-4.1.0&q=80&w=400", description: "Reimagining city transportation for better accessibility and lower emissions." },
+  "community-garden": { name: "Community Garden", initials: "CG", avatarColor: "#65a30d", bannerImage: "https://images.unsplash.com/photo-1768659347532-74d3b1efb0ae?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxkZXNpZ24lMjBtZWV0aW5nJTIwY29sbGFib3JhdGlvbiUyMHRlYW18ZW58MXx8fHwxNzY5MDg3NTg3fDA&ixlib=rb-4.1.0&q=80&w=400", description: "Growing food and community connections in urban neighborhoods." },
+  "innovation-lab": { name: "Innovation Lab", initials: "IL", avatarColor: "#7c3aed", bannerImage: "https://images.unsplash.com/photo-1676276376052-dc9c9c0b6917?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxpbm5vdmF0aW9uJTIwbGFiJTIwdGVhbXdvcmslMjBtb2Rlcm4lMjBvZmZpY2V8ZW58MXx8fHwxNzY5MDg3NTg2fDA&ixlib=rb-4.1.0&q=80&w=400", description: "A collaborative space for breakthrough ideas and rapid experimentation." },
+};
+
+function getSpaceData(slug: string): SpaceData {
+  return SPACE_DATA[slug] || {
+    name: slug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+    initials: slug.substring(0, 2).toUpperCase(),
+    avatarColor: "#64748b",
+    bannerImage: "",
+    description: "A collaborative space for innovation.",
   };
-  return (
-    map[slug] ||
-    slug
-      .replace(/-/g, " ")
-      .replace(/\b\w/g, (c) => c.toUpperCase())
-  );
 }
 
 export function SpaceSettingsPage() {
   const { spaceSlug, tab } = useParams<{ spaceSlug: string; tab: string }>();
   const location = useLocation();
-  const spaceName = spaceSlug ? slugToName(spaceSlug) : "Space";
+  const space = spaceSlug ? getSpaceData(spaceSlug) : getSpaceData("");
 
   // If no tab is provided, redirect to 'about'
   if (!tab && location.pathname.endsWith("/settings")) {
     return <Navigate to={`/space/${spaceSlug}/settings/about`} replace />;
   }
 
-  return (
-    <div className="flex flex-col min-h-[calc(100vh-64px)] bg-background">
-      {/* Space Banner — same component as the space itself */}
-      <SpaceHeader spaceSlug={spaceSlug || "default-space"} />
+  const tabs = [
+    { label: "About", icon: Info, id: "about" },
+    { label: "Layout", icon: Layout, id: "layout" },
+    { label: "Community", icon: Users, id: "community" },
+    { label: "Updates", icon: Megaphone, id: "updates" },
+    { label: "Subspaces", icon: Layers, id: "subspaces" },
+    { label: "Templates", icon: FileText, id: "templates" },
+    { label: "Storage", icon: HardDrive, id: "storage" },
+    { label: "Settings", icon: Settings, id: "settings" },
+    { label: "Account", icon: User, id: "account" },
+  ];
 
-      {/* Horizontal Tab Navigation */}
-      <div
-        className="w-full overflow-x-auto shrink-0 sticky top-16 z-10"
-        style={{
-          borderBottom: "1px solid var(--border)",
-          background: "var(--card)",
-        }}
-      >
-        <nav
-          className="px-6 md:px-8"
-          style={{
-            minHeight: 44,
-            fontFamily: "var(--font-family, 'Inter', sans-serif)",
-          }}
-        >
+  return (
+    <div className="min-h-screen bg-background pb-12">
+      {/* Sticky header with title + tabs */}
+      <div className="sticky top-16 z-20 border-b border-border bg-card">
+        <div className="px-6 md:px-8 pt-8 pb-0">
           <div className="grid grid-cols-12 gap-6">
-            <div className="col-span-12 lg:col-start-2 lg:col-span-10 flex items-center gap-0">
-          {[
-            { label: "About", icon: Info, id: "about" },
-            { label: "Layout", icon: Layout, id: "layout" },
-            { label: "Community", icon: Users, id: "community" },
-            { label: "Subspaces", icon: Layers, id: "subspaces" },
-            { label: "Templates", icon: FileText, id: "templates" },
-            { label: "Storage", icon: HardDrive, id: "storage" },
-            { label: "Settings", icon: Settings, id: "settings" },
-            { label: "Account", icon: User, id: "account" },
-          ].map((item) => {
-            const isActive = tab === item.id;
-            return (
-              <Link
-                key={item.id}
-                to={`/space/${spaceSlug}/settings/${item.id}`}
-                className={cn(
-                  "flex items-center gap-1.5 px-4 py-2.5 whitespace-nowrap transition-colors relative",
-                  isActive
-                    ? "text-primary"
-                    : "text-muted-foreground hover:text-foreground"
+            <div className="col-span-12 lg:col-start-2 lg:col-span-10">
+              <div className="flex items-center gap-4 mb-8">
+                {space.bannerImage ? (
+                  <div
+                    className="w-12 h-12 rounded-full shrink-0 overflow-hidden"
+                    style={{ border: "2px solid var(--border)" }}
+                  >
+                    <img src={space.bannerImage} alt={space.name} className="w-full h-full object-cover" />
+                  </div>
+                ) : (
+                  <div
+                    className="w-12 h-12 rounded-full flex items-center justify-center text-white text-sm font-bold shrink-0"
+                    style={{ backgroundColor: space.avatarColor }}
+                  >
+                    {space.initials}
+                  </div>
                 )}
-                style={{
-                  fontSize: "var(--text-sm)",
-                  fontWeight: isActive ? 600 : 500,
-                }}
-              >
-                <item.icon className="w-4 h-4" />
-                {item.label}
-                {/* Active indicator line */}
-                {isActive && (
-                  <span
-                    className="absolute bottom-0 left-4 right-4"
-                    style={{
-                      height: 2,
-                      background: "var(--primary)",
-                      borderRadius: "1px 1px 0 0",
-                    }}
-                  />
-                )}
-              </Link>
-            );
-          })}
+                <div>
+                  <h1 className="text-2xl font-bold tracking-tight">{space.name}</h1>
+                  <p className="text-muted-foreground text-sm mt-0.5">{space.description}</p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-6 overflow-x-auto no-scrollbar">
+                {tabs.map((item) => {
+                  const isActive = tab === item.id;
+                  return (
+                    <Link
+                      key={item.id}
+                      to={`/space/${spaceSlug}/settings/${item.id}`}
+                      className={cn(
+                        "flex items-center gap-2 pb-4 text-sm font-medium border-b-2 transition-colors whitespace-nowrap",
+                        isActive
+                          ? "border-primary text-primary"
+                          : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted"
+                      )}
+                    >
+                      <item.icon className="w-4 h-4" />
+                      {item.label}
+                    </Link>
+                  );
+                })}
+              </div>
             </div>
           </div>
-        </nav>
+        </div>
       </div>
 
-      {/* Main Content Area — full width, no sidebar */}
-      <main className="flex-1 px-6 md:px-8 py-8">
+      {/* Main Content Area */}
+      <main className="px-6 md:px-8 py-8">
         <div className="grid grid-cols-12 gap-6">
           <div className="col-span-12 lg:col-start-2 lg:col-span-10">
         <div>
@@ -126,6 +133,8 @@ export function SpaceSettingsPage() {
               <SpaceSettingsLayout />
             ) : tab === 'community' ? (
               <SpaceSettingsCommunity />
+            ) : tab === 'updates' ? (
+              <SpaceSettingsUpdates />
             ) : tab === 'subspaces' ? (
               <SpaceSettingsSubspaces />
             ) : tab === 'templates' ? (

--- a/prototype/src/app/pages/SubspacePage.tsx
+++ b/prototype/src/app/pages/SubspacePage.tsx
@@ -1,19 +1,35 @@
 import { useState, useMemo } from "react";
-import { useParams } from "react-router";
-import { Plus } from "lucide-react";
+import { useParams, useNavigate } from "react-router";
+import { Plus, Layout } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/app/components/ui/tooltip";
 import { Button } from "@/app/components/ui/button";
 import { SubspaceHeader } from "@/app/components/space/SubspaceHeader";
 import { SubspaceSidebar } from "@/app/components/space/SubspaceSidebar";
 import { CalloutTabs, type CalloutTab } from "@/app/components/space/ChannelTabs";
 import { PostCard, type PostProps } from "@/app/components/space/PostCard";
 import { AddPostModal } from "@/app/components/space/AddPostModal";
+import { SubspaceCommunityDialog } from "@/app/components/space/SubspaceCommunityDialog";
 
 /* ─── Mock subspace metadata ─── */
+
+// Parent space banner — subspaces always inherit their parent's banner
+const PARENT_SPACE_BANNER =
+  "https://images.unsplash.com/photo-1690191863988-f685cddde463?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxkZXNpZ24lMjBjaGFsbGVuZ2UlMjBjcmVhdGl2ZSUyMHdvcmtzaG9wJTIwdGVhbSUyMGNvbGxhYm9yYXRpb24lMjBpbm5vdmF0aW9uJTIwc3ByaW50JTIwZGVzaWduJTIwc3ByaW50fGVufDF8fHx8MTc2OTA5NDMxMHww&ixlib=rb-4.1.0&q=80&w=1080";
+
 interface SubspaceInfo {
   title: string;
   description: string;
   parentName: string;
-  bannerImage: string;
+  initials: string;
+  avatarColor: string;
+  avatarImage?: string;
+  parentInitials: string;
+  parentAvatarColor: string;
   memberCount: number;
   callouts: CalloutTab[];
 }
@@ -24,15 +40,17 @@ const SUBSPACE_MAP: Record<string, SubspaceInfo> = {
     description:
       "Developing strategies for municipal energy transition to 100% renewables by 2030.",
     parentName: "Green Energy Space",
-    bannerImage:
-      "https://images.unsplash.com/photo-1665813122461-2fcb38ece4b4?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxyZW5ld2FibGUlMjBlbmVyZ3klMjB3aW5kJTIwdHVyYmluZXMlMjBzdW5zZXR8ZW58MXx8fHwxNzcyNDQ2MTM5fDA&ixlib=rb-4.1.0&q=80&w=1080",
+    initials: "RE",
+    avatarColor: "#22c55e",
+    avatarImage: "https://images.unsplash.com/photo-1509391366360-2e959784a276?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
+    parentInitials: "GE",
+    parentAvatarColor: "#2563eb",
     memberCount: 24,
     callouts: [
-      { id: "all", label: "ALL ACTIVITY" },
-      { id: "strategy", label: "STRATEGY DOCS", count: 5 },
-      { id: "municipal", label: "MUNICIPAL DATA" },
-      { id: "policy", label: "POLICY DRAFTS", count: 2 },
-      { id: "stakeholders", label: "STAKEHOLDERS" },
+      { id: "strategy", label: "Strategy Docs", description: "Core strategy documents and roadmaps for the 2030 transition.", count: 5, linkedToNext: true },
+      { id: "municipal", label: "Municipal Data", description: "Data sets and reports from participating municipalities.", linkedToNext: true },
+      { id: "policy", label: "Policy Drafts", description: "Draft policy frameworks and regulatory proposals.", count: 2, linkedToNext: false },
+      { id: "stakeholders", label: "Stakeholders", description: "Stakeholder mapping, contacts, and engagement plans.", linkedToNext: false },
     ],
   },
   "urban-mobility-lab": {
@@ -40,14 +58,16 @@ const SUBSPACE_MAP: Record<string, SubspaceInfo> = {
     description:
       "Reimagining city transportation networks for better accessibility and reduced carbon footprint.",
     parentName: "Green Energy Space",
-    bannerImage:
-      "https://images.unsplash.com/photo-1743385779313-ac03bb0f997b?auto=format&fit=crop&w=1080&q=80",
+    initials: "UM",
+    avatarColor: "#0891b2",
+    avatarImage: "https://images.unsplash.com/photo-1556741533-6e6a62bd8b49?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
+    parentInitials: "GE",
+    parentAvatarColor: "#2563eb",
     memberCount: 18,
     callouts: [
-      { id: "all", label: "ALL ACTIVITY" },
-      { id: "research", label: "RESEARCH", count: 3 },
-      { id: "prototypes", label: "PROTOTYPES" },
-      { id: "field-tests", label: "FIELD TESTS", count: 1 },
+      { id: "research", label: "Research", description: "Studies and literature on urban mobility patterns.", count: 3, linkedToNext: true },
+      { id: "prototypes", label: "Prototypes", description: "Prototype designs and pilot programme documentation.", linkedToNext: false },
+      { id: "field-tests", label: "Field Tests", description: "On-the-ground testing results and feedback.", count: 1, linkedToNext: false },
     ],
   },
   "green-infrastructure": {
@@ -55,13 +75,15 @@ const SUBSPACE_MAP: Record<string, SubspaceInfo> = {
     description:
       "Planning and implementation of urban green spaces, vertical gardens, and sustainable drainage.",
     parentName: "Green Energy Space",
-    bannerImage:
-      "https://images.unsplash.com/photo-1760611656007-f767a8082758?auto=format&fit=crop&w=1080&q=80",
+    initials: "GI",
+    avatarColor: "#16a34a",
+    avatarImage: "https://images.unsplash.com/photo-1518531933037-91b2f5f229cc?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
+    parentInitials: "GE",
+    parentAvatarColor: "#2563eb",
     memberCount: 12,
     callouts: [
-      { id: "all", label: "ALL ACTIVITY" },
-      { id: "planning", label: "PLANNING", count: 4 },
-      { id: "implementation", label: "IMPLEMENTATION" },
+      { id: "planning", label: "Planning", description: "Urban green space planning documents and proposals.", count: 4, linkedToNext: true },
+      { id: "implementation", label: "Implementation", description: "Progress updates and implementation guides.", linkedToNext: false },
     ],
   },
 };
@@ -71,12 +93,13 @@ const DEFAULT_SUBSPACE: SubspaceInfo = {
   title: "Subspace",
   description: "A focused collaboration area.",
   parentName: "Space",
-  bannerImage:
-    "https://images.unsplash.com/photo-1550483428-9facac419319?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=1080",
+  initials: "SS",
+  avatarColor: "#64748b",
+  parentInitials: "SP",
+  parentAvatarColor: "#475569",
   memberCount: 10,
   callouts: [
-    { id: "all", label: "ALL ACTIVITY" },
-    { id: "general", label: "GENERAL" },
+    { id: "general", label: "General", description: "General discussions and shared content." },
   ],
 };
 
@@ -217,10 +240,7 @@ export default function SubspacePage() {
     spaceSlug = "green-energy",
     subspaceSlug = "renewable-energy-transition",
   } = useParams();
-
-  const [activeCallout, setActiveCallout] = useState("all");
-  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-  const [isPostModalOpen, setIsPostModalOpen] = useState(false);
+  const navigate = useNavigate();
 
   const info = SUBSPACE_MAP[subspaceSlug] || {
     ...DEFAULT_SUBSPACE,
@@ -229,12 +249,14 @@ export default function SubspacePage() {
       .replace(/\b\w/g, (c) => c.toUpperCase()),
   };
 
-  // Filter posts by callout
+  const [activeCallout, setActiveCallout] = useState(info.callouts[0]?.id ?? "");
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [isPostModalOpen, setIsPostModalOpen] = useState(false);
+  const [isCommunityDialogOpen, setIsCommunityDialogOpen] = useState(false);
+
+  // Filter posts by active phase
   const filteredPosts = useMemo(
-    () =>
-      activeCallout === "all"
-        ? SUBSPACE_POSTS
-        : SUBSPACE_POSTS.filter((p) => p.callout === activeCallout),
+    () => SUBSPACE_POSTS.filter((p) => p.callout === activeCallout),
     [activeCallout]
   );
 
@@ -250,8 +272,15 @@ export default function SubspacePage() {
         title={info.title}
         description={info.description}
         parentSpaceName={info.parentName}
-        imageUrl={info.bannerImage}
+        imageUrl={PARENT_SPACE_BANNER}
+        initials={info.initials}
+        avatarColor={info.avatarColor}
+        avatarImage={info.avatarImage}
+        parentInitials={info.parentInitials}
+        parentAvatarColor={info.parentAvatarColor}
+        parentBannerImage={PARENT_SPACE_BANNER}
         memberCount={info.memberCount}
+        onCommunityClick={() => setIsCommunityDialogOpen(true)}
       />
 
       {/* ── Main Content Area ── */}
@@ -282,6 +311,26 @@ export default function SubspacePage() {
             }}
           >
             <div className="flex items-center justify-between gap-4">
+              <TooltipProvider delayDuration={300}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() =>
+                        navigate(
+                          `/space/${spaceSlug}/subspaces/${subspaceSlug}/settings/layout`
+                        )
+                      }
+                      className="shrink-0 p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                      aria-label="Edit innovation flow"
+                    >
+                      <Layout className="w-4 h-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p>Edit innovation flow</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
               <CalloutTabs
                 tabs={info.callouts}
                 activeTab={activeCallout}
@@ -301,6 +350,20 @@ export default function SubspacePage() {
               </Button>
             </div>
           </div>
+
+          {/* Tab description */}
+          {info.callouts.find((c) => c.id === activeCallout)?.description && (
+            <p
+              className="mb-4"
+              style={{
+                fontSize: "var(--text-sm)",
+                color: "var(--muted-foreground)",
+                fontFamily: "'Inter', sans-serif",
+              }}
+            >
+              {info.callouts.find((c) => c.id === activeCallout)?.description}
+            </p>
+          )}
 
           {/* Feed */}
           <div className="space-y-6">
@@ -327,7 +390,7 @@ export default function SubspacePage() {
                     marginBottom: 4,
                   }}
                 >
-                  No posts in this callout yet
+                  No posts in this phase yet
                 </p>
                 <p
                   style={{
@@ -337,13 +400,6 @@ export default function SubspacePage() {
                 >
                   Be the first to share something here.
                 </p>
-                <Button
-                  variant="link"
-                  className="mt-2"
-                  onClick={() => setActiveCallout("all")}
-                >
-                  Show all activity
-                </Button>
               </div>
             )}
           </div>
@@ -355,6 +411,12 @@ export default function SubspacePage() {
       <AddPostModal
         open={isPostModalOpen}
         onOpenChange={setIsPostModalOpen}
+      />
+
+      {/* Community Dialog */}
+      <SubspaceCommunityDialog
+        open={isCommunityDialogOpen}
+        onOpenChange={setIsCommunityDialogOpen}
       />
     </div>
   );

--- a/prototype/src/app/pages/SubspaceSettingsPage.tsx
+++ b/prototype/src/app/pages/SubspaceSettingsPage.tsx
@@ -1,0 +1,234 @@
+import { useParams, Link, useLocation, Navigate } from "react-router";
+import { SubspaceSettingsAbout } from "@/app/components/space/SubspaceSettingsAbout";
+import { SubspaceSettingsLayout } from "@/app/components/space/SubspaceSettingsLayout";
+import { SubspaceSettingsCommunity } from "@/app/components/space/SubspaceSettingsCommunity";
+import { SubspaceSettingsUpdates } from "@/app/components/space/SubspaceSettingsUpdates";
+import { SubspaceSettingsSubspaces } from "@/app/components/space/SubspaceSettingsSubspaces";
+import { SubspaceSettingsSettings } from "@/app/components/space/SubspaceSettingsSettings";
+import { Info, Layout, Users, Megaphone, Layers, Settings } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface SubspaceInfo {
+  title: string;
+  description: string;
+  parentName: string;
+  initials: string;
+  avatarColor: string;
+  avatarImage?: string;
+  parentInitials: string;
+  parentAvatarColor: string;
+  memberCount: number;
+}
+
+const SUBSPACE_MAP: Record<string, SubspaceInfo> = {
+  "renewable-energy-transition": {
+    title: "Renewable Energy Transition",
+    description: "Developing strategies for municipal energy transition to 100% renewables by 2030.",
+    parentName: "Green Energy Space",
+    initials: "RE",
+    avatarColor: "#22c55e",
+    avatarImage: "https://images.unsplash.com/photo-1509391366360-2e959784a276?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
+    parentInitials: "GE",
+    parentAvatarColor: "#2563eb",
+    memberCount: 24,
+  },
+  "urban-mobility-lab": {
+    title: "Urban Mobility Lab",
+    description: "Reimagining city transportation networks for better accessibility and reduced carbon footprint.",
+    parentName: "Green Energy Space",
+    initials: "UM",
+    avatarColor: "#0891b2",
+    avatarImage: "https://images.unsplash.com/photo-1556741533-6e6a62bd8b49?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
+    parentInitials: "GE",
+    parentAvatarColor: "#2563eb",
+    memberCount: 18,
+  },
+  "green-infrastructure": {
+    title: "Green Infrastructure",
+    description: "Planning and implementation of urban green spaces, vertical gardens, and sustainable drainage.",
+    parentName: "Green Energy Space",
+    initials: "GI",
+    avatarColor: "#16a34a",
+    avatarImage: "https://images.unsplash.com/photo-1518531933037-91b2f5f229cc?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=200",
+    parentInitials: "GE",
+    parentAvatarColor: "#2563eb",
+    memberCount: 12,
+  },
+};
+
+const DEFAULT_INFO: SubspaceInfo = {
+  title: "Subspace",
+  description: "A focused collaboration area.",
+  parentName: "Space",
+  initials: "SS",
+  avatarColor: "#64748b",
+  parentInitials: "SP",
+  parentAvatarColor: "#475569",
+  memberCount: 10,
+};
+
+export default function SubspaceSettingsPage() {
+  const { spaceSlug, subspaceSlug, tab } = useParams<{
+    spaceSlug: string;
+    subspaceSlug: string;
+    tab: string;
+  }>();
+  const location = useLocation();
+
+  const info = (subspaceSlug && SUBSPACE_MAP[subspaceSlug]) || {
+    ...DEFAULT_INFO,
+    title: (subspaceSlug || "subspace")
+      .replace(/-/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase()),
+  };
+
+  // Redirect to 'about' if no tab
+  if (!tab && location.pathname.endsWith("/settings")) {
+    return (
+      <Navigate
+        to={`/space/${spaceSlug}/subspaces/${subspaceSlug}/settings/about`}
+        replace
+      />
+    );
+  }
+
+  const tabs = [
+    { label: "About", icon: Info, id: "about" },
+    { label: "Layout", icon: Layout, id: "layout" },
+    { label: "Community", icon: Users, id: "community" },
+    { label: "Updates", icon: Megaphone, id: "updates" },
+    { label: "Subspaces", icon: Layers, id: "subspaces" },
+    { label: "Settings", icon: Settings, id: "settings" },
+  ];
+
+  return (
+    <div className="min-h-screen bg-background pb-12">
+      {/* Sticky header with title + tabs */}
+      <div className="sticky top-16 z-20 border-b border-border bg-card">
+        <div className="px-6 md:px-8 pt-8 pb-0">
+          <div className="grid grid-cols-12 gap-6">
+            <div className="col-span-12 lg:col-start-2 lg:col-span-10">
+              <div className="flex items-center gap-4 mb-8">
+                {info.avatarImage ? (
+                  <div
+                    className="w-12 h-12 rounded-full shrink-0 overflow-hidden"
+                    style={{ border: "2px solid var(--border)" }}
+                  >
+                    <img src={info.avatarImage} alt={info.title} className="w-full h-full object-cover" />
+                  </div>
+                ) : (
+                  <div
+                    className="w-12 h-12 rounded-full flex items-center justify-center text-white text-sm font-bold shrink-0"
+                    style={{ backgroundColor: info.avatarColor }}
+                  >
+                    {info.initials}
+                  </div>
+                )}
+                <div>
+                  <h1 className="text-2xl font-bold tracking-tight">{info.title}</h1>
+                  <p className="text-muted-foreground text-sm mt-0.5">{info.description}</p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-6 overflow-x-auto no-scrollbar">
+                {tabs.map((item) => {
+                  const isActive = tab === item.id;
+                  return (
+                    <Link
+                      key={item.id}
+                      to={`/space/${spaceSlug}/subspaces/${subspaceSlug}/settings/${item.id}`}
+                      className={cn(
+                        "flex items-center gap-2 pb-4 text-sm font-medium border-b-2 transition-colors whitespace-nowrap",
+                        isActive
+                          ? "border-primary text-primary"
+                          : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted"
+                      )}
+                    >
+                      <item.icon className="w-4 h-4" />
+                      {item.label}
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content Area */}
+      <main className="px-6 md:px-8 py-8">
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 lg:col-start-2 lg:col-span-10">
+            <div>
+              <div
+                className="w-full min-h-[500px] p-6 md:p-8 shadow-sm"
+                style={{
+                  background: "var(--card)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius)",
+                }}
+              >
+                {tab === "about" ? (
+                  <SubspaceSettingsAbout
+                    subspaceName={info.title}
+                    initials={info.initials}
+                    avatarColor={info.avatarColor}
+                    parentInitials={info.parentInitials}
+                    parentAvatarColor={info.parentAvatarColor}
+                    memberCount={info.memberCount}
+                  />
+                ) : tab === "layout" ? (
+                  <SubspaceSettingsLayout />
+                ) : tab === "community" ? (
+                  <SubspaceSettingsCommunity />
+                ) : tab === "updates" ? (
+                  <SubspaceSettingsUpdates />
+                ) : tab === "subspaces" ? (
+                  <SubspaceSettingsSubspaces />
+                ) : tab === "settings" ? (
+                  <SubspaceSettingsSettings subspaceName={info.title} />
+                ) : (
+                  <div className="flex flex-col justify-center h-full min-h-[300px] space-y-4">
+                    <div
+                      className="w-16 h-16 rounded-full flex items-center justify-center"
+                      style={{ background: "var(--muted)" }}
+                    >
+                      <div
+                        className="w-8 h-8 rounded-md"
+                        style={{
+                          background:
+                            "color-mix(in srgb, var(--muted-foreground) 20%, transparent)",
+                        }}
+                      />
+                    </div>
+                    <div>
+                      <h2
+                        className="capitalize"
+                        style={{
+                          fontSize: "var(--text-xl)",
+                          fontWeight: 600,
+                          color: "var(--foreground)",
+                        }}
+                      >
+                        {tab}
+                      </h2>
+                      <p
+                        style={{
+                          fontSize: "var(--text-sm)",
+                          color: "var(--muted-foreground)",
+                          marginTop: 4,
+                        }}
+                      >
+                        This section is under construction.
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/prototype/src/app/pages/UserAccountPage.tsx
+++ b/prototype/src/app/pages/UserAccountPage.tsx
@@ -3,6 +3,7 @@ import { Plus, MoreVertical, Layout, Bot, FileBox, Home, Settings, CreditCard, U
 import { Button } from "@/app/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader } from "@/app/components/ui/card";
 import { Badge } from "@/app/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
 import { cn } from "@/lib/utils";
 
 export default function UserAccountPage() {
@@ -70,14 +71,20 @@ export default function UserAccountPage() {
   return (
     <div className="min-h-screen bg-background pb-12">
       {/* Header / Navigation Area */}
-      <div className="sticky top-16 z-20 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+      <div className="sticky top-16 z-20 border-b border-border bg-card">
         <div className="px-6 md:px-8 pt-8 pb-0">
           <div className="grid grid-cols-12 gap-6">
             <div className="col-span-12 lg:col-start-2 lg:col-span-10">
-          <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-4 mb-8">
+            <Avatar className="w-12 h-12 shrink-0">
+              <AvatarImage
+                src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+                alt="Jeroen Nijkamp"
+              />
+              <AvatarFallback className="bg-primary text-primary-foreground text-sm font-bold">JN</AvatarFallback>
+            </Avatar>
             <div>
-              <h1 className="text-3xl font-bold tracking-tight">Account Settings</h1>
-              <p className="text-muted-foreground mt-1">Manage your resources, subscription, and account preferences.</p>
+              <h1 className="text-2xl font-bold tracking-tight">Jeroen Nijkamp</h1>
             </div>
           </div>
           

--- a/prototype/src/app/pages/UserGenericSettingsPage.tsx
+++ b/prototype/src/app/pages/UserGenericSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useParams, Link, useLocation } from "react-router";
 import { User, Layout, CreditCard, Users, Bell, Settings } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
 import { cn } from "@/lib/utils";
 
 export default function UserGenericSettingsPage({ title = "Settings" }: { title?: string }) {
@@ -19,14 +20,20 @@ export default function UserGenericSettingsPage({ title = "Settings" }: { title?
   return (
     <div className="min-h-screen bg-background pb-12">
       {/* Sticky Header / Navigation Area */}
-      <div className="sticky top-16 z-20 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+      <div className="sticky top-16 z-20 border-b border-border bg-card">
         <div className="px-6 md:px-8 pt-8 pb-0">
           <div className="grid grid-cols-12 gap-6">
             <div className="col-span-12 lg:col-start-2 lg:col-span-10">
-          <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-4 mb-8">
+            <Avatar className="w-12 h-12 shrink-0">
+              <AvatarImage
+                src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+                alt="Jeroen Nijkamp"
+              />
+              <AvatarFallback className="bg-primary text-primary-foreground text-sm font-bold">JN</AvatarFallback>
+            </Avatar>
             <div>
-              <h1 className="text-3xl font-bold tracking-tight">Account Settings</h1>
-              <p className="text-muted-foreground mt-1">Manage your personal profile and account preferences.</p>
+              <h1 className="text-2xl font-bold tracking-tight">Jeroen Nijkamp</h1>
             </div>
           </div>
           

--- a/prototype/src/app/pages/UserMembershipPage.tsx
+++ b/prototype/src/app/pages/UserMembershipPage.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/app/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
 import { cn } from "@/lib/utils";
 
 export default function UserMembershipPage() {
@@ -109,14 +110,20 @@ export default function UserMembershipPage() {
   return (
     <div className="min-h-screen bg-background pb-12">
       {/* Header / Navigation Area */}
-      <div className="sticky top-16 z-20 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+      <div className="sticky top-16 z-20 border-b border-border bg-card">
         <div className="px-6 md:px-8 pt-8 pb-0">
           <div className="grid grid-cols-12 gap-6">
             <div className="col-span-12 lg:col-start-2 lg:col-span-10">
-          <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-4 mb-8">
+            <Avatar className="w-12 h-12 shrink-0">
+              <AvatarImage
+                src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+                alt="Jeroen Nijkamp"
+              />
+              <AvatarFallback className="bg-primary text-primary-foreground text-sm font-bold">JN</AvatarFallback>
+            </Avatar>
             <div>
-              <h1 className="text-3xl font-bold tracking-tight">Memberships</h1>
-              <p className="text-muted-foreground mt-1">View and manage memberships across spaces and subspaces.</p>
+              <h1 className="text-2xl font-bold tracking-tight">Jeroen Nijkamp</h1>
             </div>
           </div>
           

--- a/prototype/src/app/pages/UserNotificationsPage.tsx
+++ b/prototype/src/app/pages/UserNotificationsPage.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/app/components/ui/button";
 import { Switch } from "@/app/components/ui/switch";
 import { Separator } from "@/app/components/ui/separator";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/app/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/app/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
@@ -137,14 +138,20 @@ export default function UserNotificationsPage() {
   return (
     <div className="min-h-screen bg-background pb-12">
       {/* Header / Navigation Area */}
-      <div className="sticky top-16 z-20 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+      <div className="sticky top-16 z-20 border-b border-border bg-card">
         <div className="px-6 md:px-8 pt-8 pb-0">
           <div className="grid grid-cols-12 gap-6">
             <div className="col-span-12 lg:col-start-2 lg:col-span-10">
-          <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-4 mb-8">
+            <Avatar className="w-12 h-12 shrink-0">
+              <AvatarImage
+                src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+                alt="Jeroen Nijkamp"
+              />
+              <AvatarFallback className="bg-primary text-primary-foreground text-sm font-bold">JN</AvatarFallback>
+            </Avatar>
             <div>
-              <h1 className="text-3xl font-bold tracking-tight">Notifications</h1>
-              <p className="text-muted-foreground mt-1">Configure how you receive notifications across the platform.</p>
+              <h1 className="text-2xl font-bold tracking-tight">Jeroen Nijkamp</h1>
             </div>
           </div>
           

--- a/prototype/src/app/pages/UserOrganizationsPage.tsx
+++ b/prototype/src/app/pages/UserOrganizationsPage.tsx
@@ -114,14 +114,20 @@ export default function UserOrganizationsPage() {
   return (
     <div className="min-h-screen bg-background pb-12">
       {/* Header / Navigation Area */}
-      <div className="sticky top-16 z-20 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+      <div className="sticky top-16 z-20 border-b border-border bg-card">
         <div className="px-6 md:px-8 pt-8 pb-0">
           <div className="grid grid-cols-12 gap-6">
             <div className="col-span-12 lg:col-start-2 lg:col-span-10">
-          <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-4 mb-8">
+            <Avatar className="w-12 h-12 shrink-0">
+              <AvatarImage
+                src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+                alt="Jeroen Nijkamp"
+              />
+              <AvatarFallback className="bg-primary text-primary-foreground text-sm font-bold">JN</AvatarFallback>
+            </Avatar>
             <div>
-              <h1 className="text-3xl font-bold tracking-tight">Organizations</h1>
-              <p className="text-muted-foreground mt-1">Manage your professional affiliations and organization memberships.</p>
+              <h1 className="text-2xl font-bold tracking-tight">Jeroen Nijkamp</h1>
             </div>
           </div>
           

--- a/prototype/src/app/pages/UserProfileSettingsPage.tsx
+++ b/prototype/src/app/pages/UserProfileSettingsPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, Link } from "react-router";
 import { 
   User, Layout, CreditCard, Users, Bell, Settings, 
-  Camera, Plus, Link as LinkIcon, Github, Twitter, Linkedin, Mail, MapPin, Check
+  Camera, Plus, Link as LinkIcon, Github, Twitter, Linkedin, Mail, MapPin, Check, Loader2, Save, Undo2
 } from "lucide-react";
 import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
@@ -70,14 +70,20 @@ export default function UserProfileSettingsPage() {
   return (
     <div className="min-h-screen bg-background pb-12">
       {/* Header / Navigation Area */}
-      <div className="sticky top-16 z-20 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+      <div className="sticky top-16 z-20 border-b border-border bg-card">
         <div className="px-6 md:px-8 pt-8 pb-0">
           <div className="grid grid-cols-12 gap-6">
             <div className="col-span-12 lg:col-start-2 lg:col-span-10">
-          <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-4 mb-8">
+            <Avatar className="w-12 h-12 shrink-0">
+              <AvatarImage
+                src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+                alt="Jeroen Nijkamp"
+              />
+              <AvatarFallback className="bg-primary text-primary-foreground text-sm font-bold">JN</AvatarFallback>
+            </Avatar>
             <div>
-              <h1 className="text-3xl font-bold tracking-tight">Account Settings</h1>
-              <p className="text-muted-foreground mt-1">Manage your personal profile and account preferences.</p>
+              <h1 className="text-2xl font-bold tracking-tight">Jeroen Nijkamp</h1>
             </div>
           </div>
           
@@ -107,38 +113,9 @@ export default function UserProfileSettingsPage() {
         <div className="grid grid-cols-12 gap-6">
           <div className="col-span-12 lg:col-start-2 lg:col-span-10">
         {/* Removed max-w-5xl mx-auto wrapper to fix spacing issue on the left */}
-        <div className="flex flex-col md:flex-row gap-12 items-start">
+        <div className="flex flex-col lg:flex-row gap-12 items-start">
           
-          {/* Left Column: Avatar */}
-          <div className="w-full md:w-64 flex-shrink-0 flex flex-col items-center text-center">
-            <div className="relative group mb-6">
-              {/* Updated Avatar to match Profile Page EXACTLY (size, shadow, image crop) */}
-              <Avatar className="w-32 h-32 md:w-40 md:h-40 border-4 border-background shadow-lg text-4xl">
-                <AvatarImage 
-                  src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80" 
-                  alt={`${formData.firstName} ${formData.lastName}`}
-                />
-                <AvatarFallback className="bg-primary text-primary-foreground">
-                  {formData.firstName.substring(0, 1)}{formData.lastName.substring(0, 1)}
-                </AvatarFallback>
-              </Avatar>
-              <button className="absolute bottom-2 right-2 p-2 bg-primary text-primary-foreground rounded-full shadow-lg hover:bg-primary/90 transition-colors">
-                <Camera className="w-5 h-5" />
-              </button>
-            </div>
-            
-            <h2 className="text-xl font-bold">{formData.firstName} {formData.lastName}</h2>
-            {/* Nickname removed as requested */}
-            
-            <Button variant="outline" size="sm" className="w-full mt-4">
-              Change Avatar
-            </Button>
-            <p className="text-xs text-muted-foreground mt-2 text-center px-2">
-              Recommended size: 400x400px. JPG, PNG or GIF.
-            </p>
-          </div>
-
-          {/* Right Column: Profile Form */}
+          {/* Left Column: Profile Form */}
           <div className="flex-1 space-y-8 min-w-0 max-w-3xl">
             
             {/* Identity Section */}
@@ -304,23 +281,69 @@ export default function UserProfileSettingsPage() {
             <Separator />
 
             <div className="sticky bottom-0 bg-background/95 backdrop-blur py-4 border-t mt-8 -mx-4 px-4 md:mx-0 md:px-0 md:border-t-0 md:bg-transparent md:static">
-              <Button 
-                size="lg" 
-                className="w-full md:w-auto md:min-w-[200px]" 
-                onClick={handleSave} 
-                disabled={isLoading}
-              >
-                {isLoading ? (
-                  <>Saving...</>
-                ) : (
-                  <>
-                    <Check className="w-4 h-4 mr-2" />
-                    Save Changes
-                  </>
-                )}
-              </Button>
+              <div className="flex items-center gap-3">
+                <Button
+                  variant="ghost"
+                  size="lg"
+                  onClick={handleDiscard}
+                  disabled={!hasChanges}
+                  className="text-muted-foreground hover:text-destructive"
+                >
+                  <Undo2 className="w-4 h-4 mr-2" />
+                  Discard Changes
+                </Button>
+                <Button 
+                  size="lg" 
+                  className="md:min-w-[200px]" 
+                  onClick={handleSave} 
+                  disabled={!hasChanges || isLoading}
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Saving...
+                    </>
+                  ) : (
+                    <>
+                      <Save className="w-4 h-4 mr-2" />
+                      Save Changes
+                    </>
+                  )}
+                </Button>
+              </div>
             </div>
 
+          </div>
+
+          {/* Right Column: Profile Picture Preview */}
+          <div className="hidden lg:block w-80 flex-shrink-0 sticky top-52">
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium text-muted-foreground">Profile Picture</h3>
+              <div className="flex flex-col items-center text-center">
+                <div className="relative group mb-4">
+                  <Avatar className="w-40 h-40 border-4 border-background shadow-lg text-4xl">
+                    <AvatarImage
+                      src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+                      alt={`${formData.firstName} ${formData.lastName}`}
+                    />
+                    <AvatarFallback className="bg-primary text-primary-foreground">
+                      {formData.firstName.substring(0, 1)}{formData.lastName.substring(0, 1)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <button className="absolute bottom-2 right-2 p-2 bg-primary text-primary-foreground rounded-full shadow-lg hover:bg-primary/90 transition-colors">
+                    <Camera className="w-5 h-5" />
+                  </button>
+                </div>
+                <h2 className="text-lg font-bold">{formData.firstName} {formData.lastName}</h2>
+                <p className="text-sm text-muted-foreground mt-1">{formData.tagline}</p>
+                <Button variant="outline" size="sm" className="w-full mt-4">
+                  Change Avatar
+                </Button>
+                <p className="text-xs text-muted-foreground mt-2 text-center px-2">
+                  Recommended: 400x400px. JPG, PNG or GIF.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
         </div>

--- a/prototype/src/app/routes.tsx
+++ b/prototype/src/app/routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from "react-router";
+import { createBrowserRouter, Navigate } from "react-router";
 import { RootWrapper } from "./layouts/RootWrapper";
 import { MainLayout } from "./layouts/MainLayout";
 import { SpaceLayout } from "./layouts/SpaceLayout";
@@ -10,6 +10,7 @@ import { SpaceSubspaces } from "./pages/SpaceSubspaces";
 import { SpaceKnowledgeBase } from "./pages/SpaceKnowledgeBase";
 import { SpaceSettingsPage } from "./pages/SpaceSettingsPage";
 import SubspacePage from "./pages/SubspacePage";
+import SubspaceSettingsPage from "./pages/SubspaceSettingsPage";
 import UserProfilePage from "./pages/UserProfilePage";
 import UserAccountPage from "./pages/UserAccountPage";
 import UserProfileSettingsPage from "./pages/UserProfileSettingsPage";
@@ -59,6 +60,10 @@ export const router = createBrowserRouter([
 
           /* ─── User Routes ─── */
           { path: "user/:userSlug", Component: UserProfilePage },
+          {
+            path: "user/:userSlug/settings",
+            element: <Navigate to="profile" replace />,
+          },
           { path: "user/:userSlug/settings/profile", Component: UserProfileSettingsPage },
           { path: "user/:userSlug/settings/account", Component: UserAccountPage },
           { path: "user/:userSlug/settings/membership", Component: UserMembershipPage },
@@ -100,6 +105,10 @@ export const router = createBrowserRouter([
 
           /* Subspace pages — dedicated layout with channel tabs & collapsible sidebar */
           { path: "/space/:spaceSlug/subspaces/:subspaceSlug", Component: SubspacePage },
+
+          /* Subspace settings */
+          { path: "/space/:spaceSlug/subspaces/:subspaceSlug/settings", Component: SubspaceSettingsPage },
+          { path: "/space/:spaceSlug/subspaces/:subspaceSlug/settings/:tab", Component: SubspaceSettingsPage },
         ],
       },
     ],


### PR DESCRIPTION
## What

Replaces the `prototype/` folder with the latest design reference from the Shadcn UI Redesign Project.

## Changes to prototype

Includes but is not limited to:

**- Updated Space Settings —** Removed the banner from beign shown on setting level, added a description state to each tab; and some tweaking with the editing; il touch base with Polina Boneva on this if need be
**- Subspace Settings —** full parity with space settings + Updates tab
**- Subspace page —** new Innovation flow Tabs with flow arrows (simone requested the arrows between the flow states; i have even added a functionality so users can decide at add arrows in between or not; but she think that it may be best to leave that whole thing till after mvp)
**- Innovation flow descriptions —** added a way for us to display the description for each innovation flow state 
**- Space content tabs —** refreshed Feed, Members, Knowledge, Subspaces list to have descriptions; (these are then the same as the phase descriptions we currently have; making it possible to reuse innovation flow states) 
**- Headers & Sidebars —** hero banners, dialog integration 
**- User settings pages —** Profile, Notifications, Memberships, Organizations, Account (updated the user profile settings to be more in line with the space / subspace settings 
**- Subspace widgets —** Brought back the widgets for the subspaces as "quick actions' with a dialogue for recent activity; calendar; index; (sub)subspaces and community

added: 

consistent ux behaviour for ui panels (i hope) so consistent hover and active states; consitent animations; etc.. 

## Dependencies added

- `date-fns` — required by new CRD timeline/calendar components
- `react-day-picker` — date picker primitive for calendar UI

## Notes

- The `prototype/` folder is **read-only** — no code in it is executed or imported by the main application
- Commit is unsigned (YubiKey unavailable); will re-sign when hardware is available