### PR TITLE
[CRD] Toasts

### DIFF
--- a/docs/crd/notifications.md
+++ b/docs/crd/notifications.md
@@ -1,0 +1,135 @@
+# Notifications & Toasts in CRD
+
+CRD uses [sonner](https://sonner.emilkowal.ski/) for toast notifications. A single `<Toaster />` is mounted in `App.tsx` (via `CrdNotificationHandler`) and renders at `bottom-right` by default — individual toasts can override position, duration, and add action buttons.
+
+The MUI fallback (`NotificationHandler.tsx`) is still rendered when `useCrdEnabled()` is `false`. Anything you push through `useNotification()` works in both worlds.
+
+## The two ways to fire a toast
+
+### 1. `useNotification()` — for the 90% case
+
+Use this for app-state feedback: success after save, validation errors, "copied to clipboard". It writes to the global notifications store and is picked up by whichever handler is mounted (MUI or CRD), so the same call works in both.
+
+```tsx
+import { useNotification } from '@/core/ui/notifications/useNotification';
+
+const notify = useNotification();
+
+notify('Profile updated', 'success');
+notify('Could not upload — file is too large', 'error');
+notify('You have unsaved changes', 'warning');
+notify('Sync in progress…', 'info');
+```
+
+Severity values: `'info' | 'success' | 'warning' | 'error'` (default `'info'`).
+
+Auto-hide durations come from `src/core/ui/notifications/constants.ts`:
+
+- `error` → 15s (leaves time to read the Contact-Support link)
+- `success` / `info` / `warning` → 3s
+
+Apollo errors are auto-pushed by `useErrorHandlerLink` — you do not call `notify` for those.
+
+### 2. `toast` from sonner — for custom position, action buttons, or persistence
+
+When the default bottom-right + auto-hide isn't right (version-update banner, offline indicator, anything with a button), call sonner directly. No second `<Toaster />` needed — the one in `App.tsx` handles all positions.
+
+```tsx
+import { toast } from 'sonner';
+
+// Position override
+toast.info('New comment posted', { position: 'top-right' });
+
+// Persistent toast with an action button
+toast('A new version is available.', {
+  position: 'top-center',
+  duration: Infinity,
+  action: { label: 'Reload', onClick: () => window.location.reload() },
+});
+
+// Dismiss programmatically (keep the id sonner returns)
+const id = toast.warning('You are offline', { duration: Infinity });
+// …later:
+toast.dismiss(id);
+```
+
+## Positioning conventions
+
+Sonner positions: `top-left` · `top-center` · `top-right` · `bottom-left` · `bottom-center` · `bottom-right`.
+
+| Position | Use for |
+|---|---|
+| `bottom-right` (default) | Transient app feedback — Apollo errors, save confirmations, validation messages. |
+| `top-center` | Platform-level announcements the user shouldn't miss but isn't required to act on immediately — new version available, planned maintenance. |
+| `top-right` | Secondary platform indicators that need to coexist with `top-center` — e.g. offline status. |
+
+## Worked examples
+
+### Version detected (sticky, with Reload action)
+
+```tsx
+import { toast } from 'sonner';
+
+toast('A new version of Alkemio is available.', {
+  position: 'top-center',
+  duration: Infinity,
+  action: { label: 'Reload', onClick: () => window.location.reload() },
+});
+```
+
+### Offline status (sticky, dismissed when connectivity returns)
+
+```tsx
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+const useOfflineToast = (isOnline: boolean) => {
+  const toastIdRef = useRef<string | number>();
+
+  useEffect(() => {
+    if (!isOnline && toastIdRef.current === undefined) {
+      toastIdRef.current = toast.warning('You are offline. Some features may be unavailable.', {
+        position: 'top-right',
+        duration: Infinity,
+      });
+    }
+    if (isOnline && toastIdRef.current !== undefined) {
+      toast.dismiss(toastIdRef.current);
+      toastIdRef.current = undefined;
+    }
+  }, [isOnline]);
+};
+```
+
+### Error with custom message (not Apollo-derived)
+
+```tsx
+notify('Could not upload file — try a smaller image.', 'error');
+```
+
+### Promise-tied toast (loading → success/error in one call)
+
+```tsx
+toast.promise(saveProfile(), {
+  loading: 'Saving…',
+  success: 'Profile updated',
+  error: 'Save failed — try again',
+});
+```
+
+## Where the pieces live
+
+- **Primitive**: `src/crd/primitives/sonner.tsx` — wraps `<Sonner>` and bridges sonner's `--normal-bg` / `--normal-text` / `--normal-border` vars to CRD's `--popover` / `--popover-foreground` / `--border`.
+- **Global handler**: `src/core/ui/notifications/CrdNotificationHandler.tsx` — subscribes to the same notifications store as the MUI handler, fans each entry out to `toast.<severity>()`, dispatches `CLEAR_NOTIFICATION` on auto-close/dismiss, and mounts the global `<Toaster position="bottom-right" />`.
+- **MUI fallback**: `src/core/ui/notifications/NotificationHandler.tsx` — unchanged; rendered when CRD is off.
+- **Gate**: `src/main/ui/layout/topLevelWrappers/App.tsx` — `{crdEnabled ? <CrdNotificationHandler /> : <NotificationHandler />}`.
+
+## Migrating existing MUI snackbars
+
+`src/main/versionHandling.tsx` and `src/main/onlineStatus/OnlineStatusNotification.tsx` still mount their own MUI `Snackbar`s. To move them to sonner:
+
+1. Replace `<Snackbar><SnackbarContent action={…} /></Snackbar>` with a `toast(...)` call when the trigger fires.
+2. Use `duration: Infinity` (no auto-hide) and `position: 'top-center'` (version) / `'top-right'` (offline).
+3. Use sonner's `action: { label, onClick }` instead of MUI's `SnackbarContent.action`.
+4. Keep the returned id in a ref so you can `toast.dismiss(id)` when the condition clears.
+5. Gate via `useCrdEnabled()` if you want to keep the MUI behaviour for non-CRD users in the meantime.

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "remark-rehype": "^11.1.2",
     "remark-stringify": "^11.0.0",
     "socket.io-client": "^4.8.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "ts-semaphore": "^1.0.0",
     "typescript": "~5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -7134,6 +7137,12 @@ packages:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -7295,8 +7304,8 @@ packages:
   third-party-web@0.27.0:
     resolution: {integrity: sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==}
 
-  third-party-web@0.29.0:
-    resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -9962,7 +9971,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.59':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -15692,6 +15701,11 @@ snapshots:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
 
+  sonner@2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+
   source-map-js@1.2.1: {}
 
   source-map@0.5.7: {}
@@ -15858,7 +15872,7 @@ snapshots:
 
   third-party-web@0.27.0: {}
 
-  third-party-web@0.29.0: {}
+  third-party-web@0.29.2: {}
 
   through@2.3.8: {}
 

--- a/src/core/ui/notifications/CrdNotificationHandler.tsx
+++ b/src/core/ui/notifications/CrdNotificationHandler.tsx
@@ -1,0 +1,72 @@
+import type { TFunction } from 'i18next';
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { CLEAR_NOTIFICATION, type Severity } from '@/core/state/global/notifications/useNotifications';
+import { useGlobalState } from '@/core/state/useGlobalState';
+import { Toaster } from '@/crd/primitives/sonner';
+import { getNotificationAutoHideDuration } from './constants';
+import { generateSupportMailtoUrl } from './generateSupportMailtoUrl';
+
+const toastBySeverity: Record<Severity, typeof toast.error> = {
+  error: toast.error,
+  success: toast.success,
+  info: toast.info,
+  warning: toast.warning,
+};
+
+const ErrorDescription = ({ numericCode, t }: { numericCode: number | undefined; t: TFunction }) => {
+  const mailtoUrl = generateSupportMailtoUrl({ numericCode, t });
+  return (
+    <>
+      {numericCode !== undefined && (
+        <div className="opacity-80">{t('apollo.errors.support.errorCode', { code: numericCode })}</div>
+      )}
+      <a
+        href={mailtoUrl}
+        className="mt-1 inline-block underline hover:no-underline"
+        onClick={e => {
+          e.preventDefault();
+          e.stopPropagation();
+          window.location.href = mailtoUrl;
+        }}
+      >
+        {t('apollo.errors.support.linkText')}
+      </a>
+    </>
+  );
+};
+
+export const CrdNotificationHandler = () => {
+  const { notifications, notificationsDispatch } = useGlobalState();
+  const { t } = useTranslation();
+  const shownIds = useRef(new Set<string>());
+
+  useEffect(() => {
+    notifications.forEach(n => {
+      if (shownIds.current.has(n.id)) {
+        return;
+      }
+      shownIds.current.add(n.id);
+
+      const clear = () => notificationsDispatch({ type: CLEAR_NOTIFICATION, payload: { id: n.id } });
+
+      toastBySeverity[n.severity](n.message, {
+        id: n.id,
+        duration: getNotificationAutoHideDuration(n.severity),
+        description: n.severity === 'error' ? <ErrorDescription numericCode={n.numericCode} t={t} /> : undefined,
+        onAutoClose: clear,
+        onDismiss: clear,
+      });
+    });
+
+    const currentIds = new Set(notifications.map(n => n.id));
+    shownIds.current.forEach(id => {
+      if (!currentIds.has(id)) {
+        shownIds.current.delete(id);
+      }
+    });
+  }, [notifications, notificationsDispatch, t]);
+
+  return <Toaster position="bottom-right" />;
+};

--- a/src/crd/primitives/sonner.tsx
+++ b/src/crd/primitives/sonner.tsx
@@ -3,14 +3,7 @@ import { Toaster as Sonner, type ToasterProps } from 'sonner';
 const Toaster = (props: ToasterProps) => (
   <Sonner
     theme="light"
-    className="toaster group"
-    style={
-      {
-        '--normal-bg': 'var(--popover)',
-        '--normal-text': 'var(--popover-foreground)',
-        '--normal-border': 'var(--border)',
-      } as React.CSSProperties
-    }
+    className="toaster group [--normal-bg:var(--popover)] [--normal-text:var(--popover-foreground)] [--normal-border:var(--border)]"
     toastOptions={{
       classNames: {
         error: '!border-l-4 !border-l-destructive',

--- a/src/crd/primitives/sonner.tsx
+++ b/src/crd/primitives/sonner.tsx
@@ -11,6 +11,14 @@ const Toaster = (props: ToasterProps) => (
         '--normal-border': 'var(--border)',
       } as React.CSSProperties
     }
+    toastOptions={{
+      classNames: {
+        error: '!border-l-4 !border-l-destructive',
+        success: '!border-l-4 !border-l-success',
+        warning: '!border-l-4 !border-l-warning',
+        info: '!border-l-4 !border-l-info',
+      },
+    }}
     {...props}
   />
 );

--- a/src/crd/primitives/sonner.tsx
+++ b/src/crd/primitives/sonner.tsx
@@ -1,0 +1,18 @@
+import { Toaster as Sonner, type ToasterProps } from 'sonner';
+
+const Toaster = (props: ToasterProps) => (
+  <Sonner
+    theme="light"
+    className="toaster group"
+    style={
+      {
+        '--normal-bg': 'var(--popover)',
+        '--normal-text': 'var(--popover-foreground)',
+        '--normal-border': 'var(--border)',
+      } as React.CSSProperties
+    }
+    {...props}
+  />
+);
+
+export { Toaster };

--- a/src/main/ui/layout/topLevelWrappers/App.tsx
+++ b/src/main/ui/layout/topLevelWrappers/App.tsx
@@ -4,16 +4,19 @@ import { useCookies } from 'react-cookie';
 import { Outlet } from 'react-router-dom';
 import { useUserScope } from '@/core/analytics/SentryTransactionScopeContext';
 import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
+import { CrdNotificationHandler } from '@/core/ui/notifications/CrdNotificationHandler';
 import { NotificationHandler } from '@/core/ui/notifications/NotificationHandler';
 import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
 import { useConfig } from '@/domain/platform/config/useConfig';
 import { ALKEMIO_COOKIE_NAME } from '@/main/cookies/useAlkemioCookies';
+import { useCrdEnabled } from '@/main/crdPages/useCrdEnabled';
 
 const CookieConsent = lazyWithGlobalErrorHandler(() => import('@/main/cookies/CookieConsent'));
 
 const App = () => {
   const [cookies] = useCookies([ALKEMIO_COOKIE_NAME]);
   const { userModel } = useCurrentUserContext();
+  const crdEnabled = useCrdEnabled();
 
   useUserScope(userModel);
 
@@ -50,7 +53,7 @@ const App = () => {
           <CookieConsent ref={cookieConsentRef} />
         </Suspense>
       )}
-      <NotificationHandler />
+      {crdEnabled ? <CrdNotificationHandler /> : <NotificationHandler />}
     </>
   );
 };


### PR DESCRIPTION
Toast notifications ported - error, info, success. 

Passed design review:



<img width="392" height="98" alt="Screenshot 2026-05-21 at 15 07 51" src="https://github.com/user-attachments/assets/6a77d0a4-d65c-4a3d-a461-7bb6ca15ed54" />
<img width="397" height="137" alt="Screenshot 2026-05-21 at 15 08 12" src="https://github.com/user-attachments/assets/7a759777-6854-4589-845e-e6a6d8f0fdc3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now uses a unified toast-based notification system with improved styling, per-severity behavior, duplicate suppression, persistent/dismissable toasts, and automatic selection between the new handler and the existing fallback.
* **Documentation**
  * Added comprehensive docs with usage patterns, worked examples, positioning conventions, and migration guidance for moving from snackbars to toasts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/client-web/pull/9716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->