### PR TITLE
Show join/apply button on top-level space pages

### DIFF
--- a/src/main/crdPages/space/layout/CrdSpacePageLayout.test.tsx
+++ b/src/main/crdPages/space/layout/CrdSpacePageLayout.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { SpaceLevel } from '@/core/apollo/generated/graphql-schema';
+import CrdSpacePageLayout from './CrdSpacePageLayout';
+
+// ---- Mocks ----
+// CrdSpacePageLayout is a large orchestrator with many data/UI hooks. Everything
+// unrelated to the join/apply wiring under test is stubbed to a minimal value so
+// the component can render without a live Apollo/router tree, following the
+// module-mock pattern used by CrdSubspaceProtectedRoutes.test.tsx.
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+let mockPathname = '/welcome-space';
+vi.mock('react-router-dom', () => ({
+  Outlet: () => <div data-testid="outlet" />,
+  useLocation: () => ({ pathname: mockPathname }),
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock('@/core/routing/usePageTitle', () => ({
+  usePageTitle: () => {},
+}));
+
+vi.mock('@/crd/hooks/useMediaQuery', () => ({
+  useScreenSize: () => ({ isSmallScreen: false }),
+}));
+
+const useSpaceMock = vi.fn();
+vi.mock('@/domain/space/context/useSpace', () => ({
+  useSpace: () => useSpaceMock(),
+}));
+
+vi.mock('@/domain/space/hooks/useVideoCall', () => ({
+  useVideoCall: () => ({ isVideoCallEnabled: false, videoCallUrl: undefined }),
+}));
+
+vi.mock('@/domain/storage/StorageBucket/StorageConfigContext', () => ({
+  StorageConfigContextProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/main/crdPages/topLevelPages/spaceSettings/useDirtyTabGuard', () => ({
+  useDirtyTabGuard: () => ({
+    isDirty: false,
+    markDirty: () => {},
+    clearDirty: () => {},
+    requestSwitch: vi.fn().mockResolvedValue(true),
+    pendingSwitch: null,
+    resolvePendingSwitch: () => {},
+  }),
+}));
+
+vi.mock('@/main/crdPages/topLevelPages/spaceSettings/useSpaceSettingsTab', () => ({
+  useSpaceSettingsTab: () => ({ activeTab: 'about', setActiveTab: vi.fn() }),
+}));
+
+const useUrlResolverMock = vi.fn();
+vi.mock('@/main/routing/urlResolver/useUrlResolver', () => ({
+  default: () => useUrlResolverMock(),
+}));
+
+vi.mock('@/main/ui/breadcrumbs/BreadcrumbsContext', () => ({
+  useSetBreadcrumbs: () => {},
+}));
+
+vi.mock('@/main/ui/layout/BannerOverlayContext', () => ({
+  useEnableBannerOverlay: () => {},
+}));
+
+vi.mock('@/main/ui/layout/LayoutWidthContext', () => ({
+  useEnableSpaceFullWidth: () => {},
+}));
+
+vi.mock('@/main/ui/layout/useDownNoticeBanner', () => ({
+  useDownNoticeBanner: () => ({ visible: false }),
+}));
+
+vi.mock('@/main/ui/layout/useLayoutWidthPreference', () => ({
+  useLayoutWidthPreference: () => ({ wide: false, toggle: () => {} }),
+}));
+
+vi.mock('@/crd/components/common/ShareDialog', () => ({
+  ShareDialog: () => null,
+}));
+
+vi.mock('../dialogs/CrdSpaceActivityDialogConnector', () => ({
+  CrdSpaceActivityDialogConnector: () => null,
+}));
+
+vi.mock('../hooks/useCrdSpaceTabs', () => ({
+  useCrdSpaceTabs: () => ({ tabs: [], defaultTabIndex: 0, sectionCount: 1, showSettings: false }),
+}));
+
+const spaceApplyButtonConnectorSpy = vi.fn();
+vi.mock('../SpaceApplyButtonConnector', () => ({
+  SpaceApplyButtonConnector: (props: unknown) => {
+    spaceApplyButtonConnectorSpy(props);
+    return <div data-testid="space-apply-button" />;
+  },
+}));
+
+const buildSpace = () => ({
+  space: {
+    id: 'welcome-space-id',
+    nameID: 'welcome-space',
+    about: {
+      profile: {
+        displayName: 'Welcome Space',
+        tagline: 'A public welcome space',
+        url: '/welcome-space',
+        banner: undefined,
+      },
+    },
+  },
+  visibility: undefined,
+  permissions: { canRead: true },
+  loading: false,
+});
+
+describe('CrdSpacePageLayout — join/apply entry point', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = '/welcome-space';
+    useUrlResolverMock.mockReturnValue({
+      spaceId: 'welcome-space-id',
+      spaceLevel: SpaceLevel.L0,
+      loading: false,
+    });
+    useSpaceMock.mockReturnValue(buildSpace());
+  });
+
+  test('renders the apply/join button for a public, application-required L0 space', () => {
+    render(<CrdSpacePageLayout />);
+
+    expect(screen.getByTestId('space-apply-button')).toBeInTheDocument();
+    expect(spaceApplyButtonConnectorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spaceId: 'welcome-space-id',
+        spaceProfileUrl: '/welcome-space',
+        communityName: 'Welcome Space',
+      })
+    );
+  });
+
+  test('does not render the apply/join button on the space settings pages', () => {
+    mockPathname = '/welcome-space/settings';
+
+    render(<CrdSpacePageLayout />);
+
+    expect(screen.queryByTestId('space-apply-button')).not.toBeInTheDocument();
+  });
+});

