### PR TITLE
[CRD] tab titles for subspaces, hubs, packs, lib

### DIFF
--- a/src/domain/innovationHub/InnovationHubHomePage/InnovationHubHomePage.tsx
+++ b/src/domain/innovationHub/InnovationHubHomePage/InnovationHubHomePage.tsx
@@ -2,6 +2,7 @@ import { SettingsOutlined } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useDashboardSpacesQuery } from '@/core/apollo/generated/apollo-hooks';
+import { usePageTitle } from '@/core/routing/usePageTitle';
 import ScrollableCardsLayoutContainer from '@/core/ui/card/cardsLayout/ScrollableCardsLayoutContainer';
 import PageContent from '@/core/ui/content/PageContent';
 import PageContentBlock from '@/core/ui/content/PageContentBlock';
@@ -27,6 +28,11 @@ import InnovationHubBanner from './InnovationHubBanner';
 const InnovationHubHomePage = ({ innovationHub }: { innovationHub: InnovationHubAttrs }) => {
   const { t } = useTranslation();
   const { isAuthenticated } = useCurrentUserContext();
+
+  // Browser tab title: "[Hub Name] | Alkemio". This component is the single
+  // funnel for both the subdomain entry (via the Home dispatcher) and the
+  // `/hub/<slug>` path entry (via HubLandingPage).
+  usePageTitle(innovationHub.displayName);
 
   const { data: spacesData } = useDashboardSpacesQuery();
 

--- a/src/main/crdPages/innovationHub/CrdInnovationHubHomePage.tsx
+++ b/src/main/crdPages/innovationHub/CrdInnovationHubHomePage.tsx
@@ -1,6 +1,7 @@
 import { PanelsTopLeft } from 'lucide-react';
 import { useEffect } from 'react';
 import type { InnovationHubHomeInnovationHubFragment } from '@/core/apollo/generated/graphql-schema';
+import { usePageTitle } from '@/core/routing/usePageTitle';
 import Loading from '@/core/ui/loading/Loading';
 import type { BreadcrumbTrailItem } from '@/crd/components/common/BreadcrumbsTrail';
 import { InnovationHubHome } from '@/crd/components/innovationHub/InnovationHubHome';
@@ -58,6 +59,11 @@ const CrdInnovationHubHomePage = ({ innovationHubFromSubdomain }: CrdInnovationH
   const { data, loading, hub } = useInnovationHubHomeData(input);
   const { wide: fullWidth, toggle: toggleFullWidth } = useLayoutWidthPreference();
   useRedirectToHubSubdomain(hub?.subdomain, input.kind === 'byId', !loading && !resolverLoading);
+
+  // Browser tab title: "[Hub Name] | Alkemio". Covers both entry points —
+  // the subdomain branch (data from `innovationHubFromSubdomain`) and the
+  // `/hub/<slug>` path branch (resolved by id) both funnel through here.
+  usePageTitle(data?.name);
 
   // Top-bar breadcrumb: single `[PanelsTopLeft] HubName` chip, mirroring how
   // Space / User / Org public profile pages identify themselves in the topbar.

--- a/src/main/crdPages/innovationPack/CrdInnovationPackAdminPage.tsx
+++ b/src/main/crdPages/innovationPack/CrdInnovationPackAdminPage.tsx
@@ -39,6 +39,7 @@ export const CrdInnovationPackAdminPage = () => {
 
 const CrdInnovationPackAdminPageInner = () => {
   const { t } = useTranslation('crd-templates');
+  const { t: tDefault } = useTranslation();
   // Pack admin only ever EDITS an existing pack → its own bucket
   // (temporaryLocation: false). Creating a *template* inside the pack has no
   // template bucket yet → temporary against the pack bucket — mirrors MUI.
@@ -48,7 +49,11 @@ const CrdInnovationPackAdminPageInner = () => {
     templatesMarkdownUpload: { create: mdCreate, edit: mdEdit },
     descriptionUpload: mdEdit,
   });
-  usePageTitle(pack?.displayName);
+  // "[Pack Name] | Template Library | Alkemio" — mirrors the MUI InnovationPackProfileLayout.
+  const pageTitle = pack?.displayName
+    ? `${pack.displayName}${tDefault('pages.titles.separator')}${tDefault('pages.titles.templateLibrary')}`
+    : undefined;
+  usePageTitle(pageTitle);
 
   if (notFound) {
     return <Error404 />;

--- a/src/main/crdPages/innovationPack/CrdInnovationPackProfilePage.tsx
+++ b/src/main/crdPages/innovationPack/CrdInnovationPackProfilePage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Error404 } from '@/core/pages/Errors/Error404';
 import { usePageTitle } from '@/core/routing/usePageTitle';
 import { InnovationPackProfileView } from '@/crd/components/innovationPack/InnovationPackProfileView';
@@ -17,8 +18,13 @@ import { useInnovationPackProfile } from './useInnovationPackProfile';
  * extends the same gate to wrap this public profile route).
  */
 export const CrdInnovationPackProfilePage = () => {
+  const { t } = useTranslation();
   const { loading, notFound, pack, tm, canManage, adminHref, shareUrl } = useInnovationPackProfile();
-  usePageTitle(pack?.name);
+  // "[Pack Name] | Template Library | Alkemio" — mirrors the MUI InnovationPackProfileLayout.
+  const pageTitle = pack?.name
+    ? `${pack.name}${t('pages.titles.separator')}${t('pages.titles.templateLibrary')}`
+    : undefined;
+  usePageTitle(pageTitle);
 
   if (notFound) {
     return <Error404 />;

--- a/src/main/crdPages/subspace/layout/CrdSubspacePageLayout.tsx
+++ b/src/main/crdPages/subspace/layout/CrdSubspacePageLayout.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation } from 'react-router-dom';
 import { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
 import useNavigate from '@/core/routing/useNavigate';
+import { usePageTitle } from '@/core/routing/usePageTitle';
 import { LoadingSpinner } from '@/crd/components/common/LoadingSpinner';
 import { ShareDialog } from '@/crd/components/common/ShareDialog';
 import { ConfirmationDialog } from '@/crd/components/dialogs/ConfirmationDialog';
@@ -61,6 +62,12 @@ export type SubspaceOutletContext = {
 
 export default function CrdSubspacePageLayout() {
   const data = useCrdSubspace();
+
+  // Set browser tab title to the subspace name for L1/L2 subspaces. The parent
+  // CrdSpacePageLayout passes a stable `undefined` at non-L0, so this child wins
+  // once the subspace data resolves (mirrors MUI's SubspacePageLayout).
+  usePageTitle(data.subspaceName);
+
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const { spaceLevel } = useUrlResolver();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Browser tab titles now display meaningful page names across Innovation Hubs, Innovation Packs, and Subspaces for better navigation and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->