### PR TITLE
[CRD] breadcrumbs

### DIFF
--- a/docs/crd/breadcrumbs.md
+++ b/docs/crd/breadcrumbs.md
@@ -8,7 +8,7 @@ This decouples the nav from content: the Header stays presentational and just ac
 
 ## Data flow
 
-```
+```text
 Page (e.g. CrdSpacePageLayout)
    │  useSetBreadcrumbs([{ label, href?, icon? }, …])
    ▼
@@ -39,23 +39,28 @@ Rendered next to the logo, hidden below `md`
 Call `useSetBreadcrumbs` once in your page/layout component. The hook publishes the trail on mount and clears it on unmount.
 
 ```tsx
+import { useTranslation } from 'react-i18next';
+import { Layers } from 'lucide-react';
 import { useSetBreadcrumbs } from '@/main/ui/breadcrumbs/BreadcrumbsContext';
 import type { BreadcrumbTrailItem } from '@/crd/components/common/BreadcrumbsTrail';
-import { Layers } from 'lucide-react';
 
 export default function MyPage() {
+  const { t } = useTranslation('crd-spaceSettings');
   const { space } = useSpace();
+  const spaceUrl = space.about.profile.url;
 
   const items: BreadcrumbTrailItem[] = [
-    { label: space.about.profile.displayName, href: space.about.profile.url, icon: Layers },
-    { label: 'Settings', href: `${space.about.profile.url}/settings` },
-    { label: 'About' },
+    { label: space.about.profile.displayName, href: spaceUrl, icon: Layers },
+    { label: t('tabs.settings'), href: `${spaceUrl}/settings` },
+    { label: t('tabs.about') },
   ];
   useSetBreadcrumbs(items);
 
   return <MyPageContent />;
 }
 ```
+
+Business data (space name) comes from domain props; generic segments use `t()` with keys from the feature's i18n namespace. Never pass a string literal as `defaultValue` to `t()` — add the key to all language files instead.
 
 ### Item shape
 

