### PR TITLE
[CRD] update the design switch position and copy

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -223,8 +223,7 @@
   "topBar": {
     "sign-in": "Log In | Sign Up",
     "designVersion": {
-      "label": "New design (beta)",
-      "caption": "The old design will remain available for a short time.",
+      "label": "New design (preview)",
       "errorSaving": "Could not save your design preference. Please try again."
     }
   },

--- a/src/crd/i18n/layout/layout.bg.json
+++ b/src/crd/i18n/layout/layout.bg.json
@@ -15,7 +15,7 @@
     "settings": "Настройки",
     "logout": "Изход",
     "login": "Вход",
-    "beta": "Бета",
+    "preview": "превю",
     "pendingMemberships": "Чакащи членства",
     "administration": "Администрация",
     "changeLanguage": "Смяна на езика",
@@ -23,8 +23,7 @@
     "showGrid": "Покажи мрежа",
     "hideGrid": "Скрий мрежа",
     "designVersion": {
-      "label": "Нов дизайн (бета)",
-      "caption": "Старият дизайн ще остане наличен още кратко време."
+      "label": "Нов дизайн (предварителен преглед)"
     }
   },
   "footer": {

--- a/src/crd/i18n/layout/layout.de.json
+++ b/src/crd/i18n/layout/layout.de.json
@@ -15,7 +15,7 @@
     "settings": "Einstellungen",
     "logout": "Abmelden",
     "login": "Anmelden",
-    "beta": "Beta",
+    "preview": "Vorschau",
     "pendingMemberships": "Ausstehende Mitgliedschaften",
     "administration": "Verwaltung",
     "changeLanguage": "Sprache ändern",
@@ -23,8 +23,7 @@
     "showGrid": "Raster anzeigen",
     "hideGrid": "Raster ausblenden",
     "designVersion": {
-      "label": "Neues Design (Beta)",
-      "caption": "Das alte Design bleibt noch eine kurze Zeit verfügbar."
+      "label": "Neues Design (Vorschau)"
     }
   },
   "footer": {

--- a/src/crd/i18n/layout/layout.en.json
+++ b/src/crd/i18n/layout/layout.en.json
@@ -15,7 +15,7 @@
     "settings": "Settings",
     "logout": "Log out",
     "login": "Log in",
-    "beta": "Beta",
+    "preview": "Preview",
     "pendingMemberships": "Pending Memberships",
     "administration": "Administration",
     "changeLanguage": "Change Language",
@@ -23,8 +23,7 @@
     "showGrid": "Show Grid",
     "hideGrid": "Hide Grid",
     "designVersion": {
-      "label": "New design (beta)",
-      "caption": "The old design will remain available for a short time."
+      "label": "New design (preview)"
     }
   },
   "footer": {

--- a/src/crd/i18n/layout/layout.es.json
+++ b/src/crd/i18n/layout/layout.es.json
@@ -15,7 +15,7 @@
     "settings": "Configuración",
     "logout": "Cerrar sesión",
     "login": "Iniciar sesión",
-    "beta": "Beta",
+    "preview": "Versión preliminar",
     "pendingMemberships": "Membresías pendientes",
     "administration": "Administración",
     "changeLanguage": "Cambiar idioma",
@@ -23,8 +23,7 @@
     "showGrid": "Mostrar cuadrícula",
     "hideGrid": "Ocultar cuadrícula",
     "designVersion": {
-      "label": "Nuevo diseño (beta)",
-      "caption": "El diseño anterior seguirá disponible durante un tiempo limitado."
+      "label": "Nuevo diseño (versión preliminar)"
     }
   },
   "footer": {

--- a/src/crd/i18n/layout/layout.fr.json
+++ b/src/crd/i18n/layout/layout.fr.json
@@ -15,7 +15,7 @@
     "settings": "Paramètres",
     "logout": "Déconnexion",
     "login": "Connexion",
-    "beta": "Bêta",
+    "preview": "Aperçu",
     "pendingMemberships": "Adhésions en attente",
     "administration": "Administration",
     "changeLanguage": "Changer de langue",
@@ -23,8 +23,7 @@
     "showGrid": "Afficher la grille",
     "hideGrid": "Masquer la grille",
     "designVersion": {
-      "label": "Nouveau design (bêta)",
-      "caption": "L'ancien design restera disponible pendant une courte période."
+      "label": "Nouveau design (aperçu)"
     }
   },
   "footer": {

--- a/src/crd/i18n/layout/layout.nl.json
+++ b/src/crd/i18n/layout/layout.nl.json
@@ -15,7 +15,7 @@
     "settings": "Instellingen",
     "logout": "Uitloggen",
     "login": "Inloggen",
-    "beta": "Bèta",
+    "preview": "Preview",
     "pendingMemberships": "Openstaande lidmaatschappen",
     "administration": "Administratie",
     "changeLanguage": "Taal wijzigen",
@@ -23,8 +23,7 @@
     "showGrid": "Raster tonen",
     "hideGrid": "Raster verbergen",
     "designVersion": {
-      "label": "Nieuw ontwerp (bèta)",
-      "caption": "Het oude ontwerp blijft nog korte tijd beschikbaar."
+      "label": "Nieuw ontwerp (preview)"
     }
   },
   "footer": {

--- a/src/crd/layouts/components/UserMenu.tsx
+++ b/src/crd/layouts/components/UserMenu.tsx
@@ -1,5 +1,4 @@
 import { Check, CircleEllipsis, Globe, Grid3X3, HelpCircle, Home, LogOut, Settings, Shield, User } from 'lucide-react';
-import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGridOverlay } from '@/crd/hooks/useGridOverlay';
 import type { CrdDesignVersionSwitch, CrdLanguageOption, CrdNavigationHrefs, CrdUserInfo } from '@/crd/layouts/types';
