### PR TITLE
feat(004-web-ai-assistant): gate assistant cues on ACCESS_VIRTUAL_ASSISTANT privilege + admin role tab (T047/T048)

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -3390,6 +3390,7 @@ export type PlatformKeySpecifier = (
   | 'storageAggregator'
   | 'templatesManager'
   | 'updatedDate'
+  | 'virtualAssistantAccess'
   | 'wellKnownVirtualContributors'
   | PlatformKeySpecifier
 )[];
@@ -3410,6 +3411,7 @@ export type PlatformFieldPolicy = {
   storageAggregator?: FieldPolicy<any> | FieldReadFunction<any>;
   templatesManager?: FieldPolicy<any> | FieldReadFunction<any>;
   updatedDate?: FieldPolicy<any> | FieldReadFunction<any>;
+  virtualAssistantAccess?: FieldPolicy<any> | FieldReadFunction<any>;
   wellKnownVirtualContributors?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type PlatformAccessRoleKeySpecifier = ('grantedPrivileges' | 'roleName' | PlatformAccessRoleKeySpecifier)[];
@@ -3444,6 +3446,7 @@ export type PlatformAdminQueryResultsKeySpecifier = (
   | 'spaces'
   | 'userEmailChangeAuditEntries'
   | 'users'
+  | 'virtualAssistant'
   | 'virtualContributors'
   | PlatformAdminQueryResultsKeySpecifier
 )[];
@@ -3458,6 +3461,7 @@ export type PlatformAdminQueryResultsFieldPolicy = {
   spaces?: FieldPolicy<any> | FieldReadFunction<any>;
   userEmailChangeAuditEntries?: FieldPolicy<any> | FieldReadFunction<any>;
   users?: FieldPolicy<any> | FieldReadFunction<any>;
+  virtualAssistant?: FieldPolicy<any> | FieldReadFunction<any>;
   virtualContributors?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type PlatformFeatureFlagKeySpecifier = ('enabled' | 'name' | PlatformFeatureFlagKeySpecifier)[];

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -29280,6 +29280,78 @@ export function refetchAuthorizationPrivilegesForUserQuery(
 ) {
   return { query: AuthorizationPrivilegesForUserDocument, variables: variables };
 }
+export const PlatformAssistantAccessDocument = gql`
+    query PlatformAssistantAccess {
+  platform {
+    id
+    virtualAssistantAccess
+  }
+}
+    `;
+
+/**
+ * __usePlatformAssistantAccessQuery__
+ *
+ * To run a query within a React component, call `usePlatformAssistantAccessQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePlatformAssistantAccessQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePlatformAssistantAccessQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function usePlatformAssistantAccessQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    SchemaTypes.PlatformAssistantAccessQuery,
+    SchemaTypes.PlatformAssistantAccessQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SchemaTypes.PlatformAssistantAccessQuery, SchemaTypes.PlatformAssistantAccessQueryVariables>(
+    PlatformAssistantAccessDocument,
+    options
+  );
+}
+export function usePlatformAssistantAccessLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SchemaTypes.PlatformAssistantAccessQuery,
+    SchemaTypes.PlatformAssistantAccessQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SchemaTypes.PlatformAssistantAccessQuery,
+    SchemaTypes.PlatformAssistantAccessQueryVariables
+  >(PlatformAssistantAccessDocument, options);
+}
+export function usePlatformAssistantAccessSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        SchemaTypes.PlatformAssistantAccessQuery,
+        SchemaTypes.PlatformAssistantAccessQueryVariables
+      >
+) {
+  const options = baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    SchemaTypes.PlatformAssistantAccessQuery,
+    SchemaTypes.PlatformAssistantAccessQueryVariables
+  >(PlatformAssistantAccessDocument, options);
+}
+export type PlatformAssistantAccessQueryHookResult = ReturnType<typeof usePlatformAssistantAccessQuery>;
+export type PlatformAssistantAccessLazyQueryHookResult = ReturnType<typeof usePlatformAssistantAccessLazyQuery>;
+export type PlatformAssistantAccessSuspenseQueryHookResult = ReturnType<typeof usePlatformAssistantAccessSuspenseQuery>;
+export type PlatformAssistantAccessQueryResult = Apollo.QueryResult<
+  SchemaTypes.PlatformAssistantAccessQuery,
+  SchemaTypes.PlatformAssistantAccessQueryVariables
+>;
+export function refetchPlatformAssistantAccessQuery(variables?: SchemaTypes.PlatformAssistantAccessQueryVariables) {
+  return { query: PlatformAssistantAccessDocument, variables: variables };
+}
 export const PlatformCapabilitiesDocument = gql`
     query PlatformCapabilities {
   platformCapabilities {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -868,6 +868,7 @@ export type AuthorizationHasPrivilegeArgs = {
 
 export enum AuthorizationCredential {
   AccountAdmin = 'ACCOUNT_ADMIN',
+  AssistantAccess = 'ASSISTANT_ACCESS',
   BetaTester = 'BETA_TESTER',
   GlobalAdmin = 'GLOBAL_ADMIN',
   GlobalAnonymous = 'GLOBAL_ANONYMOUS',
@@ -976,6 +977,7 @@ export enum AuthorizationPolicyType {
 
 export enum AuthorizationPrivilege {
   AccessInteractiveGuidance = 'ACCESS_INTERACTIVE_GUIDANCE',
+  AccessVirtualAssistant = 'ACCESS_VIRTUAL_ASSISTANT',
   AccountLicenseManage = 'ACCOUNT_LICENSE_MANAGE',
   AuthorizationReset = 'AUTHORIZATION_RESET',
   CommunityAssignVcFromAccount = 'COMMUNITY_ASSIGN_VC_FROM_ACCOUNT',
@@ -2674,6 +2676,7 @@ export type CredentialDefinition = {
 export enum CredentialType {
   AccountAdmin = 'ACCOUNT_ADMIN',
   AccountLicensePlus = 'ACCOUNT_LICENSE_PLUS',
+  AssistantAccess = 'ASSISTANT_ACCESS',
   BetaTester = 'BETA_TESTER',
   GlobalAdmin = 'GLOBAL_ADMIN',
   GlobalAnonymous = 'GLOBAL_ANONYMOUS',
@@ -6286,6 +6289,8 @@ export type Platform = {
   templatesManager?: Maybe<TemplatesManager>;
   /** The date at which the entity was last updated. */
   updatedDate: Scalars['DateTime']['output'];
+  /** Whether the current user may use the web AI assistant (the ACCESS_VIRTUAL_ASSISTANT privilege, 004-web-ai-assistant). client-web reads this to gate every assistant UI cue. */
+  virtualAssistantAccess: Scalars['Boolean']['output'];
   /** The mappings of well-known Virtual Contributors to their UUIDs. */
   wellKnownVirtualContributors: PlatformWellKnownVirtualContributors;
 };
@@ -6347,6 +6352,8 @@ export type PlatformAdminQueryResults = {
   userEmailChangeAuditEntries: UserEmailChangeAuditEntries;
   /** Retrieve all Users on the Platform. This is only available to Platform Admins. */
   users: PaginatedUsers;
+  /** The singleton virtual-assistant actor, including its current admin capability grant and ID. This is only available to Platform Admins, and is the discovery path for updateAssistantActorCapabilities. */
+  virtualAssistant: VirtualAssistant;
   /** Retrieve all Virtual Contributors on the Platform. This is only available to Platform Admins. */
   virtualContributors: Array<VirtualContributor>;
 };
@@ -7389,6 +7396,7 @@ export enum RoleName {
   Lead = 'LEAD',
   Member = 'MEMBER',
   Owner = 'OWNER',
+  PlatformAssistantAccess = 'PLATFORM_ASSISTANT_ACCESS',
   PlatformBetaTester = 'PLATFORM_BETA_TESTER',
   PlatformVcCampaign = 'PLATFORM_VC_CAMPAIGN',
   Registered = 'REGISTERED',
@@ -8921,8 +8929,8 @@ export type UpdateInnovationFlowStateInput = {
 };
 
 export type UpdateInnovationFlowStateSettingsInput = {
-  /** The flag to set. */
-  allowNewCallouts: Scalars['Boolean']['input'];
+  /** Optional. Sets whether new callouts can be added to this State; omission leaves the stored value unchanged. */
+  allowNewCallouts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Optional. Sets whether the phase is shown in member-facing navigation; omission leaves the stored value unchanged. */
   visible?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -35339,6 +35347,13 @@ export type AuthorizationPrivilegesForUserQuery = {
     __typename?: 'LookupQueryResults';
     authorizationPrivilegesForUser?: Array<AuthorizationPrivilege> | undefined;
   };
+};
+
+export type PlatformAssistantAccessQueryVariables = Exact<{ [key: string]: never }>;
+
+export type PlatformAssistantAccessQuery = {
+  __typename?: 'Query';
+  platform: { __typename?: 'Platform'; id: string; virtualAssistantAccess: boolean };
 };
 
 export type PlatformCapabilitiesQueryVariables = Exact<{ [key: string]: never }>;

--- a/src/core/i18n/ach/translation.ach.json
+++ b/src/core/i18n/ach/translation.ach.json
@@ -626,7 +626,8 @@
       "GLOBAL_COMMUNITY_READER": "crwdns40716:0$t(common.Community)crwdne40716:0",
       "GLOBAL_SPACES_READER": "crwdns40718:0$t(common.spaces)crwdne40718:0",
       "PLATFORM_BETA_TESTER": "crwdns18124:0crwdne18124:0",
-      "PLATFORM_VC_CAMPAIGN": "crwdns18126:0crwdne18126:0"
+      "PLATFORM_VC_CAMPAIGN": "crwdns18126:0crwdne18126:0",
+      "PLATFORM_ASSISTANT_ACCESS": "crwdns18126:0crwdne18126:0"
     },
     "time": {
       "short": {

--- a/src/core/i18n/bg/translation.bg.json
+++ b/src/core/i18n/bg/translation.bg.json
@@ -626,7 +626,8 @@
       "GLOBAL_COMMUNITY_READER": "Мениджър на $t(common.community)",
       "GLOBAL_SPACES_READER": "Читател на $t(common.spaces)",
       "PLATFORM_BETA_TESTER": "Бета тестер",
-      "PLATFORM_VC_CAMPAIGN": "Ранен достъп до VC"
+      "PLATFORM_VC_CAMPAIGN": "Ранен достъп до VC",
+      "PLATFORM_ASSISTANT_ACCESS": "Достъп до AI асистента"
     },
     "time": {
       "short": {

--- a/src/core/i18n/de/translation.de.json
+++ b/src/core/i18n/de/translation.de.json
@@ -626,7 +626,8 @@
       "GLOBAL_COMMUNITY_READER": "$t(common.Community) Manager",
       "GLOBAL_SPACES_READER": "$t(common.spaces) Reader",
       "PLATFORM_BETA_TESTER": "Beta Tester",
-      "PLATFORM_VC_CAMPAIGN": "VC Early Access"
+      "PLATFORM_VC_CAMPAIGN": "VC Early Access",
+      "PLATFORM_ASSISTANT_ACCESS": "KI-Assistent-Zugang"
     },
     "time": {
       "short": {

--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -668,7 +668,8 @@
       "GLOBAL_COMMUNITY_READER": "$t(common.Community) Manager",
       "GLOBAL_SPACES_READER": "$t(common.spaces) Reader",
       "PLATFORM_BETA_TESTER": "Beta Tester",
-      "PLATFORM_VC_CAMPAIGN": "VC Early Access"
+      "PLATFORM_VC_CAMPAIGN": "VC Early Access",
+      "PLATFORM_ASSISTANT_ACCESS": "AI Assistant Access"
     },
     "time": {
       "short": {

--- a/src/core/i18n/es/translation.es.json
+++ b/src/core/i18n/es/translation.es.json
@@ -626,7 +626,8 @@
       "GLOBAL_COMMUNITY_READER": "Gestor de $t(common.Community)",
       "GLOBAL_SPACES_READER": "Lector de $t(common.spaces)",
       "PLATFORM_BETA_TESTER": "Probador beta",
-      "PLATFORM_VC_CAMPAIGN": "Acceso temprano a VC"
+      "PLATFORM_VC_CAMPAIGN": "Acceso temprano a VC",
+      "PLATFORM_ASSISTANT_ACCESS": "Acceso al Asistente de IA"
     },
     "time": {
       "short": {

--- a/src/core/i18n/fr/translation.fr.json
+++ b/src/core/i18n/fr/translation.fr.json
@@ -626,7 +626,8 @@
       "GLOBAL_COMMUNITY_READER": "$t(common.Community) Manager",
       "GLOBAL_SPACES_READER": "$t(common.spaces) Reader",
       "PLATFORM_BETA_TESTER": "Beta Tester",
-      "PLATFORM_VC_CAMPAIGN": "VC Early Access"
+      "PLATFORM_VC_CAMPAIGN": "VC Early Access",
+      "PLATFORM_ASSISTANT_ACCESS": "Accès à l'assistant IA"
     },
     "time": {
       "short": {

--- a/src/core/i18n/nl/translation.nl.json
+++ b/src/core/i18n/nl/translation.nl.json
@@ -626,7 +626,8 @@
       "GLOBAL_COMMUNITY_READER": "$t(common.Community) Manager",
       "GLOBAL_SPACES_READER": "$t(common.spaces) Lezer",
       "PLATFORM_BETA_TESTER": "Bèta Tester",
-      "PLATFORM_VC_CAMPAIGN": "VC Vroegtijdige Toegang"
+      "PLATFORM_VC_CAMPAIGN": "VC Vroegtijdige Toegang",
+      "PLATFORM_ASSISTANT_ACCESS": "AI-assistent Toegang"
     },
     "time": {
       "short": {

--- a/src/core/i18n/pt/translation.pt.json
+++ b/src/core/i18n/pt/translation.pt.json
@@ -567,7 +567,8 @@
       "GLOBAL_COMMUNITY_READER": "$t(common.Community) Manager",
       "GLOBAL_SPACES_READER": "$t(common.spaces) Reader",
       "PLATFORM_BETA_TESTER": "Beta Tester",
-      "PLATFORM_VC_CAMPAIGN": "VC Early Access"
+      "PLATFORM_VC_CAMPAIGN": "VC Early Access",
+      "PLATFORM_ASSISTANT_ACCESS": "Acesso ao Assistente de IA"
     },
     "time": {
       "short": {

--- a/src/domain/access/RoleSetManager/useRoleSetManager.ts
+++ b/src/domain/access/RoleSetManager/useRoleSetManager.ts
@@ -26,6 +26,7 @@ export const RELEVANT_ROLES = {
     RoleName.GlobalSupportManager,
     RoleName.PlatformBetaTester,
     RoleName.PlatformVcCampaign,
+    RoleName.PlatformAssistantAccess,
   ],
 } as const;
 

--- a/src/main/assistant/graphql/PlatformAssistantAccess.graphql
+++ b/src/main/assistant/graphql/PlatformAssistantAccess.graphql
@@ -1,0 +1,6 @@
+query PlatformAssistantAccess {
+  platform {
+    id
+    virtualAssistantAccess
+  }
+}

--- a/src/main/assistant/useAssistantEnabled.ts
+++ b/src/main/assistant/useAssistantEnabled.ts
@@ -1,16 +1,34 @@
+import { usePlatformAssistantAccessQuery } from '@/core/apollo/generated/apollo-hooks';
 import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
 import { env } from '@/main/env';
 
 /**
- * Gate for the AI assistant UI: render nothing unless the user is authenticated
- * **and** the feature flag is on (mirrors the user-messaging / guidance-widget
- * gating). The flag is the client `VITE_APP_ASSISTANT_ENABLED` env var
- * (config-and-secrets.md; v1 decision — a server PlatformFeatureFlagName is a
- * later enhancement). Ships OFF; the PROD rollout flips it ON.
+ * Central gate for the AI assistant UI: render nothing unless the user is
+ * authenticated, the feature flag is on, **and** the user holds the
+ * `ACCESS_VIRTUAL_ASSISTANT` authorization privilege — surfaced as the gated
+ * `Platform.virtualAssistantAccess` field (resolves `false`, non-throwing, for
+ * users without the privilege). Every assistant cue (both nav entry buttons,
+ * the lazy dialog, the US4 settings tab + route, the whiteboard rail) funnels
+ * through this single hook, so the absence of the privilege hides *every* cue —
+ * not a hardcoded list, not feature-flag-only (FR-027 /
+ * contracts/assistant-access-and-budget.md §1).
+ *
+ * The flag is the client `VITE_APP_ASSISTANT_ENABLED` env var
+ * (config-and-secrets.md). Ships OFF; the PROD rollout flips it ON. Access (the
+ * privilege) is independent of the flag — both must hold.
  */
 export const useAssistantEnabled = (): boolean => {
   const { userModel } = useCurrentUserContext();
   const isAuthenticated = !!userModel?.id;
   const flagOn = env?.VITE_APP_ASSISTANT_ENABLED === 'true';
-  return isAuthenticated && flagOn;
+
+  // Only resolve the privilege once auth + flag already hold, so we never fire
+  // the query for signed-out users or while the feature is off.
+  const { data } = usePlatformAssistantAccessQuery({
+    skip: !isAuthenticated || !flagOn,
+    fetchPolicy: 'cache-and-network',
+  });
+  const hasAccess = data?.platform.virtualAssistantAccess ?? false;
+
+  return isAuthenticated && flagOn && hasAccess;
 };


### PR DESCRIPTION
## What

Increment A of **FR-027** — the assistant **access authorization privilege** (the "specific users only" gate). client-web slice of `contracts/assistant-access-and-budget.md` §1 + §6.

**Scope = access privilege ONLY.** The budget/meter half (T046 refusal copy, T049 usage meter) is Increment B and is **not** in this PR.

## Tasks

### T047 — gate EVERY assistant cue on the privilege
Extends the central gate `src/main/assistant/useAssistantEnabled.ts` to also require the gated `Platform.virtualAssistantAccess` field (the `ACCESS_VIRTUAL_ASSISTANT` privilege — resolves `false`, non-throwing, for users without it), AND-ed with the existing auth check + `VITE_APP_ASSISTANT_ENABLED` feature flag. The query is `skip`ped until auth + flag already hold, so it never fires for signed-out users or while the feature is off.

Because **every** assistant cue funnels through this single hook, the privilege's absence hides them all:
- `AssistantButton` (MUI nav, `PlatformNavigationBar`) — gated
- `CrdAssistantButtonGate` (CRD overlay in `root.tsx`) — gated
- `AssistantDialog` (lazy panel) — gated
- `WhiteboardAssistantButton` + `WhiteboardAssistantRailConnector` — gated
- US4 settings tab: hidden in `CrdUserSettingsPage` (`hidden: !isAssistantEnabled`) **and** its route bounces in `CrdUserAssistantTab` (`<Navigate>` when not enabled) — gated

No hardcoded list, never feature-flag-only. New `PlatformAssistantAccess.graphql` query + generated `usePlatformAssistantAccessQuery`.

### T048 — admin management tab
Adds `RoleName.PlatformAssistantAccess` to `MANAGED_ROLES` (via `RELEVANT_ROLES.Platform`) so `PLATFORM_ASSISTANT_ACCESS` appears under **Administration → Authorisation** with the standard Current/Add-members UI, reusing `assignPlatformRoleToUser` / `removePlatformRoleFromUser` (gated by `GRANT_GLOBAL_ADMINS`). **No new component, no new mutation.** Adds the `common.roles.PLATFORM_ASSISTANT_ACCESS` tab label across all 8 core locales in parity.

## Codegen

Ran `graphql-codegen --config codegen.local-schema.yml` (→ `../server/schema.graphql`, server branch `feat/004-assistant-access`), which already carries `virtualAssistantAccess` + `PLATFORM_ASSISTANT_ACCESS`. Generated diff is additive-only. **Re-run `pnpm codegen` against develop once server #6163 lands** — no hand-editing of generated files.

## Exit gates
- `pnpm install` — deps present
- codegen — green (additive only)
- `tsc --noEmit` — clean
- `biome ci` + `eslint` — green (no new findings)
- `pnpm build` — green
- focused tests — `src/main/assistant/__tests__` + assistant settings tab `__tests__`: **17 passed / 6 files**

## Rollout

- **Stacked PR**: base = `feat/004-web-ai-assistant` (client #9809). Retarget to `develop` after #9809 merges.
- Pairs with **server #6163** (`feat/004-assistant-access`): adds `Platform.virtualAssistantAccess` + `RoleName.PLATFORM_ASSISTANT_ACCESS`. This client code depends on that field/enum reaching develop's schema.
- Ships with the assistant flag **OFF** (unchanged).

Refs workspace#004-web-ai-assistant · cross-references #9809 · server #6163

🤖 Generated with [Claude Code](https://claude.com/claude-code)