### PR TITLE
fix(footer): prepend the Alkemio logo before the copyright line for platform attribution (#10057)

### DIFF
--- a/src/crd/layouts/Footer.test.tsx
+++ b/src/crd/layouts/Footer.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { Footer } from './Footer';
+
+// Stub i18n so `t(key)` returns the key, letting us assert against the stable
+// `footer.*` keys instead of the resolved copy.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const baseProps = {
+  languages: [
+    { code: 'en', label: 'English' },
+    { code: 'nl', label: 'Nederlands' },
+  ],
+  currentLanguage: 'en',
+  onLanguageChange: vi.fn(),
+  links: {
+    terms: '/terms',
+    privacy: '/privacy',
+    security: '/security',
+    about: '/about',
+  },
+};
+
+describe('Footer (#10057 — platform attribution logo)', () => {
+  test('renders the Alkemio logo immediately before the copyright line', () => {
+    render(<Footer {...baseProps} />);
+
+    const copyright = screen.getByText('footer.copyright');
+    // The logo and the copyright text share the same flex container.
+    const copyrightGroup = copyright.parentElement as HTMLElement;
+    const logo = within(copyrightGroup).getByRole('img', { name: 'Alkemio' });
+
+    // The logo precedes the copyright text in DOM order (GitHub-style prefix),
+    // so it reads as platform attribution.
+    expect(logo.compareDocumentPosition(copyright) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test('the copyright logo is exposed to assistive technology (not aria-hidden)', () => {
+    render(<Footer {...baseProps} />);
+
+    const copyright = screen.getByText('footer.copyright');
+    const copyrightGroup = copyright.parentElement as HTMLElement;
+    const logo = within(copyrightGroup).getByRole('img', { name: 'Alkemio' });
+
+    // The logo announces "Alkemio" right before the copyright — it must NOT be
+    // hidden from screen readers, otherwise the attribution goal is lost.
+    expect(logo.closest('[aria-hidden="true"]')).toBeNull();
+  });
+
+  test('does not regress existing footer links', () => {
+    render(<Footer {...baseProps} />);
+
+    expect(screen.getByRole('link', { name: 'footer.terms' })).toHaveAttribute('href', '/terms');
+    expect(screen.getByRole('link', { name: 'footer.privacy' })).toHaveAttribute('href', '/privacy');
+    expect(screen.getByRole('link', { name: 'footer.security' })).toHaveAttribute('href', '/security');
+    expect(screen.getByRole('link', { name: 'footer.about' })).toHaveAttribute('href', '/about');
+  });
+});

--- a/src/crd/layouts/Footer.tsx
+++ b/src/crd/layouts/Footer.tsx
@@ -36,12 +36,14 @@ export function Footer({
   return (
     <footer className={cn('py-8 px-4 sm:px-6 mt-auto border-t border-border bg-card', className)}>
       <div className="max-w-[1600px] mx-auto flex flex-col md:flex-row items-center gap-4">
-        {/* Copyright */}
+        {/* Copyright — prefixed with the Alkemio logo so the copyright reads as
+            platform attribution, unambiguous even on branded space subdomains. */}
         <div className="md:flex-1 flex items-center gap-2 text-body text-muted-foreground">
+          <AlkemioLogo className="w-5 h-5 shrink-0" />
           <span>{t('footer.copyright')}</span>
         </div>
 
-        {/* Links + centered logo */}
+        {/* Links */}
         <nav
           aria-label="Footer"
           className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 sm:gap-x-6 text-body text-muted-foreground"
@@ -61,8 +63,6 @@ export function Footer({
               {t('footer.security')}
             </a>
           )}
-
-          <AlkemioLogo aria-hidden="true" className="w-5 h-5 opacity-40 hidden sm:block" />
 
           {onSupportClick ? (
             <button


### PR DESCRIPTION
Closes alkem-io/client-web#10057

## Problem / root cause

On space/tenant subdomains (e.g. `vng.alkem.io`) the page is heavily branded for the host organization and the space. The platform footer's `© 2026 Alkemio B.V.` copyright line was rendered as plain text with **no brand mark attached to it**, so it read ambiguously — as if the copyright referred to the host org or the space, not the Alkemio platform.

The existing `AlkemioLogo` *was* already rendered in the footer, but only as a **decorative** mark in the middle of the nav links — `aria-hidden="true"`, `opacity-40`, and `hidden sm:block` (invisible on mobile). It therefore did nothing to attribute the copyright and was invisible to assistive tech.

## Fix

`src/crd/layouts/Footer.tsx` — the single platform-wide CRD footer (`src/crd/layouts/`, `crd-layout` namespace) rendered on every page including space subdomains:

- Moved the existing `AlkemioLogo` to sit **immediately in front of** the `footer.copyright` text (GitHub-style prefix), inside the same flex container (`gap-2`, `items-center`) so it aligns vertically with the copyright line.
- Removed `aria-hidden` on that instance so the logo's built-in `role="img"` + `aria-label="Alkemio"` announces "Alkemio" right before the copyright — this is the accessible label (AC3) and the core disambiguation.
- Dropped the decorative `opacity-40 hidden sm:block`; the logo is now full-opacity and visible on **all** breakpoints. `w-5 h-5` (20px) matches the `text-body` line height; `shrink-0` prevents it squashing on narrow mobile widths so it does not wrap awkwardly (AC2).

### Logo asset reused

No new brand asset. Reuses the app's existing `@/crd/components/common/AlkemioLogo` — the same rectangular tinted brand mark already used in the header top-bar (`src/crd/layouts/Header.tsx`) and the auth card (`src/crd/components/auth/AuthCardHeader.tsx`). Its SVG has a rectangular `#09BCD4` background with `viewBox 0 0 63.7 61.1` and carries `role="img"` / `aria-label="Alkemio"` internally, so no new i18n alt-text key was needed. (The story text says "wordmark"; per the workspace guidance to prefer the existing top-bar/auth logo component, `AlkemioLogo` is that asset — this is not a new-asset design task, so no escalation.)

### Scope

Footer links (`terms`, `privacy`, `security`, `support`, `about`), the language selector, and the overall footer layout are unchanged. No org/space branding touched. No new i18n keys (copyright string is identical across all six languages).

## Regression test

Added `src/crd/layouts/Footer.test.tsx`:
- the logo precedes the copyright text in DOM order (platform-attribution prefix);
- the logo is exposed to assistive tech (not `aria-hidden`) with accessible name "Alkemio";
- existing footer links (`terms`/`privacy`/`security`/`about`) still render with correct `href`s (no regression).

## Verification / gates

- `pnpm vitest run` — 1944 passed / 2 skipped (incl. the 3 new tests).
- `pnpm lint` (typecheck:native + biome ci + eslint) — exit 0.
- `pnpm build` — exit 0 (only the known non-blocking large-chunk warnings).

Visual reasoning: the logo sits in the left-hand copyright group (`md:flex-1`), inline with the text via `flex items-center gap-2`; on mobile the footer stacks (`flex-col`) and the copyright group stays a single horizontal row with `shrink-0` guarding the logo, so no awkward wrap.

## Note for reviewer / merge

This commit is currently **unsigned**: the environment that produced it could not access the repo's SSH commit-signing key (passphrase-protected `id_yubikey_signing`, no agent/touch available headlessly). All local exit gates passed. Please re-sign before merge, e.g. `git commit --amend -S --no-edit` (or `git rebase --exec 'git commit --amend -S --no-edit' develop`) once the signing key is available.

---

Intake: forward flow via `/sdd-story`, classified as an **agentic fix** (bug-sized, single-repo, client-web only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Updated the footer copyright area to show the Alkemio logo alongside the copyright text.
  - Improved accessibility for the logo so it remains available to assistive technologies.
  - Preserved existing footer links (terms, privacy, security, and about) and kept support button and language selector behavior unchanged.
- **Tests**
  - Added/extended a Footer test to verify accessible rendering order and expected link text and URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->