@@ -53,7 +52,6 @@ export function UserMenu({
 }: UserMenuProps) {
   const { t } = useTranslation('crd-layout');
   const { isVisible: isGridVisible, toggle: toggleGrid } = useGridOverlay();
-  const designVersionCaptionId = useId();
 
   const currentLanguageLabel = languages?.find(l => currentLanguage?.startsWith(l.code))?.label;
 
@@ -77,7 +75,7 @@ export function UserMenu({
             variant="secondary"
             className="absolute -bottom-1 -right-1 px-1 py-0 h-4 border border-border text-badge leading-[14px]"
           >
-            {t('header.beta')}
+            {t('header.preview')}
           </Badge>
         </div>
       </DropdownMenuTrigger>
@@ -90,38 +88,6 @@ export function UserMenu({
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-
-        {designVersionSwitch && (
-          <>
-            <DropdownMenuItem
-              onSelect={e => {
-                e.preventDefault();
-                if (!designVersionSwitch.disabled) {
-                  designVersionSwitch.onChange(!designVersionSwitch.enabled);
-                }
-              }}
-              disabled={designVersionSwitch.disabled}
-              role="switch"
-              aria-checked={designVersionSwitch.enabled}
-              aria-describedby={designVersionCaptionId}
-              className="flex flex-col items-stretch gap-1 cursor-pointer"
-            >
-              <div className="flex w-full items-center justify-between gap-2">
-                <span className="text-control">{t('header.designVersion.label')}</span>
-                <Switch
-                  checked={designVersionSwitch.enabled}
-                  disabled={designVersionSwitch.disabled}
-                  tabIndex={-1}
-                  aria-hidden="true"
-                />
-              </div>
-              <p id={designVersionCaptionId} className="text-caption text-muted-foreground">
-                {t('header.designVersion.caption')}
-              </p>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
-        )}
 
         {/* Navigation items */}
         <DropdownMenuItem asChild={true}>
@@ -211,7 +177,36 @@ export function UserMenu({
           </DropdownMenuItem>
         )}
 
-        {(isAdmin || onHelpClick || (languages && languages.length > 0)) && <DropdownMenuSeparator />}
+        {/* Design version switch */}
+        {designVersionSwitch && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={e => {
+                e.preventDefault();
+                if (!designVersionSwitch.disabled) {
+                  designVersionSwitch.onChange(!designVersionSwitch.enabled);
+                }
+              }}
+              disabled={designVersionSwitch.disabled}
+              role="switch"
+              aria-checked={designVersionSwitch.enabled}
+              className="flex w-full items-center justify-between gap-2 cursor-pointer"
+            >
+              <span className="text-control">{t('header.designVersion.label')}</span>
+              <Switch
+                checked={designVersionSwitch.enabled}
+                disabled={designVersionSwitch.disabled}
+                tabIndex={-1}
+                aria-hidden="true"
+              />
+            </DropdownMenuItem>
+          </>
+        )}
+
+        {(isAdmin || onHelpClick || (languages && languages.length > 0) || designVersionSwitch) && (
+          <DropdownMenuSeparator />
+        )}
 
         {/* Logout */}
         <DropdownMenuItem className="text-destructive focus:text-destructive cursor-pointer" onClick={onLogout}>

--- a/src/main/ui/platformNavigation/PlatformNavigationUserMenu.tsx
+++ b/src/main/ui/platformNavigation/PlatformNavigationUserMenu.tsx
@@ -11,7 +11,7 @@ import LocalOfferOutlinedIcon from '@mui/icons-material/LocalOfferOutlined';
 import SettingsIcon from '@mui/icons-material/SettingsOutlined';
 import { Box, Divider, FormControlLabel, Menu, MenuItem, MenuList, Switch, Typography } from '@mui/material';
 import FocusTrap from '@mui/material/Unstable_TrapFocus';
-import { type PropsWithChildren, type ReactNode, Suspense, useId, useState } from 'react';
+import { type PropsWithChildren, type ReactNode, Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { AuthorizationPrivilege, RoleName } from '@/core/apollo/generated/graphql-schema';
@@ -75,7 +75,6 @@ const PlatformNavigationUserMenu = ({
   const { count: pendingInvitationsCount } = usePendingInvitationsCount();
 
   const designVersionToggle = useDesignVersionToggle();
-  const designVersionCaptionId = useId();
 
   const {
     openSelect,
@@ -151,30 +150,6 @@ const PlatformNavigationUserMenu = ({
                 </Typography>
               </NavigatableMenuItem>
             )}
-            {designVersionToggle.isVisible && (
-              <>
-                <Box sx={{ paddingX: gutters(1), paddingY: gutters(0.5) }}>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        size="small"
-                        checked={designVersionToggle.enabled}
-                        onChange={(_event, checked) => designVersionToggle.onChange(checked)}
-                        disabled={designVersionToggle.isPending}
-                        inputProps={{ 'aria-describedby': designVersionCaptionId }}
-                      />
-                    }
-                    label={t('topBar.designVersion.label')}
-                    labelPlacement="start"
-                    sx={{ marginLeft: 0, marginRight: 0, width: '100%', justifyContent: 'space-between' }}
-                  />
-                  <Caption id={designVersionCaptionId} color="neutralMedium.main">
-                    {t('topBar.designVersion.caption')}
-                  </Caption>
-                </Box>
-                <UserMenuDivider />
-              </>
-            )}
             <NavigatableMenuItem iconComponent={DashboardOutlined} route={homeUrl} onClick={onClose}>
               {t('pages.home.title')}
             </NavigatableMenuItem>
@@ -229,6 +204,27 @@ const PlatformNavigationUserMenu = ({
             >
               {t('buttons.getHelp')}
             </NavigatableMenuItem>
+            {designVersionToggle.isVisible && (
+              <>
+                <UserMenuDivider />
+                <Box sx={{ paddingX: gutters(1), paddingY: gutters(0.5) }}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        size="small"
+                        checked={designVersionToggle.enabled}
+                        onChange={(_event, checked) => designVersionToggle.onChange(checked)}
+                        disabled={designVersionToggle.isPending}
+                      />
+                    }
+                    label={t('topBar.designVersion.label')}
+                    labelPlacement="start"
+                    sx={{ marginLeft: 0, marginRight: 0, width: '100%', justifyContent: 'space-between' }}
+                  />
+                </Box>
+                <UserMenuDivider />
+              </>
+            )}
             {isAuthenticated && (
               <NavigatableMenuItem iconComponent={MeetingRoomOutlined} route={AUTH_LOGOUT_PATH} onClick={onClose}>
                 {t('buttons.sign-out')}


### PR DESCRIPTION
1. remove the text 'old design will remain...' to keep it simple; 
3. replace (beta) with (preview); 
3. and move the switch between help and sign out (insted of keepin it on top in the menu);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated design version terminology from "beta" to "preview" across English, German, Spanish, French, Dutch, and Bulgarian translations.
  * Removed design version captions from localization files.

* **UI/UX**
  * Repositioned design version toggle within user menus.
  * Changed design feature badge label from "beta" to "preview".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/client-web/pull/9681)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->