### PR TITLE
fix(chat): make conversation avatars decorative for AT + dedupe avatar helpers

### DIFF
--- a/src/crd/components/chat/ChatMessageBubble.test.tsx
+++ b/src/crd/components/chat/ChatMessageBubble.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import type { ReactNode } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import type { ChatMessage } from './types';
 
@@ -7,19 +6,8 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-// Radix only mounts AvatarPrimitive.Image once the browser reports the image as
-// loaded, which never happens in jsdom (same approach as ApplicationsBlock.test.tsx).
-vi.mock('@/crd/primitives/avatar', () => ({
-  Avatar: ({ children, className, ...rest }: { children: ReactNode; className?: string }) => (
-    <div className={className} {...rest}>
-      {children}
-    </div>
-  ),
-  AvatarImage: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
-  AvatarFallback: ({ children, className }: { children: ReactNode; className?: string }) => (
-    <span className={className}>{children}</span>
-  ),
-}));
+// Shared jsdom-safe avatar double from src/crd/primitives/__mocks__/avatar.tsx.
+vi.mock('@/crd/primitives/avatar');
 
 const { ChatMessageBubble } = await import('./ChatMessageBubble');
 

--- a/src/crd/components/chat/ChatPanel.tsx
+++ b/src/crd/components/chat/ChatPanel.tsx
@@ -70,7 +70,11 @@ export function ChatPanel({
             <ChevronLeft aria-hidden="true" className="size-5" />
           </button>
         )}