--- a/docs/crd/breadcrumbs.md
+++ b/docs/crd/breadcrumbs.md
@@ -1,0 +1,122 @@
+# CRD Breadcrumbs
+
+## Overview
+
+On CRD pages, breadcrumbs live **in the top nav**, next to the Alkemio logo — not on the page itself. Pages declare their trail with a hook; the nav reads it and renders. The `Header` component itself has no knowledge of what page is loaded.
+
+This decouples the nav from content: the Header stays presentational and just accepts a `breadcrumbs: ReactNode` prop. Coordination happens in a small app-layer context.
+
+## Data flow
+
+```
+Page (e.g. CrdSpacePageLayout)
+   │  useSetBreadcrumbs([{ label, href?, icon? }, …])
+   ▼
+BreadcrumbsProvider  ◄──── state held here
+   │  useBreadcrumbs() → items[]
+   ▼
+CrdLayoutConnector
+   │  <BreadcrumbsTrail items={items} />
+   ▼
+CrdLayout → Header (breadcrumbs prop)
+   │
+   ▼
+Rendered next to the logo, hidden below `md`
+```
+
+## Files
+
+| File | Role |
+|------|------|
+| `src/crd/primitives/breadcrumb.tsx` | shadcn primitives: `Breadcrumb`, `BreadcrumbItem`, `BreadcrumbLink`, `BreadcrumbPage`, `BreadcrumbSeparator` |
+| `src/crd/components/common/BreadcrumbsTrail.tsx` | items-based renderer; composes the primitives from a `BreadcrumbTrailItem[]` |
+| `src/main/ui/breadcrumbs/BreadcrumbsContext.tsx` | `BreadcrumbsProvider`, `useBreadcrumbs`, `useSetBreadcrumbs` |
+| `src/crd/layouts/Header.tsx` | renders `breadcrumbs?: ReactNode` next to the logo |
+| `src/main/ui/layout/CrdLayoutWrapper.tsx` | mounts the provider and wires the trail into the layout |
+
+## Adding breadcrumbs to a CRD page
+
+Call `useSetBreadcrumbs` once in your page/layout component. The hook publishes the trail on mount and clears it on unmount.
+
+```tsx
+import { useSetBreadcrumbs } from '@/main/ui/breadcrumbs/BreadcrumbsContext';
+import type { BreadcrumbTrailItem } from '@/crd/components/common/BreadcrumbsTrail';
+import { Layers } from 'lucide-react';
+
+export default function MyPage() {
+  const { space } = useSpace();
+
+  const items: BreadcrumbTrailItem[] = [
+    { label: space.about.profile.displayName, href: space.about.profile.url, icon: Layers },
+    { label: 'Settings', href: `${space.about.profile.url}/settings` },
+    { label: 'About' },
+  ];
+  useSetBreadcrumbs(items);
+
+  return <MyPageContent />;
+}
+```
+
+### Item shape
+
+```ts
+type BreadcrumbTrailItem = {
+  label: string;          // visible text
+  href?: string;          // omit on the terminal (current-page) item
+  icon?: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+};
+```
+
+- The **last** item renders as the current page (bold, no link), regardless of `href`.
+- Non-terminal items with `href` render as links; without `href`, as plain text.
+- `icon` is optional; use `lucide-react` icons.
+
+### Hook placement
+
+Call `useSetBreadcrumbs` **before any early returns** in the component. React's rules of hooks require consistent hook order between renders. Pass `[]` during loading states if you don't have data yet — the trail will update once data arrives.
+
+```tsx
+// ✅ Good — hook always called
+const items = isReady ? [...] : [];
+useSetBreadcrumbs(items);
+if (!isReady) return <LoadingSpinner />;
+
+// ❌ Bad — hook skipped when loading
+if (!isReady) return <LoadingSpinner />;
+useSetBreadcrumbs([...]);
+```
+
+### Clearing
+
+Navigating away automatically clears the trail — the hook's effect cleanup runs on unmount. If a page conditionally shows breadcrumbs (e.g. only on `/settings`), pass `[]` in the non-settings branch; the effect will publish the empty list.
+
+## What goes where
+
+| Concern | Where |
+|---------|-------|
+| Declaring a page's trail | Page/layout component via `useSetBreadcrumbs` |
+| Dynamic labels (space names, entity titles) | In the page; pull from Apollo / domain hooks and pass as `label` |
+| i18n for generic segments ("Settings", "About") | Page calls `t(...)` and passes the result as `label` |
+| Visual rendering | `BreadcrumbsTrail` + the `breadcrumb` primitives |
+| Placement in the chrome | `Header.tsx` (left of the icon cluster, after a divider) |
+
+CRD primitives and `BreadcrumbsTrail` never know about pages, routing, or GraphQL — they take plain `items` props. All business logic stays in the caller.
+
+## Responsive behavior
+
+The trail is hidden below the `md` breakpoint (`hidden md:inline-flex` on the nav wrapper). On phones, only the logo shows; the page header / title below takes over as the "where am I" cue. This keeps the top bar from overflowing on narrow viewports.
+
+## Accessibility
+
+- The primitive renders a `<nav aria-label="breadcrumb">` landmark with an `<ol>` inside.
+- Separators use `role="presentation" aria-hidden="true"` (not announced).
+- The terminal segment uses `aria-current="page"` (no `role="link"` — it is not interactive).
+- Icons decoratively paired with labels must have `aria-hidden="true"`.
+
+## Rules
+
+- **One setter at a time.** Only one component should publish breadcrumbs per route. Nested `useSetBreadcrumbs` calls clobber each other (last effect wins).
+- **Hook before early returns.** Always call `useSetBreadcrumbs` at the top of the component, before any conditional `return`.
+- **No hardcoded page text.** All segment labels must come from `t()` (for generic words like "Settings") or from domain data (for names). No literal strings in JSX like `{ label: 'Settings' }` without `t()`.
+- **Keep it shallow.** A trail of 2–3 segments is the sweet spot. Beyond 4, consider whether the information belongs in the page header instead.
+- **Dev-only: React Compiler stability.** The provider de-duplicates identical items via shallow content equality, so passing a fresh array literal each render is safe — no need for `useMemo` in callers (and it's forbidden by project rules anyway).

--- a/src/crd/components/common/BreadcrumbsTrail.tsx
+++ b/src/crd/components/common/BreadcrumbsTrail.tsx
@@ -1,0 +1,52 @@
+import { type ComponentType, Fragment } from 'react';
+import { cn } from '@/crd/lib/utils';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/crd/primitives/breadcrumb';
+
+export type BreadcrumbTrailItem = {
+  label: string;
+  href?: string;
+  icon?: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+};
+
+type BreadcrumbsTrailProps = {
+  items: BreadcrumbTrailItem[];
+  className?: string;
+};
+
+export function BreadcrumbsTrail({ items, className }: BreadcrumbsTrailProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <Breadcrumb className={cn('hidden md:inline-flex', className)}>
+      <BreadcrumbList>
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          const Icon = item.icon;
+
+          return (
+            <Fragment key={`${item.label}|${item.href ?? ''}`}>
+              {index > 0 && <BreadcrumbSeparator />}
+              <BreadcrumbItem>
+                {Icon && <Icon aria-hidden={true} className="size-3.5 shrink-0" />}
+                {isLast ? (
+                  <BreadcrumbPage className="font-medium">{item.label}</BreadcrumbPage>
+                ) : item.href ? (
+                  <BreadcrumbLink href={item.href}>{item.label}</BreadcrumbLink>
+                ) : (
+                  <span>{item.label}</span>
+                )}
+              </BreadcrumbItem>
+            </Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/src/crd/layouts/CrdLayout.tsx
+++ b/src/crd/layouts/CrdLayout.tsx
@@ -22,6 +22,7 @@ type CrdLayoutProps = {
   unreadNotificationsCount?: number;
   languages: CrdLanguageOption[];
   currentLanguage: string;
+  breadcrumbs?: ReactNode;
   onLanguageChange: (code: string) => void;
   onLogout?: () => void;
   onMessagesClick?: () => void;
@@ -45,6 +46,7 @@ export function CrdLayout({
   unreadNotificationsCount,
   languages,
   currentLanguage,
+  breadcrumbs,
   onLanguageChange,
   onLogout,
   onMessagesClick,
@@ -69,6 +71,7 @@ export function CrdLayout({
         unreadNotificationsCount={unreadNotificationsCount}
         languages={languages}
         currentLanguage={currentLanguage}
+        breadcrumbs={breadcrumbs}
         onLanguageChange={onLanguageChange}
         onLogout={onLogout}
         onMessagesClick={onMessagesClick}

--- a/src/crd/layouts/Header.tsx
+++ b/src/crd/layouts/Header.tsx
@@ -1,4 +1,5 @@
 import { Bell, LayoutGrid, MessageSquare, Search } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AlkemioLogo } from '@/crd/components/common/AlkemioLogo';
 import { PlatformNavigationMenu } from '@/crd/layouts/components/PlatformNavigationMenu';
@@ -62,6 +63,7 @@ type HeaderProps = {
   unreadNotificationsCount?: number;
   languages?: CrdLanguageOption[];
   currentLanguage?: string;
+  breadcrumbs?: ReactNode;
   onLogout?: () => void;
   onMenuClick?: () => void;
   onMessagesClick?: () => void;
@@ -85,6 +87,7 @@ export function Header({
   unreadNotificationsCount,
   languages,
   currentLanguage,
+  breadcrumbs,
   onLogout,
   onMenuClick,
   onMessagesClick,
@@ -105,11 +108,17 @@ export function Header({
         className
       )}
     >
-      {/* Left: Logo + mobile menu */}
-      <div className="flex items-center gap-4">
+      {/* Left: Logo + breadcrumbs */}
+      <div className="flex items-center gap-4 min-w-0">
         <a href={navigationHrefs.home} className="flex items-center shrink-0" aria-label={t('header.home')}>
           <AlkemioLogo className="w-8 h-8" />
         </a>
+        {breadcrumbs && (
+          <>
+            <div className="h-6 w-px hidden md:block bg-border" />
+            <div className="min-w-0">{breadcrumbs}</div>
+          </>
+        )}
       </div>
 
       {/* Right: icon row */}

--- a/src/crd/layouts/SpaceShell.tsx
+++ b/src/crd/layouts/SpaceShell.tsx
@@ -5,18 +5,16 @@ type SpaceShellProps = {
   header: ReactNode;
   sidebar?: ReactNode;
   tabs?: ReactNode;
-  breadcrumbs?: ReactNode;
   children: ReactNode;
   className?: string;
 };
 
-export function SpaceShell({ header, sidebar, tabs, breadcrumbs, children, className }: SpaceShellProps) {
+export function SpaceShell({ header, sidebar, tabs, children, className }: SpaceShellProps) {
   const hasSidebar = !!sidebar;
   const hasTabs = !!tabs;
 
   return (
     <div className={cn('flex flex-col bg-background', className)}>
-      {breadcrumbs && <div className="w-full px-6 md:px-8 py-2 text-caption text-muted-foreground">{breadcrumbs}</div>}
       {header}
 
       <div className={cn('w-full px-6 md:px-8 pb-8', hasTabs ? 'pt-8' : 'pt-0')}>

--- a/src/crd/primitives/breadcrumb.tsx
+++ b/src/crd/primitives/breadcrumb.tsx
@@ -34,7 +34,14 @@ function BreadcrumbLink({
   const Comp = asChild ? Slot : 'a';
 
   return (
-    <Comp data-slot="breadcrumb-link" className={cn('hover:text-foreground transition-colors', className)} {...props} />
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn(
+        'hover:text-foreground transition-colors outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:rounded-sm',
+        className
+      )}
+      {...props}
+    />
   );
 }
 
@@ -63,17 +70,19 @@ function BreadcrumbSeparator({ children, className, ...props }: React.ComponentP
   );
 }
 
-function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
+type BreadcrumbEllipsisProps = React.ComponentProps<'span'> & {
+  srLabel: string;
+};
+
+function BreadcrumbEllipsis({ className, srLabel, ...props }: BreadcrumbEllipsisProps) {
   return (
     <span
       data-slot="breadcrumb-ellipsis"
-      role="presentation"
-      aria-hidden="true"
       className={cn('flex size-9 items-center justify-center', className)}
       {...props}
     >
-      <MoreHorizontal className="size-4" />
-      <span className="sr-only">More</span>
+      <MoreHorizontal aria-hidden="true" className="size-4" />
+      <span className="sr-only">{srLabel}</span>
     </span>
   );
 }

--- a/src/crd/primitives/breadcrumb.tsx
+++ b/src/crd/primitives/breadcrumb.tsx
@@ -1,0 +1,89 @@
+import { Slot } from '@radix-ui/react-slot';
+import { ChevronRight, MoreHorizontal } from 'lucide-react';
+import type * as React from 'react';
+import { cn } from '@/crd/lib/utils';
+
+function Breadcrumb({ ...props }: React.ComponentProps<'nav'>) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        'text-muted-foreground flex flex-wrap items-center gap-1.5 text-control break-words sm:gap-2.5',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
+  return <li data-slot="breadcrumb-item" className={cn('inline-flex items-center gap-1.5', className)} {...props} />;
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<'a'> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot : 'a';
+
+  return (
+    <Comp data-slot="breadcrumb-link" className={cn('hover:text-foreground transition-colors', className)} {...props} />
+  );
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      aria-current="page"
+      className={cn('text-foreground font-normal', className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbSeparator({ children, className, ...props }: React.ComponentProps<'li'>) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn('[&>svg]:size-3.5', className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  );
+}
+
+function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn('flex size-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  );
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+};

--- a/src/main/crdPages/space/layout/CrdSpacePageLayout.tsx
+++ b/src/main/crdPages/space/layout/CrdSpacePageLayout.tsx
@@ -1,6 +1,5 @@
 import {
   Bookmark,
-  ChevronRight,
   HardDrive,
   History,
   Info,
@@ -18,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { SpaceLevel, VisualType } from '@/core/apollo/generated/graphql-schema';
 import { usePageTitle } from '@/core/routing/usePageTitle';
+import type { BreadcrumbTrailItem } from '@/crd/components/common/BreadcrumbsTrail';
 import { LoadingSpinner } from '@/crd/components/common/LoadingSpinner';
 import { SpaceHeader } from '@/crd/components/space/SpaceHeader';
 import { SpaceNavigationTabs } from '@/crd/components/space/SpaceNavigationTabs';
@@ -39,6 +39,7 @@ import {
 } from '@/main/crdPages/topLevelPages/spaceSettings/useSpaceSettingsTab';
 import { buildSpaceSectionUrl, TabbedLayoutParams } from '@/main/routing/urlBuilders';
 import useUrlResolver from '@/main/routing/urlResolver/useUrlResolver';
+import { useSetBreadcrumbs } from '@/main/ui/breadcrumbs/BreadcrumbsContext';
 import { mapMemberAvatars, mapSpaceVisibility } from '../dataMappers/spacePageDataMapper';
 import { useCrdSpaceTabs } from '../hooks/useCrdSpaceTabs';
 
@@ -61,6 +62,30 @@ export default function CrdSpacePageLayout() {
     spaceId,
     skip: !isLevelZero || !permissions.canRead,
   });
+
+  // Must be derived before any early returns so `useSetBreadcrumbs` is called
+  // on every render. During loading the space fields are empty strings and
+  // the trail is `[]`; it updates once Apollo populates the context.
+  const isOnSettings = pathname.includes('/settings');
+  const spaceDisplayName = space.about.profile.displayName;
+  const spaceUrl = space.about.profile.url ?? '';
+  const settingsTabSegment = isOnSettings ? (pathname.split('/settings/')[1]?.split('/')[0] ?? 'about') : '';
+  const settingsTabLabel = settingsTabSegment
+    ? settingsTabSegment.charAt(0).toUpperCase() + settingsTabSegment.slice(1)
+    : '';
+
+  const breadcrumbItems: BreadcrumbTrailItem[] =
+    isLevelZero && isOnSettings && spaceDisplayName
+      ? [
+          { label: spaceDisplayName, href: spaceUrl, icon: Layers },
+          {
+            label: t('crd-space:breadcrumbs.settings', { defaultValue: 'Settings' }),
+            href: `${spaceUrl}/settings`,
+          },
+          ...(settingsTabLabel ? [{ label: settingsTabLabel }] : []),
+        ]
+      : [];
+  useSetBreadcrumbs(breadcrumbItems);
 
   if (resolvingUrl || loadingSpace) {
     return <LoadingSpinner />;
@@ -120,17 +145,6 @@ export default function CrdSpacePageLayout() {
 
   const sidebarSlot = <div id="crd-space-sidebar" />;
 
-  // Hide space navigation tabs (Home/Community/Subspaces/Knowledge) on the
-  // Settings sub-routes — settings has its own tab strip (About/Layout/…).
-  const isOnSettings = pathname.includes('/settings');
-
-  // Extract the active settings tab name for the breadcrumb (e.g., "about" → "About").
-  const settingsTabSegment = isOnSettings ? (pathname.split('/settings/')[1]?.split('/')[0] ?? 'about') : '';
-  const settingsTabLabel = settingsTabSegment
-    ? settingsTabSegment.charAt(0).toUpperCase() + settingsTabSegment.slice(1)
-    : '';
-  const spaceHref = space.about.profile.url ?? '';
-
   const settingsTabs: ReadonlyArray<SpaceSettingsTabDescriptor<SpaceSettingsTabId>> = [
     { id: 'about', label: t('crd-spaceSettings:tabs.about', { defaultValue: 'About' }), icon: Info },
     { id: 'layout', label: t('crd-spaceSettings:tabs.layout', { defaultValue: 'Layout' }), icon: LayoutGrid },
@@ -149,26 +163,6 @@ export default function CrdSpacePageLayout() {
         <SpaceVisibilityNotice status={visibilityData.status} contactHref={visibilityData.contactHref} />
       )}
       <SpaceShell
-        breadcrumbs={
-          isOnSettings ? (
-            <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm">
-              <Layers aria-hidden="true" className="size-4 mr-1" />
-              <a href={spaceHref} className="text-muted-foreground hover:text-foreground hover:underline">
-                {space.about.profile.displayName}
-              </a>
-              <ChevronRight aria-hidden="true" className="size-3 text-muted-foreground" />
-              <a href={`${spaceHref}/settings`} className="text-muted-foreground hover:text-foreground hover:underline">
-                {t('crd-space:breadcrumbs.settings', { defaultValue: 'Settings' })}
-              </a>
-              {settingsTabLabel && (
-                <>
-                  <ChevronRight aria-hidden="true" className="size-3 text-muted-foreground" />
-                  <span className="text-foreground font-medium">{settingsTabLabel}</span>
-                </>
-              )}
-            </nav>
-          ) : undefined
-        }
         header={
           isOnSettings ? (
             <SpaceSettingsHeader

--- a/src/main/crdPages/space/layout/CrdSpacePageLayout.tsx
+++ b/src/main/crdPages/space/layout/CrdSpacePageLayout.tsx
@@ -69,20 +69,16 @@ export default function CrdSpacePageLayout() {
   const isOnSettings = pathname.includes('/settings');
   const spaceDisplayName = space.about.profile.displayName;
   const spaceUrl = space.about.profile.url ?? '';
-  const settingsTabSegment = isOnSettings ? (pathname.split('/settings/')[1]?.split('/')[0] ?? 'about') : '';
-  const settingsTabLabel = settingsTabSegment
-    ? settingsTabSegment.charAt(0).toUpperCase() + settingsTabSegment.slice(1)
-    : '';
 
   const breadcrumbItems: BreadcrumbTrailItem[] =
     isLevelZero && isOnSettings && spaceDisplayName
       ? [
           { label: spaceDisplayName, href: spaceUrl, icon: Layers },
           {
-            label: t('crd-space:breadcrumbs.settings', { defaultValue: 'Settings' }),
+            label: t('crd-spaceSettings:tabs.settings'),
             href: `${spaceUrl}/settings`,
           },
-          ...(settingsTabLabel ? [{ label: settingsTabLabel }] : []),
+          { label: t(`crd-spaceSettings:tabs.${activeSettingsTab}`) },
         ]
       : [];
   useSetBreadcrumbs(breadcrumbItems);

--- a/src/main/ui/breadcrumbs/BreadcrumbsContext.tsx
+++ b/src/main/ui/breadcrumbs/BreadcrumbsContext.tsx
@@ -45,8 +45,16 @@ export function useSetBreadcrumbs(items: BreadcrumbTrailItem[]) {
   if (!ctx) throw new Error('useSetBreadcrumbs must be used within BreadcrumbsProvider');
   const { setItems } = ctx;
 
+  // Publish on items change. The provider's shallow-equality guard makes this
+  // a no-op when content is unchanged, even if the array identity differs.
   useEffect(() => {
     setItems(items);
-    return () => setItems([]);
   }, [items, setItems]);
+
+  // Clear only on unmount. Kept separate so a re-render doesn't cycle state
+  // through [items → [] → items] (which would happen if cleanup and publish
+  // lived in the same effect).
+  useEffect(() => {
+    return () => setItems([]);
+  }, [setItems]);
 }

--- a/src/main/ui/breadcrumbs/BreadcrumbsContext.tsx
+++ b/src/main/ui/breadcrumbs/BreadcrumbsContext.tsx
@@ -1,0 +1,52 @@
+import { createContext, type ReactNode, useContext, useEffect, useState } from 'react';
+import type { BreadcrumbTrailItem } from '@/crd/components/common/BreadcrumbsTrail';
+
+type BreadcrumbsContextValue = {
+  items: BreadcrumbTrailItem[];
+  setItems: (items: BreadcrumbTrailItem[]) => void;
+};
+
+const BreadcrumbsContext = createContext<BreadcrumbsContextValue | null>(null);
+
+function itemsEqual(a: BreadcrumbTrailItem[], b: BreadcrumbTrailItem[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].label !== b[i].label || a[i].href !== b[i].href || a[i].icon !== b[i].icon) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function BreadcrumbsProvider({ children }: { children: ReactNode }) {
+  const [items, setItemsRaw] = useState<BreadcrumbTrailItem[]>([]);
+
+  // Shallow-equal guard prevents update cycles when callers pass a fresh
+  // array on every render (e.g., literals built in page layouts). Without
+  // it, useSetBreadcrumbs could loop when the React Compiler fails to
+  // memoize the caller's array.
+  const setItems = (next: BreadcrumbTrailItem[]) => {
+    setItemsRaw(prev => (itemsEqual(prev, next) ? prev : next));
+  };
+
+  const value = { items, setItems };
+  return <BreadcrumbsContext.Provider value={value}>{children}</BreadcrumbsContext.Provider>;
+}
+
+export function useBreadcrumbs(): BreadcrumbTrailItem[] {
+  const ctx = useContext(BreadcrumbsContext);
+  if (!ctx) throw new Error('useBreadcrumbs must be used within BreadcrumbsProvider');
+  return ctx.items;
+}
+
+export function useSetBreadcrumbs(items: BreadcrumbTrailItem[]) {
+  const ctx = useContext(BreadcrumbsContext);
+  if (!ctx) throw new Error('useSetBreadcrumbs must be used within BreadcrumbsProvider');
+  const { setItems } = ctx;
+
+  useEffect(() => {
+    setItems(items);
+    return () => setItems([]);
+  }, [items, setItems]);
+}

--- a/src/main/ui/layout/CrdLayoutWrapper.tsx
+++ b/src/main/ui/layout/CrdLayoutWrapper.tsx
@@ -3,6 +3,7 @@ import { Outlet } from 'react-router-dom';
 import { IdentityRoutes } from '@/core/auth/authentication/routing/IdentityRoute';
 import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
 import useNavigate from '@/core/routing/useNavigate';
+import { BreadcrumbsTrail } from '@/crd/components/common/BreadcrumbsTrail';
 import { CrdLayout } from '@/crd/layouts/CrdLayout';
 import { MarkdownConfigProvider } from '@/crd/lib/markdownConfig';
 import {
@@ -14,6 +15,7 @@ import { useConfig } from '@/domain/platform/config/useConfig';
 import { useInAppNotificationsContext } from '@/main/inAppNotifications/InAppNotificationsContext';
 import { useInAppNotifications } from '@/main/inAppNotifications/useInAppNotifications';
 import { SearchProvider, useSearch } from '@/main/search/SearchContext';
+import { BreadcrumbsProvider, useBreadcrumbs } from '@/main/ui/breadcrumbs/BreadcrumbsContext';
 import { useCrdNavigation } from '@/main/ui/layout/useCrdNavigation';
 import { useCrdUser } from '@/main/ui/layout/useCrdUser';
 import { useUserMessagingContext } from '@/main/userMessaging/UserMessagingContext';
@@ -45,6 +47,7 @@ function CrdLayoutConnector() {
   const { openSearch } = useSearch();
   const navigate = useNavigate();
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
+  const breadcrumbItems = useBreadcrumbs();
 
   const handleLogout = () => {
     navigate(IdentityRoutes.Logout);
@@ -79,6 +82,7 @@ function CrdLayoutConnector() {
         unreadNotificationsCount={notificationsUnreadCount}
         languages={languages}
         currentLanguage={currentLanguage}
+        breadcrumbs={breadcrumbItems.length > 0 ? <BreadcrumbsTrail items={breadcrumbItems} /> : undefined}
         onLanguageChange={handleLanguageChange}
         onLogout={handleLogout}
         onMessagesClick={() => setMessagingOpen(true)}
@@ -107,8 +111,10 @@ function CrdLayoutConnector() {
 
 export function CrdLayoutWrapper() {
   return (
-    <SearchProvider>
-      <CrdLayoutConnector />
-    </SearchProvider>
+    <BreadcrumbsProvider>
+      <SearchProvider>
+        <CrdLayoutConnector />
+      </SearchProvider>
+    </BreadcrumbsProvider>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breadcrumb navigation now appears next to the logo in the top header, reflecting page hierarchy and links (with optional icons); hidden on small screens.
  * Breadcrumbs are managed centrally so pages automatically surface/update trails (improved consistency across routes, including settings).

* **Documentation**
  * Added a comprehensive breadcrumb guide covering usage patterns, responsiveness, accessibility, lifecycle rules, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->