### PR TITLE
fix(auth): render login page for Kratos refresh/step-up flows (#9774)

### DIFF
--- a/src/core/auth/authentication/routing/LoginRoute.test.tsx
+++ b/src/core/auth/authentication/routing/LoginRoute.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LoginRoute from './LoginRoute';
+
+let mockSearch = '';
+const mockIsAuthenticated = vi.fn<() => boolean>();
+
+vi.mock('@/core/routing/useQueryParams', () => ({
+  useQueryParams: () => new URLSearchParams(mockSearch),
+}));
+
+vi.mock('@/core/auth/authentication/hooks/useAuthenticationContext', () => ({
+  useAuthenticationContext: () => ({ isAuthenticated: mockIsAuthenticated() }),
+}));
+
+vi.mock('../pages/LoginPage', () => ({
+  default: ({ flow }: { flow?: string }) => <div data-testid="login-page">login-page:{flow ?? 'none'}</div>,
+}));
+
+vi.mock('../pages/LoginSuccessPage', () => ({
+  default: () => <div data-testid="login-success-page" />,
+}));
+
+const renderLoginRoute = () =>
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <LoginRoute />
+    </MemoryRouter>
+  );
+
+describe('LoginRoute', () => {
+  beforeEach(() => {
+    mockSearch = '';
+    mockIsAuthenticated.mockReset();
+  });
+
+  it('renders the login page for an unauthenticated user with no flow', () => {
+    mockIsAuthenticated.mockReturnValue(false);
+
+    renderLoginRoute();
+
+    expect(screen.getByTestId('login-page')).toBeInTheDocument();
+  });
+
+  it('redirects an authenticated user away when there is no flow id', () => {
+    mockIsAuthenticated.mockReturnValue(true);
+
+    renderLoginRoute();
+
+    expect(screen.queryByTestId('login-page')).not.toBeInTheDocument();
+  });
+
+  it('renders the login page for an authenticated user when a flow id is present (refresh / step-up re-auth)', () => {
+    // Kratos redirects refresh logins here as `/login?flow=<id>` while the user
+    // still holds a (non-privileged) session — the page must render so the
+    // re-authentication can complete and the Settings change can proceed.
+    mockSearch = 'flow=refresh-flow-123';
+    mockIsAuthenticated.mockReturnValue(true);
+
+    renderLoginRoute();
+
+    expect(screen.getByTestId('login-page')).toHaveTextContent('login-page:refresh-flow-123');
+  });
+});

--- a/src/core/auth/authentication/routing/LoginRoute.tsx
+++ b/src/core/auth/authentication/routing/LoginRoute.tsx
@@ -18,16 +18,20 @@ export const LoginRoute: FC = () => {
     }
   }, [returnUrl]);
 
+  // A Kratos-initiated login arrives here with a `flow` id in the URL. This
+  // includes *refresh* (re-authentication) logins, which Kratos demands before
+  // privileged Settings changes — adding a passkey, changing the password —
+  // once the session is older than `privileged_session_max_age`. In that case
+  // the user already holds a (non-privileged) session, so the usual
+  // `NotAuthenticatedRoute` guard would bounce them to the dashboard and the
+  // re-auth form would never render, silently aborting the Settings change.
+  // Whenever a flow id is present we render the login page regardless of
+  // authentication state so the flow (incl. refresh / step-up) can complete.
+  const loginPage = <LoginPage flow={flow} />;
+
   return (
     <Routes>
-      <Route
-        path={'/'}
-        element={
-          <NotAuthenticatedRoute>
-            <LoginPage flow={flow} />
-          </NotAuthenticatedRoute>
-        }
-      />
+      <Route path={'/'} element={flow ? loginPage : <NotAuthenticatedRoute>{loginPage}</NotAuthenticatedRoute>} />
       <Route path={'success'} element={<LoginSuccessPage />} />
     </Routes>
   );

