### PR TITLE
[CRD] Fix the space banner hight, contrast and hide icons

### DIFF
--- a/src/crd/components/callout/CalloutDetailDialog.tsx
+++ b/src/crd/components/callout/CalloutDetailDialog.tsx
@@ -1,4 +1,4 @@
-import { Share2, Smile, X } from 'lucide-react';
+import { Share2, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MarkdownContent } from '@/crd/components/common/MarkdownContent';
@@ -43,7 +43,6 @@ type CalloutDetailDialogProps = {
   mediaGalleryFramingSlot?: ReactNode;
   /** Call-to-action link button rendered below description (e.g. CalloutLinkAction) */
   callToActionFramingSlot?: ReactNode;
-  onReactionsClick?: () => void;
   onShareClick?: () => void;
   /**
    * 3-dots settings slot in the sticky-header cluster. Consumer injects a
@@ -74,7 +73,6 @@ export function CalloutDetailDialog({
   memoFramingSlot,
   mediaGalleryFramingSlot,
   callToActionFramingSlot,
-  onReactionsClick,
   onShareClick,
   settingsSlot,
   commentsEnabled,
@@ -171,10 +169,6 @@ export function CalloutDetailDialog({
                 </span>
               )}
               <div className="flex-1" />
-              <Button variant="outline" size="sm" className="gap-2 rounded-full" onClick={onReactionsClick}>
-                <Smile className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
-                {t('calloutDialog.reactions')}
-              </Button>
               <Button variant="outline" size="sm" className="gap-2 rounded-full" onClick={onShareClick}>
                 <Share2 className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
                 {t('calloutDialog.share')}

--- a/src/crd/components/space/SpaceHeader.tsx
+++ b/src/crd/components/space/SpaceHeader.tsx
@@ -1,4 +1,4 @@
-import { FileText, Home, Settings, Share2, Video } from 'lucide-react';
+import { Home, Settings, Share2, Video } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { backgroundGradient } from '@/crd/lib/backgroundGradient';
 import { safeHttpUrl } from '@/crd/lib/safeHttpUrl';
@@ -58,7 +58,7 @@ export function SpaceHeader({
   return (
     <div className={cn('flex flex-col bg-background', className)}>
       <div
-        className="relative w-full h-[320px] overflow-hidden group"
+        className="relative w-full h-[256px] overflow-hidden group"
         role="img"
         aria-label={t('a11y.spaceBanner', { name: title })}
       >
@@ -71,12 +71,13 @@ export function SpaceHeader({
           )}
           style={bannerUrl ? { backgroundImage: `url(${bannerUrl})` } : color ? backgroundGradient(color) : undefined}
         />
-        {/* Gradient overlay */}
+        {/* Gradient overlay — theme-invariant darkening pass so the white hero
+            title/tagline stay readable in both light and dark mode. Values
+            match prototype/src/app/components/space/SpaceHeader.tsx. */}
         <div
           className="absolute inset-0"
           style={{
-            background:
-              'linear-gradient(to top, color-mix(in srgb, var(--foreground) 40%, transparent), color-mix(in srgb, var(--foreground) 8%, transparent))',
+            background: 'linear-gradient(to top, rgba(29,56,74,0.4), rgba(102,102,102,0.08))',
           }}
         />
 
@@ -85,23 +86,27 @@ export function SpaceHeader({
           <div className="grid grid-cols-12 gap-6">
             <div className="col-span-12 lg:col-start-2 lg:col-span-10 flex items-center justify-end">
               <div className="flex items-center gap-2">
+                {/* TODO: Documents action is not yet supported by the platform — re-enable
+                    once the activity/documents feature is wired up. Restore the `FileText`
+                    import from `lucide-react` at the top of this file when re-enabling.
                 {actions.showDocuments && (
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-9 w-9 rounded text-white hover:text-white/80 hover:bg-white/10"
+                    className="h-9 w-9 rounded text-white bg-black/20 hover:text-white/80 hover:bg-black/30"
                     onClick={actions.onDocumentsClick}
                     aria-label={t('mobile.activity')}
                   >
                     <FileText className="h-4 w-4" aria-hidden="true" />
                   </Button>
                 )}
+                */}
                 {actions.showVideoCall &&
                   (safeVideoCallUrl ? (
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-9 w-9 rounded text-white hover:text-white/80 hover:bg-white/10"
+                      className="h-9 w-9 rounded text-white bg-black/20 hover:text-white/80 hover:bg-black/30"
                       aria-label={t('mobile.videoCall')}
                       asChild={true}
                     >
@@ -113,7 +118,7 @@ export function SpaceHeader({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-9 w-9 rounded text-white hover:text-white/80 hover:bg-white/10"
+                      className="h-9 w-9 rounded text-white bg-black/20 hover:text-white/80 hover:bg-black/30"
                       onClick={actions.onVideoCallClick}
                       aria-label={t('mobile.videoCall')}
                     >
@@ -124,7 +129,7 @@ export function SpaceHeader({
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-9 w-9 rounded text-white hover:text-white/80 hover:bg-white/10"
+                    className="h-9 w-9 rounded text-white bg-black/20 hover:text-white/80 hover:bg-black/30"
                     onClick={actions.onShareClick}
                     aria-label={t('mobile.share')}
                   >
@@ -136,7 +141,7 @@ export function SpaceHeader({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-9 w-9 rounded text-white hover:text-white/80 hover:bg-white/10"
+                      className="h-9 w-9 rounded text-white bg-black/20 hover:text-white/80 hover:bg-black/30"
                       aria-label={t('mobile.settings')}
                       asChild={true}
                     >
@@ -148,7 +153,7 @@ export function SpaceHeader({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-9 w-9 rounded text-white hover:text-white/80 hover:bg-white/10"
+                      className="h-9 w-9 rounded text-white bg-black/20 hover:text-white/80 hover:bg-black/30"
                       onClick={actions.onSettingsClick}
                       aria-label={t('mobile.settings')}
                     >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed reactions-click integration from callout detail dialog.
  * Disabled Documents action in space header.

* **Style**
  * Reduced space header banner height for better visual balance.
  * Updated hover styling for top action icon buttons (video call, share, settings).
  * Modified overlay gradient styling in space header for improved contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->