### PR TITLE
[CRD] fix the user/org msg missing email copy info

### DIFF
--- a/src/crd/components/common/MessagePopover.tsx
+++ b/src/crd/components/common/MessagePopover.tsx
@@ -73,6 +73,7 @@ export function MessagePopover({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80 p-3" align="end" aria-label={t('common.messagePopover.ariaLabel')}>
+        <p className="text-body-emphasis mb-2">{t('common.messagePopover.emailTitle')}</p>
         <Textarea
           value={draft}
           onChange={e => setDraft(e.target.value)}
@@ -91,6 +92,7 @@ export function MessagePopover({
           disabled={sending}
           aria-label={t('common.messagePopover.ariaLabel')}
         />
+        <p className="text-caption text-muted-foreground mt-2">{t('common.messagePopover.emailNotice')}</p>
         {error ? (
           <p role="alert" className="text-caption text-destructive mt-2">
             {error}

--- a/src/crd/i18n/profilePages/profilePages.bg.json
+++ b/src/crd/i18n/profilePages/profilePages.bg.json
@@ -4,12 +4,15 @@
     "locationCityOnly": "{{city}}",
     "locationCountryOnly": "{{country}}",
     "messagePopover": {
-      "placeholder": "Напишете съобщение…",
+      "placeholder": "Напишете имейл…",
       "send": "Изпрати",
       "cancel": "Отмяна",
       "sending": "Изпращане…",
       "errorTitle": "Съобщението не може да бъде изпратено",
-      "ariaLabel": "Съставяне на съобщение"
+      "ariaLabel": "Съставяне на съобщение",
+      "emailTitle": "Изпрати имейл",
+      "emailNotice": "Доставя се в тяхната пощенска кутия.",
+      "successToast": "Вашият имейл беше изпратен."
     },
     "resourceTabsAriaLabel": "Раздели с ресурси",
     "loading": {

--- a/src/crd/i18n/profilePages/profilePages.de.json
+++ b/src/crd/i18n/profilePages/profilePages.de.json
@@ -4,12 +4,15 @@
     "locationCityOnly": "{{city}}",
     "locationCountryOnly": "{{country}}",
     "messagePopover": {
-      "placeholder": "Nachricht schreiben…",
+      "placeholder": "E-Mail schreiben…",
       "send": "Senden",
       "cancel": "Abbrechen",
       "sending": "Senden…",
       "errorTitle": "Nachricht konnte nicht gesendet werden",
-      "ariaLabel": "Nachricht verfassen"
+      "ariaLabel": "Nachricht verfassen",
+      "emailTitle": "E-Mail senden",
+      "emailNotice": "Wird in ihr Postfach zugestellt.",
+      "successToast": "Deine E-Mail wurde gesendet."
     },
     "resourceTabsAriaLabel": "Ressourcenbereiche",
     "loading": {

--- a/src/crd/i18n/profilePages/profilePages.en.json
+++ b/src/crd/i18n/profilePages/profilePages.en.json
@@ -4,12 +4,15 @@
     "locationCityOnly": "{{city}}",
     "locationCountryOnly": "{{country}}",
     "messagePopover": {
-      "placeholder": "Write a message…",
+      "placeholder": "Write an email…",
       "send": "Send",
       "cancel": "Cancel",
       "sending": "Sending…",
       "errorTitle": "Could not send your message",
-      "ariaLabel": "Compose message"
+      "ariaLabel": "Compose message",
+      "emailTitle": "Send an email",
+      "emailNotice": "Delivered to their inbox.",
+      "successToast": "Your email has been sent."
     },
     "resourceTabsAriaLabel": "Resource sections",
     "loading": {

--- a/src/crd/i18n/profilePages/profilePages.es.json
+++ b/src/crd/i18n/profilePages/profilePages.es.json
@@ -4,12 +4,15 @@
     "locationCityOnly": "{{city}}",
     "locationCountryOnly": "{{country}}",
     "messagePopover": {
-      "placeholder": "Escribe un mensaje…",
+      "placeholder": "Escribe un correo electrónico…",
       "send": "Enviar",
       "cancel": "Cancelar",
       "sending": "Enviando…",
       "errorTitle": "No se pudo enviar el mensaje",
-      "ariaLabel": "Redactar mensaje"
+      "ariaLabel": "Redactar mensaje",
+      "emailTitle": "Enviar un correo electrónico",
+      "emailNotice": "Se entrega en su bandeja de entrada.",
+      "successToast": "Tu correo electrónico se ha enviado."
     },
     "resourceTabsAriaLabel": "Secciones de recursos",
     "loading": {

--- a/src/crd/i18n/profilePages/profilePages.fr.json
+++ b/src/crd/i18n/profilePages/profilePages.fr.json
@@ -4,12 +4,15 @@
     "locationCityOnly": "{{city}}",
     "locationCountryOnly": "{{country}}",
     "messagePopover": {
-      "placeholder": "Écrire un message…",
+      "placeholder": "Écrire un e-mail…",
       "send": "Envoyer",
       "cancel": "Annuler",
       "sending": "Envoi…",
       "errorTitle": "Impossible d'envoyer le message",
-      "ariaLabel": "Composer un message"
+      "ariaLabel": "Composer un message",
+      "emailTitle": "Envoyer un e-mail",
+      "emailNotice": "Livré dans leur boîte de réception.",
+      "successToast": "Votre e-mail a été envoyé."
     },
     "resourceTabsAriaLabel": "Sections de ressources",
     "loading": {

--- a/src/crd/i18n/profilePages/profilePages.nl.json
+++ b/src/crd/i18n/profilePages/profilePages.nl.json
@@ -4,12 +4,15 @@
     "locationCityOnly": "{{city}}",
     "locationCountryOnly": "{{country}}",
     "messagePopover": {
-      "placeholder": "Schrijf een bericht…",
+      "placeholder": "Schrijf een e-mail…",
       "send": "Verstuur",
       "cancel": "Annuleren",
       "sending": "Versturen…",
       "errorTitle": "Bericht kon niet worden verzonden",
-      "ariaLabel": "Bericht opstellen"
+      "ariaLabel": "Bericht opstellen",
+      "emailTitle": "Stuur een e-mail",
+      "emailNotice": "Bezorgd in hun inbox.",
+      "successToast": "Je e-mail is verzonden."
     },
     "resourceTabsAriaLabel": "Resourcesecties",
     "loading": {

--- a/src/main/crdPages/topLevelPages/common/useSendMessageHandler.ts
+++ b/src/main/crdPages/topLevelPages/common/useSendMessageHandler.ts
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import {
   useSendMessageToOrganizationMutation,
   useSendMessageToUsersMutation,
@@ -11,6 +13,7 @@ export const useSendMessageToUserHandler = (params: {
   recipientUserId: string | undefined;
 }): SendMessageHandlerResult => {
   const { recipientUserId } = params;
+  const { t } = useTranslation('crd-profilePages');
   const [sendMessageToUser] = useSendMessageToUsersMutation();
 
   const onSendMessage = async (messageText: string) => {
@@ -25,6 +28,7 @@ export const useSendMessageToUserHandler = (params: {
         },
       },
     });
+    toast.success(t('common.messagePopover.successToast'));
   };
 
   return { onSendMessage };
@@ -34,6 +38,7 @@ export const useSendMessageToOrganizationHandler = (params: {
   recipientOrganizationId: string | undefined;
 }): SendMessageHandlerResult => {
   const { recipientOrganizationId } = params;
+  const { t } = useTranslation('crd-profilePages');
   const [sendMessageToOrganization] = useSendMessageToOrganizationMutation();
 
   const onSendMessage = async (messageText: string) => {
@@ -48,6 +53,7 @@ export const useSendMessageToOrganizationHandler = (params: {
         },
       },
     });
+    toast.success(t('common.messagePopover.successToast'));
   };
 
   return { onSendMessage };


### PR DESCRIPTION
Add email copy in the modal. Confirmed with Simone and Jeroen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email popover now displays informational notice text
  * Success notification appears after sending an email

* **Localization**
  * Updated email messaging terminology across Bulgarian, German, English, Spanish, French, and Dutch interfaces to improve clarity and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->