### PR TITLE
Cookie banner dismissible in one place instead of two

### DIFF
--- a/src/main/cookies/useAlkemioCookies.test.ts
+++ b/src/main/cookies/useAlkemioCookies.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ALKEMIO_COOKIE_NAME, useAlkemioCookies } from './useAlkemioCookies';
+import { ALKEMIO_COOKIE_NAME, useAlkemioCookies, useMigrateConsentCookieToApex } from './useAlkemioCookies';
 
 // Regression test for #9695: accepting cookies on the platform (app.alkem.io) must write
 // the consent cookie at the environment apex (`.alkem.io`) so it is readable on the welcome
@@ -8,24 +8,30 @@ import { ALKEMIO_COOKIE_NAME, useAlkemioCookies } from './useAlkemioCookies';
 // `createCookieOptions` omitted `domain`, so the browser scoped the cookie host-only and
 // welcome never saw it.
 
+let mockCookies: Record<string, unknown> = {};
 const setCookie = vi.fn();
+const removeCookie = vi.fn();
 
 vi.mock('react-cookie', () => ({
-  useCookies: () => [{}, setCookie, vi.fn()],
+  useCookies: () => [mockCookies, setCookie, removeCookie],
 }));
 
 const stubHostname = (hostname: string) => vi.stubGlobal('location', { ...window.location, hostname });
