### PR TITLE
feat(search): match callout contributions and framing in flow-state search

### DIFF
--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -7812,6 +7812,8 @@ export type SearchFilterInput = {
 export type SearchInput = {
   /** Return results that satisfy these conditions. */
   filters?: InputMaybe<Array<SearchFilterInput>>;
+  /** When searching Callouts (COLLABORATION_TOOLS / CALLOUT), also match in the Callout framing resources (whiteboard, memo) and its contributions (post, whiteboard, memo). Any match folds up to the containing Callout, deduped, in calloutResults. */
+  foldCalloutResources?: InputMaybe<Scalars['Boolean']['input']>;
   /** Restrict the search to a single flow state, identified by the InnovationFlowState UUID. The state UUID is globally unique and transitively identifies its Collaboration, so no separate CalloutsSet filter is needed. Default is all flow states. */
   searchInFlowStateFilter?: InputMaybe<Scalars['UUID']['input']>;
   /** Restrict the search to only the specified Space. Default is all Spaces. */

--- a/src/main/crdPages/space/hooks/useFlowStateSearch.test.tsx
+++ b/src/main/crdPages/space/hooks/useFlowStateSearch.test.tsx
@@ -27,6 +27,7 @@ type QueryArgs = {
     searchData: {
       terms: string[];
       searchInFlowStateFilter?: string;
+      foldCalloutResources?: boolean;
       filters: Array<{ cursor?: string; size: number; category: string }>;
     };
   };
@@ -63,6 +64,8 @@ describe('useFlowStateSearch', () => {
     const args = useFlowStateSearchQueryMock.mock.calls.at(-1)?.[0] as QueryArgs;
     expect(args.variables.searchData.searchInFlowStateFilter).toBe(FLOW_STATE);
     expect(args.variables.searchData.terms).toEqual(['governance']);
+    // Fold framing resources and contributions up to the matching callout.
+    expect(args.variables.searchData.foldCalloutResources).toBe(true);
     expect(args.variables.searchData.filters[0].cursor).toBeUndefined();
     expect(args.variables.searchData.filters[0].size).toBe(10);
     expect(args.skip).toBe(false);

--- a/src/main/crdPages/space/hooks/useFlowStateSearch.ts
+++ b/src/main/crdPages/space/hooks/useFlowStateSearch.ts
@@ -84,6 +84,9 @@ export function useFlowStateSearch({ flowStateID, terms, skip }: UseFlowStateSea
       searchData: {
         terms,
         searchInFlowStateFilter: flowStateID,
+        // Match in the callout framing resources and contributions too; matches
+        // fold up to the containing callout, deduped, in calloutResults.
+        foldCalloutResources: true,
         filters: [
           {
             category: SearchCategory.CollaborationTools,
@@ -152,6 +155,7 @@ export function useFlowStateSearch({ flowStateID, terms, skip }: UseFlowStateSea
         searchData: {
           terms,
           searchInFlowStateFilter: flowStateID,
+          foldCalloutResources: true,
           filters: [
             {
               category: SearchCategory.CollaborationTools,


### PR DESCRIPTION
## Summary

Wires the new server `foldCalloutResources` flag into the flow-state / KB search hook (`useFlowStateSearch`). A search term now returns a Callout when it matches the callout title/description, **any framing whiteboard/memo**, or **any contribution post/whiteboard/memo** — each Callout once (the server folds and dedupes into `calloutResults`).

## Changes

- `foldCalloutResources: true` passed in both the initial query and the `fetchMore` pagination variables.
- Generated `SearchInput` type updated to include the optional flag (codegen reproduces it identically once run against the updated server).
- Hook test asserts the flag is sent.

## Why this surface

`useFlowStateSearch` requests only `COLLABORATION_TOOLS`/`CALLOUT` and consumes only `calloutResults` — the clean fit. The global search overlay was intentionally **not** changed: it renders separate Callouts / Framings / Contributions tabs, so folding there would duplicate a hit across tabs.

## Depends on

alkem-io/server#6198 (adds the `foldCalloutResources` input field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now consistently group related callout resources during initial loading and when loading more results.
  * Updated the related test coverage to verify the new search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->