### PR TITLE
fix(ux): subspace-link first-visit follow-ups — post-apply landing, cookie-banner dismiss, sign-up return URL

### DIFF
--- a/src/core/auth/authentication/pages/LogoutPage.tsx
+++ b/src/core/auth/authentication/pages/LogoutPage.tsx
@@ -19,8 +19,13 @@ async function cleanupPushSubscription(
     }
 
     if ('serviceWorker' in navigator) {
-      const registration = await navigator.serviceWorker.ready;
-      const subscription = await registration.pushManager.getSubscription();
+      // getRegistration() resolves immediately (undefined when no SW), unlike
+      // navigator.serviceWorker.ready, which NEVER resolves without an active
+      // service worker — the SW only registers in PROD builds, so awaiting
+      // `.ready` hung the logout redirect forever on dev stacks (and would in
+      // prod for any user whose SW failed to activate).
+      const registration = await navigator.serviceWorker.getRegistration();
+      const subscription = await registration?.pushManager.getSubscription();
       if (subscription) {
         await subscription.unsubscribe();
       }

--- a/src/core/auth/authentication/utils/useSignUpReturnUrl.ts
+++ b/src/core/auth/authentication/utils/useSignUpReturnUrl.ts
@@ -17,7 +17,11 @@ const cookieDomain = (() => {
   return parts.length >= 2 ? `.${parts.slice(-2).join('.')}` : undefined;
 })();
 
-const returnUrlCookieOptions = { path: '/', domain: cookieDomain, sameSite: 'lax' } as const;
+// maxAge (1h) makes this a persistent cookie: a session cookie dies with the
+// browser session, so a first-time user who registers, closes the browser, and
+// opens the verification email later would lose the return destination and
+// land on home after signing in.
+const returnUrlCookieOptions = { path: '/', domain: cookieDomain, sameSite: 'lax', maxAge: 3600 } as const;
 
 type UseReturnUrlProvided = {
   returnUrl: string | undefined;

--- a/src/crd/components/common/CookieConsentBanner.tsx
+++ b/src/crd/components/common/CookieConsentBanner.tsx
@@ -25,6 +25,10 @@ export function CookieConsentBanner({ ref, onAcceptAll, onConfirm }: CookieConse
   return (
     <div
       ref={ref}
+      // Interacting with the banner must never dismiss an open modal (Radix
+      // treats clicks outside its layer as backdrop dismisses — e.g. accepting
+      // cookies used to close the subspace About dialog and lose the context).
+      data-dialog-dismiss-ignore=""
       className="crd-root pointer-events-auto fixed inset-x-0 bottom-0 z-[1500] border-t border-border bg-card text-card-foreground shadow-lg"
     >
       <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center justify-between gap-4 p-4">

--- a/src/crd/primitives/dialog.tsx
+++ b/src/crd/primitives/dialog.tsx
@@ -4,6 +4,29 @@ import * as React from 'react';
 
 import { cn } from '@/crd/lib/utils';
 
+/**
+ * Marker attribute for fixed overlays that live OUTSIDE the Radix dialog layer
+ * (e.g. the cookie-consent banner) but must not dismiss an open modal when
+ * clicked: Radix treats any pointer-down outside its layer as a backdrop
+ * dismiss. Tag the overlay's root element with this attribute and dialog
+ * content ignores interactions originating from it — a generic escape hatch,
+ * no overlay-specific knowledge in the dialog.
+ */
+export const DIALOG_DISMISS_IGNORE_ATTR = 'data-dialog-dismiss-ignore';
+
+type InteractOutsideHandler = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>['onInteractOutside'];
+
+const guardInteractOutside =
+  (userHandler: InteractOutsideHandler): NonNullable<InteractOutsideHandler> =>
+  event => {
+    const target = event.target as Element | null;
+    if (target?.closest?.(`[${DIALOG_DISMISS_IGNORE_ATTR}]`)) {
+      event.preventDefault();
+      return;
+    }
+    userHandler?.(event);
+  };
+
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
@@ -45,11 +68,12 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 const DialogContentRaw = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, onInteractOutside, ...props }, ref) => (
   <DialogPrimitive.Content
     ref={ref}
     data-slot="dialog-content-raw"
     className={cn('pointer-events-auto', className)}
+    onInteractOutside={guardInteractOutside(onInteractOutside)}
     {...props}
   />
 ));
@@ -62,12 +86,13 @@ const DialogContent = React.forwardRef<
     /** Optional className for the overlay — escape hatch for stacking fixes (e.g. when this dialog is opened on top of another z-[60] dialog like the whiteboard editor). */
     overlayClassName?: string;
   }
