### PR TITLE
do not register sw on identity

### DIFF
--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -17,6 +17,9 @@ type Config =
   | undefined;
 
 export function register(config?: Config): void {
+  if (window.location.hostname.startsWith('identity.')) {
+    return;
+  }
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       const swUrl = 'service-worker.js';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Service worker registration is now skipped for hosts with 'identity.' subdomains, preventing unnecessary worker processes on those specific environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/client-web/pull/9733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->