--- a/src/main/crdPages/space/layout/CrdSpacePageLayout.tsx
+++ b/src/main/crdPages/space/layout/CrdSpacePageLayout.tsx
@@ -49,6 +49,7 @@ import { CalloutShareOnAlkemioForm } from '../callout/CalloutShareOnAlkemioForm'
 import { mapSpaceVisibility } from '../dataMappers/spacePageDataMapper';
 import { CrdSpaceActivityDialogConnector } from '../dialogs/CrdSpaceActivityDialogConnector';
 import { useCrdSpaceTabs } from '../hooks/useCrdSpaceTabs';
+import { SpaceApplyButtonConnector } from '../SpaceApplyButtonConnector';
 
 export default function CrdSpacePageLayout() {
   const { t } = useTranslation(['crd-space', 'crd-spaceSettings']);
@@ -229,6 +230,19 @@ export default function CrdSpacePageLayout() {
             )
           }
         >
+          {/* Join/apply entry point for viewers who aren't yet members of this
+            (root) space — mirrors `CrdSubspacePageLayout`, which mounts the
+            same connector for L1/L2. Without it, non-members had no way to
+            apply from a public, application-required top-level space. */}
+          {!isOnSettings && (
+            <SpaceApplyButtonConnector
+              spaceId={space.id}
+              spaceProfileUrl={spaceUrl}
+              communityName={spaceDisplayName}
+              className="mb-6"
+            />
+          )}
+
           <Suspense fallback={<LoadingSpinner />}>
             <Outlet context={{ activeTabIndex, totalTabs: sectionCount }} />
           </Suspense>


### PR DESCRIPTION
## Summary
- `SpaceApplyButtonConnector` (the join/apply button, backed by the `ApplicationButton`/`RoleSet` data) was only mounted in `CrdSubspacePageLayout` — the top-level space layout (`CrdSpacePageLayout`) never rendered it, so non-members visiting a public, application-required root space (e.g. welcome-space) had no way to apply or join.
- Wire `SpaceApplyButtonConnector` into `CrdSpacePageLayout`, mirroring the subspace layout: hidden while loading/already a member, hidden on the settings pages, with the same `mb-6` spacing the subspace layout gets from its `space-y-6` wrapper (this layout doesn't have one).

<img width="1035" height="850" alt="image" src="https://github.com/user-attachments/assets/855bf52b-41f6-48d5-8cce-a5ffaad8937a" />


Fixes #10105

## Test plan
- [x] Added `CrdSpacePageLayout.test.tsx`: TDD'd against the bug — written first, watched it fail (button not rendered), then made it pass with the fix. Covers rendering with correct props and hiding on the settings route.
- [x] `pnpm vitest run` — full suite green (pre-existing bg_BG locale flake in `budgetMeter.test.tsx` unrelated to this change)
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Apply/Join button to public root-space pages.
  - The button displays relevant space information and appears before the page content.
  - The button is hidden on space settings pages.

- **Tests**
  - Added coverage verifying the button’s visibility and displayed details across supported views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->