### PR TITLE
[CRD] Contributions Sorting & Bugfix: Wb contribution default content

### DIFF
--- a/src/crd/components/callout/CalloutContributionsSortDialog.tsx
+++ b/src/crd/components/callout/CalloutContributionsSortDialog.tsx
@@ -68,6 +68,7 @@ export function CalloutContributionsSortDialog({
   useEffect(() => {
     if (!open) {
       hasSeededRef.current = false;
+      setItems([]);
       return;
     }
     if (!hasSeededRef.current && contributions.length > 0) {

--- a/src/crd/components/callout/CalloutContributionsSortDialog.tsx
+++ b/src/crd/components/callout/CalloutContributionsSortDialog.tsx
@@ -58,19 +58,23 @@ export function CalloutContributionsSortDialog({
   const { t } = useTranslation('crd-space');
   const [items, setItems] = useState<SortableContribution[]>(contributions);
 
-  // Re-seed only on the closed → open transition. A parent re-render that
-  // hands a new `contributions` reference (e.g. unrelated cache update) would
-  // otherwise wipe an in-progress drag reorder. The ref keeps `contributions`
-  // out of the effect deps without disabling the exhaustive-deps lint rule.
-  const contributionsRef = useRef(contributions);
-  contributionsRef.current = contributions;
-  const wasOpenRef = useRef(false);
+  // Seed `items` once per open cycle, the first time real data is available.
+  // The parent fires the GraphQL query on open (`skip: !sortOpen`), so the
+  // first render after open passes an empty array; this effect re-runs when
+  // the data arrives. After seeding, unrelated parent re-renders that hand a
+  // new `contributions` reference (e.g. cache updates) won't wipe an
+  // in-progress drag reorder.
+  const hasSeededRef = useRef(false);
   useEffect(() => {
-    if (open && !wasOpenRef.current) {
-      setItems(contributionsRef.current);
+    if (!open) {
+      hasSeededRef.current = false;
+      return;
     }
-    wasOpenRef.current = open;
-  }, [open]);
+    if (!hasSeededRef.current && contributions.length > 0) {
+      setItems(contributions);
+      hasSeededRef.current = true;
+    }
+  }, [open, contributions]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -104,7 +108,12 @@ export function CalloutContributionsSortDialog({
               </ul>
             </SortableContext>
           </DndContext>
-          {items.length === 0 && (
+          {loading && items.length === 0 && (
+            <output className="flex justify-center py-4" aria-label={t('sortContributions.title')}>
+              <Loader2 aria-hidden="true" className="size-4 animate-spin text-muted-foreground" />
+            </output>
+          )}
+          {!loading && items.length === 0 && (
             <p className="text-caption text-muted-foreground py-4">{t('sortContributions.empty')}</p>
           )}
         </div>

--- a/src/crd/forms/callout/ResponseDefaultsDialog.tsx
+++ b/src/crd/forms/callout/ResponseDefaultsDialog.tsx
@@ -65,6 +65,21 @@ export function ResponseDefaultsDialog({
     wasOpenRef.current = open;
   }, [open]);
 
+  // Sync `whiteboardContent` from parent values into draft whenever it changes
+  // while the dialog is open. The whiteboard sub-flow commits via the parent's
+  // `onSave` (writing straight to the form), bypassing this dialog's draft —
+  // without this sync, the outer Save would commit a stale empty
+  // `whiteboardContent` and wipe the inner dialog's save.
+  useEffect(() => {
+    if (open) {
+      setDraft(prev =>
+        prev.whiteboardContent === values.whiteboardContent
+          ? prev
+          : { ...prev, whiteboardContent: values.whiteboardContent }
+      );
+    }
+  }, [open, values.whiteboardContent]);
+
   const title = (() => {
     switch (type) {
       case 'post':
@@ -81,7 +96,13 @@ export function ResponseDefaultsDialog({
   })();
 
   const handleSave = () => {
-    onSave(draft);
+    // The whiteboard editor commits its content directly to the parent form
+    // (via the connector's `onSave` from `whiteboardSlot`), so by the time the
+    // user clicks Save here, `values.whiteboardContent` already holds the
+    // freshly-configured whiteboard. The local `draft` was seeded at open time
+    // and still has the stale value — committing it would wipe the inner
+    // dialog's save. Merge the up-to-date whiteboard content from `values`.
+    onSave({ ...draft, whiteboardContent: values.whiteboardContent });
     onOpenChange(false);
   };
 

--- a/src/main/crdPages/space/callout/calloutFormMapper.test.ts
+++ b/src/main/crdPages/space/callout/calloutFormMapper.test.ts
@@ -326,6 +326,30 @@ describe('mapFormToCalloutCreationInput — cross-cutting fields', () => {
     expect(noResponse.input.contributionDefaults).toBeUndefined();
   });
 
+  it('contributionDefaults: empty whiteboardContent is omitted for whiteboard responses (create + update)', () => {
+    const create = mapFormToCalloutCreationInput(
+      baseValues({
+        responseType: 'whiteboard',
+        contributionDefaults: { defaultDisplayName: '', postDescription: '', whiteboardContent: '' },
+      }),
+      createOptions
+    );
+    expect(create.input.contributionDefaults).toBeUndefined();
+
+    const update = mapFormToCalloutUpdateInput(
+      baseValues({
+        responseType: 'whiteboard',
+        contributionDefaults: { defaultDisplayName: '', postDescription: '', whiteboardContent: '' },
+      }),
+      updateOptions
+    );
+    expect(update.input.contributionDefaults).toEqual({
+      defaultDisplayName: undefined,
+      postDescription: undefined,
+      whiteboardContent: undefined,
+    });
+  });
+
   it('prePopulateLinkRows: only sent when responseType=link, blanks dropped', () => {
     const linkType = mapFormToCalloutCreationInput(
       baseValues({

--- a/src/main/crdPages/space/callout/calloutFormMapper.ts
+++ b/src/main/crdPages/space/callout/calloutFormMapper.ts
@@ -182,17 +182,19 @@ export const mapFormToCalloutCreationInput = (values: CalloutFormValues, options
     sendNotification: values.notifyMembers && options.visibility !== CalloutVisibility.Draft,
   };
 
-  // Contribution defaults — spec FR-40..46, D5.
+  // Contribution defaults — spec FR-40..46, D5. Mirror MUI's response-type
+  // filter: only send `postDescription` for post/memo responses, only send
+  // `whiteboardContent` for whiteboard responses. Sending whiteboardContent on
+  // a post callout (or vice-versa) trips backend DTO validation.
   if (hasResponseType) {
     const defaults = values.contributionDefaults;
-    const hasAny =
-      defaults.defaultDisplayName.trim() || defaults.postDescription.trim() || defaults.whiteboardContent.trim();
-    if (hasAny) {
-      callout.contributionDefaults = {
-        defaultDisplayName: defaults.defaultDisplayName.trim() || undefined,
-        postDescription: defaults.postDescription.trim() || undefined,
-        whiteboardContent: defaults.whiteboardContent.trim() || undefined,
-      };
+    const isWhiteboardResponse = values.responseType === 'whiteboard';
+    const isPostOrMemoResponse = values.responseType === 'post' || values.responseType === 'memo';
+    const defaultDisplayName = defaults.defaultDisplayName.trim() || undefined;
+    const postDescription = isPostOrMemoResponse ? defaults.postDescription.trim() || undefined : undefined;
+    const whiteboardContent = isWhiteboardResponse ? defaults.whiteboardContent : undefined;
+    if (defaultDisplayName || postDescription || whiteboardContent) {
+      callout.contributionDefaults = { defaultDisplayName, postDescription, whiteboardContent };
     }
   }
 

--- a/src/main/crdPages/space/callout/calloutFormMapper.ts
+++ b/src/main/crdPages/space/callout/calloutFormMapper.ts
@@ -185,14 +185,16 @@ export const mapFormToCalloutCreationInput = (values: CalloutFormValues, options
   // Contribution defaults — spec FR-40..46, D5. Mirror MUI's response-type
   // filter: only send `postDescription` for post/memo responses, only send
   // `whiteboardContent` for whiteboard responses. Sending whiteboardContent on
-  // a post callout (or vice-versa) trips backend DTO validation.
+  // a post callout (or vice-versa) trips backend DTO validation. An empty
+  // form value means "user did not configure a default" — omit it.
   if (hasResponseType) {
     const defaults = values.contributionDefaults;
     const isWhiteboardResponse = values.responseType === 'whiteboard';
     const isPostOrMemoResponse = values.responseType === 'post' || values.responseType === 'memo';
     const defaultDisplayName = defaults.defaultDisplayName.trim() || undefined;
     const postDescription = isPostOrMemoResponse ? defaults.postDescription.trim() || undefined : undefined;
-    const whiteboardContent = isWhiteboardResponse ? defaults.whiteboardContent : undefined;
+    const whiteboardContent =
+      isWhiteboardResponse && defaults.whiteboardContent ? defaults.whiteboardContent : undefined;
     if (defaultDisplayName || postDescription || whiteboardContent) {
       callout.contributionDefaults = { defaultDisplayName, postDescription, whiteboardContent };
     }
@@ -386,6 +388,7 @@ export const mapFormToCalloutUpdateInput = (values: CalloutFormValues, options: 
   };
   if (contributionSettings) settings.contribution = contributionSettings;
 
+  const whiteboardDefault = values.contributionDefaults.whiteboardContent;
   const contributionDefaultsInput: UpdateCalloutEntityInput['contributionDefaults'] | undefined = hasResponseType
     ? {
         defaultDisplayName: values.contributionDefaults.defaultDisplayName.trim() || undefined,
@@ -393,10 +396,7 @@ export const mapFormToCalloutUpdateInput = (values: CalloutFormValues, options: 
           values.responseType === 'post' || values.responseType === 'memo'
             ? values.contributionDefaults.postDescription.trim() || undefined
             : undefined,
-        whiteboardContent:
-          values.responseType === 'whiteboard'
-            ? values.contributionDefaults.whiteboardContent.trim() || undefined
-            : undefined,
+        whiteboardContent: values.responseType === 'whiteboard' && whiteboardDefault ? whiteboardDefault : undefined,
       }
     : undefined;
 

--- a/src/main/crdPages/space/callout/dataMappers/mapCalloutDetailsToFormValues.ts
+++ b/src/main/crdPages/space/callout/dataMappers/mapCalloutDetailsToFormValues.ts
@@ -6,6 +6,7 @@ import {
   PollResultsVisibility,
 } from '@/core/apollo/generated/graphql-schema';
 import { DefaultWhiteboardPreviewSettings } from '@/domain/collaboration/whiteboard/WhiteboardPreviewSettings/WhiteboardPreviewSettingsModel';
+import { EmptyWhiteboardString } from '@/domain/common/whiteboard/EmptyWhiteboard';
 import { allowedActorsFromServer } from '@/main/crdPages/space/callout/calloutFormMapper';
 import type { CalloutFormValues, FramingChip, ResponseType } from '@/main/crdPages/space/hooks/useCrdCalloutForm';
 
@@ -103,7 +104,14 @@ export const mapCalloutDetailsToFormValues = (data: CalloutContentQuery | undefi
     contributionDefaults: {
       defaultDisplayName: contributionDefaults.defaultDisplayName ?? '',
       postDescription: contributionDefaults.postDescription ?? '',
-      whiteboardContent: contributionDefaults.whiteboardContent ?? '',
+      // Legacy callouts may have `EmptyWhiteboardString` persisted as the
+      // default-whiteboard sentinel from a prior buggy create path. Normalize
+      // it back to "" so the form treats this as "no default configured" and
+      // the mapper omits it on update — instead of round-tripping the sentinel.
+      whiteboardContent:
+        !contributionDefaults.whiteboardContent || contributionDefaults.whiteboardContent === EmptyWhiteboardString
+          ? ''
+          : contributionDefaults.whiteboardContent,
     },
     prePopulateLinkRows: [],
     referenceRows:

--- a/src/main/crdPages/space/hooks/useCrdCalloutForm.ts
+++ b/src/main/crdPages/space/hooks/useCrdCalloutForm.ts
@@ -99,7 +99,7 @@ export const EMPTY_CALLOUT_FORM_VALUES: CalloutFormValues = {
   responseType: 'none',
   allowedActors: { members: true, admins: true },
   contributionCommentsEnabled: true,
-  contributionDefaults: { defaultDisplayName: '', postDescription: '', whiteboardContent: EmptyWhiteboardString },
+  contributionDefaults: { defaultDisplayName: '', postDescription: '', whiteboardContent: '' },
   prePopulateLinkRows: [],
   referenceRows: [],
   notifyMembers: false,

--- a/src/main/crdPages/space/hooks/useCrdCalloutForm.ts
+++ b/src/main/crdPages/space/hooks/useCrdCalloutForm.ts
@@ -99,7 +99,7 @@ export const EMPTY_CALLOUT_FORM_VALUES: CalloutFormValues = {
   responseType: 'none',
   allowedActors: { members: true, admins: true },
   contributionCommentsEnabled: true,
-  contributionDefaults: { defaultDisplayName: '', postDescription: '', whiteboardContent: '' },
+  contributionDefaults: { defaultDisplayName: '', postDescription: '', whiteboardContent: EmptyWhiteboardString },
   prePopulateLinkRows: [],
   referenceRows: [],
   notifyMembers: false,


### PR DESCRIPTION
- FIX: Callout > Contribute with whiteboards > Default whiteboard content was not properly stored / used
- Contributions sorting dialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved contribution defaults handling to correctly filter settings based on response type (post, memo, or whiteboard).
  * Fixed whiteboard content synchronization to preserve user edits when saving form changes.
  * Enhanced handling of legacy whiteboard data to prevent stale values from persisting.

* **Tests**
  * Added unit test coverage for edge cases involving empty contribution defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->