### PR TITLE
[CRD] fix can't update callout with documents

### DIFF
--- a/src/main/crdPages/space/callout/calloutFormMapper.test.ts
+++ b/src/main/crdPages/space/callout/calloutFormMapper.test.ts
@@ -502,15 +502,58 @@ describe('mapFormToCalloutCreationInput — cross-cutting fields', () => {
 });
 
 describe('mapFormToCalloutUpdateInput', () => {
-  it('always emits ID + framing.type + trimmed displayName + description', () => {
+  it('always emits ID + trimmed displayName + description; omits framing.type when unchanged', () => {
     const result = mapFormToCalloutUpdateInput(
-      baseValues({ title: '  My title  ', description: 'desc' }),
+      baseValues({
+        title: '  My title  ',
+        description: 'desc',
+        editMeta: {
+          framingProfileId: 'framing-profile-id',
+          originalReferenceIds: [],
+          originalFramingType: CalloutFramingType.None,
+        },
+      }),
       updateOptions
     );
     expect(result.input.ID).toBe('callout-1');
-    expect(result.input.framing?.type).toBe(CalloutFramingType.None);
+    // `framing.type` is intentionally omitted when the form's framing type matches
+    // the prefilled `editMeta.originalFramingType` — sending it unchanged makes the
+    // server treat the request as a type switch (regression: COLLABORA_DOCUMENT
+    // rejected the update with "Collabora document input is required when switching
+    // to COLLABORA_DOCUMENT framing type").
+    expect(result.input.framing?.type).toBeUndefined();
     expect(result.input.framing?.profile?.displayName).toBe('My title');
     expect(result.input.framing?.profile?.description).toBe('desc');
+  });
+
+  it('emits framing.type when the framing type is actually changing (e.g. clearing to None on edit)', () => {
+    const result = mapFormToCalloutUpdateInput(
+      baseValues({
+        framingChip: 'none',
+        editMeta: {
+          framingProfileId: 'framing-profile-id',
+          originalReferenceIds: [],
+          originalFramingType: CalloutFramingType.CollaboraDocument,
+        },
+      }),
+      updateOptions
+    );
+    expect(result.input.framing?.type).toBe(CalloutFramingType.None);
+  });
+
+  it('omits framing.type when the original is COLLABORA_DOCUMENT and the chip is unchanged (the original bug)', () => {
+    const result = mapFormToCalloutUpdateInput(
+      baseValues({
+        framingChip: 'document',
+        editMeta: {
+          framingProfileId: 'framing-profile-id',
+          originalReferenceIds: [],
+          originalFramingType: CalloutFramingType.CollaboraDocument,
+        },
+      }),
+      updateOptions
+    );
+    expect(result.input.framing?.type).toBeUndefined();
   });
 
   it('references: only rows with id pass; blank name/uri filtered out; tagsets absent without editMeta tagsetId', () => {
@@ -551,10 +594,15 @@ describe('mapFormToCalloutUpdateInput', () => {
         framingChip: 'whiteboard',
         whiteboardContent: '<wb/>',
         whiteboardPreviewImages: [previewBlob],
+        editMeta: {
+          framingProfileId: 'framing-profile-id',
+          originalReferenceIds: [],
+          originalFramingType: CalloutFramingType.Whiteboard,
+        },
       }),
       updateOptions
     );
-    expect(result.input.framing?.type).toBe(CalloutFramingType.Whiteboard);
+    expect(result.input.framing?.type).toBeUndefined();
     expect(result.input.framing?.whiteboardContent).toBeUndefined();
     expect(result.input.framing?.whiteboardPreviewSettings).toBeUndefined();
     // Preview blobs still travel out-of-band when present
@@ -563,10 +611,18 @@ describe('mapFormToCalloutUpdateInput', () => {
 
   it('Memo framing on update never sends memo body (edited via dedicated dialog)', () => {
     const result = mapFormToCalloutUpdateInput(
-      baseValues({ framingChip: 'memo', memoMarkdown: '# body' }),
+      baseValues({
+        framingChip: 'memo',
+        memoMarkdown: '# body',
+        editMeta: {
+          framingProfileId: 'framing-profile-id',
+          originalReferenceIds: [],
+          originalFramingType: CalloutFramingType.Memo,
+        },
+      }),
       updateOptions
     );
-    expect(result.input.framing?.type).toBe(CalloutFramingType.Memo);
+    expect(result.input.framing?.type).toBeUndefined();
     expect(result.input.framing?.memoContent).toBeUndefined();
   });
 

--- a/src/main/crdPages/space/callout/calloutFormMapper.ts
+++ b/src/main/crdPages/space/callout/calloutFormMapper.ts
@@ -385,8 +385,18 @@ export const mapFormToCalloutUpdateInput = (values: CalloutFormValues, options: 
       ]
     : undefined;
 
+  // Only emit `framing.type` when it actually changes. The framing chip is
+  // locked on edit (`FramingChipStrip locked={mode === 'edit'}`); the only
+  // permitted transition is to `None`. Sending an unchanged `type` makes the
+  // server treat the request as a type switch — for `COLLABORA_DOCUMENT` that
+  // triggers "Collabora document input is required when switching to
+  // COLLABORA_DOCUMENT framing type", because we have no reason to send a
+  // `collaboraDocument` block on a no-op type.
+  const originalFramingType = values.editMeta?.originalFramingType;
+  const framingTypeChanged = originalFramingType !== undefined && framingType !== originalFramingType;
+
   const framing: UpdateCalloutEntityInput['framing'] = {
-    type: framingType,
+    ...(framingTypeChanged ? { type: framingType } : {}),
     profile: {
       displayName: values.title.trim(),
       description: values.description || undefined,

--- a/src/main/crdPages/space/callout/dataMappers/mapCalloutDetailsToFormValues.ts
+++ b/src/main/crdPages/space/callout/dataMappers/mapCalloutDetailsToFormValues.ts
@@ -147,6 +147,7 @@ export const mapCalloutDetailsToFormValues = (data: CalloutContentQuery | undefi
       whiteboardId: framing.whiteboard?.id,
       framingProfileId: framing.profile.id,
       originalReferenceIds: framing.profile.references?.map(r => r.id) ?? [],
+      originalFramingType: framing.type,
     },
   };
 

--- a/src/main/crdPages/space/hooks/useCrdCalloutForm.ts
+++ b/src/main/crdPages/space/hooks/useCrdCalloutForm.ts
@@ -2,7 +2,7 @@ import { isEqual } from 'lodash-es';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
-import { CollaboraDocumentType } from '@/core/apollo/generated/graphql-schema';
+import { type CalloutFramingType, CollaboraDocumentType } from '@/core/apollo/generated/graphql-schema';
 import { MARKDOWN_TEXT_LENGTH, MID_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@/core/ui/forms/field-length.constants';
 import type { PollOptionValue } from '@/crd/forms/callout/PollOptionsEditor';
 import { MAX_POLL_OPTIONS, MIN_POLL_OPTIONS } from '@/crd/forms/callout/PollOptionsEditor';
@@ -101,6 +101,14 @@ export type CalloutFormValues = {
     framingProfileId: string;
     /** Reference ids present at edit-open, so the submit can detect which references were removed. */
     originalReferenceIds: string[];
+    /**
+     * Framing type as loaded from the server at edit-open. The update mapper omits
+     * `framing.type` from the mutation input when the current form value matches
+     * this — sending an unchanged `type` makes the server treat the request as a
+     * type switch and reject it (e.g. `COLLABORA_DOCUMENT` then requires a
+     * `collaboraDocument` block we have no reason to send).
+     */
+    originalFramingType?: CalloutFramingType;
   };
 };
 


### PR DESCRIPTION
Line 29, R59 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated callout editing to track the original framing type and only include framing type information in update requests when the value actually changes, reducing unnecessary data transmission during edits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/client-web/pull/9730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->