### PR TITLE
feat: resolve absolute URL for id-token-hint

### DIFF
--- a/src/core/auth/authentication/constants/authentication.constants.ts
+++ b/src/core/auth/authentication/constants/authentication.constants.ts
@@ -19,11 +19,13 @@ export const AUTH_PAGE_PREFIXES = [_AUTH_LOGIN_PATH, AUTH_REGISTRATION_PATH, AUT
 
 // OIDC BFF (Backend-For-Frontend) proxy routes served by alkemio-server on the
 // same origin as the SPA. Not OIDC-standard endpoints — those live on the IdP
-// and are advertised via the discovery document. These paths must stay relative
+// and are advertised via the discovery document. login/logout must stay relative
 // (same-origin) because the BFF only mounts on the apex domain.
 export const OIDC_BFF_BASE = '/api/auth/oidc';
 export const OIDC_LOGIN_PATH = `${OIDC_BFF_BASE}/login`;
 export const OIDC_LOGOUT_PATH = `${OIDC_BFF_BASE}/logout`;
+// id-token-hint is served on the identity subdomain — resolve the absolute URL
+// via useIdTokenHintUrl, which prepends the identity origin (issuer).
 export const OIDC_ID_TOKEN_HINT_PATH = `${OIDC_BFF_BASE}/id-token-hint`;
 
 // sessionStorage marker (see useOidcSessionRecovery): a silent recovery redirect

--- a/src/core/auth/authentication/hooks/useIdTokenHint.ts
+++ b/src/core/auth/authentication/hooks/useIdTokenHint.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { OIDC_ID_TOKEN_HINT_PATH } from '@/core/auth/authentication/constants/authentication.constants';
+import { useIdTokenHintUrl } from '@/core/auth/authentication/hooks/useIdTokenHintUrl';
 
 type IdTokenHintResponse = {
   id_token: string;
@@ -16,12 +16,13 @@ export const useIdTokenHint = (): UseIdTokenHint => {
   const [idToken, setIdToken] = useState<string>();
   const [error, setError] = useState<Error>();
   const [loading, setLoading] = useState<boolean>(false);
+  const idTokenHintUrl = useIdTokenHintUrl();
 
   const fetchIdTokenHint = async () => {
     setLoading(true);
     setError(undefined);
     try {
-      const response = await fetch(OIDC_ID_TOKEN_HINT_PATH, {
+      const response = await fetch(idTokenHintUrl, {
         credentials: 'include',
         cache: 'no-store',
         headers: { Accept: 'application/json' },

--- a/src/core/auth/authentication/hooks/useIdTokenHintUrl.ts
+++ b/src/core/auth/authentication/hooks/useIdTokenHintUrl.ts
@@ -8,8 +8,17 @@ import { useConfig } from '@/domain/platform/config/useConfig';
 export const useIdTokenHintUrl = (): string => {
   const config = useConfig();
 
-  const identityOrigin =
-    import.meta.env.MODE === 'development' ? undefined : config.authentication?.providers[0].config.issuer;
+  const issuer =
+    import.meta.env.MODE === 'development' ? undefined : config.authentication?.providers?.[0]?.config?.issuer;
+
+  let identityOrigin: string | undefined;
+  if (issuer) {
+    try {
+      identityOrigin = new URL(issuer).origin;
+    } catch {
+      identityOrigin = undefined;
+    }
+  }
 
   return identityOrigin ? `${identityOrigin}${OIDC_ID_TOKEN_HINT_PATH}` : OIDC_ID_TOKEN_HINT_PATH;
 };

--- a/src/core/auth/authentication/hooks/useIdTokenHintUrl.ts
+++ b/src/core/auth/authentication/hooks/useIdTokenHintUrl.ts
@@ -1,0 +1,15 @@
+import { OIDC_ID_TOKEN_HINT_PATH } from '@/core/auth/authentication/constants/authentication.constants';
+import { useConfig } from '@/domain/platform/config/useConfig';
+
+// The id-token-hint BFF endpoint is served by the IdP on the identity
+// subdomain, so the request must target the identity origin (the issuer)
+// rather than the apex where the SPA runs. In development the Kratos config
+// is unreliable, so we fall back to the relative same-origin path.
+export const useIdTokenHintUrl = (): string => {
+  const config = useConfig();
+
+  const identityOrigin =
+    import.meta.env.MODE === 'development' ? undefined : config.authentication?.providers[0].config.issuer;
+
+  return identityOrigin ? `${identityOrigin}${OIDC_ID_TOKEN_HINT_PATH}` : OIDC_ID_TOKEN_HINT_PATH;
+};

--- a/src/core/auth/authentication/hooks/useOidcSessionStatus.ts
+++ b/src/core/auth/authentication/hooks/useOidcSessionStatus.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { OIDC_ID_TOKEN_HINT_PATH } from '@/core/auth/authentication/constants/authentication.constants';
+import { useIdTokenHintUrl } from '@/core/auth/authentication/hooks/useIdTokenHintUrl';
 
 // Probes the BFF for an active OIDC (alkemio_session) session by hitting
 // the id-token-hint endpoint. Status 200 implies a live session; 401 means
@@ -9,12 +9,13 @@ import { OIDC_ID_TOKEN_HINT_PATH } from '@/core/auth/authentication/constants/au
 export const useOidcSessionStatus = () => {
   const [active, setActive] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
+  const idTokenHintUrl = useIdTokenHintUrl();
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const response = await fetch(OIDC_ID_TOKEN_HINT_PATH, {
+        const response = await fetch(idTokenHintUrl, {
           credentials: 'include',
           cache: 'no-store',
           headers: { Accept: 'application/json' },
@@ -35,7 +36,7 @@ export const useOidcSessionStatus = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [idTokenHintUrl]);
 
   return { active, loading };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved OpenID Connect authentication by introducing a centralized way to resolve the correct `id-token-hint` URL for session status checks and token handling.
  * Session status probing now automatically updates when the resolved `id-token-hint` URL changes, improving reliability across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->