### PR TITLE
sort the phases in the post index dialog

### DIFF
--- a/src/main/crdPages/subspace/dialogs/CrdSubspaceIndexDialogConnector.tsx
+++ b/src/main/crdPages/subspace/dialogs/CrdSubspaceIndexDialogConnector.tsx
@@ -7,12 +7,15 @@ type CrdSubspaceIndexDialogConnectorProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   calloutsSetId: string | undefined;
+  /** Flow state names in innovation-flow order, so the index groups match the tab strip. */
+  phaseNames: string[];
 };
 
 export function CrdSubspaceIndexDialogConnector({
   open,
   onOpenChange,
   calloutsSetId,
+  phaseNames,
 }: CrdSubspaceIndexDialogConnectorProps) {
   const { t } = useTranslation('crd-subspace');
 
@@ -32,10 +35,18 @@ export function CrdSubspaceIndexDialogConnector({
       arr.push(c);
       map.set(state, arr);
     });
-    return Array.from(map.entries()).map(([state, items]) => ({
-      state,
-      items: [...(items ?? [])].sort((a, b) => a.sortOrder - b.sortOrder),
-    }));
+    // Groups follow the innovation-flow order shown in the tab strip; any state
+    // no longer in the flow (or the "—" bucket) trails behind it.
+    const orderOf = (state: string) => {
+      const index = phaseNames.indexOf(state);
+      return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+    };
+    return Array.from(map.entries())
+      .map(([state, items]) => ({
+        state,
+        items: [...(items ?? [])].sort((a, b) => a.sortOrder - b.sortOrder),
+      }))
+      .sort((a, b) => orderOf(a.state) - orderOf(b.state));
   })();
 
   return (

--- a/src/main/crdPages/subspace/layout/CrdSubspacePageLayout.tsx
+++ b/src/main/crdPages/subspace/layout/CrdSubspacePageLayout.tsx
@@ -354,6 +354,7 @@ export default function CrdSubspacePageLayout() {
         open={activeDialog === 'index'}
         onOpenChange={open => setActiveDialog(open ? 'index' : null)}
         calloutsSetId={data.calloutsSetId}
+        phaseNames={data.phases.map(phase => phase.label)}
       />
 
       <CrdSubspaceSubspacesDialogConnector


### PR DESCRIPTION
Addresses: https://github.com/alkem-io/alkemio/issues/2018
(not tested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Callout groups in the subspace index dialog now appear in the configured innovation-flow phase order.
  - Unrecognized or unassigned states are placed at the end.
  - Callouts within each phase remain sorted consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->