### PR TITLE
[CRD] [Admin] Add search for already added users to the authorisation groups

### DIFF
--- a/src/crd/components/admin/__tests__/RoleMembersEditor.test.tsx
+++ b/src/crd/components/admin/__tests__/RoleMembersEditor.test.tsx
@@ -13,6 +13,8 @@ const baseProps = {
   roleLabel: 'Global Admin',
   members: [{ id: 'u1', displayName: 'Alice', email: 'alice@x.io' }],
   availableUsers: [{ id: 'u2', displayName: 'Bob', email: 'bob@x.io' }],
+  memberSearchTerm: '',
+  onMemberSearchTermChange: vi.fn(),
   searchTerm: '',
   onSearchTermChange: vi.fn(),
   onAdd: vi.fn(),
@@ -43,11 +45,30 @@ describe('RoleMembersEditor', () => {
     expect(onRemove).toHaveBeenCalledWith('u1');
   });
 
-  test('search input fires onSearchTermChange', async () => {
+  test('available-users search input fires onSearchTermChange', async () => {
     const onSearchTermChange = vi.fn();
     render(<RoleMembersEditor {...baseProps} onSearchTermChange={onSearchTermChange} />);
-    await userEvent.type(screen.getByRole('searchbox'), 'b');
+    await userEvent.type(screen.getByPlaceholderText('roleMembers.searchPlaceholder'), 'b');
     expect(onSearchTermChange).toHaveBeenCalledWith('b');
+  });
+
+  test('members filter input fires onMemberSearchTermChange', async () => {
+    const onMemberSearchTermChange = vi.fn();
+    render(<RoleMembersEditor {...baseProps} onMemberSearchTermChange={onMemberSearchTermChange} />);
+    await userEvent.type(screen.getByPlaceholderText('roleMembers.filterMembersPlaceholder'), 'a');
+    expect(onMemberSearchTermChange).toHaveBeenCalledWith('a');
+  });
+
+  test('hides the members filter when there are no members and no active search', () => {
+    render(<RoleMembersEditor {...baseProps} members={[]} />);
+    expect(screen.queryByPlaceholderText('roleMembers.filterMembersPlaceholder')).toBeNull();
+  });
+
+  test('keeps the members filter visible when a search matches nothing', () => {
+    render(<RoleMembersEditor {...baseProps} members={[]} memberSearchTerm="zzz" />);
+    expect(screen.getByPlaceholderText('roleMembers.filterMembersPlaceholder')).toBeInTheDocument();
+    // The members column shows "no results", not "no members".
+    expect(screen.getByText('roleMembers.noResults')).toBeInTheDocument();
   });
 
   test('shows empty states when there are no members / no results', () => {

--- a/src/crd/components/admin/roles/RoleMembersEditor.tsx
+++ b/src/crd/components/admin/roles/RoleMembersEditor.tsx
@@ -14,8 +14,12 @@ export type RoleMember = {
 type RoleMembersEditorProps = {
   /** Translated name of the role being edited. */
   roleLabel: string;
+  /** Current members, already filtered by `memberSearchTerm` upstream. */
   members: RoleMember[];
   availableUsers: RoleMember[];
+  /** Client-side filter over the current members. */
+  memberSearchTerm: string;
+  onMemberSearchTermChange: (term: string) => void;
   searchTerm: string;
   onSearchTermChange: (term: string) => void;
   onAdd: (userId: string) => void;
@@ -40,6 +44,8 @@ export function RoleMembersEditor({
   roleLabel,
   members,
   availableUsers,
+  memberSearchTerm,
+  onMemberSearchTermChange,
   searchTerm,
   onSearchTermChange,
   onAdd,
@@ -53,6 +59,10 @@ export function RoleMembersEditor({
   const { t } = useTranslation('crd-admin');
   const [pendingRemove, setPendingRemove] = useState<RoleMember | null>(null);
 
+  // Show the members filter once there's something to search — or while a search
+  // is active even if it currently matches nothing (so the box doesn't vanish).
+  const showMemberSearch = members.length > 0 || Boolean(memberSearchTerm);
+
   return (
     <div className="flex flex-col gap-6">
       <h2 className="text-section-title">{roleLabel}</h2>
@@ -61,8 +71,17 @@ export function RoleMembersEditor({
         {/* Current members */}
         <section className="flex flex-col gap-3">
           <h3 className="text-subheader font-semibold">{t('roleMembers.currentMembers')}</h3>
+          {showMemberSearch && (
+            <SearchField
+              value={memberSearchTerm}
+              onValueChange={onMemberSearchTermChange}
+              placeholder={t('roleMembers.filterMembersPlaceholder')}
+            />
+          )}
           {members.length === 0 ? (
-            <p className="text-body text-muted-foreground">{t('roleMembers.noMembers')}</p>
+            <p className="text-body text-muted-foreground">
+              {memberSearchTerm ? t('roleMembers.noResults') : t('roleMembers.noMembers')}
+            </p>
           ) : (
             <ul className="flex flex-col gap-2">
               {members.map(member => (

--- a/src/crd/i18n/admin/admin.bg.json
+++ b/src/crd/i18n/admin/admin.bg.json
@@ -79,6 +79,7 @@
   },
   "roleMembers": {
     "currentMembers": "Текущи членове",
+    "filterMembersPlaceholder": "Филтриране на членове…",
     "addMembers": "Добавяне на членове",
     "searchPlaceholder": "Търсене на потребители…",
     "add": "Добавяне",

--- a/src/crd/i18n/admin/admin.de.json
+++ b/src/crd/i18n/admin/admin.de.json
@@ -79,6 +79,7 @@
   },
   "roleMembers": {
     "currentMembers": "Aktuelle Mitglieder",
+    "filterMembersPlaceholder": "Mitglieder filtern…",
     "addMembers": "Mitglieder hinzufügen",
     "searchPlaceholder": "Benutzer suchen…",
     "add": "Hinzufügen",

--- a/src/crd/i18n/admin/admin.en.json
+++ b/src/crd/i18n/admin/admin.en.json
@@ -79,6 +79,7 @@
   },
   "roleMembers": {
     "currentMembers": "Current members",
+    "filterMembersPlaceholder": "Filter members…",
     "addMembers": "Add members",
     "searchPlaceholder": "Search users…",
     "add": "Add",

--- a/src/crd/i18n/admin/admin.es.json
+++ b/src/crd/i18n/admin/admin.es.json
@@ -79,6 +79,7 @@
   },
   "roleMembers": {
     "currentMembers": "Miembros actuales",
+    "filterMembersPlaceholder": "Filtrar miembros…",
     "addMembers": "Añadir miembros",
     "searchPlaceholder": "Buscar usuarios…",
     "add": "Añadir",

--- a/src/crd/i18n/admin/admin.fr.json
+++ b/src/crd/i18n/admin/admin.fr.json
@@ -79,6 +79,7 @@
   },
   "roleMembers": {
     "currentMembers": "Membres actuels",
+    "filterMembersPlaceholder": "Filtrer les membres…",
     "addMembers": "Ajouter des membres",
     "searchPlaceholder": "Rechercher des utilisateurs…",
     "add": "Ajouter",

--- a/src/crd/i18n/admin/admin.nl.json
+++ b/src/crd/i18n/admin/admin.nl.json
@@ -79,6 +79,7 @@
   },
   "roleMembers": {
     "currentMembers": "Huidige leden",
+    "filterMembersPlaceholder": "Leden filteren…",
     "addMembers": "Leden toevoegen",
     "searchPlaceholder": "Gebruikers zoeken…",
     "add": "Toevoegen",

--- a/src/main/crdPages/topLevelPages/admin/authorization/CrdAdminGlobalRolesPage.tsx
+++ b/src/main/crdPages/topLevelPages/admin/authorization/CrdAdminGlobalRolesPage.tsx
@@ -28,6 +28,9 @@ const CrdAdminGlobalRolesPage = () => {
   const [searchInput, setSearchInput] = useState('');
   const searchTerm = useDebouncedValue(searchInput);
 
+  // Client-side filter over the already-loaded current members (no refetch).
+  const [memberSearch, setMemberSearch] = useState('');
+
   const segments = pathname.split('/').filter(Boolean);
   const rolesIdx = segments.indexOf('roles');
   const roleFromUrl = rolesIdx >= 0 && rolesIdx < segments.length - 1 ? segments[rolesIdx + 1] : undefined;
@@ -49,6 +52,15 @@ const CrdAdminGlobalRolesPage = () => {
     displayName: user.profile?.displayName ?? '',
     email: user.email ?? undefined,
   }));
+
+  const memberFilter = memberSearch.trim().toLowerCase();
+  const filteredMembers = memberFilter
+    ? members.filter(
+        member =>
+          member.displayName.toLowerCase().includes(memberFilter) ||
+          (member.email?.toLowerCase().includes(memberFilter) ?? false)
+      )
+    : members;
 
   const {
     users: availableUsers = [],
@@ -101,8 +113,10 @@ const CrdAdminGlobalRolesPage = () => {
 
       <RoleMembersEditor
         roleLabel={roleLabels[selectedRole]}
-        members={members}
+        members={filteredMembers}
         availableUsers={available}
+        memberSearchTerm={memberSearch}
+        onMemberSearchTermChange={setMemberSearch}
         searchTerm={searchInput}
         onSearchTermChange={setSearchInput}
         onAdd={userId => {

--- a/src/main/crdPages/topLevelPages/admin/authorization/__tests__/CrdAdminGlobalRolesPage.test.tsx
+++ b/src/main/crdPages/topLevelPages/admin/authorization/__tests__/CrdAdminGlobalRolesPage.test.tsx
@@ -90,4 +90,18 @@ describe('CrdAdminGlobalRolesPage', () => {
     await userEvent.click(within(dialog).getByRole('button', { name: 'roleMembers.remove' }));
     expect(removePlatformRoleFromUser).toHaveBeenCalledWith('u1', 'GLOBAL_ADMIN');
   });
+
+  test('filtering current members narrows the list client-side without refetching', async () => {
+    render(<CrdAdminGlobalRolesPage />);
+    expect(screen.getByText('Alice (alice@x.io)')).toBeInTheDocument();
+
+    const filter = screen.getByPlaceholderText('roleMembers.filterMembersPlaceholder');
+    await userEvent.type(filter, 'ali');
+    expect(screen.getByText('Alice (alice@x.io)')).toBeInTheDocument(); // matches name
+
+    await userEvent.clear(filter);
+    await userEvent.type(filter, 'zzz');
+    expect(screen.queryByText('Alice (alice@x.io)')).toBeNull(); // filtered out
+    expect(screen.getByText('roleMembers.noResults')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Bugfix in CRD.
This PR adds a search over the already added users to a group under the Authorisation tab in the global administration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search/filter functionality for role members in the admin roles interface, enabling case-insensitive filtering by name and email.
  * Updated empty state messaging to distinguish between "no members" and "no search results".
  * Extended multi-language support across all supported locales for the members filter feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->