### PR TITLE
fix the callout creation on non-home tabs

### DIFF
--- a/src/main/crdPages/space/hooks/useCrdSpaceCommunity.ts
+++ b/src/main/crdPages/space/hooks/useCrdSpaceCommunity.ts
@@ -18,6 +18,7 @@ export function useCrdSpaceCommunity() {
   const {
     calloutsSetId,
     classificationTagsets,
+    flowStateForNewCallouts,
     tabDescription,
     loading: tabLoading,
   } = useSpaceTabProvider({ tabPosition: 1 });
@@ -76,6 +77,7 @@ export function useCrdSpaceCommunity() {
     calloutsSetId,
     canCreateCallout: calloutsSetProvided.canCreateCallout,
     tabDescription: tabDescription ?? '',
+    flowStateForNewCallouts,
     leadUsers,
     leadOrganizations,
     virtualContributors,

--- a/src/main/crdPages/space/tabs/CrdSpaceCommunityPage.tsx
+++ b/src/main/crdPages/space/tabs/CrdSpaceCommunityPage.tsx
@@ -29,6 +29,7 @@ export default function CrdSpaceCommunityPage() {
     calloutsSetId,
     canCreateCallout,
     tabDescription,
+    flowStateForNewCallouts,
     leadUsers,
     leadOrganizations,
     virtualContributors,
@@ -103,7 +104,12 @@ export default function CrdSpaceCommunityPage() {
       </div>
 
       {canCreateCallout && (
-        <CalloutFormConnector open={createOpen} onOpenChange={setCreateOpen} calloutsSetId={calloutsSetId} />
+        <CalloutFormConnector
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          calloutsSetId={calloutsSetId}
+          activeFlowStateName={flowStateForNewCallouts?.displayName}
+        />
       )}
 
       {canInvite && (

--- a/src/main/crdPages/space/tabs/CrdSpaceCustomTabPage.tsx
+++ b/src/main/crdPages/space/tabs/CrdSpaceCustomTabPage.tsx
@@ -28,11 +28,18 @@ export default function CrdSpaceCustomTabPage({ sectionIndex }: CrdSpaceCustomTa
   const [tagsFilter, setTagsFilter] = useState<string[]>([]);
   const [createOpen, setCreateOpen] = useState(false);
 
-  const { callouts, calloutsSetId, classificationTagsets, canCreateCallout, tabDescription, loading } =
-    useCrdCalloutList({
-      tabPosition: sectionIndex,
-      tagsFilter: tagsFilter.length > 0 ? tagsFilter : undefined,
-    });
+  const {
+    callouts,
+    calloutsSetId,
+    classificationTagsets,
+    canCreateCallout,
+    tabDescription,
+    flowStateForNewCallouts,
+    loading,
+  } = useCrdCalloutList({
+    tabPosition: sectionIndex,
+    tagsFilter: tagsFilter.length > 0 ? tagsFilter : undefined,
+  });
 
   // Fetch tags via the same GraphQL query the MUI version uses
   const { data: tagsData } = useCalloutsSetTagsQuery({
@@ -115,7 +122,12 @@ export default function CrdSpaceCustomTabPage({ sectionIndex }: CrdSpaceCustomTa
       </div>
 
       {canCreateCallout && (
-        <CalloutFormConnector open={createOpen} onOpenChange={setCreateOpen} calloutsSetId={calloutsSetId} />
+        <CalloutFormConnector
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          calloutsSetId={calloutsSetId}
+          activeFlowStateName={flowStateForNewCallouts?.displayName}
+        />
       )}
     </>
   );

--- a/src/main/crdPages/space/tabs/CrdSpaceDashboardPage.tsx
+++ b/src/main/crdPages/space/tabs/CrdSpaceDashboardPage.tsx
@@ -23,8 +23,15 @@ export default function CrdSpaceDashboardPage() {
   const { t } = useTranslation('crd-space');
   const { space } = useSpace();
   const navigate = useNavigate();
-  const { callouts, calloutsSetId, canCreateCallout, tabDescription, dashboardNavigation, loading } =
-    useCrdSpaceDashboard();
+  const {
+    callouts,
+    calloutsSetId,
+    canCreateCallout,
+    tabDescription,
+    dashboardNavigation,
+    flowStateForNewCallouts,
+    loading,
+  } = useCrdSpaceDashboard();
   const { events: sidebarEvents, canCreateEvents } = useCrdCalendarSidebar();
   const { navigateToList, navigateToCreate, navigateToEvent } = useCrdCalendarUrlState();
   const locale = useCrdSpaceLocale();
@@ -90,7 +97,12 @@ export default function CrdSpaceDashboardPage() {
       <CalloutListConnector callouts={callouts} calloutsSetId={calloutsSetId} loading={loading} />
 
       {canCreateCallout && (
-        <CalloutFormConnector open={createOpen} onOpenChange={setCreateOpen} calloutsSetId={calloutsSetId} />
+        <CalloutFormConnector
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          calloutsSetId={calloutsSetId}
+          activeFlowStateName={flowStateForNewCallouts?.displayName}
+        />
       )}
 
       <CrdCalendarDialogConnector open={calendarOpen} onOpenChange={setCalendarOpen} />

--- a/src/main/crdPages/space/tabs/CrdSpaceSubspacesPage.tsx
+++ b/src/main/crdPages/space/tabs/CrdSpaceSubspacesPage.tsx
@@ -30,6 +30,7 @@ export default function CrdSpaceSubspacesPage() {
     calloutsSetId,
     canCreateCallout,
     tabDescription,
+    flowStateForNewCallouts,
     loading: calloutsLoading,
   } = useCrdCalloutList({
     tabPosition: 2,
@@ -99,6 +100,7 @@ export default function CrdSpaceSubspacesPage() {
           open={createCalloutOpen}
           onOpenChange={setCreateCalloutOpen}
           calloutsSetId={calloutsSetId}
+          activeFlowStateName={flowStateForNewCallouts?.displayName}
         />
       )}
 


### PR DESCRIPTION
- [x] posts added to knowledge base land on the home
- [x] avatar in space L0 settings (should be hidden, only available for non-L0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Callout creation forms now integrate active flow state context across community pages, custom tabs, dashboard, and subspaces for improved organization of new discussions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->