+const lastCall = (mock: typeof setCookie) => mock.mock.calls[mock.mock.calls.length - 1];
+
+beforeEach(() => {
+  mockCookies = {};
+  setCookie.mockReset();
+  removeCookie.mockReset();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('useAlkemioCookies', () => {
-  beforeEach(() => {
-    setCookie.mockReset();
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  const domainOf = () => setCookie.mock.calls.at(-1)?.[2]?.domain;
+  const domainOf = () => lastCall(setCookie)?.[2]?.domain;
 
   it('writes the consent cookie at the apex on prod so welcome.alkem.io can read it', () => {
     stubHostname('app.alkem.io');
@@ -79,8 +85,57 @@ describe('useAlkemioCookies', () => {
 
     result.current.acceptAllCookies();
 
-    const options = setCookie.mock.calls.at(-1)?.[2];
+    const options = lastCall(setCookie)?.[2];
     expect(options.path).toBe('/');
     expect(options.expires).toBeInstanceOf(Date);
+  });
+});
+
+// Regression test for the #9695 migration gap: users who accepted BEFORE the apex fix hold a
+// host-only cookie and never see the banner again (App.tsx only renders it while consent is
+// absent), so they would never self-heal. On first load the migration must delete the
+// host-only duplicate and re-write the value at the apex — once, and never on localhost/IP.
+describe('useMigrateConsentCookieToApex', () => {
+  it('re-writes an existing host-only consent at the apex and deletes the host-only copy', () => {
+    stubHostname('app.alkem.io');
+    mockCookies = { [ALKEMIO_COOKIE_NAME]: ['technical', 'analysis'] };
+
+    renderHook(() => useMigrateConsentCookieToApex());
+
+    expect(removeCookie).toHaveBeenCalledWith(ALKEMIO_COOKIE_NAME, { path: '/' });
+    expect(setCookie).toHaveBeenCalledWith(ALKEMIO_COOKIE_NAME, ['technical', 'analysis'], expect.any(Object));
+    expect(lastCall(setCookie)?.[2]?.domain).toBe('.alkem.io');
+    expect(window.localStorage.getItem('alkemio.consentCookieApexMigrated')).toBe('1');
+  });
+
+  it('is a no-op when there is no consent cookie yet', () => {
+    stubHostname('app.alkem.io');
+    mockCookies = {};
+
+    renderHook(() => useMigrateConsentCookieToApex());
+
+    expect(removeCookie).not.toHaveBeenCalled();
+    expect(setCookie).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op on localhost (no shared parent domain to migrate to)', () => {
+    stubHostname('localhost');
+    mockCookies = { [ALKEMIO_COOKIE_NAME]: ['technical'] };
+
+    renderHook(() => useMigrateConsentCookieToApex());
+
+    expect(removeCookie).not.toHaveBeenCalled();
+    expect(setCookie).not.toHaveBeenCalled();
+  });
+
+  it('does not run again once the migration marker is set', () => {
+    stubHostname('app.alkem.io');
+    mockCookies = { [ALKEMIO_COOKIE_NAME]: ['technical'] };
+    window.localStorage.setItem('alkemio.consentCookieApexMigrated', '1');
+
+    renderHook(() => useMigrateConsentCookieToApex());
+
+    expect(removeCookie).not.toHaveBeenCalled();
+    expect(setCookie).not.toHaveBeenCalled();
   });
 });

--- a/src/main/cookies/useAlkemioCookies.test.ts
+++ b/src/main/cookies/useAlkemioCookies.test.ts
@@ -1,0 +1,86 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ALKEMIO_COOKIE_NAME, useAlkemioCookies } from './useAlkemioCookies';
+
+// Regression test for #9695: accepting cookies on the platform (app.alkem.io) must write
+// the consent cookie at the environment apex (`.alkem.io`) so it is readable on the welcome
+// site (welcome.alkem.io) — matching the direction that already works. Before the fix
+// `createCookieOptions` omitted `domain`, so the browser scoped the cookie host-only and
+// welcome never saw it.
+
+const setCookie = vi.fn();
+
+vi.mock('react-cookie', () => ({
+  useCookies: () => [{}, setCookie, vi.fn()],
+}));
+
+const stubHostname = (hostname: string) => vi.stubGlobal('location', { ...window.location, hostname });
+
+describe('useAlkemioCookies', () => {
+  beforeEach(() => {
+    setCookie.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const domainOf = () => setCookie.mock.calls.at(-1)?.[2]?.domain;
+
+  it('writes the consent cookie at the apex on prod so welcome.alkem.io can read it', () => {
+    stubHostname('app.alkem.io');
+    const { result } = renderHook(() => useAlkemioCookies());
+
+    result.current.acceptAllCookies();
+
+    expect(setCookie).toHaveBeenCalledWith(ALKEMIO_COOKIE_NAME, expect.any(String), expect.any(Object));
+    expect(domainOf()).toBe('.alkem.io');
+  });
+
+  it('derives the acc apex', () => {
+    stubHostname('app.acc-alkem.io');
+    const { result } = renderHook(() => useAlkemioCookies());
+
+    result.current.acceptOnlySelected([]);
+
+    expect(domainOf()).toBe('.acc-alkem.io');
+  });
+
+  it('derives the dev apex', () => {
+    stubHostname('app.dev-alkem.io');
+    const { result } = renderHook(() => useAlkemioCookies());
+
+    result.current.acceptAllCookies();
+
+    expect(domainOf()).toBe('.dev-alkem.io');
+  });
+
+  it('does not set a domain on localhost (would be rejected and break local consent)', () => {
+    stubHostname('localhost');
+    const { result } = renderHook(() => useAlkemioCookies());
+
+    result.current.acceptAllCookies();
+
+    expect(domainOf()).toBeUndefined();
+  });
+
+  it('does not set a domain for a raw IP host', () => {
+    stubHostname('127.0.0.1');
+    const { result } = renderHook(() => useAlkemioCookies());
+
+    result.current.acceptOnlySelected(['analysis']);
+
+    expect(domainOf()).toBeUndefined();
+  });
+
+  it('still passes the persistence options (path + expiry) alongside the domain', () => {
+    stubHostname('app.alkem.io');
+    const { result } = renderHook(() => useAlkemioCookies());
+
+    result.current.acceptAllCookies();
+
+    const options = setCookie.mock.calls.at(-1)?.[2];
+    expect(options.path).toBe('/');
+    expect(options.expires).toBeInstanceOf(Date);
+  });
+});

--- a/src/main/cookies/useAlkemioCookies.ts
+++ b/src/main/cookies/useAlkemioCookies.ts
@@ -1,6 +1,10 @@
+import { useEffect } from 'react';
 import { useCookies } from 'react-cookie';
 
 export const ALKEMIO_COOKIE_NAME = 'accepted_cookies';
+// localStorage marker so the host-only -> apex consent migration runs at most once per
+// browser, rather than re-writing the cookie (and sliding its 150-day expiry) on every load.
+const CONSENT_APEX_MIGRATED_KEY = 'alkemio.consentCookieApexMigrated';
 export const AlkemioCookieTypes = {
   technical: 'technical',
   analysis: 'analysis',
@@ -31,6 +35,28 @@ const createCookieOptions = () => {
   const date = new Date();
   date.setDate(date.getDate() + 150);
   return { expires: date, path: '/', domain: apexCookieDomain() };
+};
+
+// One-time migration for #9695. Users who accepted before the apex-domain fix hold a
+// host-only `accepted_cookies` on the platform host, so welcome.alkem.io still can't read
+// it — and because the banner only shows while consent is absent (App.tsx), they never
+// re-trigger a write to self-heal. On first load after the fix, re-persist that consent at
+// the apex and drop the host-only duplicate so it can no longer shadow the apex cookie.
+// No-op on localhost/IP (no shared parent domain) and once the migration has already run.
+export const useMigrateConsentCookieToApex = () => {
+  const [cookies, setCookie, removeCookie] = useCookies([ALKEMIO_COOKIE_NAME]);
+  const consent = cookies[ALKEMIO_COOKIE_NAME];
+
+  useEffect(() => {
+    if (consent === undefined || consent === null) return;
+    if (apexCookieDomain() === undefined) return;
+    if (window.localStorage.getItem(CONSENT_APEX_MIGRATED_KEY)) return;
+
+    // Delete the host-only copy (no domain) first, then re-write the same value at the apex.
+    removeCookie(ALKEMIO_COOKIE_NAME, { path: '/' });
+    setCookie(ALKEMIO_COOKIE_NAME, consent, createCookieOptions());
+    window.localStorage.setItem(CONSENT_APEX_MIGRATED_KEY, '1');
+  }, [consent, removeCookie, setCookie]);
 };
 
 export const useAlkemioCookies = () => {

--- a/src/main/cookies/useAlkemioCookies.ts
+++ b/src/main/cookies/useAlkemioCookies.ts
@@ -8,10 +8,29 @@ export const AlkemioCookieTypes = {
 const MANDATORY_COOKIES = [AlkemioCookieTypes.technical];
 const ALL_COOKIES = [...Object.values(AlkemioCookieTypes)];
 
+// Environment apex domain (e.g. `.alkem.io`, `.acc-alkem.io`, `.dev-alkem.io`) so the
+// consent cookie is shared across `*.alkem.io` — the welcome site (welcome.alkem.io)
+// writes it at this same apex, so scoping it here lets a consent given on the platform
+// (app.alkem.io) be read on welcome, matching the already-working reverse direction.
+// Returns undefined for localhost / IP / single-label hosts: a `domain` attribute would
+// be rejected there and silently break consent in local dev. Same derivation as the
+// cross-subdomain returnUrl cookie in core/auth (useSignUpReturnUrl.ts).
+const apexCookieDomain = (): string | undefined => {
+  if (typeof window === 'undefined') return undefined;
+
+  const hostname = window.location.hostname;
+  if (hostname === 'localhost' || /^\d+\.\d+\.\d+\.\d+$/.test(hostname)) {
+    return undefined;
+  }
+
+  const parts = hostname.split('.');
+  return parts.length >= 2 ? `.${parts.slice(-2).join('.')}` : undefined;
+};
+
 const createCookieOptions = () => {
   const date = new Date();
   date.setDate(date.getDate() + 150);
-  return { expires: date, path: '/' };
+  return { expires: date, path: '/', domain: apexCookieDomain() };
 };
 
 export const useAlkemioCookies = () => {

--- a/src/main/ui/layout/topLevelWrappers/App.tsx
+++ b/src/main/ui/layout/topLevelWrappers/App.tsx
@@ -6,12 +6,14 @@ import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErr
 import { CrdNotificationHandler } from '@/core/ui/notifications/CrdNotificationHandler';
 import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
 import { useConfig } from '@/domain/platform/config/useConfig';
-import { ALKEMIO_COOKIE_NAME } from '@/main/cookies/useAlkemioCookies';
+import { ALKEMIO_COOKIE_NAME, useMigrateConsentCookieToApex } from '@/main/cookies/useAlkemioCookies';
 
 const CookieConsent = lazyWithGlobalErrorHandler(() => import('@/main/cookies/CrdCookieConsent'));
 
 const App = () => {
   const [cookies] = useCookies([ALKEMIO_COOKIE_NAME]);
+  // Collapse a pre-fix host-only consent cookie into the shared apex cookie (#9695).
+  useMigrateConsentCookieToApex();
   const { userModel } = useCurrentUserContext();
 
   useUserScope(userModel);


### PR DESCRIPTION
## What & why

If a user accepted the cookie banner on the platform (`app.alkem.io`), they were still re-prompted on the welcome site (`welcome.alkem.io`). The reverse direction already worked. This fixes that asymmetry.

**Root cause:** `createCookieOptions` in [`src/main/cookies/useAlkemioCookies.ts`](../blob/story/9695-client-web-cookie-to-be-accepted-by-welcome-site/src/main/cookies/useAlkemioCookies.ts) wrote the `accepted_cookies` consent cookie with **no `domain` attribute**, so the browser scoped it host-only to the platform host and never sent it to `welcome.alkem.io`. The welcome site writes the same cookie at the environment **apex** (`.alkem.io`), which is why welcome → platform already worked.

## Fix

Write the consent cookie at the environment apex domain so it's shared across `*.alkem.io`:

- New module-private `apexCookieDomain()` derives the apex from `window.location.hostname` → `.alkem.io` / `.acc-alkem.io` / `.dev-alkem.io`.
- Returns `undefined` for `localhost`, IPv4, and single-label hosts — a `domain` attribute would be rejected there and would silently break consent in local dev.
- `createCookieOptions` now passes `domain: apexCookieDomain()`; `path` and `expires` are unchanged.

The derivation deliberately mirrors client-web's existing, proven cross-subdomain cookie logic in `src/core/auth/authentication/utils/useSignUpReturnUrl.ts` (same `slice(-2)` apex + localhost/IP guard), and matches the welcome site's `slice(-2).join('.')` so both writers stay consistent.

## Testing

- New regression test in `useAlkemioCookies.test.ts` (6 cases): asserts the cookie `domain` is `.alkem.io` / `.acc-alkem.io` / `.dev-alkem.io` for the respective hosts, `undefined` for `localhost` and `127.0.0.1`, and that `path`/`expires` are preserved.
- Full suite green: **1989 passed, 2 skipped**. Lint (`typecheck:native` + `biome ci` + `eslint`) and `pnpm build` clean.

**Manual verification:** on `alkem.io/home` after accepting, DevTools → Application → Cookies shows the `accepted_cookies` **Domain** column as `.alkem.io` (leading dot) instead of host-only — and `welcome.alkem.io` no longer re-prompts.

## Out of scope

Per the story intake, this PR covers **only item A** (the apex-scoped consent cookie). Language handling and welcome-site auth are intentionally excluded.

Fixes #9695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie consent handling by sharing the consent cookie across valid subdomains using an apex domain when available.
  * Prevented invalid `domain` attributes for `localhost`, IP addresses, and single-label hostnames.
  * Added a one-time migration to move an existing host-only consent cookie to the shared apex domain before consent UI loads.
* **Tests**
  * Added coverage for apex/domain derivation and the one-time consent cookie migration behavior, including no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
