### PR TITLE
fix(auth): terms checkbox un-ticks itself on the sign-up password step

### DIFF
--- a/src/main/crdPages/auth/SignUpCrdRoute.test.tsx
+++ b/src/main/crdPages/auth/SignUpCrdRoute.test.tsx
@@ -1,12 +1,12 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { SignUpCrdRoute } from './SignUpCrdRoute';
+import { RegistrationCrdRoute, SignUpCrdRoute } from './SignUpCrdRoute';
 
 // Shared, hoisted holder so the (hoisted) vi.mock factories can expose state we
-// control per-test: the guest-session hook return and the props the page passes
-// to GuestReturnNotice.
+// control per-test: the guest-session hook return, the props the page passes
+// to GuestReturnNotice, the mocked Kratos flow, and the props passed to SignUpCard.
 const h = vi.hoisted(() => ({
   guest: {
     shouldShowNotification: false,
@@ -16,6 +16,8 @@ const h = vi.hoisted(() => ({
     clearSession: vi.fn(),
   },
   noticeProps: undefined as undefined | { onBackToWhiteboard: () => void; onGoToWebsite: () => void },
+  flow: undefined as undefined | { id: string; ui: { nodes: unknown[]; messages: unknown[] } },
+  signUpCardProps: undefined as undefined | { hasAcceptedTerms: boolean; onAcceptedTermsChange: (v: boolean) => void },
 }));
 
 // The unit under test is the conditional wiring — stub the heavy children with
@@ -30,7 +32,19 @@ vi.mock('@/crd/components/auth/GuestReturnNotice', () => ({
   },
 }));
 vi.mock('@/crd/components/auth/SignUpCard', () => ({
-  SignUpCard: () => <div data-testid="crd-signup-card" />,
+  SignUpCard: (props: { hasAcceptedTerms: boolean; onAcceptedTermsChange: (v: boolean) => void }) => {
+    h.signUpCardProps = props;
+    return (
+      <div data-testid="crd-signup-card">
+        <input
+          type="checkbox"
+          aria-label="accept-terms"
+          checked={props.hasAcceptedTerms}
+          onChange={event => props.onAcceptedTermsChange(event.target.checked)}
+        />
+      </div>
+    );
+  },
 }));
 vi.mock('./AuthShellWrapper', () => ({
   AuthShellWrapper: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -40,10 +54,13 @@ vi.mock('@/domain/platform/config/useConfig', () => ({
   useConfig: () => ({ locations: { terms: '#', privacy: '#' } }),
 }));
 vi.mock('@/core/auth/authentication/hooks/useKratosFlow', () => ({
-  default: () => ({ flow: undefined, loading: false }),
+  default: () => ({ flow: h.flow, loading: false }),
   FlowTypeName: { Registration: 'Registration' },
 }));
 vi.mock('@/core/auth/authentication/hooks/usePasskeyScript', () => ({ default: () => ({}) }));
+vi.mock('@/core/auth/authentication/hooks/useAuthenticationContext', () => ({
+  useAuthenticationContext: () => ({ isAuthenticated: false }),
+}));
 vi.mock('@/core/auth/authentication/utils/useSignUpReturnUrl', () => ({
   useReturnUrl: () => ({ setReturnUrl: vi.fn() }),
   useSignUpRoundTrip: () => ({ armed: false, arm: vi.fn(), clearArmed: vi.fn() }),
@@ -71,6 +88,9 @@ describe('SignUpCrdRoute — guest return notice wiring', () => {
     h.guest.handleGoToWebsite.mockReset();
     h.guest.clearSession.mockReset();
     h.noticeProps = undefined;
+    h.flow = undefined;
+    h.signUpCardProps = undefined;
+    sessionStorage.clear();
   });
 
   it('[US1] renders the notice above the sign-up form when a guest session is active (FR-001)', () => {
@@ -120,5 +140,87 @@ describe('SignUpCrdRoute — guest return notice wiring', () => {
     // Neither rendering nor acting on the notice may end the session — only
     // successful auth (existing clearAllGuestSessionData) does.
     expect(h.guest.clearSession).not.toHaveBeenCalled();
+  });
+});
+
+// Regression: incidental-defect-signup-terms-checkbox — `/sign_up` and
+// `/registration` can resolve to the same Kratos flow id, so the second step
+// re-hydrates `accepted` as `true` from the shared sessionStorage key. Before
+// the fix, a stray click on the already-checked box on `/registration` simply
+// toggled it back to `false` (plain checkbox semantics), silently disabling
+// submit. These specs prove that once a mount hydrates as already-accepted,
+// further toggling is a no-op, while a fresh/unaccepted mount stays a fully
+// interactive checkbox.
+describe('SignUpCrdRoute / RegistrationCrdRoute — accept-terms persistence across the shared flow id', () => {
+  const storageKeyFor = (flowId: string) => `crd-auth-accepted-terms-${flowId}`;
+
+  beforeEach(() => {
+    h.guest.shouldShowNotification = false;
+    h.guest.whiteboardUrl = null;
+    h.noticeProps = undefined;
+    h.signUpCardProps = undefined;
+    sessionStorage.clear();
+  });
+
+  const renderSignUp = () =>
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <SignUpCrdRoute />
+      </MemoryRouter>
+    );
+
+  const renderRegistration = () =>
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <RegistrationCrdRoute />
+      </MemoryRouter>
+    );
+
+  it('[/sign_up] a fresh checkbox is fully interactive: ticking then re-ticking toggles normally', () => {
+    h.flow = { id: 'flow-1', ui: { nodes: [], messages: [] } };
+
+    renderSignUp();
+    const checkbox = screen.getByLabelText('accept-terms');
+
+    fireEvent.click(checkbox); // check
+    expect(h.signUpCardProps?.hasAcceptedTerms).toBe(true);
+    expect(sessionStorage.getItem(storageKeyFor('flow-1'))).toBe('true');
+
+    fireEvent.click(checkbox); // un-check — a real, first-time toggle is never locked
+    expect(h.signUpCardProps?.hasAcceptedTerms).toBe(false);
+    expect(sessionStorage.getItem(storageKeyFor('flow-1'))).toBe('false');
+  });
+
+  it('[/registration, already accepted] re-ticking the pre-checked box is a no-op, not an uncheck', () => {
+    // Simulate the carry-over from `/sign_up`: same flow id, already accepted.
+    sessionStorage.setItem(storageKeyFor('flow-1'), 'true');
+    h.flow = { id: 'flow-1', ui: { nodes: [], messages: [] } };
+
+    renderRegistration();
+    const checkbox = screen.getByLabelText('accept-terms') as HTMLInputElement;
+
+    expect(checkbox.checked).toBe(true);
+    expect(h.signUpCardProps?.hasAcceptedTerms).toBe(true);
+
+    fireEvent.click(checkbox); // the reported "re-tick" — must be a no-op
+
+    expect(h.signUpCardProps?.hasAcceptedTerms).toBe(true);
+    expect(sessionStorage.getItem(storageKeyFor('flow-1'))).toBe('true');
+  });
+
+  it('[/registration, not yet accepted] reached directly (no prior acceptance) stays fully interactive', () => {
+    h.flow = { id: 'flow-2', ui: { nodes: [], messages: [] } };
+
+    renderRegistration();
+    const checkbox = screen.getByLabelText('accept-terms') as HTMLInputElement;
+
+    expect(checkbox.checked).toBe(false);
+
+    fireEvent.click(checkbox); // first-time acceptance on this very step must work
+    expect(h.signUpCardProps?.hasAcceptedTerms).toBe(true);
+    expect(sessionStorage.getItem(storageKeyFor('flow-2'))).toBe('true');
+
+    fireEvent.click(checkbox); // and can still be un-checked before it was ever hydrated as true
+    expect(h.signUpCardProps?.hasAcceptedTerms).toBe(false);
   });
 });

--- a/src/main/crdPages/auth/SignUpCrdRoute.tsx
+++ b/src/main/crdPages/auth/SignUpCrdRoute.tsx
@@ -30,12 +30,31 @@ import { useTranslateDescriptor } from './useKratosMessageCopy';
 // them on a registration form they can never complete.
 const MESSAGE_CODE_ACCOUNT_EXIST_FOR_ID = 4000007;
 
+type CrdSignUpPageProps = {
+  /**
+   * `/sign_up` and `/registration` can resolve to the very same Kratos flow
+   * id (Kratos bounces a validation error on a later field back to
+   * `/registration?flow=<id>`). When that happens, this step's mount
+   * re-hydrates `accepted` as `true` from sessionStorage — which is exactly
+   * the point of persisting it across the re-render — but the checkbox
+   * itself is still a plain toggle, so a stray second click on what is
+   * already checked just unchecks it (ordinary checkbox semantics), silently
+   * disabling submit with no visible error. Passing `true` here makes
+   * further toggling a no-op once the *initial* hydration for this mount
+   * found terms already accepted — it never locks a value the user sets
+   * during the current mount, only one carried over from a prior step. The
+   * checkbox stays a normal, non-`disabled` form field throughout (so its
+   * `checked` value keeps posting to Kratos with the rest of the form).
+   */
+  lockAcceptedTerms?: boolean;
+};
+
 /**
  * Shared sign-up page logic. Drives the Kratos registration flow and persists
  * the accept-terms checkbox per flow id, because Kratos resets that trait on a
  * validation-error re-render (mirrors the MUI `RegistrationPage` workaround).
  */
-function CrdSignUpPage() {
+function CrdSignUpPage({ lockAcceptedTerms }: CrdSignUpPageProps) {
   useTransactionScope({ type: 'authentication' });
   const { t } = useTranslation();
   usePageTitle(t('pages.titles.signUp'));
@@ -69,15 +88,29 @@ function CrdSignUpPage() {
   usePasskeyScript(registrationFlow?.ui?.nodes);
 
   const [accepted, setAccepted] = useState(false);
+  // Set once, from this mount's initial sessionStorage hydration only — never
+  // touched by `handleAcceptedChange` — so it captures "was already accepted
+  // before this step loaded" as distinct from "the user just ticked it here".
+  const [wasPreAccepted, setWasPreAccepted] = useState(false);
   const storageKey = registrationFlow ? `crd-auth-accepted-terms-${registrationFlow.id}` : undefined;
 
   useEffect(() => {
     if (storageKey) {
-      setAccepted(sessionStorage.getItem(storageKey) === 'true');
+      const stored = sessionStorage.getItem(storageKey) === 'true';
+      setAccepted(stored);
+      setWasPreAccepted(stored);
     }
   }, [storageKey]);
 
+  // Once this step's own mount found terms already accepted (carried over
+  // from an earlier step of the same Kratos flow), further checkbox
+  // interaction is a no-op — see `lockAcceptedTerms` above.
+  const acceptedTermsLocked = Boolean(lockAcceptedTerms && wasPreAccepted);
+
   const handleAcceptedChange = (value: boolean) => {
+    if (acceptedTermsLocked) {
+      return;
+    }
     setAccepted(value);
     if (storageKey) {
       sessionStorage.setItem(storageKey, String(value));
@@ -152,7 +185,11 @@ export function RegistrationCrdRoute() {
         path="/"
         element={
           <NotAuthenticatedRoute>
-            <CrdSignUpPage />
+            {/* Reached from `/sign_up` on the same Kratos flow id (e.g. after a
+                validation error on a later field) — lock the checkbox once it
+                re-hydrates as already accepted, instead of leaving it a live
+                toggle a stray click can silently uncheck (see `lockAcceptedTerms`). */}
+            <CrdSignUpPage lockAcceptedTerms={true} />
           </NotAuthenticatedRoute>
         }
       />


### PR DESCRIPTION
## What & why

Fixes a pre-existing sign-up bug: on `/sign_up`, ticking **"I accept the Terms…"**, continuing to `/registration` (password step), and ticking the **same** checkbox again silently toggles accept-terms back to `false`. Because both steps now share one Kratos flow id, the `crd-auth-accepted-terms-<flowId>` sessionStorage value survives the navigation, so the second click un-checks it — permanently disabling the password step's **Next** button with no visible error.

`SignUpCrdRoute.tsx`'s existing comment ("Kratos resets that trait on a validation-error re-render") assumed the two steps get independent flow ids, which no longer holds.

## How

Guard the accepted-terms persistence so a re-tick on the shared flow can't drive it back to unchecked (see diff). Adds coverage in `SignUpCrdRoute.test.tsx`.

## Provenance

Discovered by the `033-chat-avatars` forge verification run while building the real sign-up fixture (the "register 2 users via sign-up" recipe hit this dead-end). It is **unrelated to the avatars feature**, so it's carried on its own branch/PR rather than in [client-web#10086](https://github.com/alkem-io/client-web/pull/10086). Ships with its own unit test (green during the forge run); CI validates on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved accepted terms across sign-up and registration validation flows.
  * Prevented the terms checkbox from being accidentally unchecked when acceptance was restored.
  * Ensured the checkbox remains interactive when no prior acceptance exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->