### PR TITLE
Fix/9955 contributor collection callout

### DIFF
--- a/src/crd/components/callout/CalloutDetailDialog.tsx
+++ b/src/crd/components/callout/CalloutDetailDialog.tsx
@@ -64,6 +64,8 @@ type CalloutDetailDialogProps = {
   collaboraFramingSlot?: ReactNode;
   /** Call-to-action link button rendered below description (e.g. CalloutLinkAction) */
   callToActionFramingSlot?: ReactNode;
+  /** Contributor collection (cards/map) rendered below description (feature 008) */
+  contributorsFramingSlot?: ReactNode;
   onShareClick?: () => void;
   /**
    * 3-dots settings slot in the sticky-header cluster. Consumer injects a
@@ -96,6 +98,7 @@ export function CalloutDetailDialog({
   mediaGalleryFramingSlot,
   collaboraFramingSlot,
   callToActionFramingSlot,
+  contributorsFramingSlot,
   onShareClick,
   settingsSlot,
   commentsEnabled,
@@ -205,6 +208,7 @@ export function CalloutDetailDialog({
               {mediaGalleryFramingSlot && <div className="pt-2">{mediaGalleryFramingSlot}</div>}
               {collaboraFramingSlot && <div className="pt-2">{collaboraFramingSlot}</div>}
               {callToActionFramingSlot && <div className="pt-2">{callToActionFramingSlot}</div>}
+              {contributorsFramingSlot && <div className="pt-2">{contributorsFramingSlot}</div>}
               {pollSlot && <div className="pt-2">{pollSlot}</div>}
             </div>
 

--- a/src/main/crdPages/space/callout/CalloutDetailDialogConnector.tsx
+++ b/src/main/crdPages/space/callout/CalloutDetailDialogConnector.tsx
@@ -36,6 +36,7 @@ import { CallToActionFramingConnector } from './CallToActionFramingConnector';
 import { CollaboraFramingConnector } from './CollaboraFramingConnector';
 import { CollaboraFramingEditorOverlay } from './CollaboraFramingEditorOverlay';
 import { ContributionGridConnector } from './ContributionGridConnector';
+import { ContributorCollectionConnector } from './ContributorCollectionConnector';
 import { toCollaboraPreviewType } from './collaboraDocumentTypeMap';
 import { LinkContributionAddConnector } from './LinkContributionAddConnector';
 import { LinkContributionEditConnector } from './LinkContributionEditConnector';
@@ -372,6 +373,14 @@ export function CalloutDetailDialogConnector({
   const hasCallToAction = callout.framing.type === CalloutFramingType.Link && !!callout.framing.link;
   const callToActionFramingSlot = hasCallToAction ? <CallToActionFramingConnector callout={callout} /> : undefined;
 
+  // Contributor-collection body (feature 008) — the self-updating cards/map for
+  // the active type. Rendered in the detail dialog just like the inline feed card
+  // (LazyCalloutItem), so opening the callout shows the collection too.
+  const hasContributors = callout.framing.type === CalloutFramingType.Contributors;
+  const contributorsFramingSlot = hasContributors ? (
+    <ContributorCollectionConnector calloutId={callout.id} />
+  ) : undefined;
+
   const handleContributionClick = (contributionId: string, clickedEntityId?: string) => {
     if (contributionType === CalloutContributionType.Memo) {
       setMemoContributionId(contributionId);
@@ -630,6 +639,7 @@ export function CalloutDetailDialogConnector({
           mediaGalleryFramingSlot={mediaGalleryFramingSlot}
           collaboraFramingSlot={collaboraFramingSlot}
           callToActionFramingSlot={callToActionFramingSlot}
+          contributorsFramingSlot={contributorsFramingSlot}
           hasContributions={hasContributionType}
           contributionsSlot={contributionsSlot}
           contributionsCount={callout.contributions.length}
@@ -689,6 +699,7 @@ export function CalloutDetailDialogConnector({
             mediaGalleryFramingSlot={mediaGalleryFramingSlot}
             collaboraFramingSlot={collaboraFramingSlot}
             callToActionFramingSlot={callToActionFramingSlot}
+            contributorsFramingSlot={contributorsFramingSlot}
             settingsSlot={settingsSlot}
             onShareClick={handleShareClick}
           />

--- a/src/main/crdPages/templates/CalloutTemplateForm.tsx
+++ b/src/main/crdPages/templates/CalloutTemplateForm.tsx
@@ -29,6 +29,7 @@ import { MarkdownEditor, type MarkdownUploadProps } from '@/crd/forms/markdown/M
 import { ReferencesEditor } from '@/crd/forms/references/ReferencesEditor';
 import { TagsInput } from '@/crd/forms/tags-input';
 import { Label } from '@/crd/primitives/label';
+import { healContributorCollection } from '@/main/crdPages/space/callout/contributorCollectionMapper';
 import { FramingEditorConnector } from '@/main/crdPages/space/callout/FramingEditorConnector';
 import { ResponseDefaultsConnector } from '@/main/crdPages/space/callout/ResponseDefaultsConnector';
 import { referenceRowErrors, type UseCrdCalloutFormResult } from '@/main/crdPages/space/hooks/useCrdCalloutForm';
@@ -154,6 +155,9 @@ export function CalloutTemplateForm({
           onMediaGalleryVisualsChange={v => setField('mediaGalleryVisuals', v)}
           collaboraDocumentType={values.collaboraDocumentType}
           onCollaboraDocumentTypeChange={v => setField('collaboraDocumentType', v)}
+          contributorCollection={values.contributorCollection}
+          onContributorCollectionChange={v => setField('contributorCollection', healContributorCollection(v))}
+          contributorCollectionError={errors.contributorCollection}
         />
       </div>
 

--- a/src/main/crdPages/templates/__tests__/calloutTemplateMapper.test.ts
+++ b/src/main/crdPages/templates/__tests__/calloutTemplateMapper.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ActorType,
   CalloutAllowedActors,
   CalloutContributionType,
   CalloutFramingType,
   type CalloutTemplateContentFragment,
   CalloutVisibility,
   CollaboraDocumentType,
+  ContributorCollectionView,
   PollResultsDetail,
   PollResultsVisibility,
   PollStatus,
@@ -206,6 +208,34 @@ describe('calloutTemplateContentToFormValues', () => {
     });
     expect(v.referenceRows).toEqual([{ id: 'ref-1', name: 'Docs', uri: 'https://x.test', description: 'd' }]);
     expect(v.editMeta?.framingProfileTagsetId).toBe('ts-1');
+  });
+
+  // Feature 008 — applying a contributors template MUST carry its captured config
+  // (types / default type / default view), not fall back to the form default.
+  // Regression guard for the apply-template prefill gap.
+  it('reads back the contributor-collection config (feature 008)', () => {
+    const base = baseFragment({ type: CalloutFramingType.Contributors });
+    const v = calloutTemplateContentToFormValues({
+      ...base,
+      settings: {
+        ...base.settings,
+        framing: {
+          ...base.settings.framing,
+          contributors: {
+            __typename: 'CalloutContributorsSettings',
+            contributorTypes: [ActorType.Organization],
+            defaultContributorType: ActorType.Organization,
+            defaultView: ContributorCollectionView.Map,
+          },
+        },
+      },
+    });
+    expect(v.framingChip).toBe('contributors');
+    expect(v.contributorCollection).toEqual({
+      types: ['organization'],
+      defaultType: 'organization',
+      defaultView: 'map',
+    });
   });
 
   it('copies the whiteboard drawing (unlike the live-callout edit prefill)', () => {

--- a/src/main/crdPages/templates/calloutTemplateMapper.ts
+++ b/src/main/crdPages/templates/calloutTemplateMapper.ts
@@ -29,6 +29,7 @@ import {
   mapFormToCalloutCreationInput,
   mapFormToCalloutUpdateInput,
 } from '@/main/crdPages/space/callout/calloutFormMapper';
+import { contributorCollectionFromServer } from '@/main/crdPages/space/callout/contributorCollectionMapper';
 import type { CalloutFormValues, FramingChip, ResponseType } from '@/main/crdPages/space/hooks/useCrdCalloutForm';
 
 export type CalloutTemplateMapperFallbacks = {
@@ -145,6 +146,11 @@ export function calloutTemplateContentToFormValues(
     tags: findDefaultTagset(framing.profile.tagsets)?.tags ?? [],
     framingChip,
     framingCommentsEnabled: settings.framing.commentsEnabled,
+    // Contributor-collection config (feature 008) travels in the template's framing
+    // settings; read it back so applying a contributors template preserves the
+    // captured types/default-type/default-view instead of falling back to the form
+    // default. Yields the default (all types) for non-contributors framing.
+    contributorCollection: contributorCollectionFromServer(settings.framing.contributors),
     memoMarkdown: framing.memo?.markdown ?? '',
     linkUrl: framing.link?.uri ?? '',
     linkDisplayName: framing.link?.profile.displayName ?? '',

--- a/src/main/crdPages/templates/templateContentMapper.ts
+++ b/src/main/crdPages/templates/templateContentMapper.ts
@@ -43,6 +43,8 @@ export function mapGqlFramingType(gql: CalloutFramingType): FramingKind {
       return 'image';
     case CalloutFramingType.Poll:
       return 'poll';
+    case CalloutFramingType.Contributors:
+      return 'contributors';
     default:
       return 'none';
   }


### PR DESCRIPTION
- Fixes on Contributors callouts templates
- Add contributors framing to the callout dialog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a contributors framing layout in callout dialogs.
  * Contributors information can now appear between the call-to-action area and poll section.
  * Callout templates now preserve and restore contributors framing settings in the editor.

* **Bug Fixes**
  * Fixed contributors-framed callouts so they no longer fall back to a default layout.
  * Improved template loading so saved contributor configuration stays intact when editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->