### PR TITLE
[CRD] Fix comments timeago formatting

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -642,7 +642,8 @@
         "year_one": "{{count}}y",
         "year_other": "{{count}}y",
         "moreThanYears_one": "> {{count}}y",
-        "moreThanYears_other": "> {{count}}y"
+        "moreThanYears_other": "> {{count}}y",
+        "justNow": "now"
       },
       "long": {
         "timeAgo": "{{time}} ago",
@@ -659,7 +660,8 @@
         "year_one": "{{count}} year",
         "year_other": "{{count}} years",
         "moreThanYears_one": "> {{count}} year",
-        "moreThanYears_other": "> {{count}} years"
+        "moreThanYears_other": "> {{count}} years",
+        "justNow": "just now"
       }
     },
     "supportEmail": "support@alkem.io",

--- a/src/crd/app/data/space.ts
+++ b/src/crd/app/data/space.ts
@@ -393,6 +393,7 @@ export const MOCK_COMMENTS: CommentData[] = [
     author: { id: 'u1', name: 'Sarah Chen', avatarUrl: AVATARS.sarah },
     content: 'Great kickoff. I can help with policy review and timeline planning.',
     timestamp: new Date(Date.now() - 1000 * 60 * 90).toISOString(),
+    timestampMs: Date.now() - 1000 * 60 * 90,
     reactions: [
       {
         emoji: '👍',
@@ -418,6 +419,7 @@ export const MOCK_COMMENTS: CommentData[] = [
     author: { id: 'u2', name: 'David Miller', avatarUrl: AVATARS.david },
     content: 'Agreed. We should prioritize municipal buildings first.',
     timestamp: new Date(Date.now() - 1000 * 60 * 45).toISOString(),
+    timestampMs: Date.now() - 1000 * 60 * 45,
     parentId: 'c1',
     reactions: [],
     canDelete: false,
@@ -427,6 +429,7 @@ export const MOCK_COMMENTS: CommentData[] = [
     author: { id: 'deleted', name: 'Deleted user' },
     content: '',
     timestamp: new Date(Date.now() - 1000 * 60 * 70).toISOString(),
+    timestampMs: Date.now() - 1000 * 60 * 70,
     reactions: [],
     isDeleted: true,
     canDelete: false,
@@ -436,6 +439,7 @@ export const MOCK_COMMENTS: CommentData[] = [
     author: { id: 'u5', name: 'Maya Ross', avatarUrl: AVATARS.maya },
     content: 'I can contribute data on current consumption patterns.',
     timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+    timestampMs: Date.now() - 1000 * 60 * 30,
     parentId: 'c3',
     reactions: [
       {

--- a/src/crd/components/comment/CommentItem.tsx
+++ b/src/crd/components/comment/CommentItem.tsx
@@ -72,9 +72,7 @@ export function CommentItem({
             <div className="rounded-lg bg-muted/50 px-3 py-2">
               <div className="flex items-center gap-2">
                 <span className="text-body-emphasis text-foreground">{comment.author.name}</span>
-                <span className="text-caption text-muted-foreground">
-                  {new Date(comment.timestamp).toLocaleString()}
-                </span>
+                <span className="text-caption text-muted-foreground">{comment.timestamp}</span>
               </div>
 
               {comment.isDeleted ? (

--- a/src/crd/components/comment/CommentThread.tsx
+++ b/src/crd/components/comment/CommentThread.tsx
@@ -47,14 +47,15 @@ export function CommentThread({
     repliesByParent.set(comment.parentId, [...existing, comment]);
   }
 
-  const sortedTopLevel = [...topLevel].sort(
-    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-  );
+  // Sort numerically on the raw epoch-ms field. The display `timestamp`
+  // ("2 minutes ago") cannot be parsed back into a Date, so sorting on it
+  // would silently no-op (NaN comparator) — see CommentData.timestampMs.
+  const sortedTopLevel = [...topLevel].sort((a, b) => b.timestampMs - a.timestampMs);
 
   for (const [parentId, replies] of repliesByParent.entries()) {
     repliesByParent.set(
       parentId,
-      [...replies].sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+      [...replies].sort((a, b) => a.timestampMs - b.timestampMs)
     );
   }
 

--- a/src/crd/components/comment/types.ts
+++ b/src/crd/components/comment/types.ts
@@ -20,7 +20,18 @@ export type CommentData = {
   id: string;
   author: CommentAuthor;
   content: string;
+  /** Pre-formatted relative-time display string (e.g. "2 minutes ago",
+   *  "just now"). Produced by the integration-layer mapper via
+   *  `formatTimeElapsed` so the CRD component renders it as-is. The mapper's
+   *  consumer is expected to re-run periodically (see `useNow` in
+   *  `useCrdRoomComments`) to keep the string current. */
   timestamp: string;
+  /** Raw epoch milliseconds for the message. Used by `CommentThread` to
+   *  sort comments numerically (newest-first for top-level, oldest-first
+   *  for replies within a parent). Kept separate from `timestamp` because
+   *  the display string ("2 minutes ago") cannot be reliably parsed back
+   *  into a Date. */
+  timestampMs: number;
   parentId?: string;
   isDeleted?: boolean;
   reactions: CommentReaction[];

--- a/src/crd/hooks/useNow.ts
+++ b/src/crd/hooks/useNow.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Re-renders the consumer at a fixed interval so wall-clock-derived UI
+ * (e.g. relative timestamps like "2 minutes ago") stays current while the
+ * page is open. Returns the current epoch milliseconds; consumers that only
+ * need the tick can ignore the value.
+ */
+export function useNow(intervalMs: number = 30_000): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  return now;
+}

--- a/src/domain/shared/utils/formatTimeElapsed.ts
+++ b/src/domain/shared/utils/formatTimeElapsed.ts
@@ -51,7 +51,7 @@ export const formatTimeElapsed = (date: Date | string, t: TFunction, format: 'sh
   const timeDiff = Math.round(diffInTime / ONE_SECOND);
 
   if (timeDiff === 0) {
-    return 'just now';
+    return t(`common.time.${format}.justNow` as const);
   }
 
   return t(`common.time.${format}.timeAgo` as const, {

--- a/src/main/crdPages/space/dataMappers/commentDataMapper.test.ts
+++ b/src/main/crdPages/space/dataMappers/commentDataMapper.test.ts
@@ -1,0 +1,172 @@
+import type { TFunction } from 'i18next';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CommentsWithMessagesModel } from '@/domain/communication/room/models/CommentsWithMessagesModel';
+import { mapRoomToCommentData } from './commentDataMapper';
+
+/**
+ * Stand-in for the real `t` returned by `useTranslation()`. `formatTimeElapsed`
+ * only calls `t('common.time.<format>.<key>', { count })` and
+ * `t('common.time.<format>.timeAgo', { time })`, so we re-implement just
+ * enough of the English `common.time.long` resource set to produce the
+ * exact strings the production code does.
+ */
+const longFormatStrings: Record<string, string> = {
+  'common.time.long.justNow': 'just now',
+  'common.time.long.second_one': '{{count}} second',
+  'common.time.long.second_other': '{{count}} seconds',
+  'common.time.long.minute_one': '{{count}} minute',
+  'common.time.long.minute_other': '{{count}} minutes',
+  'common.time.long.hour_one': '{{count}} hour',
+  'common.time.long.hour_other': '{{count}} hours',
+  'common.time.long.day_one': '{{count}} day',
+  'common.time.long.day_other': '{{count}} days',
+  'common.time.long.month_one': '{{count}} month',
+  'common.time.long.month_other': '{{count}} months',
+  'common.time.long.year_one': '{{count}} year',
+  'common.time.long.year_other': '{{count}} years',
+  'common.time.long.moreThanYears_one': '> {{count}} year',
+  'common.time.long.moreThanYears_other': '> {{count}} years',
+};
+
+const tStub = ((key: string, options?: { count?: number; time?: string }): string => {
+  if (key === 'common.time.long.timeAgo') {
+    return `${options?.time} ago`;
+  }
+  // Non-pluralised keys (e.g. justNow) are looked up directly first.
+  if (longFormatStrings[key]) {
+    return longFormatStrings[key];
+  }
+  const count = options?.count ?? 0;
+  const pluralKey = count === 1 ? `${key}_one` : `${key}_other`;
+  const template = longFormatStrings[pluralKey] ?? key;
+  return template.replace('{{count}}', String(count));
+}) as unknown as TFunction;
+
+type Message = CommentsWithMessagesModel['messages'][number];
+
+const baseMessage = (overrides: Partial<Message> & Pick<Message, 'id' | 'timestamp'>): Message => ({
+  message: 'hello',
+  reactions: [],
+  ...overrides,
+});
+
+describe('mapRoomToCommentData', () => {
+  beforeEach(() => {
+    // Anchor "now" so relative-time assertions are deterministic.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-13T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns an empty list when the room is undefined', () => {
+    expect(mapRoomToCommentData(undefined, { t: tStub })).toEqual([]);
+  });
+
+  it('renders sub-second diffs as "just now"', () => {
+    const room: CommentsWithMessagesModel = {
+      id: 'room-1',
+      messagesCount: 1,
+      authorization: { myPrivileges: [] },
+      messages: [baseMessage({ id: 'm-1', timestamp: new Date('2026-05-13T12:00:00.000Z').getTime() })],
+      vcInteractions: [],
+    };
+
+    const result = mapRoomToCommentData(room, { t: tStub });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.timestamp).toBe('just now');
+  });
+
+  it('renders minute-level diffs in long form ("X minutes ago")', () => {
+    const fiveMinutesAgo = new Date('2026-05-13T11:55:00.000Z').getTime();
+    const room: CommentsWithMessagesModel = {
+      id: 'room-2',
+      messagesCount: 1,
+      authorization: { myPrivileges: [] },
+      messages: [baseMessage({ id: 'm-2', timestamp: fiveMinutesAgo })],
+      vcInteractions: [],
+    };
+
+    const result = mapRoomToCommentData(room, { t: tStub });
+
+    expect(result[0]?.timestamp).toBe('5 minutes ago');
+  });
+
+  it('renders hour-level diffs in long form ("X hours ago")', () => {
+    const twoHoursAgo = new Date('2026-05-13T10:00:00.000Z').getTime();
+    const room: CommentsWithMessagesModel = {
+      id: 'room-3',
+      messagesCount: 1,
+      authorization: { myPrivileges: [] },
+      messages: [baseMessage({ id: 'm-3', timestamp: twoHoursAgo })],
+      vcInteractions: [],
+    };
+
+    const result = mapRoomToCommentData(room, { t: tStub });
+
+    expect(result[0]?.timestamp).toBe('2 hours ago');
+  });
+
+  it('renders day-level diffs in long form ("X days ago")', () => {
+    const threeDaysAgo = new Date('2026-05-10T12:00:00.000Z').getTime();
+    const room: CommentsWithMessagesModel = {
+      id: 'room-4',
+      messagesCount: 1,
+      authorization: { myPrivileges: [] },
+      messages: [baseMessage({ id: 'm-4', timestamp: threeDaysAgo })],
+      vcInteractions: [],
+    };
+
+    const result = mapRoomToCommentData(room, { t: tStub });
+
+    expect(result[0]?.timestamp).toBe('3 days ago');
+  });
+
+  it('synthesises a placeholder for a missing parent and uses the earliest reply timestamp', () => {
+    const olderReply = new Date('2026-05-13T11:50:00.000Z').getTime(); // 10 min ago
+    const newerReply = new Date('2026-05-13T11:58:00.000Z').getTime(); // 2 min ago
+    const room: CommentsWithMessagesModel = {
+      id: 'room-5',
+      messagesCount: 2,
+      authorization: { myPrivileges: [] },
+      messages: [
+        baseMessage({ id: 'reply-1', timestamp: newerReply, threadID: 'deleted-parent' }),
+        baseMessage({ id: 'reply-2', timestamp: olderReply, threadID: 'deleted-parent' }),
+      ],
+      vcInteractions: [],
+    };
+
+    const result = mapRoomToCommentData(room, { t: tStub });
+
+    const placeholder = result.find(c => c.id === 'deleted-parent');
+    expect(placeholder).toBeDefined();
+    expect(placeholder?.isDeleted).toBe(true);
+    // Placeholder should track the EARLIEST reply (10 minutes ago), not the
+    // later one (2 minutes ago) — see mapper's age-comparison logic.
+    expect(placeholder?.timestamp).toBe('10 minutes ago');
+    expect(placeholder?.timestampMs).toBe(olderReply);
+  });
+
+  it('exposes the raw epoch ms via `timestampMs` for downstream sorting', () => {
+    const messageA = new Date('2026-05-13T10:00:00.000Z').getTime();
+    const messageB = new Date('2026-05-13T11:00:00.000Z').getTime();
+    const room: CommentsWithMessagesModel = {
+      id: 'room-6',
+      messagesCount: 2,
+      authorization: { myPrivileges: [] },
+      messages: [baseMessage({ id: 'a', timestamp: messageA }), baseMessage({ id: 'b', timestamp: messageB })],
+      vcInteractions: [],
+    };
+
+    const result = mapRoomToCommentData(room, { t: tStub });
+
+    // The mapper preserves server insertion order; `CommentThread` re-sorts
+    // by `timestampMs` for display. We only assert the field is populated
+    // and correct — order is the thread component's concern.
+    expect(result.find(c => c.id === 'a')?.timestampMs).toBe(messageA);
+    expect(result.find(c => c.id === 'b')?.timestampMs).toBe(messageB);
+  });
+});

--- a/src/main/crdPages/space/dataMappers/commentDataMapper.ts
+++ b/src/main/crdPages/space/dataMappers/commentDataMapper.ts
@@ -1,22 +1,29 @@
+import type { TFunction } from 'i18next';
 import { AuthorizationPrivilege } from '@/core/apollo/generated/graphql-schema';
 import type { CommentData, CommentReaction } from '@/crd/components/comment/types';
 import type { CommentsWithMessagesModel } from '@/domain/communication/room/models/CommentsWithMessagesModel';
+import { formatTimeElapsed } from '@/domain/shared/utils/formatTimeElapsed';
 
 type RoomWithMessages = Pick<CommentsWithMessagesModel, 'messages' | 'authorization'>;
 
 type MapRoomToCommentDataOptions = {
   currentUserId?: string;
+  /** `t` from `useTranslation()` (default `translation` namespace). Required —
+   *  the mapper now pre-formats `timestamp` into a relative "X minutes ago"
+   *  string via `common.time.long.*` so the CRD component can render it
+   *  as-is. Pass `tMain` (typed against `translation`) from the consumer. */
+  t: TFunction;
 };
 
 export function mapRoomToCommentData(
   room: RoomWithMessages | undefined,
-  options: MapRoomToCommentDataOptions = {}
+  options: MapRoomToCommentDataOptions
 ): CommentData[] {
   if (!room) {
     return [];
   }
 
-  const { currentUserId } = options;
+  const { currentUserId, t } = options;
   const canDeleteAny = room.authorization?.myPrivileges?.includes(AuthorizationPrivilege.Delete) ?? false;
 
   const messageIds = new Set(room.messages.map(message => message.id));
@@ -33,12 +40,18 @@ export function mapRoomToCommentData(
         avatarUrl: message.sender?.profile?.avatar?.uri,
       },
       content: message.message,
-      timestamp: new Date(message.timestamp).toISOString(),
+      timestamp: formatTimeElapsed(new Date(message.timestamp), t, 'long'),
+      timestampMs: message.timestamp,
       parentId: message.threadID,
       reactions: mapReactions(message.reactions, currentUserId),
       canDelete,
     };
   });
+
+  // Track the raw epoch ms of each placeholder so we can compare ages with
+  // `message.timestamp` (also epoch ms). Comparing on `existing.timestamp`
+  // no longer works — it is now a pre-formatted display string, not a date.
+  const placeholderRawTimestamps = new Map<string, number>();
 
   const placeholders = room.messages.reduce<Record<string, CommentData>>((restored, message) => {
     const parentId = message.threadID;
@@ -48,7 +61,7 @@ export function mapRoomToCommentData(
     }
 
     const existing = restored[parentId];
-    const timestamp = new Date(message.timestamp).toISOString();
+    const formattedTimestamp = formatTimeElapsed(new Date(message.timestamp), t, 'long');
 
     if (!existing) {
       restored[parentId] = {
@@ -58,16 +71,20 @@ export function mapRoomToCommentData(
           name: 'Deleted user',
         },
         content: '',
-        timestamp,
+        timestamp: formattedTimestamp,
+        timestampMs: message.timestamp,
         reactions: [],
         canDelete: false,
         isDeleted: true,
       };
-    } else if (new Date(existing.timestamp).getTime() > message.timestamp) {
+      placeholderRawTimestamps.set(parentId, message.timestamp);
+    } else if ((placeholderRawTimestamps.get(parentId) ?? Number.POSITIVE_INFINITY) > message.timestamp) {
       restored[parentId] = {
         ...existing,
-        timestamp,
+        timestamp: formattedTimestamp,
+        timestampMs: message.timestamp,
       };
+      placeholderRawTimestamps.set(parentId, message.timestamp);
     }
 
     return restored;

--- a/src/main/crdPages/space/hooks/useCrdRoomComments.tsx
+++ b/src/main/crdPages/space/hooks/useCrdRoomComments.tsx
@@ -6,6 +6,7 @@ import { evictFromCache } from '@/core/apollo/utils/removeFromCache';
 import { CommentInput } from '@/crd/components/comment/CommentInput';
 import { CommentThread } from '@/crd/components/comment/CommentThread';
 import { ConfirmationDialog } from '@/crd/components/dialogs/ConfirmationDialog';
+import { useNow } from '@/crd/hooks/useNow';
 import useSubscribeOnRoomEvents from '@/domain/collaboration/callout/useSubscribeOnRoomEvents';
 import useCommentReactionsMutations from '@/domain/communication/room/Comments/useCommentReactionsMutations';
 import usePostMessageMutations from '@/domain/communication/room/Comments/usePostMessageMutations';
@@ -46,8 +47,17 @@ export function useCrdRoomComments({
   skipSubscription = false,
 }: UseCrdRoomCommentsParams): CrdRoomCommentsSlots {
   const { t } = useTranslation('crd-space');
+  // `tMain` resolves the default `translation` namespace, where the
+  // `common.time.*` keys used by `formatTimeElapsed` live. Following the
+  // dashboard mappers pattern (see DashboardWithMemberships → tMain).
+  const { t: tMain } = useTranslation();
   const { userModel, isAuthenticated } = useCurrentUserContext();
   const mentionSearch = useMentionableContributors();
+
+  // Tick every 30 s so relative-time strings ("2 minutes ago") in the
+  // mapper's output stay current while the thread is open. The returned
+  // value is unused; the state-change inside the hook triggers re-render.
+  useNow(30_000);
 
   const isSubscribed = useSubscribeOnRoomEvents(roomId, skipSubscription);
 
@@ -66,7 +76,7 @@ export function useCrdRoomComments({
   const privileges = room?.authorization?.myPrivileges ?? [];
   const canComment = isAuthenticated && privileges.includes(AuthorizationPrivilege.CreateMessage);
 
-  const comments = mapRoomToCommentData(room, { currentUserId: userModel?.id });
+  const comments = mapRoomToCommentData(room, { currentUserId: userModel?.id, t: tMain });
 
   const currentUser = userModel
     ? {


### PR DESCRIPTION
- Better formatting;
- update on 30sec*;

*Claude suggested a tick/update of the timeago. I liked the idea. It works good. I had implementation that ticked only for the timestamps that makes sense, but it was adding a lot of complexity which is redundant for just an interval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comments now periodically update to display accurate relative timestamps (e.g., "just now," "minutes ago").
  * Added localized "just now" translation strings for short and long time formats.

* **Bug Fixes**
  * Improved comment sorting reliability using numeric timestamps.
  * Fixed timestamp display to consistently use localized time-ago translations.

* **Tests**
  * Added test coverage for comment timestamp rendering and sorting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/client-web/pull/9661)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->