### PR TITLE
ci(027): route push CI to hardened ARC lane, PRs to hosted (workspace#027-arc-v3-runner-migration)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: [develop, main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
-    runs-on: [self-hosted, macOS, ARM64, apple-silicon, m4]
+    runs-on: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')) && 'arc-trusted-linux-x64' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -9,9 +9,12 @@ on:
 env:
   NODE_VERSION: '24.14.0'
 
+permissions:
+  contents: read
+
 jobs:
   setup:
-    runs-on: [self-hosted, macOS, ARM64, apple-silicon, m4]
+    runs-on: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')) && 'arc-trusted-linux-x64' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -47,7 +50,7 @@ jobs:
 
   typecheck:
     needs: setup
-    runs-on: [self-hosted, macOS, ARM64, apple-silicon, m4]
+    runs-on: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')) && 'arc-trusted-linux-x64' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -86,7 +89,7 @@ jobs:
 
   lint:
     needs: setup
-    runs-on: [self-hosted, macOS, ARM64, apple-silicon, m4]
+    runs-on: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')) && 'arc-trusted-linux-x64' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -125,7 +128,7 @@ jobs:
 
   eslint-compiler:
     needs: setup
-    runs-on: [self-hosted, macOS, ARM64, apple-silicon, m4]
+    runs-on: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')) && 'arc-trusted-linux-x64' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: [develop, main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    runs-on: [self-hosted, macOS, ARM64, apple-silicon, m4]
+    runs-on: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')) && 'arc-trusted-linux-x64' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## workspace#027-arc-v3-runner-migration — client-web (wave 2)

Routes the 6 ARC-eligible jobs (`ci-test.test`, `ci-build.build`, `ci-lint.{setup,typecheck,lint,eslint-compiler}`) to `arc-trusted-linux-x64` on trusted triggers; every `pull_request` job → `ubuntu-latest`. Adds `permissions: contents: read`.

**Verified:** routing checker PASS; pre-commit suite green (1993 tests). Review clean.

⛔ **Merge-blocked until W1v + H3** (runbook.md): this PR introduces an \`arc-trusted-linux-x64\` selector; unmatched selectors queue forever with no fallback. Do not merge before the platform lane is live-verified (W1v) and the runner group is locked down (H3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)