### PR TITLE
fix: don't show inactive spaces on the organization profile (#1938)

### DIFF
--- a/src/core/apollo/generated/apollo-helpers.ts
+++ b/src/core/apollo/generated/apollo-helpers.ts
@@ -4007,6 +4007,7 @@ export type QueryKeySpecifier = (
   | 'adminIdentitiesUnverified'
   | 'aiServer'
   | 'collaboraEditorUrl'
+  | 'collaboraServiceAvailable'
   | 'exploreSpaces'
   | 'inputCreator'
   | 'lookup'
@@ -4048,6 +4049,7 @@ export type QueryFieldPolicy = {
   adminIdentitiesUnverified?: FieldPolicy<any> | FieldReadFunction<any>;
   aiServer?: FieldPolicy<any> | FieldReadFunction<any>;
   collaboraEditorUrl?: FieldPolicy<any> | FieldReadFunction<any>;
+  collaboraServiceAvailable?: FieldPolicy<any> | FieldReadFunction<any>;
   exploreSpaces?: FieldPolicy<any> | FieldReadFunction<any>;
   inputCreator?: FieldPolicy<any> | FieldReadFunction<any>;
   lookup?: FieldPolicy<any> | FieldReadFunction<any>;

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -14804,9 +14804,7 @@ export function refetchUsersModelFullQuery(variables: SchemaTypes.UsersModelFull
 }
 export const UserContributionsDocument = gql`
     query UserContributions($userId: UUID!) {
-  rolesUser(
-    rolesData: {actorID: $userId, filter: {visibilities: [ACTIVE, DEMO]}}
-  ) {
+  rolesUser(rolesData: {actorID: $userId, filter: {visibilities: [ACTIVE, DEMO]}}) {
     id
     spaces {
       id

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -14804,7 +14804,9 @@ export function refetchUsersModelFullQuery(variables: SchemaTypes.UsersModelFull
 }
 export const UserContributionsDocument = gql`
     query UserContributions($userId: UUID!) {
-  rolesUser(rolesData: {actorID: $userId, filter: {visibilities: [ACTIVE, DEMO]}}) {
+  rolesUser(
+    rolesData: {actorID: $userId, filter: {visibilities: [ACTIVE, DEMO, INACTIVE]}}
+  ) {
     id
     spaces {
       id

--- a/src/core/apollo/generated/apollo-hooks.ts
+++ b/src/core/apollo/generated/apollo-hooks.ts
@@ -13623,7 +13623,7 @@ export function refetchOrganizationAuthorizationQuery(variables: SchemaTypes.Org
 export const RolesOrganizationDocument = gql`
     query rolesOrganization($organizationId: UUID!) {
   rolesOrganization(
-    rolesData: {actorID: $organizationId, filter: {visibilities: [ACTIVE, DEMO, INACTIVE]}}
+    rolesData: {actorID: $organizationId, filter: {visibilities: [ACTIVE, DEMO]}}
   ) {
     id
     spaces {
@@ -14805,7 +14805,7 @@ export function refetchUsersModelFullQuery(variables: SchemaTypes.UsersModelFull
 export const UserContributionsDocument = gql`
     query UserContributions($userId: UUID!) {
   rolesUser(
-    rolesData: {actorID: $userId, filter: {visibilities: [ACTIVE, DEMO, INACTIVE]}}
+    rolesData: {actorID: $userId, filter: {visibilities: [ACTIVE, DEMO]}}
   ) {
     id
     spaces {

--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -12,25 +12,15 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
   Float: { input: number; output: number };
-  /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
   DateTime: { input: Date; output: Date };
-  /** An Emoji. */
   Emoji: { input: string; output: string };
-  /** A representation of a Lifecycle Definition, based on XState. It is serialized JSON. */
   LifecycleDefinition: { input: string; output: string };
-  /** A markdown string. */
   Markdown: { input: string; output: string };
-  /** An identifier that originates from the underlying messaging platform. */
   MessageID: { input: string; output: string };
-  /** A human readable identifier, 3 <= length <= 28. Used for URL paths in clients. Characters allowed: a-z,A-Z,0-9. */
   NameID: { input: string; output: string };
-  /** Cursor used for paginating search results. */
   SearchCursor: { input: string; output: string };
-  /** A uuid identifier. Length 36 characters. */
   UUID: { input: string; output: string };
-  /** The `Upload` scalar type represents a file upload. */
   Upload: { input: File; output: File };
-  /** Content of a Whiteboard, as JSON. */
   WhiteboardContent: { input: string; output: string };
 };
 
@@ -1426,7 +1416,7 @@ export enum CollaboraDocumentType {
 
 export type CollaboraEditorUrlResult = {
   __typename?: 'CollaboraEditorUrlResult';
-  /** The time-to-live of the access token in seconds. */
+  /** When the access token expires, as an absolute Unix timestamp in milliseconds (the WOPI access_token_ttl passed through from the WOPI host); 0 means it does not expire. */
   accessTokenTTL: Scalars['Float']['output'];
   /** The URL to open the document in the Collabora editor. */
   editorUrl: Scalars['String']['output'];
@@ -7073,6 +7063,8 @@ export type Query = {
   aiServer: AiServer;
   /** Retrieves the editor URL for the specified CollaboraDocument. */
   collaboraEditorUrl: CollaboraEditorUrlResult;
+  /** Whether the WOPI save service backing this CollaboraDocument is currently reachable. A side-effect-free health check — unlike collaboraEditorUrl it issues no access token and records no analytics — used to surface a save-path outage in the editor. */
+  collaboraServiceAvailable: Scalars['Boolean']['output'];
   /** Active Spaces only, order by most active in the past X days. */
   exploreSpaces: Array<Space>;
   /** Allow creation of inputs based on existing entities in the domain model */
@@ -7161,6 +7153,10 @@ export type QueryActorsWithCredentialArgs = {
 };
 
 export type QueryCollaboraEditorUrlArgs = {
+  collaboraDocumentID: Scalars['UUID']['input'];
+};
+
+export type QueryCollaboraServiceAvailableArgs = {
   collaboraDocumentID: Scalars['UUID']['input'];
 };
 

--- a/src/domain/community/organization/useOrganization/useOrganizationQueries.graphql
+++ b/src/domain/community/organization/useOrganization/useOrganizationQueries.graphql
@@ -1,5 +1,5 @@
 query rolesOrganization($organizationId: UUID!) {
-  rolesOrganization(rolesData: { actorID: $organizationId, filter: { visibilities: [ACTIVE, DEMO, INACTIVE] } }) {
+  rolesOrganization(rolesData: { actorID: $organizationId, filter: { visibilities: [ACTIVE, DEMO] } }) {
     id
     spaces {
       id

--- a/src/domain/community/user/userContributions/UserContributions.graphql
+++ b/src/domain/community/user/userContributions/UserContributions.graphql
@@ -1,5 +1,5 @@
 query UserContributions($userId: UUID!) {
-  rolesUser(rolesData: { actorID: $userId, filter: { visibilities: [ACTIVE, DEMO] } }) {
+  rolesUser(rolesData: { actorID: $userId, filter: { visibilities: [ACTIVE, DEMO, INACTIVE] } }) {
     id
     spaces {
       id

--- a/src/domain/community/user/userContributions/UserContributions.graphql
+++ b/src/domain/community/user/userContributions/UserContributions.graphql
@@ -1,5 +1,5 @@
 query UserContributions($userId: UUID!) {
-  rolesUser(rolesData: { actorID: $userId, filter: { visibilities: [ACTIVE, DEMO, INACTIVE] } }) {
+  rolesUser(rolesData: { actorID: $userId, filter: { visibilities: [ACTIVE, DEMO] } }) {
     id
     spaces {
       id

--- a/src/main/crdPages/topLevelPages/common/profileMapperHelpers.ts
+++ b/src/main/crdPages/topLevelPages/common/profileMapperHelpers.ts
@@ -8,10 +8,13 @@ import type {
 import type { SpaceGridCardData } from '@/crd/components/user/SpaceGridCard';
 import { pickColorFromId } from '@/crd/lib/pickColorFromId';
 
-// Spaces in these visibilities are hidden from public profiles (issue #1938).
-// Denylist rather than an ACTIVE/DEMO allowlist so a space with an unexpected
-// or absent visibility is still shown rather than silently dropped.
-const HIDDEN_HOSTED_VISIBILITIES: SpaceVisibility[] = [SpaceVisibility.Inactive, SpaceVisibility.Archived];
+// Spaces in these visibilities are never shown on public (user/org) profiles
+// (issue #1938). A denylist — not an ACTIVE/DEMO allowlist — so a space with an
+// unexpected or absent visibility still shows rather than silently disappearing.
+const HIDDEN_PROFILE_VISIBILITIES: SpaceVisibility[] = [SpaceVisibility.Inactive, SpaceVisibility.Archived];
+
+const isSpaceHiddenOnProfile = (visibility: SpaceVisibility | undefined): boolean =>
+  visibility !== undefined && HIDDEN_PROFILE_VISIBILITIES.includes(visibility);
 
 export type RawReference = {
   id: string;
@@ -88,7 +91,7 @@ export const mapAccountHostedResources = (input: AccountResourcesShape, vcType: 
   const hostedSpaces: SpaceGridCardData[] = (input?.spaces ?? []).flatMap(s => {
     const profile = s.about?.profile;
     if (!profile) return [];
-    if (s.visibility && HIDDEN_HOSTED_VISIBILITIES.includes(s.visibility)) return [];
+    if (isSpaceHiddenOnProfile(s.visibility)) return [];
     return [
       {
         id: s.id,

--- a/src/main/crdPages/topLevelPages/common/profileMapperHelpers.ts
+++ b/src/main/crdPages/topLevelPages/common/profileMapperHelpers.ts
@@ -1,3 +1,4 @@
+import { SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
 import type {
   ReferenceLink,
   SimpleResourceCardItem,
@@ -6,6 +7,11 @@ import type {
 } from '@/crd/components/common/profileTypes';
 import type { SpaceGridCardData } from '@/crd/components/user/SpaceGridCard';
 import { pickColorFromId } from '@/crd/lib/pickColorFromId';
+
+// Spaces in these visibilities are hidden from public profiles (issue #1938).
+// Denylist rather than an ACTIVE/DEMO allowlist so a space with an unexpected
+// or absent visibility is still shown rather than silently dropped.
+const HIDDEN_HOSTED_VISIBILITIES: SpaceVisibility[] = [SpaceVisibility.Inactive, SpaceVisibility.Archived];
 
 export type RawReference = {
   id: string;
@@ -41,6 +47,7 @@ export type AccountResourcesShape =
   | {
       spaces?: Array<{
         id: string;
+        visibility?: SpaceVisibility;
         about?: { profile?: AccountResourceProfileLike; isContentPublic?: boolean };
       }>;
       virtualContributors?: Array<{ id: string; profile?: AccountResourceProfileLike }>;
@@ -81,6 +88,7 @@ export const mapAccountHostedResources = (input: AccountResourcesShape, vcType: 
   const hostedSpaces: SpaceGridCardData[] = (input?.spaces ?? []).flatMap(s => {
     const profile = s.about?.profile;
     if (!profile) return [];
+    if (s.visibility && HIDDEN_HOSTED_VISIBILITIES.includes(s.visibility)) return [];
     return [
       {
         id: s.id,

--- a/src/main/crdPages/topLevelPages/common/profileMapperHelpers.ts
+++ b/src/main/crdPages/topLevelPages/common/profileMapperHelpers.ts
@@ -1,4 +1,4 @@
-import { SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
+import type { SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
 import type {
   ReferenceLink,
   SimpleResourceCardItem,
@@ -7,14 +7,6 @@ import type {
 } from '@/crd/components/common/profileTypes';
 import type { SpaceGridCardData } from '@/crd/components/user/SpaceGridCard';
 import { pickColorFromId } from '@/crd/lib/pickColorFromId';
-
-// Spaces in these visibilities are never shown on public (user/org) profiles
-// (issue #1938). A denylist — not an ACTIVE/DEMO allowlist — so a space with an
-// unexpected or absent visibility still shows rather than silently disappearing.
-const HIDDEN_PROFILE_VISIBILITIES: SpaceVisibility[] = [SpaceVisibility.Inactive, SpaceVisibility.Archived];
-
-const isSpaceHiddenOnProfile = (visibility: SpaceVisibility | undefined): boolean =>
-  visibility !== undefined && HIDDEN_PROFILE_VISIBILITIES.includes(visibility);
 
 export type RawReference = {
   id: string;
@@ -91,7 +83,6 @@ export const mapAccountHostedResources = (input: AccountResourcesShape, vcType: 
   const hostedSpaces: SpaceGridCardData[] = (input?.spaces ?? []).flatMap(s => {
     const profile = s.about?.profile;
     if (!profile) return [];
-    if (isSpaceHiddenOnProfile(s.visibility)) return [];
     return [
       {
         id: s.id,

--- a/src/main/crdPages/topLevelPages/organizationPages/publicProfile/__tests__/organizationProfileMapper.test.ts
+++ b/src/main/crdPages/topLevelPages/organizationPages/publicProfile/__tests__/organizationProfileMapper.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
 import {
   type AccountResourcesShape,
   type AssociateInput,
@@ -60,6 +61,31 @@ describe('mapOrgHostedResources', () => {
     const result = mapOrgHostedResources(resources, vcType);
     expect(result.hostedSpaces).toHaveLength(1);
     expect(result.hostedSpaces[0].id).toBe('s-ok');
+  });
+
+  it('hides inactive and archived hosted spaces, keeps active and demo ones', () => {
+    const withVisibility = (id: string, visibility: SpaceVisibility) => ({
+      id,
+      visibility,
+      about: { profile: { displayName: id, url: `/s/${id}` }, isContentPublic: true },
+    });
+    const resources: AccountResourcesShape = {
+      spaces: [
+        withVisibility('active', SpaceVisibility.Active),
+        withVisibility('demo', SpaceVisibility.Demo),
+        withVisibility('inactive', SpaceVisibility.Inactive),
+        withVisibility('archived', SpaceVisibility.Archived),
+      ],
+    };
+    const result = mapOrgHostedResources(resources, vcType);
+    expect(result.hostedSpaces.map(s => s.id)).toEqual(['active', 'demo']);
+  });
+
+  it('keeps hosted spaces whose visibility is absent (defensive)', () => {
+    const resources: AccountResourcesShape = {
+      spaces: [{ id: 's-no-vis', about: { profile: { displayName: 'S', url: '/s' }, isContentPublic: true } }],
+    };
+    expect(mapOrgHostedResources(resources, vcType).hostedSpaces.map(s => s.id)).toEqual(['s-no-vis']);
   });
 
   it('maps a space with banner + tagline to SpaceGridCardData', () => {

--- a/src/main/crdPages/topLevelPages/organizationPages/publicProfile/organizationProfileMapper.ts
+++ b/src/main/crdPages/topLevelPages/organizationPages/publicProfile/organizationProfileMapper.ts
@@ -1,3 +1,4 @@
+import { SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
 import type { AssociateGridItem } from '@/crd/components/organization/OrganizationProfileSidebar';
 import {
   type AccountResourcesShape,
@@ -21,4 +22,20 @@ export const mapAssociates = (associates: AssociateInput[]): AssociateGridItem[]
 
 export type { AccountResourcesShape };
 
-export const mapOrgHostedResources = mapAccountHostedResources;
+// Spaces in these visibilities are hidden from the organization's public
+// profile (issue #1938). Denylist rather than an ACTIVE/DEMO allowlist so a
+// space with an unexpected or absent visibility still shows rather than
+// silently disappearing.
+const HIDDEN_PROFILE_VISIBILITIES: SpaceVisibility[] = [SpaceVisibility.Inactive, SpaceVisibility.Archived];
+
+const isSpaceHiddenOnProfile = (visibility: SpaceVisibility | undefined): boolean =>
+  visibility !== undefined && HIDDEN_PROFILE_VISIBILITIES.includes(visibility);
+
+// Org-specific wrapper over the shared hosted-resources mapper: it drops
+// inactive/archived hosted spaces. The user profile intentionally keeps the
+// shared mapper's default (unfiltered) behaviour.
+export const mapOrgHostedResources = (input: AccountResourcesShape, vcType: string) =>
+  mapAccountHostedResources(
+    input ? { ...input, spaces: input.spaces?.filter(s => !isSpaceHiddenOnProfile(s.visibility)) } : input,
+    vcType
+  );

--- a/src/main/crdPages/topLevelPages/organizationPages/publicProfile/organizationProfileMapper.ts
+++ b/src/main/crdPages/topLevelPages/organizationPages/publicProfile/organizationProfileMapper.ts
@@ -23,9 +23,9 @@ export const mapAssociates = (associates: AssociateInput[]): AssociateGridItem[]
 export type { AccountResourcesShape };
 
 // Spaces in these visibilities are hidden from the organization's public
-// profile (issue #1938). Denylist rather than an ACTIVE/DEMO allowlist so a
-// space with an unexpected or absent visibility still shows rather than
-// silently disappearing.
+// profile. Denylist rather than an ACTIVE/DEMO allowlist so a space with an
+// unexpected or absent visibility still shows rather than silently
+// disappearing.
 const HIDDEN_PROFILE_VISIBILITIES: SpaceVisibility[] = [SpaceVisibility.Inactive, SpaceVisibility.Archived];
 
 const isSpaceHiddenOnProfile = (visibility: SpaceVisibility | undefined): boolean =>

--- a/src/main/crdPages/topLevelPages/userPages/publicProfile/__tests__/publicProfileMapper.test.ts
+++ b/src/main/crdPages/topLevelPages/userPages/publicProfile/__tests__/publicProfileMapper.test.ts
@@ -87,7 +87,7 @@ describe('mapHostedSpacesToCardData', () => {
     expect(result.hostedSpaces[0].id).toBe('s-2');
   });
 
-  it('keeps inactive spaces — visibility filtering is org-profile-only (issue #1938)', () => {
+  it('keeps inactive spaces — visibility filtering is org-profile-only', () => {
     const resources: AccountResourcesShape = {
       spaces: [
         { id: 'active', visibility: SpaceVisibility.Active, about: { profile: { displayName: 'A', url: '/a' } } },

--- a/src/main/crdPages/topLevelPages/userPages/publicProfile/__tests__/publicProfileMapper.test.ts
+++ b/src/main/crdPages/topLevelPages/userPages/publicProfile/__tests__/publicProfileMapper.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { SpaceVisibility } from '@/core/apollo/generated/graphql-schema';
 import { type AccountResourcesShape, buildUserProfileTagsets, mapHostedSpacesToCardData } from '../publicProfileMapper';
 
 const tagsetLabels = { keywords: 'Keywords', skills: 'Skills' };
@@ -84,6 +85,16 @@ describe('mapHostedSpacesToCardData', () => {
     const result = mapHostedSpacesToCardData(resources, vcType);
     expect(result.hostedSpaces).toHaveLength(1);
     expect(result.hostedSpaces[0].id).toBe('s-2');
+  });
+
+  it('keeps inactive spaces — visibility filtering is org-profile-only (issue #1938)', () => {
+    const resources: AccountResourcesShape = {
+      spaces: [
+        { id: 'active', visibility: SpaceVisibility.Active, about: { profile: { displayName: 'A', url: '/a' } } },
+        { id: 'inactive', visibility: SpaceVisibility.Inactive, about: { profile: { displayName: 'I', url: '/i' } } },
+      ],
+    };
+    expect(mapHostedSpacesToCardData(resources, vcType).hostedSpaces.map(s => s.id)).toEqual(['active', 'inactive']);
   });
 
   it('maps a space with a banner — uses real banner over gradient fallback', () => {


### PR DESCRIPTION
## What

Inactive (and archived) spaces were surfacing on the **organization** public profile — under both the **Lead** section and the **Resources-hosted** section. This hides them, matching the issue.

Fixes alkem-io/alkemio#1938.

## Scope

**Organization profile only**, per the issue description and comments. An earlier revision also touched the user profile; that has been reverted — see the note below.

## Why it happened

Two org-profile code paths didn't exclude inactive spaces:

1. **Lead** (`rolesOrganization`) — the query explicitly opted into `visibilities: [ACTIVE, DEMO, INACTIVE]`. The server defaults to `[ACTIVE]`, but the client overrode it. → narrowed to `[ACTIVE, DEMO]`.
2. **Resources-hosted** (`account.spaces`) — the mapper ignored each space's `visibility`. → the org-specific `mapOrgHostedResources` wrapper now drops `INACTIVE`/`ARCHIVED` (denylist, so an absent/unexpected visibility still shows).

`rolesOrganization` has a single consumer (the org profile), so both changes are org-scoped. The hosted-resources mapper is shared with the user profile, so the filter lives in the org wrapper — the shared `mapAccountHostedResources` keeps its default (unfiltered) behaviour.

## Deliberately out of scope — user side

`UserContributions` (`rolesUser`) is left at `[ACTIVE, DEMO, INACTIVE]`. It's shared by the user public profile **and** the Membership settings tab (view/leave your own memberships), so whether/where to hide inactive there is a separate product decision — raised on the issue.

## Testing

- Org mapper unit tests: inactive/archived hidden, active/demo kept, absent-visibility kept.
- Guard test: the shared (user) mapper keeps inactive spaces — filtering is org-only.
- Verified live against a seeded dev stack: `rolesOrganization` with the fixed filter returns ACTIVE + DEMO only; `account.spaces` still returns INACTIVE from the server, confirming the wrapper is what hides it.
- `pnpm lint` clean; full vitest suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Organization public profiles now hide inactive and archived spaces while continuing to show active and demo spaces.
  * Spaces without visibility information remain available where applicable.
  * Organization role listings now include only active and demo roles.
  * User profile hosted spaces continue to display inactive spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->