### PR TITLE
fix(crd): memo markdown toolbar buttons clickable, iframe round-trip, link insert

### DIFF
--- a/src/crd/components/common/EmojiPicker.tsx
+++ b/src/crd/components/common/EmojiPicker.tsx
@@ -18,7 +18,7 @@ export function EmojiPicker({ onSelect, trigger }: EmojiPickerProps) {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild={true}>{trigger}</PopoverTrigger>
-      <PopoverContent side="top" align="start" className="w-auto border p-0 shadow-lg">
+      <PopoverContent side="top" align="start" className="z-[70] w-auto border p-0 shadow-lg">
         <EmojiPickerLib
           onEmojiClick={handleEmojiClick}
           emojiStyle={EmojiStyle.NATIVE}

--- a/src/crd/forms/markdown/ToolbarEmbedDialog.tsx
+++ b/src/crd/forms/markdown/ToolbarEmbedDialog.tsx
@@ -77,7 +77,7 @@ export function ToolbarEmbedDialog({ editor, iframeAllowedUrls, onError, disable
           <MonitorPlay className="w-4 h-4" aria-hidden="true" />
         </button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="z-[70] sm:max-w-lg" overlayClassName="z-[70]">
         <DialogHeader>
           <DialogTitle>{t('editor.embed.dialogTitle')}</DialogTitle>
         </DialogHeader>

--- a/src/crd/forms/markdown/ToolbarImageDialog.tsx
+++ b/src/crd/forms/markdown/ToolbarImageDialog.tsx
@@ -76,7 +76,7 @@ export function ToolbarImageDialog({ editor, onImageUpload, onError }: ToolbarIm
           <ImageIcon className="w-4 h-4" aria-hidden="true" />
         </button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="z-[70] sm:max-w-md" overlayClassName="z-[70]">
         <DialogHeader>
           <DialogTitle>{t('editor.image.dialogTitle')}</DialogTitle>
         </DialogHeader>

--- a/src/crd/forms/markdown/ToolbarLinkDialog.tsx
+++ b/src/crd/forms/markdown/ToolbarLinkDialog.tsx
@@ -1,6 +1,6 @@
 import type { Editor } from '@tiptap/react';
 import { Link } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/crd/lib/utils';
 import { Button } from '@/crd/primitives/button';
@@ -15,34 +15,66 @@ export function ToolbarLinkDialog({ editor }: ToolbarLinkDialogProps) {
   const [open, setOpen] = useState(false);
   const [url, setUrl] = useState('');
   const [error, setError] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const input = inputRef.current;
+    if (!input) return;
+    const id = requestAnimationFrame(() => {
+      input.focus();
+      const len = input.value.length;
+      input.setSelectionRange(len, len);
+    });
+    return () => cancelAnimationFrame(id);
+  }, [open]);
 
   const isLinkActive = editor.isActive('link');
 
   const handleOpen = (nextOpen: boolean) => {
     if (nextOpen) {
       const currentHref = editor.getAttributes('link').href ?? '';
-      setUrl(currentHref);
+      setUrl(currentHref || 'https://');
       setError('');
     }
     setOpen(nextOpen);
   };
 
-  const validate = (value: string): boolean => {
-    if (!value.trim()) {
+  const normalizeHref = (value: string): string => {
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return trimmed;
+    return `https://${trimmed}`;
+  };
+
+  const validate = (value: string): { ok: boolean; href: string } => {
+    const href = normalizeHref(value);
+    if (!href || href === 'https://' || href === 'http://') {
       setError('');
-      return false;
-    }
-    if (!value.startsWith('http://') && !value.startsWith('https://')) {
-      setError(t('editor.link.invalid'));
-      return false;
+      return { ok: false, href: '' };
     }
     setError('');
-    return true;
+    return { ok: true, href };
   };
 
   const handleApply = () => {
-    if (!validate(url)) return;
-    editor.chain().focus().setLink({ href: url.trim() }).run();
+    const { ok, href } = validate(url);
+    if (!ok) return;
+    const { selection } = editor.state;
+    if (selection.empty && !isLinkActive) {
+      const from = selection.from;
+      const to = from + href.length;
+      editor
+        .chain()
+        .focus()
+        .insertContentAt(from, href)
+        .setTextSelection({ from, to })
+        .setLink({ href })
+        .setTextSelection(to)
+        .run();
+    } else {
+      editor.chain().focus().setLink({ href }).run();
+    }
     setOpen(false);
   };
 
@@ -73,12 +105,13 @@ export function ToolbarLinkDialog({ editor }: ToolbarLinkDialogProps) {
           <Link className="w-4 h-4" aria-hidden="true" />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-80 p-3 space-y-2" align="start">
+      <PopoverContent className="w-80 p-3 space-y-2" align="start" onOpenAutoFocus={e => e.preventDefault()}>
         <label className="text-caption font-medium text-foreground" htmlFor="toolbar-link-url">
           {t('editor.link.url')}
         </label>
         <input
           id="toolbar-link-url"
+          ref={inputRef}
           type="url"
           value={url}
           onChange={e => {
@@ -97,7 +130,11 @@ export function ToolbarLinkDialog({ editor }: ToolbarLinkDialogProps) {
               {t('editor.link.remove')}
             </Button>
           )}
-          <Button size="sm" onClick={handleApply} disabled={!url.trim()}>
+          <Button
+            size="sm"
+            onClick={handleApply}
+            disabled={!url.trim() || url.trim() === 'https://' || url.trim() === 'http://'}
+          >
             {t('editor.link.apply')}
           </Button>
         </div>

--- a/src/crd/forms/markdown/ToolbarLinkDialog.tsx
+++ b/src/crd/forms/markdown/ToolbarLinkDialog.tsx
@@ -105,7 +105,7 @@ export function ToolbarLinkDialog({ editor }: ToolbarLinkDialogProps) {
           <Link className="w-4 h-4" aria-hidden="true" />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-80 p-3 space-y-2" align="start" onOpenAutoFocus={e => e.preventDefault()}>
+      <PopoverContent className="z-[70] w-80 p-3 space-y-2" align="start" onOpenAutoFocus={e => e.preventDefault()}>
         <label className="text-caption font-medium text-foreground" htmlFor="toolbar-link-url">
           {t('editor.link.url')}
         </label>

--- a/src/crd/forms/markdown/ToolbarTableOpsMenu.tsx
+++ b/src/crd/forms/markdown/ToolbarTableOpsMenu.tsx
@@ -60,7 +60,7 @@ export function ToolbarTableOpsMenu({ editor }: ToolbarTableOpsMenuProps) {
             <TableIcon className="w-4 h-4" aria-hidden="true" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
+        <DropdownMenuContent className="z-[70]" align="start">
           <DropdownMenuItem onClick={() => run(c => c.addColumnBefore())}>
             <ArrowLeftToLine className="w-4 h-4 mr-2" aria-hidden="true" />
             {t('editor.table.addColumnBefore')}

--- a/src/crd/forms/markdown/ToolbarTablePicker.tsx
+++ b/src/crd/forms/markdown/ToolbarTablePicker.tsx
@@ -71,7 +71,7 @@ export function ToolbarTablePicker({ editor }: ToolbarTablePickerProps) {
           <TableIcon className="w-4 h-4" aria-hidden="true" />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-2" align="start">
+      <PopoverContent className="z-[70] w-auto p-2" align="start">
         {!customMode ? (
           <>
             {/* biome-ignore lint/a11y/noStaticElementInteractions: mouseLeave only resets hover state — accessible interaction is delegated to per-cell buttons */}

--- a/src/crd/forms/markdown/markdownConverter.ts
+++ b/src/crd/forms/markdown/markdownConverter.ts
@@ -2,12 +2,25 @@
  * Stateless markdown ↔ HTML conversion using the unified pipeline.
  *
  * Two pure async functions that lazily build their pipelines on first call.
- * Custom handlers mirror UnifiedConverter.ts for round-trip fidelity,
- * minus iframe handling (deferred to the iframe-whitelist spec).
+ * Custom handlers mirror UnifiedConverter.ts for round-trip fidelity.
  */
 
 import type { Element, ElementContent } from 'hast';
 import type { Html, Parent as MDASTParent, PhrasingContent } from 'mdast';
+
+const ALLOWED_IFRAME_ATTRIBUTES = [
+  'src',
+  'width',
+  'height',
+  'title',
+  'allow',
+  'loading',
+  'frameborder',
+  'referrerpolicy',
+  'allowfullscreen',
+  'webkitallowfullscreen',
+  'mozallowfullscreen',
+];
 
 // Extend MDAST Parent with optional tagName (always present at runtime for HTML elements)
 type Parent = MDASTParent & { tagName?: string } & { children: Element[] };
@@ -92,6 +105,10 @@ async function buildHtmlToMdPipeline() {
           },
           strong: trimmer('strong'),
           emphasis: trimmer('emphasis'),
+          iframe: (_state: unknown, element: Element) => ({
+            type: 'html',
+            value: `<iframe src="${element.properties?.src ?? ''}" width="100%" height="100%" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="clipboard-write" title="${element.properties?.title ?? 'Embedded iframe'}" loading="lazy"></iframe>`,
+          }),
         },
       })
       .use(remarkGfm)
@@ -127,6 +144,15 @@ async function buildMdToHtmlPipeline() {
 
   const text = (value: string) => u('text', value);
   const emptyParagraph = () => u('element', { tagName: 'p', children: [], properties: {} });
+
+  const sanitizeSchema = {
+    ...defaultSchema,
+    tagNames: [...(defaultSchema.tagNames ?? []), 'iframe'],
+    attributes: {
+      ...(defaultSchema.attributes ?? {}),
+      iframe: ALLOWED_IFRAME_ATTRIBUTES,
+    },
+  };
 
   return unified()
     .use(remarkParse)
@@ -167,8 +193,8 @@ async function buildMdToHtmlPipeline() {
         },
       },
     })
-    .use(rehypeRaw)
-    .use(rehypeSanitize, defaultSchema)
+    .use(rehypeRaw, { passThrough: ['iframe'] })
+    .use(rehypeSanitize, sanitizeSchema)
     .use(rehypeStringify);
 }
 

--- a/src/main/crdPages/dashboard/CrdPendingMembershipsDialog.tsx
+++ b/src/main/crdPages/dashboard/CrdPendingMembershipsDialog.tsx
@@ -5,8 +5,8 @@ import { ActorType } from '@/core/apollo/generated/graphql-schema';
 import useNavigate from '@/core/routing/useNavigate';
 import Gutters from '@/core/ui/grid/Gutters';
 import { gutters } from '@/core/ui/grid/utils';
-import WrapperMarkdown from '@/core/ui/markdown/WrapperMarkdown';
 import { BlockSectionTitle, Caption, Text } from '@/core/ui/typography';
+import { MarkdownContent } from '@/crd/components/common/MarkdownContent';
 import { InvitationDetailDialog } from '@/crd/components/dashboard/InvitationDetailDialog';
 import { PendingApplicationCard } from '@/crd/components/dashboard/PendingApplicationCard';
 import { PendingInvitationCard, PendingInvitationCardSkeleton } from '@/crd/components/dashboard/PendingInvitationCard';
@@ -156,9 +156,7 @@ const InvitationDetailContainer = ({
       <BlockSectionTitle paddingTop={gutters()}>{communityGuidelines.profile.displayName}</BlockSectionTitle>
       <Gutters disablePadding={true}>
         <div style={{ wordWrap: 'break-word' }}>
-          <WrapperMarkdown disableParagraphPadding={true}>
-            {communityGuidelines.profile.description ?? ''}
-          </WrapperMarkdown>
+          <MarkdownContent content={communityGuidelines.profile.description ?? ''} />
         </div>
         <References compact={true} references={communityGuidelines.profile.references} />
       </Gutters>


### PR DESCRIPTION
## Summary

Three related fixes to the CRD markdown toolbar so it works correctly inside the memo dialog (and any other host dialog).

- **Toolbar buttons clickable inside the memo dialog.** `MemoEditorShell` overlays at `z-[60]` so it sits above the host `CalloutDetailDialog` (`z-50`), but every toolbar floating surface (`Link` popover, `Table` picker, `Image` / `Embed` dialogs, `TableOps` dropdown, `Emoji` picker) was portaled at the shadcn default `z-50`. The popovers *did* open — they just rendered underneath memo's opaque `bg-background/80 backdrop-blur-sm` overlay, so users saw nothing happen. Each surface now portals at `z-[70]` (same convention as `ShareDialog`, still below `ConfirmationDialog` at `z-[90]`).
- **Iframe preserved on save and edit.** Embedded iframes now survive the markdown → HTML → markdown round-trip and render correctly when reopening a memo / post.
- **Link insert working correctly.** `ToolbarLinkDialog` validates / normalizes the URL and restores focus correctly so inserting a link no longer drops the trailing text or steals the editor selection.

Also swaps the legacy MUI `WrapperMarkdown` for `MarkdownContent` in `CrdPendingMembershipsDialog`'s community-guidelines slot — one less MUI surface inside a `crdPages` file, visually consistent with the host CRD `InvitationDetailDialog`.

## Test plan

- [ ] Open a memo from a callout. Click each toolbar button (Bold/Italic/Headings/Lists/Quote/Code/HR work as before; Table/Link/Image/Embed/Emoji now open their popover/dialog above the memo overlay).
- [ ] Insert a link via the toolbar; verify the URL is normalized (adds `https://` when missing), the selection is preserved, and the inserted link is clickable.
- [ ] Embed an iframe (e.g. YouTube). Save, close, reopen — iframe still renders. Edit again — iframe still present.
- [ ] Repeat in a Post contribution dialog to confirm no regression.
- [ ] Open the Pending Memberships → invitation detail; verify community guidelines render with CRD typography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iframe embedding support in markdown content with built-in security measures.

* **Bug Fixes**
  * Improved visual layering of dialogs, popovers, and dropdown menus for better UI element stacking.
  * Enhanced URL input handling with auto-focus and automatic protocol normalization.
  * Updated markdown rendering in membership dialog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/client-web/pull/9667)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->