-        {titleAvatar && <span className="shrink-0">{titleAvatar}</span>}
+        {titleAvatar && (
+          <span aria-hidden="true" className="shrink-0">
+            {titleAvatar}
+          </span>
+        )}
         <span className="text-subsection-title min-w-0 flex-1 truncate px-1">{title}</span>
         {headerActions}
         {onGoToSettings && (

--- a/src/crd/components/chat/ConversationAvatar.test.tsx
+++ b/src/crd/components/chat/ConversationAvatar.test.tsx
@@ -1,21 +1,9 @@
 import { render } from '@testing-library/react';
-import type { ReactNode } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { ConversationAvatar } from './ConversationAvatar';
 
-// Radix only mounts AvatarPrimitive.Image once the browser reports the image as
-// loaded, which never happens in jsdom. Swap it for a plain <img> so the props
-// this component (and the GroupAvatar it composes) pass down are observable
-// (same approach as ApplicationsBlock.test.tsx).
-vi.mock('@/crd/primitives/avatar', () => ({
-  Avatar: ({ children, className }: { children: ReactNode; className?: string }) => (
-    <div className={className}>{children}</div>
-  ),
-  AvatarImage: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
-  AvatarFallback: ({ children, className }: { children: ReactNode; className?: string }) => (
-    <span className={className}>{children}</span>
-  ),
-}));
+// Shared jsdom-safe avatar double from src/crd/primitives/__mocks__/avatar.tsx.
+vi.mock('@/crd/primitives/avatar');
 
 describe('ConversationAvatar', () => {
   test('guidance branch renders the bot circle, no image', () => {
@@ -39,8 +27,8 @@ describe('ConversationAvatar', () => {
     );
     const img = container.querySelector('img');
     expect(img).toHaveAttribute('src', 'https://example.com/group.png');
-    // Composite grid root carries aria-hidden — absent when the single-photo branch is used.
-    expect(container.querySelector('[aria-hidden="true"]')).not.toBeInTheDocument();
+    // Single photo avatar — the composite would render one avatar per member.
+    expect(container.querySelectorAll('[data-testid="avatar"]')).toHaveLength(1);
   });
 
   test('group without avatarUrl renders the composite for 2-4 members, initials for those without a photo', () => {
@@ -55,8 +43,7 @@ describe('ConversationAvatar', () => {
         ]}
       />
     );
-    const composite = container.querySelector('[aria-hidden="true"]');
-    expect(composite).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-testid="avatar"]')).toHaveLength(2);
     expect(container.querySelectorAll('img')).toHaveLength(1);
     expect(getByText('BJ')).toBeInTheDocument();
   });
@@ -69,9 +56,25 @@ describe('ConversationAvatar', () => {
     expect(getByText('JD')).toBeInTheDocument();
   });
 
-  test('a11y: composite root is aria-hidden, avatar images have empty alt, no interactive elements', () => {
-    const { container } = render(
+  test('a11y: every branch is decorative (aria-hidden root), avatar images have empty alt, no interactive elements', () => {
+    const branches = [
+      <ConversationAvatar key="guidance" displayName="Guidance" isGroup={false} isGuidance={true} />,
       <ConversationAvatar
+        key="single"
+        displayName="Jane Doe"
+        isGroup={false}
+        isGuidance={false}
+        avatarUrl="https://example.com/jane.png"
+      />,
+      <ConversationAvatar
+        key="group-photo"
+        displayName="Team"
+        isGroup={true}
+        isGuidance={false}
+        avatarUrl="https://example.com/group.png"
+      />,
+      <ConversationAvatar
+        key="composite"
         displayName="Team"
         isGroup={true}
         isGuidance={false}
@@ -79,12 +82,16 @@ describe('ConversationAvatar', () => {
           { id: '1', name: 'Alice', avatarUrl: 'https://example.com/alice.png' },
           { id: '2', name: 'Bob', avatarUrl: 'https://example.com/bob.png' },
         ]}
-      />
-    );
-    expect(container.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
-    container.querySelectorAll('img').forEach(img => {
-      expect(img).toHaveAttribute('alt', '');
-    });
-    expect(container.querySelectorAll('button, a')).toHaveLength(0);
+      />,
+    ];
+
+    for (const branch of branches) {
+      const { container } = render(branch);
+      expect(container.firstElementChild).toHaveAttribute('aria-hidden', 'true');
+      container.querySelectorAll('img').forEach(img => {
+        expect(img).toHaveAttribute('alt', '');
+      });
+      expect(container.querySelectorAll('button, a')).toHaveLength(0);
+    }
   });
 });

--- a/src/crd/components/chat/ConversationAvatar.tsx
+++ b/src/crd/components/chat/ConversationAvatar.tsx
@@ -1,15 +1,10 @@
 import { Bot } from 'lucide-react';
 import { cn } from '@/crd/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '@/crd/primitives/avatar';
+import { AVATAR_SIZE_CLASS, type AvatarSize } from './avatarSizes';
 import { GroupAvatar } from './GroupAvatar';
 import { initials } from './initials';
 import type { ChatMemberAvatar } from './types';
-
-const SIZE_CLASS = {
-  sm: 'size-8',
-  md: 'size-10',
-  lg: 'size-12',
-} as const;
 
 const ICON_SIZE_CLASS = {
   sm: 'size-4',
@@ -23,7 +18,7 @@ export type ConversationAvatarProps = {
   isGroup: boolean;
   isGuidance: boolean;
   memberAvatars?: ChatMemberAvatar[];
-  size?: keyof typeof SIZE_CLASS;
+  size?: AvatarSize;
   className?: string;
 };
 
@@ -32,6 +27,10 @@ export type ConversationAvatarProps = {
  * custom photo or 4-avatar composite, or a single 1:1 avatar. Used by both
  * the conversation list rows and the thread header, so the two surfaces can
  * never disagree (research D2/D4).
+ *
+ * Always decorative (`aria-hidden`): the conversation title/display name is the
+ * adjacent accessible text on every surface, so exposing the avatar (notably the
+ * initials fallback) would only duplicate it for assistive technology.
  */
 export function ConversationAvatar({
   displayName,
@@ -45,13 +44,14 @@ export function ConversationAvatar({
   if (isGuidance) {
     return (
       <span
+        aria-hidden="true"
         className={cn(
           'flex shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary',
-          SIZE_CLASS[size],
+          AVATAR_SIZE_CLASS[size],
           className
         )}
       >
-        <Bot aria-hidden="true" className={ICON_SIZE_CLASS[size]} />
+        <Bot className={ICON_SIZE_CLASS[size]} />
       </span>
     );
   }
@@ -61,7 +61,7 @@ export function ConversationAvatar({
   }
 
   return (
-    <Avatar className={cn(SIZE_CLASS[size], 'shrink-0', className)}>
+    <Avatar aria-hidden="true" className={cn(AVATAR_SIZE_CLASS[size], 'shrink-0', className)}>
       {avatarUrl && <AvatarImage src={avatarUrl} alt="" />}
       <AvatarFallback className="text-caption">{initials(displayName)}</AvatarFallback>
     </Avatar>

--- a/src/crd/components/chat/GroupAvatar.tsx
+++ b/src/crd/components/chat/GroupAvatar.tsx
@@ -1,23 +1,19 @@
 import { cn } from '@/crd/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '@/crd/primitives/avatar';
+import { AVATAR_SIZE_CLASS, type AvatarSize } from './avatarSizes';
 import { initials } from './initials';
 import type { ChatMemberAvatar } from './types';
 
-const SIZE_CLASS = {
-  sm: 'size-8',
-  md: 'size-10',
-  lg: 'size-12',
-} as const;
-
 type GroupAvatarProps = {
   members: ChatMemberAvatar[];
-  size?: keyof typeof SIZE_CLASS;
+  size?: AvatarSize;
   className?: string;
 };
 
 /**
  * Composite avatar for a conversation: a single avatar for 1 member, or a 2×2
- * grid of up to 4 member avatars for a group.
+ * grid of up to 4 member avatars for a group. Always decorative (`aria-hidden`) —
+ * the group name is the adjacent accessible text wherever it renders.
  */
 export function GroupAvatar({ members, size = 'md', className }: GroupAvatarProps) {
   const shown = members.slice(0, 4);
@@ -25,7 +21,7 @@ export function GroupAvatar({ members, size = 'md', className }: GroupAvatarProp
   if (shown.length <= 1) {
     const member = shown[0];
     return (
-      <Avatar className={cn(SIZE_CLASS[size], className)}>
+      <Avatar aria-hidden="true" className={cn(AVATAR_SIZE_CLASS[size], className)}>
         {member?.avatarUrl && <AvatarImage src={member.avatarUrl} alt="" />}
         <AvatarFallback className="text-caption">{member ? initials(member.name) : '?'}</AvatarFallback>
       </Avatar>
@@ -34,7 +30,11 @@ export function GroupAvatar({ members, size = 'md', className }: GroupAvatarProp
 
   return (
     <div
-      className={cn('grid shrink-0 grid-cols-2 grid-rows-2 overflow-hidden rounded-full', SIZE_CLASS[size], className)}
+      className={cn(
+        'grid shrink-0 grid-cols-2 grid-rows-2 overflow-hidden rounded-full',
+        AVATAR_SIZE_CLASS[size],
+        className
+      )}
       aria-hidden="true"
     >
       {shown.map(member => (

--- a/src/crd/components/chat/avatarSizes.ts
+++ b/src/crd/components/chat/avatarSizes.ts
@@ -1,0 +1,8 @@
+/** Shared chat avatar size scale (outer circle) — single source for every chat avatar surface. */
+export const AVATAR_SIZE_CLASS = {
+  sm: 'size-8',
+  md: 'size-10',
+  lg: 'size-12',
+} as const;
+
+export type AvatarSize = keyof typeof AVATAR_SIZE_CLASS;

--- a/src/crd/components/chat/initials.test.ts
+++ b/src/crd/components/chat/initials.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import { initials } from './initials';
+
+describe('initials', () => {
+  test('first letter of the first two words, uppercased', () => {
+    expect(initials('Jane Doe')).toBe('JD');
+    expect(initials('jane')).toBe('J');
+    expect(initials('Anna Maria van der Berg')).toBe('AM');
+  });
+
+  test('trims and collapses whitespace', () => {
+    expect(initials('  Jane   Doe  ')).toBe('JD');
+  });
+
+  test('empty or blank input falls back to ?', () => {
+    expect(initials('')).toBe('?');
+    expect(initials('   ')).toBe('?');
+  });
+
+  test('astral-plane first characters stay whole code points, not half-surrogates', () => {
+    expect(initials('𝕏 Corp')).toBe('𝕏C');
+    expect(initials('😀 Team')).toBe('😀T');
+  });
+});

--- a/src/crd/components/chat/initials.ts
+++ b/src/crd/components/chat/initials.ts
@@ -4,5 +4,7 @@ export const initials = (name: string) =>
     .trim()
     .split(/\s+/)
     .slice(0, 2)
-    .map(word => word[0]?.toUpperCase() ?? '')
+    // Spread to iterate code points, not UTF-16 units — word[0] on an astral-plane
+    // character (emoji, 𝕏, CJK extensions) would yield a broken half-surrogate.
+    .map(word => [...word][0]?.toUpperCase() ?? '')
     .join('') || '?';

--- a/src/crd/components/dashboard/ApplicationsBlock.test.tsx
+++ b/src/crd/components/dashboard/ApplicationsBlock.test.tsx
@@ -6,17 +6,8 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-// Radix only mounts AvatarPrimitive.Image once the browser reports the image as
-// loaded, which never happens in jsdom. Swap it for a plain <img> so the props
-// this component passes down are observable (same approach as
-// CrdRedirectToAncestorDialog.test.tsx).
-vi.mock('@/crd/primitives/avatar', () => ({
-  Avatar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AvatarImage: ({ src, alt, className }: { src: string; alt: string; className?: string }) => (
-    <img src={src} alt={alt} className={className} />
-  ),
-  AvatarFallback: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
-}));
+// Shared jsdom-safe avatar double from src/crd/primitives/__mocks__/avatar.tsx.
+vi.mock('@/crd/primitives/avatar');
 
 const applications = [
   {

--- a/src/crd/primitives/__mocks__/avatar.tsx
+++ b/src/crd/primitives/__mocks__/avatar.tsx
@@ -1,0 +1,25 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+// Shared test double for the Radix-based avatar primitives: Radix only mounts
+// AvatarPrimitive.Image once the browser reports the image as loaded, which
+// never happens in jsdom. Tests activate it with `vi.mock('@/crd/primitives/avatar')`
+// (no factory) so the props components pass down stay observable.
+export const Avatar = ({
+  children,
+  className,
+  ...rest
+}: { children?: ReactNode } & ComponentPropsWithoutRef<'div'>) => (
+  <div className={className} data-testid="avatar" {...rest}>
+    {children}
+  </div>
+);
+
+export const AvatarImage = ({ src, alt, className }: { src?: string; alt?: string; className?: string }) => (
+  <img src={src} alt={alt} className={className} data-testid="avatar-image" />
+);
+
+export const AvatarFallback = ({ children, className }: { children?: ReactNode; className?: string }) => (
+  <span className={className} data-testid="avatar-fallback">
+    {children}
+  </span>
+);

--- a/src/main/crdPages/error/CrdRedirectToAncestorDialog.test.tsx
+++ b/src/main/crdPages/error/CrdRedirectToAncestorDialog.test.tsx
@@ -72,15 +72,8 @@ vi.mock('@/crd/components/error/CrdRedirectDialog', () => ({
     ) : null,
 }));
 
-// Strip the Avatar/Skeleton primitives down so the slot test isn't sensitive
-// to their internals.
-vi.mock('@/crd/primitives/avatar', () => ({
-  Avatar: ({ children }: { children?: React.ReactNode }) => <div data-testid="avatar">{children}</div>,
-  AvatarFallback: ({ children }: { children?: React.ReactNode }) => (
-    <span data-testid="avatar-fallback">{children}</span>
-  ),
-  AvatarImage: ({ src }: { src?: string }) => <img alt="" data-testid="avatar-image" src={src} />,
-}));
+// Shared jsdom-safe avatar double from src/crd/primitives/__mocks__/avatar.tsx.
+vi.mock('@/crd/primitives/avatar');
 vi.mock('@/crd/primitives/skeleton', () => ({
   Skeleton: () => <div data-testid="skeleton" />,
 }));


### PR DESCRIPTION
## What & why

Follow-up to #10086 (chat popup avatars), addressing the review findings — the two AI-reviewer a11y comments (CodeRabbit on `ChatPanel`, Copilot on `ConversationAvatar`) plus the duplication flagged in post-merge review. UI/test-only, no data or GraphQL changes.

### A11y (WCAG 2.1 AA — decorative avatars)

- **`ConversationAvatar`** is now `aria-hidden` on every branch. The single-avatar branch exposed its `AvatarFallback` initials to assistive technology, so screen readers announced e.g. "JD Jane Doe" in the thread header and conversation-list rows. The conversation title / display name is the adjacent accessible text on every surface, so the avatar is decorative by contract (now stated in the component doc).
- **`GroupAvatar`** single-member branch gets the same `aria-hidden` its composite branch already had.
- **`ChatPanel`** `titleAvatar` slot wrapper is `aria-hidden`, declaring the slot decorative for any future consumer.

### Deduplication

- New `src/crd/components/chat/avatarSizes.ts` — shared `AVATAR_SIZE_CLASS` scale + `AvatarSize` type, replacing identical local maps in `ConversationAvatar` and `GroupAvatar`.
- New `src/crd/primitives/__mocks__/avatar.tsx` — one jsdom-safe Radix avatar test double (Radix never mounts `AvatarPrimitive.Image` in jsdom), replacing four per-file `vi.mock` factory copies (`ChatMessageBubble`, `ConversationAvatar`, `ApplicationsBlock`, `CrdRedirectToAncestorDialog` tests). Tests now just call `vi.mock('@/crd/primitives/avatar')`.

### Correctness

- `initials()` iterates code points (`[...word][0]`) instead of UTF-16 units, so a name starting with an astral-plane character (emoji, 𝕏) yields the whole character instead of a broken half-surrogate. New `initials.test.ts` covers this plus trim/blank/two-word cases.

### Test updates

- `ConversationAvatar.test.tsx`: the group-with-photo test used *absence of `aria-hidden`* to distinguish the single-photo branch from the composite — that discriminator is gone by design, so it now counts avatar roots (structural, not styling-coupled). The a11y test asserts `aria-hidden` on the root of all four branches.

### Deliberately not changed

- `isGroup`/`isGuidance` prop names (CodeRabbit nitpick on #10086): consistent with `ChatListItem`/`ChatMessage`/`ChatThreadHeader` across the chat feature; renaming only the new component would make it the odd one out.

## Evidence

`pnpm lint` ✓ (exit 0, only pre-existing warnings) · `pnpm vitest run` ✓ **2166 passed / 2 skipped** (252 files) — also re-run by the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXRhgAy3Y1Dj8WA1EwXnQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved screen reader behavior for decorative conversation, group, title, and guidance avatars.
  - Added clearer accessible handling for avatar images, grouped avatars, and composite avatar displays.
  - Preserved accessible text alongside decorative avatar visuals.

- **Bug Fixes**
  - Improved initials rendering for names containing emoji and other Unicode characters.
  - Blank or whitespace-only names continue to receive a `?` fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->