### PR TITLE
[CRD] Inno hubs - fix the subdomain url resolver issue when loading /home

### DIFF
--- a/src/main/crdPages/innovationHub/CrdInnovationHubHomePage.tsx
+++ b/src/main/crdPages/innovationHub/CrdInnovationHubHomePage.tsx
@@ -58,7 +58,13 @@ const CrdInnovationHubHomePage = ({ innovationHubFromSubdomain }: CrdInnovationH
 
   const { data, loading, hub } = useInnovationHubHomeData(input);
   const { wide: fullWidth, toggle: toggleFullWidth } = useLayoutWidthPreference();
-  useRedirectToHubSubdomain(hub?.subdomain, input.kind === 'byId', !loading && !resolverLoading);
+
+  // The URL resolver is only consulted on the `/hub/<slug>` path entry (to get the
+  // hub id). The subdomain entry already has the fully-resolved hub from the prop,
+  // so it must NOT block on `resolverLoading` — on a real hub subdomain the resolver
+  // never resolves `/home` to a handled type and its `loading` stays true forever.
+  const isPathEntry = input.kind === 'byId';
+  useRedirectToHubSubdomain(hub?.subdomain, isPathEntry, !loading && !resolverLoading);
 
   // Browser tab title: "[Hub Name] | Alkemio". Covers both entry points —
   // the subdomain branch (data from `innovationHubFromSubdomain`) and the
@@ -70,7 +76,7 @@ const CrdInnovationHubHomePage = ({ innovationHubFromSubdomain }: CrdInnovationH
   const breadcrumbItems: BreadcrumbTrailItem[] = data ? [{ label: data.name, icon: PanelsTopLeft }] : [];
   useSetBreadcrumbs(breadcrumbItems);
 
-  if (resolverLoading || loading || !data) {
+  if ((isPathEntry && resolverLoading) || loading || !data) {
     return <Loading />;
   }
 

--- a/src/main/crdPages/innovationHub/hooks/useInnovationHubHomeData.ts
+++ b/src/main/crdPages/innovationHub/hooks/useInnovationHubHomeData.ts
@@ -29,12 +29,16 @@ export const useInnovationHubHomeData = (input: UseInnovationHubHomeDataInput): 
   const resolvedHub: InnovationHubHomeInnovationHubFragment | undefined =
     input.kind === 'byId' ? hubByIdData?.platform.innovationHub : input.hub;
 
-  const { data: spacesData, loading: spacesLoading } = useDashboardSpacesQuery();
+  // Spaces are secondary content: the page renders the hub (banner, description)
+  // as soon as the hub fragment resolves, and the curated Spaces section fills in
+  // when `DashboardSpaces` returns. Mirrors the legacy pages, which never block
+  // the whole page on the spaces query.
+  const { data: spacesData } = useDashboardSpacesQuery();
 
   const { isAuthenticated } = useCurrentUserContext();
   const { locations } = useConfig();
 
-  const loading = (byIdActive && hubByIdLoading) || spacesLoading;
+  const loading = byIdActive && hubByIdLoading;
 
   if (!resolvedHub) {
     return { data: undefined, hub: undefined, loading };

--- a/src/main/crdPages/topLevelPages/contributorAccountMapper.ts
+++ b/src/main/crdPages/topLevelPages/contributorAccountMapper.ts
@@ -9,7 +9,7 @@ import type {
   ContributorAccountViewProps,
 } from '@/crd/components/contributor/settings/ContributorAccountView.types';
 import { pickColorFromId } from '@/crd/lib/pickColorFromId';
-import { buildHubHomePath, buildHubSettingsPath } from '@/main/crdPages/innovationHub/lib/hubUrls';
+import { buildHubSettingsPath } from '@/main/crdPages/innovationHub/lib/hubUrls';
 
 export type AccountResourceKind = 'space' | 'virtualContributor' | 'innovationPack' | 'innovationHub';
 
@@ -219,11 +219,13 @@ export function mapAccountToViewProps(
     capacity: hubCapacity,
     items:
       account?.innovationHubs.map<AccountResourceCardItem>(hub => {
-        // Use the canonical `/hub/<nameID>` path for the card (public hub
-        // home) and `/hub/<nameID>/settings` for the kebab Manage action —
-        // never the server-provided `profile.url` (legacy `/innovation-hub/...`),
-        // and never `subdomain` (hostname identifier, can diverge from nameID).
-        const hubHomePath = buildHubHomePath(hub.nameID);
+        // Link the card to `/hub/<nameID>/settings`, not the public hub home.
+        // The public home redirects to the hub's subdomain in production, which
+        // shows a broken page when the subdomain isn't configured yet — so from
+        // the owner's account we land on settings, where the hub can be set up.
+        // Always use `nameID` (the route param the server resolves) — never the
+        // server-provided `profile.url` (legacy `/innovation-hub/...`), and never
+        // `subdomain` (hostname identifier, can diverge from nameID).
         const hubSettingsPath = buildHubSettingsPath(hub.nameID);
         return {
           id: hub.id,
@@ -231,7 +233,7 @@ export function mapAccountToViewProps(
           description: hub.profile.description,
           avatarUrl: hub.profile.banner?.uri || undefined,
           color: pickColorFromId(hub.id),
-          href: hubHomePath,
+          href: hubSettingsPath,
           actions: buildKebab('innovationHub', hub.id, hub.profile.displayName, hubSettingsPath),
         };
       }) ?? [],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Innovation Hub page could remain stuck showing a loading state when accessed via subdomain; entry method is now distinguished so pages load correctly.
  * Adjusted hub home data loading so the page no longer waits on unrelated space loading before rendering.

* **Changes**
  * Hub cards now navigate directly to the hub's settings page from the main listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->