### PR TITLE
fix(uploads): allow .ics files in the UI file pickers

### DIFF
--- a/src/main/crdPages/space/callout/LinkUrlAttachFileButton.tsx
+++ b/src/main/crdPages/space/callout/LinkUrlAttachFileButton.tsx
@@ -18,6 +18,7 @@ const MIME_TO_EXT: Record<string, string> = {
   'application/msword': '.doc',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
   'application/vnd.oasis.opendocument.text': '.odt',
+  'text/calendar': '.ics',
   'image/bmp': '.bmp',
   'image/jpg': '.jpg',
   'image/jpeg': '.jpg,.jpeg',

--- a/src/main/crdPages/utils/useReferenceFileUpload.test.ts
+++ b/src/main/crdPages/utils/useReferenceFileUpload.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import type { StorageConfig } from '@/domain/storage/StorageBucket/useStorageConfig';
+import { useReferenceFileUpload } from './useReferenceFileUpload';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/core/apollo/generated/apollo-hooks', () => ({
+  useUploadFileMutation: () => [vi.fn(), { loading: false }],
+}));
+
+vi.mock('@/core/ui/notifications/useNotification', () => ({
+  useNotification: () => vi.fn(),
+}));
+
+const baseConfig: StorageConfig = {
+  storageBucketId: 'bucket-1',
+  allowedMimeTypes: [],
+  maxFileSize: 1024,
+  canUpload: true,
+  temporaryLocation: true,
+};
+
+describe('useReferenceFileUpload accept derivation', () => {
+  test('offers .ics when text/calendar is allowed (server#6159 / server#6194)', () => {
+    const storageConfig: StorageConfig = {
+      ...baseConfig,
+      allowedMimeTypes: ['application/pdf', 'text/calendar'],
+    };
+
+    const { result } = renderHook(() => useReferenceFileUpload(storageConfig));
+
+    expect(result.current.accept).toBeDefined();
+    expect(result.current.accept?.split(',')).toContain('.ics');
+    expect(result.current.accept?.split(',')).toContain('.pdf');
+  });
+
+  test('does not offer .ics when text/calendar is not allowed', () => {
+    const storageConfig: StorageConfig = {
+      ...baseConfig,
+      allowedMimeTypes: ['application/pdf'],
+    };
+
+    const { result } = renderHook(() => useReferenceFileUpload(storageConfig));
+
+    expect(result.current.accept?.split(',')).not.toContain('.ics');
+  });
+});

--- a/src/main/crdPages/utils/useReferenceFileUpload.ts
+++ b/src/main/crdPages/utils/useReferenceFileUpload.ts
@@ -16,6 +16,7 @@ const MIME_TO_EXT: Record<string, string> = {
   'application/msword': '.doc',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
   'application/vnd.oasis.opendocument.text': '.odt',
+  'text/calendar': '.ics',
   'image/bmp': '.bmp',
   'image/jpg': '.jpg',
   'image/jpeg': '.jpg,.jpeg',


### PR DESCRIPTION
## Summary

Companion to the server slice of alkem-io/server#6159 — "Allow users to upload .ics files". The server allowlist change shipped in alkem-io/server#6194 (`text/calendar` / `.ics` added to the document MIME enum feeding `DEFAULT_ALLOWED_MIME_TYPES`, plus a backfill migration), so the backend already accepts `.ics` uploads everywhere. This PR closes the matching gap in the client UI.

## Root cause

Each file picker derives its `accept` attribute by mapping the backend's `storageConfig.allowedMimeTypes` through a local MIME→extension map and dropping any MIME not present in the map. Both maps lacked a `text/calendar` entry, so even though buckets now allow `.ics`, the pickers never offered the extension.

## Fix

Added `'text/calendar': '.ics'` to both mirrored MIME→extension maps (kept in sync by design):

- `src/main/crdPages/utils/useReferenceFileUpload.ts` — central config for all CRD reference file uploads.
- `src/main/crdPages/space/callout/LinkUrlAttachFileButton.tsx` — link contribution attachments.

Because `accept` is the intersection of the backend allowlist and these maps, the pickers now update automatically across every in-scope surface: post additional-content CTA, post references editor, post reactions links & files, About-this-Space references, and community-guidelines references.

A repo-wide grep confirmed these are the only two copies of the map; there is no third mirror to update. No backend or i18n changes are needed.

## Decisions

- Placed the new entry directly after the document/text MIME types and before the image types, mirroring the server's "document MIME enum" grouping and keeping both maps byte-identical.
- No new mechanism introduced; image-only pickers, Collabora imports, and the removed legacy MUI upload layer were left untouched, per the story's out-of-scope list.

## Regression test

Added `src/main/crdPages/utils/useReferenceFileUpload.test.ts` asserting the `accept` derivation offers `.ics` iff `text/calendar` is in `allowedMimeTypes`.

## Exit gates

- `pnpm lint` (tsc + Biome + ESLint) — clean (no new findings on changed files)
- `pnpm vitest run` — 1537 passed (incl. 2 new), 2 skipped
- `pnpm build` — succeeds

Closes alkem-io/client-web#9943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading `.ics` calendar files where calendar file types are allowed.
* **Tests**
  * Added coverage to verify file upload options include `.ics` when calendar files are enabled, and exclude it when they are not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->