--- a/src/main/crdPages/auth/LoginCrdRoute.test.tsx
+++ b/src/main/crdPages/auth/LoginCrdRoute.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LoginCrdRoute } from './LoginCrdRoute';
+
+let mockSearch = '';
+const mockIsAuthenticated = vi.fn<() => boolean>();
+
+vi.mock('@/core/routing/useQueryParams', () => ({
+  useQueryParams: () => new URLSearchParams(mockSearch),
+}));
+
+vi.mock('@/core/auth/authentication/hooks/useAuthenticationContext', () => ({
+  useAuthenticationContext: () => ({ isAuthenticated: mockIsAuthenticated() }),
+}));
+
+// Render a cheap sentinel for the login screen so we can assert whether it
+// mounted without pulling in the full CRD auth UI / Kratos stack.
+vi.mock('@/crd/components/auth/LoginCard', () => ({
+  LoginCard: ({ descriptor }: { descriptor?: { flowType?: string } }) => (
+    <div data-testid="crd-login-card">{descriptor?.flowType ?? 'no-descriptor'}</div>
+  ),
+}));
+vi.mock('./AuthShellWrapper', () => ({
+  AuthShellWrapper: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/core/auth/authentication/pages/LoginSuccessPage', () => ({ default: () => <div /> }));
+vi.mock('@/core/auth/authentication/hooks/useKratosFlow', () => ({
+  default: () => ({ flow: undefined, error: undefined, loading: false, refetch: vi.fn() }),
+  FlowTypeName: { Login: 'Login' },
+}));
+vi.mock('@/core/auth/authentication/hooks/usePasskeyScript', () => ({
+  default: () => ({ status: 'idle', error: null, isReady: false }),
+}));
+vi.mock('@/core/analytics/SentryTransactionScopeContext', () => ({ useTransactionScope: () => {} }));
+vi.mock('@/core/routing/usePageTitle', () => ({ usePageTitle: () => {} }));
+vi.mock('./useKratosMessageCopy', () => ({ useTranslateDescriptor: () => (descriptor: unknown) => descriptor }));
+vi.mock('./flowDescriptorAdapter', () => ({ flowDescriptorAdapter: () => ({}) }));
+vi.mock('./passkeyTrigger', () => ({
+  invokePasskeyTrigger: vi.fn(),
+  PasskeyTriggerError: class extends Error {},
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+const renderRoute = () =>
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <LoginCrdRoute />
+    </MemoryRouter>
+  );
+
+describe('LoginCrdRoute', () => {
+  beforeEach(() => {
+    mockSearch = '';
+    mockIsAuthenticated.mockReset();
+  });
+
+  it('renders the login page for an unauthenticated user with no flow', () => {
+    mockIsAuthenticated.mockReturnValue(false);
+
+    renderRoute();
+
+    expect(screen.getByTestId('crd-login-card')).toBeInTheDocument();
+  });
+
+  it('redirects an authenticated user away when there is no flow id', () => {
+    mockIsAuthenticated.mockReturnValue(true);
+
+    renderRoute();
+
+    expect(screen.queryByTestId('crd-login-card')).not.toBeInTheDocument();
+  });
+
+  it('renders the login page for an authenticated user when a flow id is present (refresh / step-up re-auth)', () => {
+    // Kratos redirects refresh logins here as `/login?flow=<id>` while the user
+    // still holds a (non-privileged) session — the page must render so the
+    // re-authentication can complete and the Settings change can proceed.
+    mockSearch = 'flow=refresh-flow-123';
+    mockIsAuthenticated.mockReturnValue(true);
+
+    renderRoute();
+
+    expect(screen.getByTestId('crd-login-card')).toBeInTheDocument();
+  });
+});

--- a/src/main/crdPages/auth/LoginCrdRoute.tsx
+++ b/src/main/crdPages/auth/LoginCrdRoute.tsx
@@ -115,9 +115,19 @@ function translatePasskeyError(t: TFunction, error: unknown): string {
 }
 
 /**
- * CRD login route — the un-gated replacement for the MUI `LoginRoute`.
+ * CRD login route — the replacement for the MUI `LoginRoute`.
  * Mirrors its structure: the login screen at `/` and the post-login
  * success handler at `/success`.
+ *
+ * A Kratos-initiated login arrives here with a `flow` id in the URL. This
+ * includes *refresh* (re-authentication) logins, which Kratos demands before
+ * privileged Settings changes — adding a passkey, changing the password —
+ * once the session is older than `privileged_session_max_age`. In that case
+ * the user already holds a (non-privileged) session, so the usual
+ * `NotAuthenticatedRoute` guard would bounce them to the dashboard and the
+ * re-auth form would never render, silently aborting the Settings change.
+ * Whenever a flow id is present we render the login page regardless of
+ * authentication state so the flow (incl. refresh / step-up) can complete.
  */
 export function LoginCrdRoute() {
   const params = useQueryParams();
@@ -130,16 +140,11 @@ export function LoginCrdRoute() {
     }
   }, [returnUrl]);
 
+  const loginPage = <CrdLoginPage flow={flow} />;
+
   return (
     <Routes>
-      <Route
-        path="/"
-        element={
-          <NotAuthenticatedRoute>
-            <CrdLoginPage flow={flow} />
-          </NotAuthenticatedRoute>
-        }
-      />
+      <Route path="/" element={flow ? loginPage : <NotAuthenticatedRoute>{loginPage}</NotAuthenticatedRoute>} />
       <Route path="success" element={<LoginSuccessPage />} />
     </Routes>
   );


### PR DESCRIPTION
## Problem

Setting a passkey — and changing the password — **silently fails** on acceptance when the user has been logged in for more than a few minutes. Reported in #9774 (observed with Microsoft accounts, but the cause is account-agnostic).

## Root cause (confirmed against acc Kratos)

Privileged Settings changes (passkey registration, password change) are rendered by `KratosForm` as a **native HTML `<form action method>`**, so submitting them is a full-page POST to Kratos — not an axios call.

Kratos enforces `privileged_session_max_age: 15m`. Once the session is older than that, the settings POST is rejected:

```
POST /self-service/settings?flow=…  → 403 Forbidden
  reason: The login session is too old and thus not allowed to update these fields. Please re-authenticate.
→ 303 → GET /self-service/login/browser?refresh=true&return_to=…/self-service/settings?flow=…
→ 303 → /login?flow=<id>   (refresh re-authentication)
```

The browser lands on client-web's `/login`, which is wrapped in `NotAuthenticatedRoute`. The user still holds a valid (just **not privileged**) session, so the guard does `<Navigate to={ROUTE_HOME}>` — the re-authentication form is **never rendered**, no login is submitted, the privileged session is never obtained, and the Settings change is silently dropped. (`useKratosFlow`'s existing 403 `session_refresh_required` handler only covers flows loaded via the axios Ory client, not the native-form submit path.)

This affects **any** credential change (passkey *and* password) attempted >15 min after login, for any account type.

## Fix

A Kratos-initiated login — including refresh / step-up re-auth — always arrives at `/login` with a `flow` id. Render the login page whenever a flow id is present, regardless of authentication state, so the re-authentication can complete; Kratos then returns to the original Settings flow via its `return_to`. Manual visits to `/login` with no flow keep the existing "redirect authenticated users home" behaviour.

```diff
- <NotAuthenticatedRoute><LoginPage flow={flow} /></NotAuthenticatedRoute>
+ {flow ? <LoginPage flow={flow} /> : <NotAuthenticatedRoute><LoginPage flow={flow} /></NotAuthenticatedRoute>}
```

Per the repo's no-duct-tape rule, this fixes the broken refresh round-trip rather than widening `privileged_session_max_age`.

## Tests

New `LoginRoute.test.tsx`:
- unauthenticated, no flow → login page renders
- authenticated, no flow → redirected away (existing behaviour preserved)
- authenticated **with** flow id → login page renders (refresh / step-up re-auth)

`pnpm lint` clean, full `pnpm vitest run` green (via pre-commit hook).

## Manual verification

After this change, on a >15-min-old session: clicking **Add passkey** / **Save password** routes through the refresh login, and after re-authenticating the user is returned to the Settings flow to complete the change (the WebAuthn step must be re-triggered, since the prior ceremony was bound to the rejected flow).

Fixes #9774

🤖 Generated with [Claude Code](https://claude.com/claude-code)