->(({ className, children, closeLabel, overlayClassName, ...props }, ref) => (
+>(({ className, children, closeLabel, overlayClassName, onInteractOutside, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       data-slot="dialog-content"
+      onInteractOutside={guardInteractOutside(onInteractOutside)}
       className={cn(
         'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
         className

--- a/src/main/crdPages/auth/CrdEmailVerificationRequiredPage.tsx
+++ b/src/main/crdPages/auth/CrdEmailVerificationRequiredPage.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useTransactionScope } from '@/core/analytics/SentryTransactionScopeContext';
+import { useReturnUrl } from '@/core/auth/authentication/utils/useSignUpReturnUrl';
 import type TranslationKey from '@/core/i18n/utils/TranslationKey';
 import { usePageTitle } from '@/core/routing/usePageTitle';
 import { EmailVerificationRequiredCard } from '@/crd/components/auth/EmailVerificationRequiredCard';
@@ -20,10 +21,14 @@ export function CrdEmailVerificationRequiredPage({ pageTitleKey }: CrdEmailVerif
   useTransactionScope({ type: 'authentication' });
   const { t } = useTranslation();
   usePageTitle(t(pageTitleKey));
+  // Carry the pending returnUrl into the sign-in link: buildLoginUrl() with no
+  // argument defaults the param to home, which would OVERWRITE the stored
+  // return destination the moment the user signs in after verifying.
+  const { returnUrl } = useReturnUrl();
 
   return (
     <AuthShellWrapper>
-      <EmailVerificationRequiredCard signInHref={buildLoginUrl()} />
+      <EmailVerificationRequiredCard signInHref={buildLoginUrl(returnUrl)} />
     </AuthShellWrapper>
   );
 }

--- a/src/main/crdPages/auth/LoginCrdRoute.tsx
+++ b/src/main/crdPages/auth/LoginCrdRoute.tsx
@@ -22,6 +22,7 @@ import { useQueryParams } from '@/core/routing/useQueryParams';
 import type { KratosFlowDescriptor, KratosMessage } from '@/crd/components/auth/flowDescriptor';
 import { LoginCard } from '@/crd/components/auth/LoginCard';
 import usePlatformOrigin from '@/domain/platform/routes/usePlatformOrigin';
+import { buildSignUpUrl } from '@/main/routing/urlBuilders';
 import { AuthShellWrapper } from './AuthShellWrapper';
 import { flowDescriptorAdapter } from './flowDescriptorAdapter';
 import { invokePasskeyTrigger, PasskeyTriggerError } from './passkeyTrigger';
@@ -56,6 +57,7 @@ function CrdLoginPage({ flow }: { flow?: string }) {
   // render the form as normal (the flow id is opaque state Kratos owns).
   const returnUrlFromParam = params.get(PARAM_NAME_RETURN_URL) ?? undefined;
   const { returnUrl: storedReturnUrl, setReturnUrl } = useReturnUrl();
+  const signUpReturnUrl = returnUrlFromParam ?? storedReturnUrl;
   const platformOrigin = usePlatformOrigin();
   const isOidcEntry = !flow;
 
@@ -144,7 +146,12 @@ function CrdLoginPage({ flow }: { flow?: string }) {
         <LoginCard
           descriptor={undefined}
           isLoading={true}
-          signUpHref={AUTH_SIGN_UP_PATH}
+          signUpHref={
+            // Forward the pending returnUrl so a first-time visitor who came
+            // for a specific space/subspace keeps that destination through
+            // sign-up (bare /sign_up would drop it — they'd land on home).
+            signUpReturnUrl ? buildSignUpUrl(signUpReturnUrl) : AUTH_SIGN_UP_PATH
+          }
           forgotPasswordHref={AUTH_RESET_PASSWORD_PATH}
         />
       </AuthShellWrapper>
@@ -156,7 +163,12 @@ function CrdLoginPage({ flow }: { flow?: string }) {
       <LoginCard
         descriptor={descriptor}
         isLoading={loading}
-        signUpHref={AUTH_SIGN_UP_PATH}
+        signUpHref={
+          // Forward the pending returnUrl so a first-time visitor who came
+          // for a specific space/subspace keeps that destination through
+          // sign-up (bare /sign_up would drop it — they'd land on home).
+          signUpReturnUrl ? buildSignUpUrl(signUpReturnUrl) : AUTH_SIGN_UP_PATH
+        }
         forgotPasswordHref={AUTH_RESET_PASSWORD_PATH}
         onPasskeyTrigger={trigger => {
           setPasskeyError(undefined);

--- a/src/main/crdPages/auth/SignUpCrdRoute.tsx
+++ b/src/main/crdPages/auth/SignUpCrdRoute.tsx
@@ -49,7 +49,7 @@ function CrdSignUpPage() {
   // that URL after registering + verifying (parity with MUI `SignUp`). The cookie
   // survives the email-verification round-trip, even across a new tab.
   const returnUrl = params.get(PARAM_NAME_RETURN_URL);
-  const { setReturnUrl } = useReturnUrl();
+  const { returnUrl: storedReturnUrl, setReturnUrl } = useReturnUrl();
   useEffect(() => {
     setReturnUrl(returnUrl);
   }, [returnUrl]);
@@ -107,7 +107,13 @@ function CrdSignUpPage() {
           <SignUpCard
             descriptor={descriptor}
             isLoading={loading}
-            signInHref={buildLoginUrl()}
+            signInHref={
+              // Carry the destination into the sign-in link: buildLoginUrl()
+              // with no argument defaults the param to home, and the login
+              // route STORES the param — a bare link would clobber the saved
+              // destination for a user who switches to sign-in.
+              buildLoginUrl(returnUrl ?? storedReturnUrl)
+            }
             termsOfUseHref={locations?.terms ?? '#'}
             privacyPolicyHref={locations?.privacy ?? '#'}
             hasAcceptedTerms={accepted}

--- a/src/main/crdPages/auth/VerifyCrdRoute.tsx
+++ b/src/main/crdPages/auth/VerifyCrdRoute.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { useTransactionScope } from '@/core/analytics/SentryTransactionScopeContext';
 import useKratosFlow, { FlowTypeName } from '@/core/auth/authentication/hooks/useKratosFlow';
+import { useReturnUrl } from '@/core/auth/authentication/utils/useSignUpReturnUrl';
 import { error, TagCategoryValues } from '@/core/logging/sentry/log';
 import { usePageTitle } from '@/core/routing/usePageTitle';
 import { useQueryParams } from '@/core/routing/useQueryParams';
@@ -21,6 +22,9 @@ function CrdVerificationPage() {
 
   const flowId = useQueryParams().get('flow') || undefined;
   const { flow: verificationFlow, loading } = useKratosFlow(FlowTypeName.Verification, flowId);
+  // Carry the pending returnUrl into the sign-in link — buildLoginUrl() with no
+  // argument defaults the param to home, overwriting the stored destination.
+  const { returnUrl } = useReturnUrl();
   const translateDescriptor = useTranslateDescriptor();
 
   const baseDescriptor = verificationFlow ? flowDescriptorAdapter(verificationFlow, 'verification') : undefined;
@@ -44,7 +48,7 @@ function CrdVerificationPage() {
 
   return (
     <AuthShellWrapper>
-      <VerificationCard descriptor={descriptor} isLoading={loading} signInHref={buildLoginUrl()} />
+      <VerificationCard descriptor={descriptor} isLoading={loading} signInHref={buildLoginUrl(returnUrl)} />
     </AuthShellWrapper>
   );
 }

--- a/src/main/crdPages/space/useSpaceApplyFlow.tsx
+++ b/src/main/crdPages/space/useSpaceApplyFlow.tsx
@@ -29,6 +29,9 @@ export type UseSpaceApplyFlowParams = {
 export type UseSpaceApplyFlowResult = {
   loading: boolean;
   isMember: boolean;
+  /** True once the viewer submitted an application in this session — lets
+   * close paths distinguish a fresh applicant from a merely-browsing visitor. */
+  hasApplied: boolean;
   buttonProps: Omit<SpaceAboutApplyButtonProps, 'className'>;
   dialogs: ReactNode;
 };
@@ -139,6 +142,7 @@ export function useSpaceApplyFlow({
   return {
     loading,
     isMember: applicationButtonProps.isMember,
+    hasApplied,
     buttonProps,
     dialogs,
   };

--- a/src/main/crdPages/subspace/about/CrdSubspaceAbout.tsx
+++ b/src/main/crdPages/subspace/about/CrdSubspaceAbout.tsx
@@ -12,7 +12,10 @@ import { useSpaceApplyFlow } from '../../space/useSpaceApplyFlow';
 
 type CrdSubspaceAboutProps = {
   open: boolean;
-  onClose: () => void;
+  /** `hasApplied` is true when the viewer submitted an application while the
+   * About was open — the /about route uses it to pick a close destination
+   * that doesn't contradict the fresh application (no parent Apply CTA). */
+  onClose: (context?: { hasApplied: boolean }) => void;
 };
 
 /**
@@ -45,6 +48,7 @@ export function CrdSubspaceAbout({ open, onClose }: CrdSubspaceAboutProps) {
   const {
     loading: applyLoading,
     isMember,
+    hasApplied,
     buttonProps,
     dialogs,
   } = useSpaceApplyFlow({
@@ -54,7 +58,7 @@ export function CrdSubspaceAbout({ open, onClose }: CrdSubspaceAboutProps) {
     parentSpaceId,
     // Joining from the About dialog closes it via the normal close path instead
     // of letting the default navigate yank the open modal (which froze the page).
-    onJoined: onClose,
+    onJoined: () => onClose(),
   });
 
   const guidelinesId = data?.lookup.space?.about.guidelines.id;
@@ -167,7 +171,7 @@ export function CrdSubspaceAbout({ open, onClose }: CrdSubspaceAboutProps) {
         open={open}
         onOpenChange={isOpen => {
           if (!isOpen) {
-            onClose();
+            onClose({ hasApplied });
           }
         }}
         data={aboutData}

--- a/src/main/crdPages/subspace/about/CrdSubspaceAboutPage.tsx
+++ b/src/main/crdPages/subspace/about/CrdSubspaceAboutPage.tsx
@@ -16,6 +16,11 @@ import { CrdSubspaceAbout } from './CrdSubspaceAbout';
  * URL and trap the user in a redirect loop. We navigate to the most specific
  * place the viewer can actually open:
  *  - the subspace itself when they can read it (member),
+ *  - else, when they just APPLIED here (combined subspace application — the
+ *    application is pending, so canRead is still false), home — where the
+ *    memberships panel confirms the pending application. Landing on the parent
+ *    would greet them with the parent's own big "Apply" CTA, contradicting the
+ *    application they just submitted.
  *  - else the parent space when they can read that,
  *  - else home — so a user with only a pending invitation (no access to either
  *    the subspace or its private parent) can still escape the About dialog
@@ -33,9 +38,11 @@ export default function CrdSubspaceAboutPage() {
   } = useSpace();
   const navigate = useNavigate();
 
-  const handleClose = () => {
+  const handleClose = (context?: { hasApplied: boolean }) => {
     if (permissions.canRead) {
       navigate(subspace.about.profile.url);
+    } else if (context?.hasApplied) {
+      navigate(ROUTE_HOME);
     } else if (parentPermissions.canRead && parentSpaceUrl) {
       navigate(parentSpaceUrl);
     } else {


### PR DESCRIPTION
## Summary

Addresses the three remaining UX issues @bobbykolev reported on alkem-io/server#6189 (the fourth — error toast instead of the parent-first modal — was fixed server-side in alkem-io/server#6232). **Targets `release/66`** so the fixes ship with the combined-subspace-application feature they affect.

### 1. Fresh applicant no longer lands on the parent's Apply CTA
Closing the `/about` route of a private subspace right after applying navigated to the parent space, whose own big "Apply" contradicted the just-submitted application. The close handler now knows the viewer applied this session (`useSpaceApplyFlow` exposes `hasApplied`) and routes a fresh applicant **home**, where the memberships panel confirms the pending application. Browsing-only closes keep today's parent destination; the sidebar About trigger is unaffected.

### 2. Cookie-banner clicks no longer dismiss open dialogs
The consent banner lives outside the Radix dialog layer, so "Accept All" registered as a pointer-down-outside and dismissed the blocking subspace About dialog → redirect to the parent, losing the shared-link context. Fixed generically at the primitive: `DialogContent`/`DialogContentRaw` ignore interact-outside events from any element tagged `data-dialog-dismiss-ignore`; the banner tags its root. Normal backdrop-close preserved, no cookie-specific knowledge in the primitive.

### 3. Sign-up flow preserves the return URL (Signalen-critical)
A first-time visitor on a subspace link who **registered** (vs signed in) landed on home. Three drops, fixed to mirror the working login path:
- login card's sign-up link forwarded no `returnUrl` → now `buildSignUpUrl(returnUrl)`
- the `returnUrl` cookie was session-scoped and died before the verification email was opened → now `maxAge` 1h
- the verification cards' sign-in links called `buildLoginUrl()` bare, which **defaults the param to home and overwrote** any surviving destination → now pass the stored `returnUrl`

**Follow-up (not here):** passing `return_to` into the Kratos registration flow itself (`createBrowserRegistrationFlow`) so Kratos carries the destination through its own redirects — needs allow-list validation; too invasive for a release branch.

### Verification
- `pnpm lint` clean, `pnpm vitest run` 1556 passed, `pnpm build` clean.
- Live browser verification against the local stack to follow in a comment.

Refs alkem-io/server#6189 · `workspace#017-combined-subspace-application`

🤖 Generated with [Claude Code](https://claude.com/claude-code)