### PR TITLE
[CRD] Invites: Admin of Space doesn't see Invite button (nonGA)

### DIFF
--- a/src/crd/components/space/settings/SpaceSettingsCommunityView.tsx
+++ b/src/crd/components/space/settings/SpaceSettingsCommunityView.tsx
@@ -79,7 +79,7 @@ export type SpaceSettingsCommunityViewProps = {
   applicationFormSlot?: ReactNode;
   communityGuidelinesSlot?: ReactNode;
   permissions: {
-    canAddUsers: boolean;
+    canInvite: boolean;
     canAddOrganizations: boolean;
     canAddVirtualContributors: boolean;
   };
@@ -192,7 +192,7 @@ export function SpaceSettingsCommunityView({
                 className="h-9 w-[220px] pl-9 text-control"
               />
             </div>
-            {permissions.canAddUsers && (
+            {permissions.canInvite && (
               <Button type="button" size="sm" className="gap-2" onClick={onInviteUsers}>
                 <UserPlus aria-hidden="true" className="size-4" />
                 {t('community.members.invite')}

--- a/src/domain/spaceAdmin/SpaceAdminCommunity/hooks/useCommunityAdmin.ts
+++ b/src/domain/spaceAdmin/SpaceAdminCommunity/hooks/useCommunityAdmin.ts
@@ -72,6 +72,7 @@ export interface useCommunityAdminProvided {
   };
   permissions: {
     canAddUsers: boolean;
+    canInvite: boolean;
     canAddOrganizations: boolean;
     canAddVirtualContributors: boolean;
     canAddVirtualContributorsFromAccount: boolean;
@@ -192,6 +193,9 @@ const useCommunityAdmin = ({ roleSetId }: useCommunityAdminParams): useCommunity
 
   const permissions = {
     canAddUsers: authorizationPrivileges.some(priv => priv === AuthorizationPrivilege.RolesetEntryRoleAssign),
+    // Inviting (incl. by email) is gated by the dedicated invite privilege, which space admins
+    // hold even when they lack RolesetEntryRoleAssign (the direct-add privilege reserved for PAs).
+    canInvite: authorizationPrivileges.some(priv => priv === AuthorizationPrivilege.RolesetEntryRoleInvite),
     canAddOrganizations:
       authorizationPrivileges.some(priv => priv === AuthorizationPrivilege.RolesetEntryRoleAssignOrganization) &&
       authorizationPrivileges.some(priv => priv === AuthorizationPrivilege.Grant),

--- a/src/main/crdPages/topLevelPages/spaceSettings/community/useCommunityTabData.ts
+++ b/src/main/crdPages/topLevelPages/spaceSettings/community/useCommunityTabData.ts
@@ -40,7 +40,7 @@ export type UseCommunityTabDataResult = {
   organizations: CommunityOrg[];
   virtualContributors: CommunityVC[];
   permissions: {
-    canAddUsers: boolean;
+    canInvite: boolean;
     canAddOrganizations: boolean;
     canAddVirtualContributors: boolean;
   };
@@ -343,7 +343,7 @@ export function useCommunityTabData(roleSetId: string): UseCommunityTabDataResul
     organizations,
     virtualContributors,
     permissions: {
-      canAddUsers: community.permissions.canAddUsers,
+      canInvite: community.permissions.canInvite,
       canAddOrganizations: community.permissions.canAddOrganizations,
       // Mirror MUI (`SpaceAdminCommunityPage`): a space admin may add a VC via
       // EITHER the role-set assign privilege OR the account-assign privilege.


### PR DESCRIPTION
### Describe the background of your pull request

Before:
<img width="2572" height="1564" alt="image" src="https://github.com/user-attachments/assets/e23a20db-675e-45a8-a233-7911e524af5c" />

After:

<img width="1252" height="798" alt="image" src="https://github.com/user-attachments/assets/a1aca4e0-e78a-42b4-bdee-44d77eda00b8" />


### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated space settings permission terminology for community management features, clarifying the distinction between user invitation and direct user addition capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->