### PR TITLE
fix: persist header language picker to the account

### DIFF
--- a/src/main/ui/layout/useCrdNavigation.test.ts
+++ b/src/main/ui/layout/useCrdNavigation.test.ts
@@ -1,0 +1,90 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+// ---- Mocks ----
+
+const mockI18nInstance = {
+  language: 'en',
+  changeLanguage: vi.fn(),
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: mockI18nInstance }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/', search: '' }),
+}));
+
+vi.mock('@/core/i18n/config', () => ({
+  supportedLngs: ['en', 'nl', 'de', 'fr', 'es', 'bg'],
+}));
+
+vi.mock('@/domain/platform/config/useConfig', () => ({
+  useConfig: () => ({ locations: undefined }),
+}));
+
+const updateUserSettingsMock = vi.fn();
+const refetchUserSettingsQueryMock = vi.fn((v: unknown) => ({ query: 'UserSettings', variables: v }));
+vi.mock('@/core/apollo/generated/apollo-hooks', () => ({
+  useUpdateUserSettingsMutation: () => [updateUserSettingsMock, { loading: false }],
+  refetchUserSettingsQuery: (v: unknown) => refetchUserSettingsQueryMock(v),
+}));
+
+const notifyMock = vi.fn();
+vi.mock('@/core/ui/notifications/useNotification', () => ({ useNotification: () => notifyMock }));
+
+let mockCurrentUserContext: { userModel?: { id: string }; isAuthenticated: boolean };
+vi.mock('@/domain/community/userCurrent/useCurrentUserContext', () => ({
+  useCurrentUserContext: () => mockCurrentUserContext,
+}));
+
+// Re-import after mock setup.
+import { useCrdNavigation } from './useCrdNavigation';
+
+describe('useCrdNavigation — handleLanguageChange', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('guest (unauthenticated): applies the language display-only, never calls updateUserSettings', async () => {
+    mockCurrentUserContext = { userModel: undefined, isAuthenticated: false };
+    const { result } = renderHook(() => useCrdNavigation());
+
+    await result.current.handleLanguageChange('bg');
+
+    expect(updateUserSettingsMock).not.toHaveBeenCalled();
+    expect(mockI18nInstance.changeLanguage).toHaveBeenCalledWith('bg');
+  });
+
+  test('authenticated user: persists via updateUserSettings before applying the language', async () => {
+    mockCurrentUserContext = { userModel: { id: 'user-1' }, isAuthenticated: true };
+    updateUserSettingsMock.mockResolvedValue({});
+    const { result } = renderHook(() => useCrdNavigation());
+
+    await result.current.handleLanguageChange('bg');
+
+    expect(updateUserSettingsMock).toHaveBeenCalledWith({
+      variables: {
+        settingsData: {
+          userID: 'user-1',
+          settings: { language: 'bg' },
+        },
+      },
+      refetchQueries: [refetchUserSettingsQueryMock({ userID: 'user-1' })],
+      awaitRefetchQueries: true,
+    });
+    expect(mockI18nInstance.changeLanguage).toHaveBeenCalledWith('bg');
+  });
+
+  test('authenticated user, persistence fails: notifies and does not change the display language', async () => {
+    mockCurrentUserContext = { userModel: { id: 'user-1' }, isAuthenticated: true };
+    updateUserSettingsMock.mockRejectedValue(new Error('network down'));
+    const { result } = renderHook(() => useCrdNavigation());
+
+    await result.current.handleLanguageChange('bg');
+
+    expect(notifyMock).toHaveBeenCalledWith('user.settings.language.error', 'error');
+    expect(mockI18nInstance.changeLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/ui/layout/useCrdNavigation.ts
+++ b/src/main/ui/layout/useCrdNavigation.ts
@@ -2,7 +2,10 @@ import { BookOpen, Compass, Lightbulb, MessageCircle } from 'lucide-react';
 import { createElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
+import { refetchUserSettingsQuery, useUpdateUserSettingsMutation } from '@/core/apollo/generated/apollo-hooks';
 import { supportedLngs } from '@/core/i18n/config';
+import { useNotification } from '@/core/ui/notifications/useNotification';
+import { useCurrentUserContext } from '@/domain/community/userCurrent/useCurrentUserContext';
 import { useConfig } from '@/domain/platform/config/useConfig';
 import { ROUTE_HOME, ROUTE_USER_ME } from '@/domain/platform/routes/constants';
 import { TopLevelRoutePath } from '@/main/routing/TopLevelRoutePath';
@@ -20,9 +23,13 @@ const STATIC_NAVIGATION_HREFS = {
 
 export function useCrdNavigation() {
   const { t, i18n } = useTranslation();
+  const { t: tContributorSettings } = useTranslation('crd-contributorSettings');
   const { pathname, search } = useLocation();
   const { locations } = useConfig();
   const canonicalDomain = locations?.domain;
+  const { userModel, isAuthenticated } = useCurrentUserContext();
+  const [updateUserSettings] = useUpdateUserSettingsMutation();
+  const notify = useNotification();
 
   // When the visitor is on a hub subdomain (e.g. `acme.alkemio.org`), every
   // top-nav / platform link must hop them off the subdomain back to the main
@@ -50,7 +57,32 @@ export function useCrdNavigation() {
     .filter(lng => lng !== 'inContextTool')
     .map(lng => ({ code: lng, label: t(`languages.${lng}`) }));
 
-  const handleLanguageChange = (code: string) => i18n.changeLanguage(code);
+  // Must persist the same way the Account Settings language dropdown does
+  // (CrdUserSettingsTab.tsx's onLanguageChange) — otherwise a pick made here
+  // is lost on refresh and never counts as "having chosen a language" for the
+  // offer-banner gate (FR-023 of 029-detect-signup-language).
+  const handleLanguageChange = async (code: string) => {
+    if (!isAuthenticated || !userModel?.id) {
+      // No account to persist to (guest/anonymous) — display-only, as before.
+      void i18n.changeLanguage(code);
+      return;
+    }
+    try {
+      await updateUserSettings({
+        variables: {
+          settingsData: {
+            userID: userModel.id,
+            settings: { language: code },
+          },
+        },
+        refetchQueries: [refetchUserSettingsQuery({ userID: userModel.id })],
+        awaitRefetchQueries: true,
+      });
+      void i18n.changeLanguage(code);
+    } catch {
+      notify(tContributorSettings('user.settings.language.error'), 'error');
+    }
+  };
 
   const platformNavigationItems = [
     {


### PR DESCRIPTION
## Summary
- The header account-menu language dropdown only called `i18n.changeLanguage()` client-side — it never called `updateUserSettings`, so a pick made there was lost on refresh and never counted as "having chosen a language" for the offer-banner gate (FR-023 of `029-detect-signup-language`).
- `useCrdNavigation`'s `handleLanguageChange` now mirrors `CrdUserSettingsTab.tsx`'s `onLanguageChange` for authenticated users: persist via `updateUserSettings`, then apply the language; on failure, show the existing error toast and leave the display language unchanged. Guests keep the previous display-only behavior (no account to persist to).

Closes #10111.

## Test plan
- [x] `pnpm vitest run` — 256/256 test files pass, incl. 3 new tests covering guest (no persistence), authenticated success (mutation called + language applied), and authenticated failure (toast shown, language unchanged)
- [x] `tsc --noEmit` clean
- [x] `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language preferences are now saved for authenticated users.
  * Unauthenticated users can still change the displayed language for the current session.
  * A localized notification is shown if saving the language preference fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->