### PR TITLE
[CRD] fix the grid layout on the dashboard

### DIFF
--- a/src/crd/components/dashboard/DashboardLayout.tsx
+++ b/src/crd/components/dashboard/DashboardLayout.tsx
@@ -86,7 +86,7 @@ export function DashboardLayout({ sidebar, children, className }: DashboardLayou
           <div className={cn('col-span-12', contentColumnClass())}>
             <div className="grid grid-cols-1 md:grid-cols-[240px_1fr] gap-6">
               {/* Desktop sidebar */}
-              <nav aria-label="Dashboard navigation" className="hidden md:block">
+              <nav aria-label={t('sidebar.navigation')} className="hidden md:block">
                 {sidebar}
               </nav>
 
@@ -136,7 +136,7 @@ export function DashboardLayout({ sidebar, children, className }: DashboardLayou
             id="dashboard-mobile-drawer"
             role="dialog"
             aria-modal="true"
-            aria-label="Dashboard navigation"
+            aria-label={t('sidebar.navigation')}
             className={cn(
               'absolute inset-y-0 left-0 w-[280px] bg-background shadow-xl overflow-y-auto transition-transform duration-200 ease-out',
               visible ? 'translate-x-0' : '-translate-x-full'

--- a/src/crd/components/dashboard/DashboardLayout.tsx
+++ b/src/crd/components/dashboard/DashboardLayout.tsx
@@ -1,6 +1,7 @@
 import { Menu, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { contentColumnClass } from '@/crd/lib/contentColumn';
 import { cn } from '@/crd/lib/utils';
 import { Button } from '@/crd/primitives/button';
 
@@ -80,19 +81,20 @@ export function DashboardLayout({ sidebar, children, className }: DashboardLayou
 
   return (
     <>
-      <div
-        className={cn(
-          'grid grid-cols-1 md:grid-cols-[240px_1fr] gap-6 max-w-[1600px] mx-auto px-4 sm:px-6 py-6',
-          className
-        )}
-      >
-        {/* Desktop sidebar */}
-        <nav aria-label="Dashboard navigation" className="hidden md:block">
-          {sidebar}
-        </nav>
+      <div className={cn('w-full px-6 md:px-8 py-6', className)}>
+        <div className="grid grid-cols-12 gap-6">
+          <div className={cn('col-span-12', contentColumnClass())}>
+            <div className="grid grid-cols-1 md:grid-cols-[240px_1fr] gap-6">
+              {/* Desktop sidebar */}
+              <nav aria-label="Dashboard navigation" className="hidden md:block">
+                {sidebar}
+              </nav>
 
-        {/* Content. Bottom padding on mobile clears the fixed hamburger bar (h-14). */}
-        <div className="min-w-0 space-y-6 pb-14 md:pb-0">{children}</div>
+              {/* Content. Bottom padding on mobile clears the fixed hamburger bar (h-14). */}
+              <div className="min-w-0 space-y-6 pb-14 md:pb-0">{children}</div>
+            </div>
+          </div>
+        </div>
       </div>
 
       {/* Mobile-only fixed bottom bar — mirrors the SpaceNavigationTabs pattern. */}

--- a/src/crd/components/dashboard/RecentSpaces.tsx
+++ b/src/crd/components/dashboard/RecentSpaces.tsx
@@ -10,6 +10,12 @@ type RecentSpacesProps = {
   loading?: boolean;
   hasHomeSpace: boolean;
   homeSpaceSettingsHref?: string;
+  /**
+   * Maximum cards shown in the single row, counting the pin / home-space slot.
+   * The grid is `lg:grid-cols-4`, so 4 keeps everything on one row; the rest is
+   * reachable via "Explore all". Default 4.
+   */
+  maxItems?: number;
   onExploreAllClick?: () => void;
   onPinClick?: () => void;
   className?: string;
@@ -20,11 +26,18 @@ export function RecentSpaces({
   loading,
   hasHomeSpace,
   homeSpaceSettingsHref,
+  maxItems = 4,
   onExploreAllClick,
   onPinClick,
   className,
 }: RecentSpacesProps) {
   const { t } = useTranslation('crd-dashboard');
+
+  // The pin-button placeholder (shown only when there is no home space) takes one
+  // of the row's slots, so the space cards fill the remainder. When a home space
+  // exists it is already the first entry in `spaces`, so no slot is reserved here.
+  const placeholderShown = !hasHomeSpace && !!homeSpaceSettingsHref;
+  const visibleSpaces = spaces.slice(0, Math.max(0, maxItems - (placeholderShown ? 1 : 0)));
 
   return (
     <section className={cn('space-y-4', className)}>
@@ -44,11 +57,11 @@ export function RecentSpaces({
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         {loading ? (
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
-          Array.from({ length: 4 }).map((_, i) => <CompactSpaceCardSkeleton key={i} />)
+          Array.from({ length: maxItems }).map((_, i) => <CompactSpaceCardSkeleton key={i} />)
         ) : (
           <>
-            {!hasHomeSpace && homeSpaceSettingsHref && <HomeSpacePlaceholder settingsHref={homeSpaceSettingsHref} />}
-            {spaces.map(space => (
+            {placeholderShown && homeSpaceSettingsHref && <HomeSpacePlaceholder settingsHref={homeSpaceSettingsHref} />}
+            {visibleSpaces.map(space => (
               <CompactSpaceCard key={space.id} {...space} onPinClick={space.isHomeSpace ? onPinClick : undefined} />
             ))}
           </>

--- a/src/crd/components/space/SpaceExplorer.tsx
+++ b/src/crd/components/space/SpaceExplorer.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { SpaceCardData, SpaceCardParent } from '@/crd/components/space/SpaceCard';
 import { SpaceCard, SpaceCardSkeleton } from '@/crd/components/space/SpaceCard';
 import { TagsInput } from '@/crd/forms/tags-input';
+import { contentColumnClass } from '@/crd/lib/contentColumn';
 import { cn } from '@/crd/lib/utils';
 import { Badge } from '@/crd/primitives/badge';
 import { Button } from '@/crd/primitives/button';
@@ -100,221 +101,232 @@ export function SpaceExplorer({
   const showSkeletons = loading && spaces.length === 0;
 
   return (
-    <div className={cn('w-full max-w-[1600px] mx-auto px-4 sm:px-6 py-8', className)}>
-      {/* Page header */}
-      <div className="mb-8">
-        <h1 className="text-page-title text-foreground">{t('spaces.title')}</h1>
-        <p className="mt-1 text-body text-muted-foreground">{t('spaces.subtitle')}</p>
-      </div>
+    <div className={cn('w-full px-6 md:px-8 py-8', className)}>
+      <div className="grid grid-cols-12 gap-6">
+        <div className={cn('col-span-12', contentColumnClass())}>
+          {/* Page header */}
+          <div className="mb-8">
+            <h1 className="text-page-title text-foreground">{t('spaces.title')}</h1>
+            <p className="mt-1 text-body text-muted-foreground">{t('spaces.subtitle')}</p>
+          </div>
 
-      {/* Search + Sort + Filters */}
-      <div className="flex flex-col sm:flex-row gap-3 mb-6">
-        {/* Tag-based search input */}
-        <TagsInput
-          value={searchTerms}
-          onChange={onSearchTermsChange}
-          placeholder={t('spaces.searchPlaceholder')}
-          className="flex-1"
-          icon={<Search className="shrink-0 size-4 text-muted-foreground" />}
-        />
+          {/* Search + Sort + Filters */}
+          <div className="flex flex-col sm:flex-row gap-3 mb-6">
+            {/* Tag-based search input */}
+            <TagsInput
+              value={searchTerms}
+              onChange={onSearchTermsChange}
+              placeholder={t('spaces.searchPlaceholder')}
+              className="flex-1"
+              icon={<Search className="shrink-0 size-4 text-muted-foreground" />}
+            />
 
-        {/* Filters dropdown */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild={true}>
-            <Button
-              variant="outline"
-              className={cn(
-                'gap-2 h-10 rounded-lg',
-                activeFilterCount > 0 ? 'text-primary border-primary' : 'text-foreground border-border'
-              )}
-            >
-              <SlidersHorizontal className="size-3.5" />
-              {t('spaces.filters')}
-              {activeFilterCount > 0 && (
-                <Badge className="text-badge px-[5px] h-[18px] bg-primary text-primary-foreground rounded-full ml-0.5">
-                  {activeFilterCount}
-                </Badge>
-              )}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="min-w-[200px]">
-            {/* Membership section (server-side) */}
-            <DropdownMenuLabel className={filterLabelClassName}>{t('spaces.filterMembership')}</DropdownMenuLabel>
-            <DropdownMenuCheckboxItem
-              checked={membershipFilter === 'all'}
-              onCheckedChange={() => onMembershipFilterChange?.('all')}
-            >
-              {t('spaces.filterAll')}
-            </DropdownMenuCheckboxItem>
-            {authenticated && (
-              <DropdownMenuCheckboxItem
-                checked={membershipFilter === 'member'}
-                onCheckedChange={() => onMembershipFilterChange?.('member')}
-              >
-                {t('spaces.filterMember')}
-              </DropdownMenuCheckboxItem>
-            )}
-            <DropdownMenuCheckboxItem
-              checked={membershipFilter === 'public'}
-              onCheckedChange={() => onMembershipFilterChange?.('public')}
-            >
-              {t('spaces.filterPublic')}
-            </DropdownMenuCheckboxItem>
-
-            <DropdownMenuSeparator />
-
-            {/* Privacy section (client-side) */}
-            <DropdownMenuLabel className={filterLabelClassName}>{t('spaces.filterPrivacy')}</DropdownMenuLabel>
-            <DropdownMenuCheckboxItem checked={privacyFilter === 'all'} onCheckedChange={() => setPrivacyFilter('all')}>
-              {t('spaces.filterAll')}
-            </DropdownMenuCheckboxItem>
-            <DropdownMenuCheckboxItem
-              checked={privacyFilter === 'public'}
-              onCheckedChange={() => setPrivacyFilter('public')}
-            >
-              {t('spaces.filterPublicOnly')}
-            </DropdownMenuCheckboxItem>
-            <DropdownMenuCheckboxItem
-              checked={privacyFilter === 'private'}
-              onCheckedChange={() => setPrivacyFilter('private')}
-            >
-              {t('spaces.filterPrivateOnly')}
-            </DropdownMenuCheckboxItem>
-
-            <DropdownMenuSeparator />
-
-            {/* Type section (client-side) */}
-            <DropdownMenuLabel className={filterLabelClassName}>{t('spaces.filterType')}</DropdownMenuLabel>
-            <DropdownMenuCheckboxItem checked={typeFilter === 'all'} onCheckedChange={() => setTypeFilter('all')}>
-              {t('spaces.filterAllTypes')}
-            </DropdownMenuCheckboxItem>
-            <DropdownMenuCheckboxItem checked={typeFilter === 'spaces'} onCheckedChange={() => setTypeFilter('spaces')}>
-              {t('spaces.filterSpacesOnly')}
-            </DropdownMenuCheckboxItem>
-            <DropdownMenuCheckboxItem
-              checked={typeFilter === 'subspaces'}
-              onCheckedChange={() => setTypeFilter('subspaces')}
-            >
-              {t('spaces.filterSubspacesOnly')}
-            </DropdownMenuCheckboxItem>
-
-            {activeFilterCount > 0 && (
-              <>
-                <DropdownMenuSeparator />
-                <div className="px-2 py-1">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={clearFilters}
-                    className="w-full justify-start gap-2 text-destructive h-8"
+            {/* Filters dropdown */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild={true}>
+                <Button
+                  variant="outline"
+                  className={cn(
+                    'gap-2 h-10 rounded-lg',
+                    activeFilterCount > 0 ? 'text-primary border-primary' : 'text-foreground border-border'
+                  )}
+                >
+                  <SlidersHorizontal className="size-3.5" />
+                  {t('spaces.filters')}
+                  {activeFilterCount > 0 && (
+                    <Badge className="text-badge px-[5px] h-[18px] bg-primary text-primary-foreground rounded-full ml-0.5">
+                      {activeFilterCount}
+                    </Badge>
+                  )}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[200px]">
+                {/* Membership section (server-side) */}
+                <DropdownMenuLabel className={filterLabelClassName}>{t('spaces.filterMembership')}</DropdownMenuLabel>
+                <DropdownMenuCheckboxItem
+                  checked={membershipFilter === 'all'}
+                  onCheckedChange={() => onMembershipFilterChange?.('all')}
+                >
+                  {t('spaces.filterAll')}
+                </DropdownMenuCheckboxItem>
+                {authenticated && (
+                  <DropdownMenuCheckboxItem
+                    checked={membershipFilter === 'member'}
+                    onCheckedChange={() => onMembershipFilterChange?.('member')}
                   >
-                    <X className="size-3" />
-                    {t('spaces.clearFilters')}
-                  </Button>
-                </div>
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+                    {t('spaces.filterMember')}
+                  </DropdownMenuCheckboxItem>
+                )}
+                <DropdownMenuCheckboxItem
+                  checked={membershipFilter === 'public'}
+                  onCheckedChange={() => onMembershipFilterChange?.('public')}
+                >
+                  {t('spaces.filterPublic')}
+                </DropdownMenuCheckboxItem>
 
-      {/* Active filter chips */}
-      {activeFilterCount > 0 && (
-        <div className="flex flex-wrap items-center gap-2 mb-4">
-          {privacyFilter !== 'all' && (
-            <button
-              type="button"
-              onClick={() => setPrivacyFilter('all')}
-              className="inline-flex items-center gap-1 cursor-pointer rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 text-caption px-2.5 py-1"
-            >
-              {privacyFilter === 'public' ? t('spaces.filterPublicOnly') : t('spaces.filterPrivateOnly')}
-              <X aria-hidden="true" className="size-2.5" />
-              <span className="sr-only">, {t('spaces.removeFilter')}</span>
-            </button>
-          )}
-          {typeFilter !== 'all' && (
-            <button
-              type="button"
-              onClick={() => setTypeFilter('all')}
-              className="inline-flex items-center gap-1 cursor-pointer rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 text-caption px-2.5 py-1"
-            >
-              {typeFilter === 'spaces' ? t('spaces.filterSpacesOnly') : t('spaces.filterSubspacesOnly')}
-              <X aria-hidden="true" className="size-2.5" />
-              <span className="sr-only">, {t('spaces.removeFilter')}</span>
-            </button>
-          )}
-        </div>
-      )}
+                <DropdownMenuSeparator />
 
-      {/* Results count */}
-      {!showSkeletons && displayedSpaces.length > 0 && (
-        <div className="flex items-center justify-between mb-4">
-          <p className="text-body text-muted-foreground">
-            {t('spaces.showing')} <span className="text-body-emphasis text-foreground">{displayedSpaces.length}</span>{' '}
-            {t('spaces.spacesLabel')}
-          </p>
-        </div>
-      )}
+                {/* Privacy section (client-side) */}
+                <DropdownMenuLabel className={filterLabelClassName}>{t('spaces.filterPrivacy')}</DropdownMenuLabel>
+                <DropdownMenuCheckboxItem
+                  checked={privacyFilter === 'all'}
+                  onCheckedChange={() => setPrivacyFilter('all')}
+                >
+                  {t('spaces.filterAll')}
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={privacyFilter === 'public'}
+                  onCheckedChange={() => setPrivacyFilter('public')}
+                >
+                  {t('spaces.filterPublicOnly')}
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={privacyFilter === 'private'}
+                  onCheckedChange={() => setPrivacyFilter('private')}
+                >
+                  {t('spaces.filterPrivateOnly')}
+                </DropdownMenuCheckboxItem>
 
-      {/* Loading search indicator */}
-      {loadingSearchResults && (
-        <output className="flex items-center justify-center py-8" aria-label={t('spaces.loading')}>
-          <div className="animate-spin rounded-full size-6 border-2 border-border border-t-transparent" />
-        </output>
-      )}
+                <DropdownMenuSeparator />
 
-      {/* Cards grid */}
-      {showSkeletons ? (
-        <output className={cn('grid gap-6', gridCols)} aria-label={t('spaces.loading')}>
-          {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no stable key
-            <SpaceCardSkeleton key={i} />
-          ))}
-        </output>
-      ) : displayedSpaces.length > 0 ? (
-        <ul className={cn('grid gap-6 list-none p-0 m-0', gridCols)} aria-label={t('spaces.spacesLabel')}>
-          {displayedSpaces.map(space => (
-            <li key={space.id}>
-              <SpaceCard space={space} onParentClick={onParentClick} />
-            </li>
-          ))}
-        </ul>
-      ) : null}
+                {/* Type section (client-side) */}
+                <DropdownMenuLabel className={filterLabelClassName}>{t('spaces.filterType')}</DropdownMenuLabel>
+                <DropdownMenuCheckboxItem checked={typeFilter === 'all'} onCheckedChange={() => setTypeFilter('all')}>
+                  {t('spaces.filterAllTypes')}
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={typeFilter === 'spaces'}
+                  onCheckedChange={() => setTypeFilter('spaces')}
+                >
+                  {t('spaces.filterSpacesOnly')}
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={typeFilter === 'subspaces'}
+                  onCheckedChange={() => setTypeFilter('subspaces')}
+                >
+                  {t('spaces.filterSubspacesOnly')}
+                </DropdownMenuCheckboxItem>
 
-      {/* Empty state */}
-      {showEmpty && (
-        <div className="flex flex-col items-center justify-center text-center py-16 px-6 border border-dashed border-border rounded-xl bg-muted">
-          <FolderOpen aria-hidden="true" className="size-10 text-muted-foreground opacity-50 mb-3" />
-          <h3 className="text-subsection-title mb-1 text-foreground">{t('spaces.emptyTitle')}</h3>
-          <p className="text-body text-muted-foreground max-w-[360px] mb-4">{t('spaces.emptyMessage')}</p>
+                {activeFilterCount > 0 && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <div className="px-2 py-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={clearFilters}
+                        className="w-full justify-start gap-2 text-destructive h-8"
+                      >
+                        <X className="size-3" />
+                        {t('spaces.clearFilters')}
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          {/* Active filter chips */}
           {activeFilterCount > 0 && (
-            <Button variant="outline" onClick={clearFilters} className="gap-2">
-              <X className="size-3.5" />
-              {t('spaces.clearFilters')}
-            </Button>
+            <div className="flex flex-wrap items-center gap-2 mb-4">
+              {privacyFilter !== 'all' && (
+                <button
+                  type="button"
+                  onClick={() => setPrivacyFilter('all')}
+                  className="inline-flex items-center gap-1 cursor-pointer rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 text-caption px-2.5 py-1"
+                >
+                  {privacyFilter === 'public' ? t('spaces.filterPublicOnly') : t('spaces.filterPrivateOnly')}
+                  <X aria-hidden="true" className="size-2.5" />
+                  <span className="sr-only">, {t('spaces.removeFilter')}</span>
+                </button>
+              )}
+              {typeFilter !== 'all' && (
+                <button
+                  type="button"
+                  onClick={() => setTypeFilter('all')}
+                  className="inline-flex items-center gap-1 cursor-pointer rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 text-caption px-2.5 py-1"
+                >
+                  {typeFilter === 'spaces' ? t('spaces.filterSpacesOnly') : t('spaces.filterSubspacesOnly')}
+                  <X aria-hidden="true" className="size-2.5" />
+                  <span className="sr-only">, {t('spaces.removeFilter')}</span>
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Results count */}
+          {!showSkeletons && displayedSpaces.length > 0 && (
+            <div className="flex items-center justify-between mb-4">
+              <p className="text-body text-muted-foreground">
+                {t('spaces.showing')}{' '}
+                <span className="text-body-emphasis text-foreground">{displayedSpaces.length}</span>{' '}
+                {t('spaces.spacesLabel')}
+              </p>
+            </div>
+          )}
+
+          {/* Loading search indicator */}
+          {loadingSearchResults && (
+            <output className="flex items-center justify-center py-8" aria-label={t('spaces.loading')}>
+              <div className="animate-spin rounded-full size-6 border-2 border-border border-t-transparent" />
+            </output>
+          )}
+
+          {/* Cards grid */}
+          {showSkeletons ? (
+            <output className={cn('grid gap-6', gridCols)} aria-label={t('spaces.loading')}>
+              {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no stable key
+                <SpaceCardSkeleton key={i} />
+              ))}
+            </output>
+          ) : displayedSpaces.length > 0 ? (
+            <ul className={cn('grid gap-6 list-none p-0 m-0', gridCols)} aria-label={t('spaces.spacesLabel')}>
+              {displayedSpaces.map(space => (
+                <li key={space.id}>
+                  <SpaceCard space={space} onParentClick={onParentClick} />
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          {/* Empty state */}
+          {showEmpty && (
+            <div className="flex flex-col items-center justify-center text-center py-16 px-6 border border-dashed border-border rounded-xl bg-muted">
+              <FolderOpen aria-hidden="true" className="size-10 text-muted-foreground opacity-50 mb-3" />
+              <h3 className="text-subsection-title mb-1 text-foreground">{t('spaces.emptyTitle')}</h3>
+              <p className="text-body text-muted-foreground max-w-[360px] mb-4">{t('spaces.emptyMessage')}</p>
+              {activeFilterCount > 0 && (
+                <Button variant="outline" onClick={clearFilters} className="gap-2">
+                  <X className="size-3.5" />
+                  {t('spaces.clearFilters')}
+                </Button>
+              )}
+            </div>
+          )}
+
+          {/* Load More */}
+          {hasMore && displayedSpaces.length > 0 && !loading && (
+            <div className="flex justify-center mt-8">
+              <Button
+                variant="outline"
+                onClick={handleLoadMore}
+                disabled={loadingMore}
+                aria-busy={loadingMore}
+                className="gap-2"
+              >
+                {loadingMore ? (
+                  <div className="animate-spin rounded-full size-4 border-2 border-current border-t-transparent" />
+                ) : (
+                  <ChevronDown className="size-4" />
+                )}
+                {t('crd-common:loadMore')}
+              </Button>
+            </div>
           )}
         </div>
-      )}
-
-      {/* Load More */}
-      {hasMore && displayedSpaces.length > 0 && !loading && (
-        <div className="flex justify-center mt-8">
-          <Button
-            variant="outline"
-            onClick={handleLoadMore}
-            disabled={loadingMore}
-            aria-busy={loadingMore}
-            className="gap-2"
-          >
-            {loadingMore ? (
-              <div className="animate-spin rounded-full size-4 border-2 border-current border-t-transparent" />
-            ) : (
-              <ChevronDown className="size-4" />
-            )}
-            {t('crd-common:loadMore')}
-          </Button>
-        </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/crd/components/space/SpaceExplorer.tsx
+++ b/src/crd/components/space/SpaceExplorer.tsx
@@ -62,6 +62,7 @@ export function SpaceExplorer({
   const [loadingMore, setLoadingMore] = useState(false);
 
   const gridCols = gridClassName ?? 'grid-cols-[repeat(auto-fill,minmax(280px,1fr))]';
+  const cardsListClassName = cn('grid gap-6 list-none p-0 m-0', gridCols);
 
   // Client-side filters
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
@@ -234,7 +235,7 @@ export function SpaceExplorer({
                 <button
                   type="button"
                   onClick={() => setPrivacyFilter('all')}
-                  className="inline-flex items-center gap-1 cursor-pointer rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 text-caption px-2.5 py-1"
+                  className="inline-flex items-center gap-1 cursor-pointer rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 text-caption px-2.5 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
                   {privacyFilter === 'public' ? t('spaces.filterPublicOnly') : t('spaces.filterPrivateOnly')}
                   <X aria-hidden="true" className="size-2.5" />
@@ -245,7 +246,7 @@ export function SpaceExplorer({
                 <button
                   type="button"
                   onClick={() => setTypeFilter('all')}
-                  className="inline-flex items-center gap-1 cursor-pointer rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 text-caption px-2.5 py-1"
+                  className="inline-flex items-center gap-1 cursor-pointer rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 text-caption px-2.5 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
                   {typeFilter === 'spaces' ? t('spaces.filterSpacesOnly') : t('spaces.filterSubspacesOnly')}
                   <X aria-hidden="true" className="size-2.5" />
@@ -282,7 +283,9 @@ export function SpaceExplorer({
               ))}
             </output>
           ) : displayedSpaces.length > 0 ? (
-            <ul className={cn('grid gap-6 list-none p-0 m-0', gridCols)} aria-label={t('spaces.spacesLabel')}>
+            // biome-ignore lint/a11y/noRedundantRoles: Tailwind preflight removes list-style
+            // biome-ignore lint/a11y/useSemanticElements: role="list" restores list semantics after the list-style reset
+            <ul role="list" className={cardsListClassName} aria-label={t('spaces.spacesLabel')}>
               {displayedSpaces.map(space => (
                 <li key={space.id}>
                   <SpaceCard space={space} onParentClick={onParentClick} />

--- a/src/crd/i18n/dashboard/dashboard.bg.json
+++ b/src/crd/i18n/dashboard/dashboard.bg.json
@@ -11,6 +11,7 @@
     "innovationPacks": "Иновационни пакети",
     "openMenu": "Отвори менюто",
     "closeMenu": "Затвори менюто",
+    "navigation": "Навигация в таблото",
     "pendingCount": "{{count}} чакащи"
   },
   "recentSpaces": {

--- a/src/crd/i18n/dashboard/dashboard.de.json
+++ b/src/crd/i18n/dashboard/dashboard.de.json
@@ -11,6 +11,7 @@
     "innovationPacks": "Innovationspakete",
     "openMenu": "Menü öffnen",
     "closeMenu": "Menü schließen",
+    "navigation": "Dashboard-Navigation",
     "pendingCount": "{{count}} ausstehend"
   },
   "recentSpaces": {

--- a/src/crd/i18n/dashboard/dashboard.en.json
+++ b/src/crd/i18n/dashboard/dashboard.en.json
@@ -11,6 +11,7 @@
     "innovationPacks": "Innovation Packs",
     "openMenu": "Open menu",
     "closeMenu": "Close menu",
+    "navigation": "Dashboard navigation",
     "pendingCount": "{{count}} pending"
   },
   "recentSpaces": {

--- a/src/crd/i18n/dashboard/dashboard.es.json
+++ b/src/crd/i18n/dashboard/dashboard.es.json
@@ -11,6 +11,7 @@
     "innovationPacks": "Paquetes de Innovación",
     "openMenu": "Abrir menú",
     "closeMenu": "Cerrar menú",
+    "navigation": "Navegación del panel",
     "pendingCount": "{{count}} pendiente(s)"
   },
   "recentSpaces": {

--- a/src/crd/i18n/dashboard/dashboard.fr.json
+++ b/src/crd/i18n/dashboard/dashboard.fr.json
@@ -11,6 +11,7 @@
     "innovationPacks": "Packs d'Innovation",
     "openMenu": "Ouvrir le menu",
     "closeMenu": "Fermer le menu",
+    "navigation": "Navigation du tableau de bord",
     "pendingCount": "{{count}} en attente"
   },
   "recentSpaces": {

--- a/src/crd/i18n/dashboard/dashboard.nl.json
+++ b/src/crd/i18n/dashboard/dashboard.nl.json
@@ -11,6 +11,7 @@
     "innovationPacks": "Innovatie Pakketten",
     "openMenu": "Menu openen",
     "closeMenu": "Menu sluiten",
+    "navigation": "Dashboardnavigatie",
     "pendingCount": "{{count}} openstaand"
   },
   "recentSpaces": {


### PR DESCRIPTION
Reuse the layout from Space page on the dashboard and explore spaces. Fixes the mismatch between the topbar and the content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted dashboard and space list layouts to a multi-column grid, improving desktop content width and responsive behavior.

* **New Features**
  * Recent spaces list now supports a configurable maximum number of items (defaults preserved), affecting skeleton and card counts.

* **Localization / Accessibility**
  * Added sidebar navigation translations and switched the mobile drawer label to use the translated string for better accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->