### PR TITLE
[CRD] fix the spaces filter for inno hubs

### DIFF
--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -12159,6 +12159,106 @@ export type AddReactionMutationOptions = Apollo.BaseMutationOptions<
   SchemaTypes.AddReactionMutation,
   SchemaTypes.AddReactionMutationVariables
 >;
+export const ForumMentionableContributorsDocument = gql`
+    query ForumMentionableContributors($filter: ContributorFilterInput, $limit: Int = 30) {
+  platform {
+    id
+    forum {
+      id
+      mentionableContributors(filter: $filter, limit: $limit) {
+        id
+        type
+        nameID
+        profile {
+          id
+          url
+          displayName
+          location {
+            id
+            city
+            country
+          }
+          avatar: visual(type: AVATAR) {
+            ...VisualModel
+          }
+        }
+      }
+    }
+  }
+}
+    ${VisualModelFragmentDoc}`;
+
+/**
+ * __useForumMentionableContributorsQuery__
+ *
+ * To run a query within a React component, call `useForumMentionableContributorsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useForumMentionableContributorsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useForumMentionableContributorsQuery({
+ *   variables: {
+ *      filter: // value for 'filter'
+ *      limit: // value for 'limit'
+ *   },
+ * });
+ */
+export function useForumMentionableContributorsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    SchemaTypes.ForumMentionableContributorsQuery,
+    SchemaTypes.ForumMentionableContributorsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    SchemaTypes.ForumMentionableContributorsQuery,
+    SchemaTypes.ForumMentionableContributorsQueryVariables
+  >(ForumMentionableContributorsDocument, options);
+}
+export function useForumMentionableContributorsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.ForumMentionableContributorsQuery,
+    SchemaTypes.ForumMentionableContributorsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SchemaTypes.ForumMentionableContributorsQuery,
+    SchemaTypes.ForumMentionableContributorsQueryVariables
+  >(ForumMentionableContributorsDocument, options);
+}
+export function useForumMentionableContributorsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        SchemaTypes.ForumMentionableContributorsQuery,
+        SchemaTypes.ForumMentionableContributorsQueryVariables
+      >
+) {
+  const options = baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    SchemaTypes.ForumMentionableContributorsQuery,
+    SchemaTypes.ForumMentionableContributorsQueryVariables
+  >(ForumMentionableContributorsDocument, options);
+}
+export type ForumMentionableContributorsQueryHookResult = ReturnType<typeof useForumMentionableContributorsQuery>;
+export type ForumMentionableContributorsLazyQueryHookResult = ReturnType<
+  typeof useForumMentionableContributorsLazyQuery
+>;
+export type ForumMentionableContributorsSuspenseQueryHookResult = ReturnType<
+  typeof useForumMentionableContributorsSuspenseQuery
+>;
+export type ForumMentionableContributorsQueryResult = Apollo.QueryResult<
+  SchemaTypes.ForumMentionableContributorsQuery,
+  SchemaTypes.ForumMentionableContributorsQueryVariables
+>;
+export function refetchForumMentionableContributorsQuery(
+  variables?: SchemaTypes.ForumMentionableContributorsQueryVariables
+) {
+  return { query: ForumMentionableContributorsDocument, variables: variables };
+}
 export const RemoveReactionDocument = gql`
     mutation RemoveReaction($roomId: UUID!, $reactionId: MessageID!) {
   removeReactionToMessageInRoom(
@@ -12264,106 +12364,6 @@ export type ReplyToMessageMutationOptions = Apollo.BaseMutationOptions<
   SchemaTypes.ReplyToMessageMutation,
   SchemaTypes.ReplyToMessageMutationVariables
 >;
-export const ForumMentionableContributorsDocument = gql`
-    query ForumMentionableContributors($filter: ContributorFilterInput, $limit: Int = 30) {
-  platform {
-    id
-    forum {
-      id
-      mentionableContributors(filter: $filter, limit: $limit) {
-        id
-        type
-        nameID
-        profile {
-          id
-          url
-          displayName
-          location {
-            id
-            city
-            country
-          }
-          avatar: visual(type: AVATAR) {
-            ...VisualModel
-          }
-        }
-      }
-    }
-  }
-}
-    ${VisualModelFragmentDoc}`;
-
-/**
- * __useForumMentionableContributorsQuery__
- *
- * To run a query within a React component, call `useForumMentionableContributorsQuery` and pass it any options that fit your needs.
- * When your component renders, `useForumMentionableContributorsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useForumMentionableContributorsQuery({
- *   variables: {
- *      filter: // value for 'filter'
- *      limit: // value for 'limit'
- *   },
- * });
- */
-export function useForumMentionableContributorsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    SchemaTypes.ForumMentionableContributorsQuery,
-    SchemaTypes.ForumMentionableContributorsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    SchemaTypes.ForumMentionableContributorsQuery,
-    SchemaTypes.ForumMentionableContributorsQueryVariables
-  >(ForumMentionableContributorsDocument, options);
-}
-export function useForumMentionableContributorsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    SchemaTypes.ForumMentionableContributorsQuery,
-    SchemaTypes.ForumMentionableContributorsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    SchemaTypes.ForumMentionableContributorsQuery,
-    SchemaTypes.ForumMentionableContributorsQueryVariables
-  >(ForumMentionableContributorsDocument, options);
-}
-export function useForumMentionableContributorsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        SchemaTypes.ForumMentionableContributorsQuery,
-        SchemaTypes.ForumMentionableContributorsQueryVariables
-      >
-) {
-  const options = baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
-  return Apollo.useSuspenseQuery<
-    SchemaTypes.ForumMentionableContributorsQuery,
-    SchemaTypes.ForumMentionableContributorsQueryVariables
-  >(ForumMentionableContributorsDocument, options);
-}
-export type ForumMentionableContributorsQueryHookResult = ReturnType<typeof useForumMentionableContributorsQuery>;
-export type ForumMentionableContributorsLazyQueryHookResult = ReturnType<
-  typeof useForumMentionableContributorsLazyQuery
->;
-export type ForumMentionableContributorsSuspenseQueryHookResult = ReturnType<
-  typeof useForumMentionableContributorsSuspenseQuery
->;
-export type ForumMentionableContributorsQueryResult = Apollo.QueryResult<
-  SchemaTypes.ForumMentionableContributorsQuery,
-  SchemaTypes.ForumMentionableContributorsQueryVariables
->;
-export function refetchForumMentionableContributorsQuery(
-  variables?: SchemaTypes.ForumMentionableContributorsQueryVariables
-) {
-  return { query: ForumMentionableContributorsDocument, variables: variables };
-}
 export const MentionableContributorsDocument = gql`
     query MentionableContributors($spaceID: UUID!, $filter: ContributorFilterInput, $limit: Int = 30) {
   lookup {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -12,25 +12,15 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
   Float: { input: number; output: number };
-  /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
   DateTime: { input: Date; output: Date };
-  /** An Emoji. */
   Emoji: { input: string; output: string };
-  /** A representation of a Lifecycle Definition, based on XState. It is serialized JSON. */
   LifecycleDefinition: { input: string; output: string };
-  /** A markdown string. */
   Markdown: { input: string; output: string };
-  /** An identifier that originates from the underlying messaging platform. */
   MessageID: { input: string; output: string };
-  /** A human readable identifier, 3 <= length <= 28. Used for URL paths in clients. Characters allowed: a-z,A-Z,0-9. */
   NameID: { input: string; output: string };
-  /** Cursor used for paginating search results. */
   SearchCursor: { input: string; output: string };
-  /** A uuid identifier. Length 36 characters. */
   UUID: { input: string; output: string };
-  /** The `Upload` scalar type represents a file upload. */
   Upload: { input: File; output: File };
-  /** Content of a Whiteboard, as JSON. */
   WhiteboardContent: { input: string; output: string };
 };
 
@@ -5866,6 +5856,7 @@ export enum NotificationEvent {
   UserEmailChangeSpaceAdminNotification = 'USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION',
   UserMentioned = 'USER_MENTIONED',
   UserMessage = 'USER_MESSAGE',
+  UserPasswordChangeSecuritySignal = 'USER_PASSWORD_CHANGE_SECURITY_SIGNAL',
   UserSignUpWelcome = 'USER_SIGN_UP_WELCOME',
   UserSpaceCommunityApplicationDeclined = 'USER_SPACE_COMMUNITY_APPLICATION_DECLINED',
   UserSpaceCommunityInvitation = 'USER_SPACE_COMMUNITY_INVITATION',
@@ -20073,36 +20064,6 @@ export type CommentsWithMessagesFragment = {
   vcInteractions: Array<{ __typename?: 'VcInteraction'; threadID: string; virtualContributorID: string }>;
 };
 
-export type RemoveReactionMutationVariables = Exact<{
-  roomId: Scalars['UUID']['input'];
-  reactionId: Scalars['MessageID']['input'];
-}>;
-
-export type RemoveReactionMutation = { __typename?: 'Mutation'; removeReactionToMessageInRoom: boolean };
-
-export type ReplyToMessageMutationVariables = Exact<{
-  roomId: Scalars['UUID']['input'];
-  message: Scalars['String']['input'];
-  threadId: Scalars['MessageID']['input'];
-}>;
-
-export type ReplyToMessageMutation = {
-  __typename?: 'Mutation';
-  sendMessageReplyToRoom: {
-    __typename?: 'Message';
-    id: string;
-    message: string;
-    timestamp: number;
-    sender?: { __typename?: 'Actor'; id: string; type: ActorType } | undefined;
-  };
-};
-
-export type VcInteractionsDetailsFragment = {
-  __typename?: 'VcInteraction';
-  threadID: string;
-  virtualContributorID: string;
-};
-
 export type ForumMentionableContributorsQueryVariables = Exact<{
   filter?: InputMaybe<ContributorFilterInput>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -20276,6 +20237,36 @@ export type ForumMentionableContributorsQuery = {
       >;
     };
   };
+};
+
+export type RemoveReactionMutationVariables = Exact<{
+  roomId: Scalars['UUID']['input'];
+  reactionId: Scalars['MessageID']['input'];
+}>;
+
+export type RemoveReactionMutation = { __typename?: 'Mutation'; removeReactionToMessageInRoom: boolean };
+
+export type ReplyToMessageMutationVariables = Exact<{
+  roomId: Scalars['UUID']['input'];
+  message: Scalars['String']['input'];
+  threadId: Scalars['MessageID']['input'];
+}>;
+
+export type ReplyToMessageMutation = {
+  __typename?: 'Mutation';
+  sendMessageReplyToRoom: {
+    __typename?: 'Message';
+    id: string;
+    message: string;
+    timestamp: number;
+    sender?: { __typename?: 'Actor'; id: string; type: ActorType } | undefined;
+  };
+};
+
+export type VcInteractionsDetailsFragment = {
+  __typename?: 'VcInteraction';
+  threadID: string;
+  virtualContributorID: string;
 };
 
 export type MentionableContributorsQueryVariables = Exact<{

--- a/src/main/crdPages/innovationHub/__tests__/mapInnovationHubToHomeData.test.ts
+++ b/src/main/crdPages/innovationHub/__tests__/mapInnovationHubToHomeData.test.ts
@@ -79,10 +79,13 @@ describe('mapInnovationHubToHomeData', () => {
     expect(data.settingsUrl).toBeUndefined();
   });
 
-  test('spaces are intersected with dashboardSpaces and reordered by filter order', () => {
+  test('shows only the curated spaceListFilter, in filter order — never the full platform list', () => {
     const data = mapInnovationHubToHomeData({
       hub: {
         ...baseHub,
+        // 's-2' precedes 's-1'; 's-missing' is curated but absent from the platform
+        // results (deleted/inaccessible) and is dropped. 's-3' is a platform Space
+        // NOT in the hub — it must NOT leak onto the hub home.
         spaceListFilter: [{ id: 's-2' }, { id: 's-1' }, { id: 's-missing' }],
       },
       // dashboardSpaces shape is structurally compatible with SpaceWithParent for the mapper test
@@ -91,6 +94,16 @@ describe('mapInnovationHubToHomeData', () => {
       canonicalDomain: 'alkemio.org',
     });
     expect(data.spaces.map(s => s.id)).toEqual(['s-2', 's-1']);
+  });
+
+  test('keeps a curated space regardless of its visibility (present in the all-visibilities results)', () => {
+    const data = mapInnovationHubToHomeData({
+      hub: { ...baseHub, spaceListFilter: [{ id: 's-1' }, { id: 's-2' }, { id: 's-3' }] },
+      dashboardSpaces: dashboardSpaces as never,
+      authenticated: false,
+      canonicalDomain: 'alkemio.org',
+    });
+    expect(data.spaces.map(s => s.id)).toEqual(['s-1', 's-2', 's-3']);
   });
 
   test('empty spaceListFilter yields empty spaces array', () => {

--- a/src/main/crdPages/innovationHub/dataMappers/mapInnovationHubToHomeData.ts
+++ b/src/main/crdPages/innovationHub/dataMappers/mapInnovationHubToHomeData.ts
@@ -11,8 +11,10 @@ import { buildMainDomainUrl, buildSettingsUrl, URL_SPACE_EXPLORER } from '@/main
 /**
  * Builds the curated, ordered Spaces list shown on the hub home: intersects the hub's
  * `spaceListFilter` (id list, from the home fragment) with the rich `DashboardSpaces`
- * shape, preserving the admin's configured order. Spaces present in `spaceListFilter`
- * but absent from `dashboardSpaces` (e.g. unpublished / out-of-visibility) are dropped.
+ * shape, preserving the admin's configured order. The caller fetches `DashboardSpaces`
+ * across ALL visibilities, so a curated Space is kept regardless of its own visibility
+ * (a `list` hub may include DEMO / INACTIVE Spaces) — only Spaces genuinely absent from
+ * the platform results (e.g. deleted / inaccessible) are dropped.
  */
 const buildCuratedSpaces = (
   hub: InnovationHubHomeInnovationHubFragment,
@@ -59,6 +61,10 @@ export const mapInnovationHubToHomeData = ({
     // Use `nameID` — the route is `/hub/:innovationHubNameId` and the server's
     // URL resolver expects nameID. `subdomain` is only for the hostname.
     settingsUrl: canEdit ? buildSettingsUrl(`/hub/${hub.nameID}`) : undefined,
+    // The home shows exactly the curated `spaceListFilter` (same set the admin
+    // manages in settings), preserving its order — never the full platform list.
+    // The caller passes `DashboardSpaces` fetched across all visibilities so the
+    // intersection keeps curated Spaces whatever their visibility.
     spaces: buildCuratedSpaces(hub, dashboardSpaces, authenticated),
     // Always points off the current host (subdomain or otherwise) to the canonical
     // platform Spaces explorer. `buildMainDomainUrl` tolerates `locations.domain`

--- a/src/main/crdPages/innovationHub/hooks/useInnovationHubHomeData.ts
+++ b/src/main/crdPages/innovationHub/hooks/useInnovationHubHomeData.ts
@@ -1,5 +1,5 @@
 import { useDashboardSpacesQuery, useInnovationHubByIdQuery } from '@/core/apollo/generated/apollo-hooks';
-import type { InnovationHubHomeInnovationHubFragment } from '@/core/apollo/generated/graphql-schema';
+import { type InnovationHubHomeInnovationHubFragment, SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
 import type { InnovationHubHomeData } from '@/crd/components/innovationHub/InnovationHubHome';
 import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
 import { useConfig } from '@/domain/platform/config/useConfig';
@@ -33,7 +33,17 @@ export const useInnovationHubHomeData = (input: UseInnovationHubHomeDataInput): 
   // as soon as the hub fragment resolves, and the curated Spaces section fills in
   // when `DashboardSpaces` returns. Mirrors the legacy pages, which never block
   // the whole page on the spaces query.
-  const { data: spacesData } = useDashboardSpacesQuery();
+  //
+  // Fetch ALL visibilities (not the default ACTIVE-only): the hub's curated
+  // `spaceListFilter` may include DEMO / INACTIVE / ARCHIVED Spaces, and those must
+  // still appear on the home. The mapper intersects this list with the curated ids,
+  // so only the hub's Spaces are ever shown — the extra visibilities just ensure none
+  // are dropped for being non-active.
+  const { data: spacesData } = useDashboardSpacesQuery({
+    variables: {
+      visibilities: [SpaceVisibility.Active, SpaceVisibility.Demo, SpaceVisibility.Inactive, SpaceVisibility.Archived],
+    },
+  });
 
   const { isAuthenticated } = useCurrentUserContext();
   const { locations } = useConfig();


### PR DESCRIPTION
The demo spaces were not visible neither in the home nor in settings. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Innovation Hub curation to display spaces in the specified order.
  * Fixed handling of inaccessible or deleted spaces—they are now properly excluded from curated lists.
  * Enhanced support for including archived and inactive spaces in curated collections when explicitly configured.

* **Documentation**
  * Clarified internal documentation on how curated space lists are built and ordered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->