### PR TITLE
feat(004-web-ai-assistant): budget meter + two distinct refusals (Increment B, T046/T049)

### DIFF
--- a/src/core/i18n/en/translation.en.json
+++ b/src/core/i18n/en/translation.en.json
@@ -30,10 +30,15 @@
       "userTurn": "Your message",
       "assistantTurn": "Assistant reply"
     },
+    "budget": {
+      "usage": "{{used}} of {{limit}} monthly tokens · resets on the 1st",
+      "noLimit": "No monthly token limit configured",
+      "a11y": "Monthly assistant usage: {{used}} of {{limit}} tokens"
+    },
     "errors": {
       "capability_unavailable": "A required capability is temporarily unavailable. Please try again shortly.",
-      "permission_denied": "You don't have permission to do that, or the capability is disabled in your settings.",
-      "usage_limit_reached": "You've reached your assistant usage limit for now. Please try again later.",
+      "permission_denied": "You don't have access to the assistant, or the capability is disabled in your settings.",
+      "usage_limit_reached": "You've reached your monthly assistant usage limit. Your allowance resets on the 1st of next month.",
       "session_invalid": "Your session ended. Please sign in again and re-ask.",
       "internal_error": "Something went wrong. Please try again.",
       "transport": "The connection was interrupted. Please try again."

--- a/src/crd/i18n/admin/admin.bg.json
+++ b/src/crd/i18n/admin/admin.bg.json
@@ -75,7 +75,8 @@
     "GLOBAL_PLATFORM_MANAGER": "Global Platform Manager",
     "GLOBAL_SUPPORT_MANAGER": "Global Support Manager",
     "PLATFORM_BETA_TESTER": "Platform Beta Tester",
-    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign"
+    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign",
+    "PLATFORM_ASSISTANT_ACCESS": "AI Assistant Access"
   },
   "roleMembers": {
     "currentMembers": "Текущи членове",

--- a/src/crd/i18n/admin/admin.de.json
+++ b/src/crd/i18n/admin/admin.de.json
@@ -75,7 +75,8 @@
     "GLOBAL_PLATFORM_MANAGER": "Global Platform Manager",
     "GLOBAL_SUPPORT_MANAGER": "Global Support Manager",
     "PLATFORM_BETA_TESTER": "Platform Beta Tester",
-    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign"
+    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign",
+    "PLATFORM_ASSISTANT_ACCESS": "AI Assistant Access"
   },
   "roleMembers": {
     "currentMembers": "Aktuelle Mitglieder",

--- a/src/crd/i18n/admin/admin.en.json
+++ b/src/crd/i18n/admin/admin.en.json
@@ -75,7 +75,8 @@
     "GLOBAL_PLATFORM_MANAGER": "Global Platform Manager",
     "GLOBAL_SUPPORT_MANAGER": "Global Support Manager",
     "PLATFORM_BETA_TESTER": "Platform Beta Tester",
-    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign"
+    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign",
+    "PLATFORM_ASSISTANT_ACCESS": "AI Assistant Access"
   },
   "roleMembers": {
     "currentMembers": "Current members",

--- a/src/crd/i18n/admin/admin.es.json
+++ b/src/crd/i18n/admin/admin.es.json
@@ -75,7 +75,8 @@
     "GLOBAL_PLATFORM_MANAGER": "Global Platform Manager",
     "GLOBAL_SUPPORT_MANAGER": "Global Support Manager",
     "PLATFORM_BETA_TESTER": "Platform Beta Tester",
-    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign"
+    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign",
+    "PLATFORM_ASSISTANT_ACCESS": "AI Assistant Access"
   },
   "roleMembers": {
     "currentMembers": "Miembros actuales",

--- a/src/crd/i18n/admin/admin.fr.json
+++ b/src/crd/i18n/admin/admin.fr.json
@@ -75,7 +75,8 @@
     "GLOBAL_PLATFORM_MANAGER": "Global Platform Manager",
     "GLOBAL_SUPPORT_MANAGER": "Global Support Manager",
     "PLATFORM_BETA_TESTER": "Platform Beta Tester",
-    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign"
+    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign",
+    "PLATFORM_ASSISTANT_ACCESS": "AI Assistant Access"
   },
   "roleMembers": {
     "currentMembers": "Membres actuels",

--- a/src/crd/i18n/admin/admin.nl.json
+++ b/src/crd/i18n/admin/admin.nl.json
@@ -75,7 +75,8 @@
     "GLOBAL_PLATFORM_MANAGER": "Global Platform Manager",
     "GLOBAL_SUPPORT_MANAGER": "Global Support Manager",
     "PLATFORM_BETA_TESTER": "Platform Beta Tester",
-    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign"
+    "PLATFORM_VC_CAMPAIGN": "Platform VC Campaign",
+    "PLATFORM_ASSISTANT_ACCESS": "AI Assistant Access"
   },
   "roleMembers": {
     "currentMembers": "Huidige leden",

--- a/src/domain/platformAdmin/management/authorization/AdminAuthorizationPage.tsx
+++ b/src/domain/platformAdmin/management/authorization/AdminAuthorizationPage.tsx
@@ -55,7 +55,13 @@ const AdminAuthorizationPage = ({ selectedRole }: AdminAuthorizationPageProps) =
       {!loading && roleSetId && (
         <>
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-            <Tabs sx={{ '.MuiTabs-flexContainer': { gap: gutters() } }} value={selectedRole ?? '_none'}>
+            <Tabs
+              variant="scrollable"
+              scrollButtons="auto"
+              allowScrollButtonsMobile
+              sx={{ '.MuiTabs-flexContainer': { gap: gutters() } }}
+              value={selectedRole ?? '_none'}
+            >
               <Tab value="_none" hidden={true} />
               {MANAGED_ROLES.map(tab => (
                 <Tab

--- a/src/main/assistant/AssistantBudgetMeter.tsx
+++ b/src/main/assistant/AssistantBudgetMeter.tsx
@@ -1,0 +1,67 @@
+import { Box, LinearProgress, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { gutters } from '@/core/ui/grid/utils';
+import type { AssistantBudget } from './types';
+
+/**
+ * The unobtrusive read-only monthly usage meter (D1 — T049 /
+ * assistant-access-and-budget.md §7): "X of Y monthly tokens · resets on the
+ * 1st", rendered in the assistant-panel header. Source is the asvc budget
+ * endpoint (useAssistantBudget); this component is purely presentational and
+ * enforces nothing.
+ *
+ * D3 — when `tokensPerMonth` is null/absent there is no resolvable limit, so we
+ * MUST NOT render a misleading "0 of 0" / 0-limit bar: show a plain "no limit
+ * configured" caption with no progress bar instead.
+ */
+const AssistantBudgetMeter = ({ budget }: { budget: AssistantBudget | null }) => {
+  const { t } = useTranslation();
+
+  if (!budget) {
+    return null;
+  }
+
+  const { tokensPerMonth, monthToDateUsed } = budget;
+
+  // D3: no resolvable allowance → informational caption, never a 0-limit meter.
+  if (tokensPerMonth === null || tokensPerMonth === undefined) {
+    return (
+      <Box paddingX={gutters(0.5)} paddingBottom={gutters(0.25)}>
+        <Typography variant="caption" color="text.secondary">
+          {t('assistant.budget.noLimit')}
+        </Typography>
+      </Box>
+    );
+  }
+
+  const used = Math.max(0, monthToDateUsed);
+  const fraction = tokensPerMonth > 0 ? Math.min(1, used / tokensPerMonth) : 0;
+  const percent = Math.round(fraction * 100);
+
+  return (
+    <Box
+      paddingX={gutters(0.5)}
+      paddingBottom={gutters(0.25)}
+      display="flex"
+      flexDirection="column"
+      gap={gutters(0.25)}
+    >
+      <Typography variant="caption" color="text.secondary">
+        {t('assistant.budget.usage', {
+          used: used.toLocaleString(),
+          limit: tokensPerMonth.toLocaleString(),
+        })}
+      </Typography>
+      <LinearProgress
+        variant="determinate"
+        value={percent}
+        aria-label={t('assistant.budget.a11y', {
+          used: used.toLocaleString(),
+          limit: tokensPerMonth.toLocaleString(),
+        })}
+      />
+    </Box>
+  );
+};
+
+export default AssistantBudgetMeter;

--- a/src/main/assistant/AssistantContext.tsx
+++ b/src/main/assistant/AssistantContext.tsx
@@ -39,6 +39,13 @@ export type AssistantState = {
   lastEventId: string | null;
   /** A non-blocking turn error (the red error UI); cleared on the next turn. */
   error: AssistantError | null;
+  /**
+   * Live month-to-date weighted-token usage, pushed by assistant-service in the
+   * `done` event at turn end (B / D1). Null until the first turn pushes a value;
+   * the budget meter prefers it over the initial REST snapshot so it updates
+   * without a refetch.
+   */
+  monthToDateUsed: number | null;
 };
 
 const initialState: AssistantState = {
@@ -48,6 +55,7 @@ const initialState: AssistantState = {
   pendingConfirmationId: null,
   lastEventId: null,
   error: null,
+  monthToDateUsed: null,
 };
 
 export type AssistantAction =
@@ -171,7 +179,9 @@ function applyStreamEvent(state: AssistantState, event: AssistantStreamEvent): A
       );
       // A turn that terminates with `done` is no longer awaiting a confirmation
       // (a decline ends with `done`; an approve streams results then `done`).
-      return { ...state, messages, isStreaming: false, lastEventId, pendingConfirmationId: null };
+      // The meter updates live off the pushed month-to-date (B / D1).
+      const monthToDateUsed = event.data.monthToDateUsed ?? state.monthToDateUsed;
+      return { ...state, messages, isStreaming: false, lastEventId, pendingConfirmationId: null, monthToDateUsed };
     }
 
     case 'error': {

--- a/src/main/assistant/AssistantPanelContent.tsx
+++ b/src/main/assistant/AssistantPanelContent.tsx
@@ -38,7 +38,7 @@ type AssistantPanelContentProps = {
 
 const AssistantPanelContent = ({ isOpen, onClose }: AssistantPanelContentProps) => {
   const { t } = useTranslation();
-  const { panelContext, clearPanelContext } = useAssistantContext();
+  const { state, panelContext, clearPanelContext } = useAssistantContext();
   const { sendMessage, cancel, isStreaming, startNewConversation } = useAssistantConversation();
   const [draft, setDraft] = useState('');
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -47,9 +47,14 @@ const AssistantPanelContent = ({ isOpen, onClose }: AssistantPanelContentProps) 
   // confirmation) and reconnect an in-flight turn (US3 / FR-011).
   useAssistantRehydrate();
 
-  // Read-only monthly usage meter (D1 / T049). Fetched only while the panel is
-  // open; hides itself when the asvc budget endpoint is absent (404) or fails.
+  // Read-only monthly usage meter (D1 / T049). The initial snapshot is fetched
+  // while the panel is open; it then stays live off the `monthToDateUsed` pushed
+  // in each `done` SSE event (B), preferred over the initial fetch so the meter
+  // updates per turn without a refetch. Hides itself when the asvc endpoint is
+  // absent (404) or fails.
   const { budget } = useAssistantBudget(isOpen);
+  const liveBudget =
+    budget && state.monthToDateUsed !== null ? { ...budget, monthToDateUsed: state.monthToDateUsed } : budget;
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   // Excalidraw aggressively reclaims focus when the panel opens over a whiteboard,
@@ -122,7 +127,7 @@ const AssistantPanelContent = ({ isOpen, onClose }: AssistantPanelContentProps) 
         </Box>
       </Box>
 
-      <AssistantBudgetMeter budget={budget} />
+      <AssistantBudgetMeter budget={liveBudget} />
 
       <AssistantConversationView />
 

--- a/src/main/assistant/AssistantPanelContent.tsx
+++ b/src/main/assistant/AssistantPanelContent.tsx
@@ -7,10 +7,12 @@ import { FocusScope } from '@radix-ui/react-focus-scope';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { gutters } from '@/core/ui/grid/utils';
+import AssistantBudgetMeter from './AssistantBudgetMeter';
 import { useAssistantContext } from './AssistantContext';
 import { AssistantConversationView } from './AssistantConversationView';
 import AssistantNewConversationButton from './AssistantNewConversationButton';
 import AssistantSettingsDialog from './AssistantSettingsDialog';
+import { useAssistantBudget } from './useAssistantBudget';
 import { useAssistantConversation } from './useAssistantConversation';
 import { useAssistantRehydrate } from './useAssistantRehydrate';
 
@@ -44,6 +46,10 @@ const AssistantPanelContent = ({ isOpen, onClose }: AssistantPanelContentProps) 
   // Rehydrate the single rolling thread on open/reload (incl. a pending
   // confirmation) and reconnect an in-flight turn (US3 / FR-011).
   useAssistantRehydrate();
+
+  // Read-only monthly usage meter (D1 / T049). Fetched only while the panel is
+  // open; hides itself when the asvc budget endpoint is absent (404) or fails.
+  const { budget } = useAssistantBudget(isOpen);
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   // Excalidraw aggressively reclaims focus when the panel opens over a whiteboard,
@@ -115,6 +121,8 @@ const AssistantPanelContent = ({ isOpen, onClose }: AssistantPanelContentProps) 
           </IconButton>
         </Box>
       </Box>
+
+      <AssistantBudgetMeter budget={budget} />
 
       <AssistantConversationView />
 

--- a/src/main/assistant/__tests__/budgetApi.test.ts
+++ b/src/main/assistant/__tests__/budgetApi.test.ts
@@ -1,0 +1,47 @@
+/**
+ * T049 — the asvc budget endpoint client (`getBudget`).
+ *
+ * - Cookie auth only, no Authorization header (SC-006), same as the rest of the
+ *   assistant REST surface.
+ * - Graceful degradation: a 404 (endpoint not yet deployed — asvc T056) or a 204
+ *   resolves to `null` so the meter hides; a real failure rejects.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getBudget } from '../assistantApi';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getBudget', () => {
+  it('returns the parsed budget on 200, with cookie auth and no Authorization header', async () => {
+    const payload = { tokensPerMonth: 100000, monthToDateUsed: 1234, resetsOn: '2026-07-01' };
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      );
+
+    const result = await getBudget();
+    expect(result).toEqual(payload);
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init?.credentials).toBe('include');
+    expect(new Headers(init?.headers).has('authorization')).toBe(false);
+  });
+
+  it('resolves to null on 404 (endpoint not deployed) — the meter hides', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 404 }));
+    await expect(getBudget()).resolves.toBeNull();
+  });
+
+  it('resolves to null on 204 (no content)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    await expect(getBudget()).resolves.toBeNull();
+  });
+
+  it('rejects on a real failure (e.g. 500) so it is not silently masked', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 500 }));
+    await expect(getBudget()).rejects.toThrow(/budget request failed: 500/);
+  });
+});

--- a/src/main/assistant/__tests__/budgetMeter.test.tsx
+++ b/src/main/assistant/__tests__/budgetMeter.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * T049 — D1 read-only budget meter (assistant-access-and-budget.md §7).
+ *
+ * - A resolved budget renders "X of Y monthly tokens · resets on the 1st".
+ * - D3: a null `tokensPerMonth` shows "no limit configured", never a 0-of-0 bar.
+ * - A null budget (endpoint 404 / not yet deployed — asvc T056) renders nothing.
+ */
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@/main/test/testUtils';
+import AssistantBudgetMeter from '../AssistantBudgetMeter';
+
+describe('AssistantBudgetMeter', () => {
+  it('renders the used/limit usage line with a progress bar', () => {
+    render(
+      <AssistantBudgetMeter budget={{ tokensPerMonth: 100000, monthToDateUsed: 25000, resetsOn: '2026-07-01' }} />
+    );
+
+    expect(screen.getByText(/25,000 of 100,000 monthly tokens/)).toBeInTheDocument();
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '25');
+  });
+
+  it('D3: shows "no limit configured" when tokensPerMonth is null (no 0-of-0 bar)', () => {
+    render(<AssistantBudgetMeter budget={{ tokensPerMonth: null, monthToDateUsed: 0 }} />);
+
+    expect(screen.getByText(/No monthly token limit configured/)).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the budget is unavailable (endpoint 404 / not deployed)', () => {
+    const { container } = render(<AssistantBudgetMeter budget={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/main/assistant/__tests__/refusals.test.tsx
+++ b/src/main/assistant/__tests__/refusals.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * T046 — the two refusals MUST read distinctly, never collapsed into one generic
+ * error (assistant-access-and-budget.md §6 / §7 + Edge cases):
+ *
+ * - `permission_denied` → no-access / eligibility framing (the in-flight fallback
+ *   for a session that lost ACCESS_VIRTUAL_ASSISTANT; entry points are already
+ *   hidden by useAssistantEnabled, D2).
+ * - `usage_limit_reached` → monthly-allowance framing with the reset wording.
+ */
+import { useEffect } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@/main/test/testUtils';
+import { AssistantProvider, useAssistantContext } from '../AssistantContext';
+import { AssistantConversationView } from '../AssistantConversationView';
+import type { AssistantErrorCode } from '../types';
+
+vi.mock('@/domain/platform/config/useConfig', () => ({
+  useConfig: () => ({ integration: { iframeAllowedUrls: [] } }),
+}));
+
+/** Seeds a turn that ends in an `error` event with the given code (empty server message → client copy). */
+const RefusalDriver = ({ code }: { code: AssistantErrorCode }) => {
+  const { dispatch } = useAssistantContext();
+  useEffect(() => {
+    dispatch({ type: 'set-conversation', conversationId: 'c1' });
+    dispatch({ type: 'append-user-message', content: 'do the thing', id: 'u1' });
+    dispatch({ type: 'begin-turn' });
+    dispatch({ type: 'stream-event', event: { event: 'error', data: { code, message: '' } } });
+  }, [dispatch, code]);
+  return (
+    <MemoryRouter>
+      <AssistantConversationView />
+    </MemoryRouter>
+  );
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('assistant refusal copy (T046)', () => {
+  it('permission_denied reads as a no-access / eligibility refusal', async () => {
+    render(
+      <AssistantProvider>
+        <RefusalDriver code="permission_denied" />
+      </AssistantProvider>
+    );
+    expect(await screen.findByText(/don't have access to the assistant/i)).toBeInTheDocument();
+  });
+
+  it('usage_limit_reached reads as a monthly-allowance refusal with reset wording', async () => {
+    render(
+      <AssistantProvider>
+        <RefusalDriver code="usage_limit_reached" />
+      </AssistantProvider>
+    );
+    const text = await screen.findByText(/monthly assistant usage limit/i);
+    expect(text).toBeInTheDocument();
+    expect(text.textContent).toMatch(/resets on the 1st/i);
+  });
+
+  it('the two refusals do not share copy (not collapsed into one generic error)', () => {
+    const { unmount } = render(
+      <AssistantProvider>
+        <RefusalDriver code="permission_denied" />
+      </AssistantProvider>
+    );
+    const permissionCopy = screen.getAllByRole('alert')[0].textContent;
+    unmount();
+
+    render(
+      <AssistantProvider>
+        <RefusalDriver code="usage_limit_reached" />
+      </AssistantProvider>
+    );
+    const usageCopy = screen.getAllByRole('alert')[0].textContent;
+
+    expect(permissionCopy).not.toEqual(usageCopy);
+  });
+});

--- a/src/main/assistant/assistantApi.ts
+++ b/src/main/assistant/assistantApi.ts
@@ -1,5 +1,5 @@
 import { assistantEndpoint } from '@/main/constants/endpoints';
-import type { AssistantConversation, AssistantMessage } from './types';
+import type { AssistantBudget, AssistantConversation, AssistantMessage } from './types';
 
 /**
  * REST client for the AI assistant JSON endpoints
@@ -28,6 +28,30 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     return undefined as T;
   }
   return (await response.json()) as T;
+}
+
+/**
+ * Read the signed-in user's monthly budget snapshot (D1 — meter source,
+ * assistant-access-and-budget.md §7). The endpoint is owned by
+ * **assistant-service** (asvc T056) and may not be deployed yet, so this MUST
+ * degrade gracefully: a 404 (endpoint absent / not yet rolled out) or any
+ * empty/204 body resolves to `null`, and the caller hides the meter. A real
+ * non-404 failure still rejects so it isn't silently masked. No client
+ * enforcement — purely informational.
+ */
+export async function getBudget(): Promise<AssistantBudget | null> {
+  const response = await fetch(`${assistantEndpoint}/budget`, {
+    credentials: 'include',
+    headers: jsonHeaders,
+  });
+  // Endpoint not deployed yet (asvc T056) or no budget for this user → hide.
+  if (response.status === 404 || response.status === 204) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Assistant budget request failed: ${response.status}`);
+  }
+  return (await response.json()) as AssistantBudget;
 }
 
 /** List the signed-in user's conversations, most-recent first (US3). */

--- a/src/main/assistant/types.ts
+++ b/src/main/assistant/types.ts
@@ -158,6 +158,12 @@ export type MessageEvent = {
 export type DoneEvent = {
   messageId: string;
   tokenUsage?: { prompt: number; completion: number };
+  /**
+   * Post-debit month-to-date weighted-token usage, pushed by assistant-service at
+   * turn end so the budget meter updates live from the SSE stream (no refetch).
+   * Optional — absent if the asvc could not read its counter for this turn.
+   */
+  monthToDateUsed?: number;
 };
 
 export type ErrorEvent = {

--- a/src/main/assistant/types.ts
+++ b/src/main/assistant/types.ts
@@ -106,6 +106,27 @@ export type AssistantConversation = {
   state?: AssistantConversationState;
 };
 
+/**
+ * Read-only monthly budget snapshot (D1 — contract §7 /
+ * assistant-access-and-budget.md). Surfaced by **assistant-service** at
+ * `GET /api/private/rest/assistant/budget`, NOT a server GraphQL field — asvc
+ * owns both numbers (`tokensPerMonth` from the §3 MCP budget resource it reads,
+ * `monthToDateUsed` from its own monthly counter). Same cookie-auth,
+ * privilege-gated edge as the rest of the assistant; read-only, no client
+ * enforcement.
+ *
+ * `tokensPerMonth: null` ⇒ no limit resolvable for the account (D3) — render
+ * "no limit configured", never a misleading "0 of 0" meter.
+ */
+export type AssistantBudget = {
+  /** Weighted-token monthly allowance, or `null` when none is configured (D3). */
+  tokensPerMonth: number | null;
+  /** Weighted tokens spent so far this UTC calendar month. */
+  monthToDateUsed: number;
+  /** When the monthly counter resets (ISO date / month-boundary wording source). */
+  resetsOn?: string;
+};
+
 // ---------------------------------------------------------------------------
 // SSE events — the wire frames the transport parses (event: / data: / id:).
 // ---------------------------------------------------------------------------

--- a/src/main/assistant/useAssistantBudget.ts
+++ b/src/main/assistant/useAssistantBudget.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { getBudget } from './assistantApi';
+import type { AssistantBudget } from './types';
+
+/**
+ * Fetch the signed-in user's monthly budget snapshot for the read-only meter
+ * (D1 — T049 / assistant-access-and-budget.md §7). Fed by the
+ * **assistant-service** endpoint `GET /api/private/rest/assistant/budget`
+ * (asvc T056), reached through the same same-origin, cookie-authenticated edge
+ * as the rest of the assistant — no Authorization header, no client enforcement.
+ *
+ * Graceful degradation is the contract: the endpoint may not be deployed yet
+ * (asvc T056 ships in parallel), so a 404 / empty body resolves to `budget:
+ * null` and the meter hides itself. Any other failure also leaves `budget`
+ * null (the meter simply doesn't render) — the budget is informational, never a
+ * gate, so a fetch failure must never block the panel.
+ *
+ * `enabled` lets the caller defer the fetch until the panel is actually open
+ * (so a closed panel never hits the endpoint).
+ */
+export function useAssistantBudget(enabled: boolean): { budget: AssistantBudget | null; loading: boolean } {
+  const [budget, setBudget] = useState<AssistantBudget | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    getBudget()
+      .then(result => {
+        if (!cancelled) {
+          setBudget(result);
+        }
+      })
+      .catch(() => {
+        // Endpoint missing or transient failure → hide the meter; never surface
+        // an error in the panel for a purely informational read.
+        if (!cancelled) {
+          setBudget(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return { budget, loading };
+}

--- a/src/main/assistant/useAssistantBudget.ts
+++ b/src/main/assistant/useAssistantBudget.ts
@@ -9,10 +9,13 @@ import type { AssistantBudget } from './types';
  * (asvc T056), reached through the same same-origin, cookie-authenticated edge
  * as the rest of the assistant — no Authorization header, no client enforcement.
  *
- * Graceful degradation is the contract: the endpoint may not be deployed yet
- * (asvc T056 ships in parallel), so a 404 / empty body resolves to `budget:
- * null` and the meter hides itself. Any other failure also leaves `budget`
- * null (the meter simply doesn't render) — the budget is informational, never a
+ * This is the INITIAL snapshot only (on panel open). The meter then stays live
+ * off the `monthToDateUsed` pushed in each `done` SSE event (B / D1) — see the
+ * reducer's `done` case + AssistantPanelContent — so no per-turn refetch.
+ *
+ * Graceful degradation is the contract: the endpoint may not be deployed yet, so
+ * a 404 / empty body resolves to `budget: null` and the meter hides itself. Any
+ * other failure also leaves `budget` null — the budget is informational, never a
  * gate, so a fetch failure must never block the panel.
  *
  * `enabled` lets the caller defer the fetch until the panel is actually open

--- a/src/main/crdPages/topLevelPages/admin/authorization/CrdAdminGlobalRolesPage.tsx
+++ b/src/main/crdPages/topLevelPages/admin/authorization/CrdAdminGlobalRolesPage.tsx
@@ -92,6 +92,7 @@ const CrdAdminGlobalRolesPage = () => {
     [RoleName.GlobalSupportManager]: t('roles.GLOBAL_SUPPORT_MANAGER'),
     [RoleName.PlatformBetaTester]: t('roles.PLATFORM_BETA_TESTER'),
     [RoleName.PlatformVcCampaign]: t('roles.PLATFORM_VC_CAMPAIGN'),
+    [RoleName.PlatformAssistantAccess]: t('roles.PLATFORM_ASSISTANT_ACCESS'),
   };
 
   return (


### PR DESCRIPTION
## Increment B — client-web slice (budget meter + two-refusal copy)

Implements the **client-web** slice of Increment B for `workspace#004-web-ai-assistant`.
Contract: `specs/004-web-ai-assistant/contracts/assistant-access-and-budget.md` §6 (consumer responsibilities) + §7 D1/D3 + Edge cases. Tasks **T046** + **T049** in `tasks/client-web.md`.

> **Stacked PR.** Base is `feat/004-assistant-access` (Increment A — access-gating UI, PR #9894), so the privilege gate (`useAssistantEnabled` → `ACCESS_VIRTUAL_ASSISTANT`) is present. **Retarget to `develop` once #9894 merges.**

### T046 — two distinct refusals
The assistant refuses for two orthogonal reasons; the copy now distinguishes them instead of collapsing into one generic error:
- **`permission_denied`** → no-access / eligibility framing. Entry points are already hidden by `useAssistantEnabled` (D2); this is the in-flight fallback if a live session loses `ACCESS_VIRTUAL_ASSISTANT` (Edge case: *access revoked mid-session*).
- **`usage_limit_reached`** → monthly-allowance wording with reset framing (*"resets on the 1st of next month"*), mapped from asvc's `usage_limit_reached` (`app/streaming/errors.py`).

The codes already flow through the SSE `error` channel verbatim (T013) into `state.error.code`; this PR refines the `assistant.errors.*` i18n copy and locks the distinction with tests. No client-side enforcement.

### T049 — read-only budget meter (D1)
New `AssistantBudgetMeter` in the panel header, fed by **`GET /api/private/rest/assistant/budget`** (the **assistant-service** endpoint — asvc **T056**) via the existing same-origin, cookie-authenticated assistant REST client (`assistantApi.ts` → `getBudget()`). Response shape `{ tokensPerMonth, monthToDateUsed, resetsOn }`; renders *"X of Y monthly tokens · resets on the 1st"* + a `LinearProgress`.

**Graceful degradation (endpoint may not be live yet — asvc T056 ships in parallel):** `getBudget()` resolves `null` on a 404 (endpoint absent) or 204, and the meter hides itself; a real failure (e.g. 500) still rejects so it isn't silently masked, and the hook swallows it to `null` (informational, never a gate). **D3:** a `null` `tokensPerMonth` renders *"No monthly token limit configured"* rather than a misleading 0-of-0 bar.

⚠️ **Needs an integration check once asvc T056 deploys** — built against the documented shape; not yet exercised against a live endpoint.

### Scope notes
- **No schema/codegen change** — REST endpoint (asvc) + existing access gating only.
- i18n keys (`assistant.errors.*` refined, `assistant.budget.*` added) are in the core/legacy MUI namespace where the assistant block already lives (English-only there — no other-locale parity to maintain for this block).

### Exit gates
- `pnpm install` ✓
- `tsc --noEmit` (typecheck) ✓ clean
- `pnpm build` ✓
- Biome + ESLint ✓ on changed files (2 repo-wide Biome errors are pre-existing on the base branch, not in this diff)
- Tests ✓ — full suite green via pre-commit (1609 passed); 10 new assistant tests: `budgetMeter.test.tsx`, `budgetApi.test.ts`, `refusals.test.tsx`

Refs `workspace#004-web-ai-assistant`. Depends on **assistant-service T056** (budget endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)