### PR TITLE
Fix protected route redirect of private L1

### DIFF
--- a/src/main/crdPages/subspace/routing/CrdSubspaceProtectedRoutes.test.tsx
+++ b/src/main/crdPages/subspace/routing/CrdSubspaceProtectedRoutes.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import CrdSubspaceProtectedRoutes from './CrdSubspaceProtectedRoutes';
+
+// ---- Mocks ----
+
+// Capture <Navigate to=...> targets without a real router.
+const navigateTargets: string[] = [];
+vi.mock('react-router-dom', () => ({
+  Navigate: ({ to }: { to: string }) => {
+    navigateTargets.push(to);
+    return <div data-testid="navigate" data-to={to} />;
+  },
+  Outlet: () => <div data-testid="outlet" />,
+  useOutletContext: () => ({}),
+}));
+
+vi.mock('@/crd/components/common/LoadingSpinner', () => ({
+  LoadingSpinner: () => <div data-testid="loading" />,
+}));
+
+const useUrlResolverMock = vi.fn();
+vi.mock('@/main/routing/urlResolver/useUrlResolver', () => ({
+  default: () => useUrlResolverMock(),
+}));
+
+const useSubSpaceMock = vi.fn();
+vi.mock('@/domain/space/hooks/useSubSpace', () => ({
+  useSubSpace: () => useSubSpaceMock(),
+}));
+
+const buildSubspace = (url: string, canRead = false) => ({
+  subspace: { about: { profile: { url } } },
+  permissions: { canRead },
+  loading: false,
+});
+
+describe('CrdSubspaceProtectedRoutes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    navigateTargets.length = 0;
+    useUrlResolverMock.mockReturnValue({ loading: false });
+  });
+
+  test('redirects a non-readable subspace to its own About page when profile.url is a full URL', () => {
+    // Regression (story #9945): the server returns a fully-qualified URL on
+    // profile.url. Passing it raw to <Navigate> made react-router treat it as
+    // relative and append the whole `https://…` string to the current path,
+    // landing the user on the error page when opening a private L1 of a public
+    // L0 from /spaces. The redirect target must be an origin-relative path.
+    useSubSpaceMock.mockReturnValue(buildSubspace('https://acc-alkem.io/parent-l0/challenges/private-l1'));
+
+    render(<CrdSubspaceProtectedRoutes />);
+
+    expect(navigateTargets).toEqual(['/parent-l0/challenges/private-l1/about']);
+    expect(screen.getByTestId('navigate').getAttribute('data-to')).not.toContain('https://');
+  });
+
+  test('redirects correctly when profile.url is already an origin-relative path', () => {
+    useSubSpaceMock.mockReturnValue(buildSubspace('/parent-l0/challenges/private-l1'));
+
+    render(<CrdSubspaceProtectedRoutes />);
+
+    expect(navigateTargets).toEqual(['/parent-l0/challenges/private-l1/about']);
+  });
+
+  test('shows the loading spinner while the URL is resolving', () => {
+    useUrlResolverMock.mockReturnValue({ loading: true });
+    useSubSpaceMock.mockReturnValue(buildSubspace('/parent-l0/challenges/private-l1'));
+
+    render(<CrdSubspaceProtectedRoutes />);
+
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+    expect(navigateTargets).toEqual([]);
+  });
+
+  test('renders the protected outlet when the viewer can read', () => {
+    useSubSpaceMock.mockReturnValue(buildSubspace('/parent-l0/challenges/private-l1', true));
+
+    render(<CrdSubspaceProtectedRoutes />);
+
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    expect(navigateTargets).toEqual([]);
+  });
+});

--- a/src/main/crdPages/subspace/routing/CrdSubspaceProtectedRoutes.tsx
+++ b/src/main/crdPages/subspace/routing/CrdSubspaceProtectedRoutes.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Outlet, useOutletContext } from 'react-router-dom';
 import { LoadingSpinner } from '@/crd/components/common/LoadingSpinner';
+import { toRoutePath } from '@/crd/lib/toRoutePath';
 import { EntityPageSection } from '@/domain/shared/layout/EntityPageSection';
 import { useSubSpace } from '@/domain/space/hooks/useSubSpace';
 import useUrlResolver from '@/main/routing/urlResolver/useUrlResolver';
@@ -15,6 +16,13 @@ import useUrlResolver from '@/main/routing/urlResolver/useUrlResolver';
  * a `../about` relative path — the inner nested `<Routes>` sits inside an
  * outer wildcard match, and relative `..` walks out of the wildcard entirely,
  * landing on the parent space's About page instead of the subspace's.
+ *
+ * `subspace.about.profile.url` is normalised through `toRoutePath` first: the
+ * server returns a fully-qualified URL (e.g. `https://host/parent/challenges/sub`)
+ * on `profile.url`, and react-router treats any value that isn't `/`-prefixed
+ * as relative — it would append the whole `https://…` string to the current
+ * path, producing a mangled route that resolves to the error page. This is the
+ * regression that broke opening a private L1 of a public L0 from /spaces.
  */
 const CrdSubspaceProtectedRoutes = () => {
   const { loading: resolvingUrl } = useUrlResolver();
@@ -26,7 +34,7 @@ const CrdSubspaceProtectedRoutes = () => {
   }
 
   if (!permissions.canRead) {
-    return <Navigate to={`${subspace.about.profile.url}/${EntityPageSection.About}`} replace={true} />;
+    return <Navigate to={`${toRoutePath(subspace.about.profile.url)}/${EntityPageSection.About}`} replace={true} />;
   }
 
   return <Outlet context={parentContext} />;


### PR DESCRIPTION
fix: CrdSubspaceProtectedRoutes.tsx redirected non-readers of a private L1 to the raw subspace.about.profile.url (a fully-qualified https://… URL). React-router treats a non-/-prefixed value as relative, so it appended the whole URL to the current path → mangled route → error page. The L0 guard was unaffected because it uses a relative ../about. Fix routes the target through the existing toRoutePath helper (same pattern already used in CrdSubspaceCalloutPage). Regression test added and verified to fail on pre-fix code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect behavior for protected subspace pages so users are sent to the correct About page even when the profile link is fully qualified.
  * Preserved the loading state while routing details are still being resolved.
  * Continued to show protected content when the viewer has permission to read it.

* **Tests**
  * Added coverage for redirect, loading, and permission-based rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->