### PR TITLE
fix: application notifications open the space community settings

### DIFF
--- a/src/main/ui/layout/notificationDataMapper.test.ts
+++ b/src/main/ui/layout/notificationDataMapper.test.ts
@@ -1,0 +1,203 @@
+import type { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+import {
+  CalendarEventType,
+  NotificationEvent,
+  NotificationEventCategory,
+  NotificationEventInAppState,
+  NotificationEventPayload,
+} from '@/core/apollo/generated/graphql-schema';
+import type { InAppNotificationModel } from '@/main/inAppNotifications/model/InAppNotificationModel';
+import type { InAppNotificationPayloadModel } from '@/main/inAppNotifications/model/InAppNotificationPayloadModel';
+import { mapNotificationToItemData } from './notificationDataMapper';
+
+const t = ((key: string) => key) as unknown as TFunction;
+
+const spacePayload = (url = '/my-space'): InAppNotificationPayloadModel['space'] => ({
+  id: 'space-1',
+  about: { profile: { displayName: 'My Space', url } },
+});
+
+const notification = (
+  type: NotificationEvent,
+  payload: Partial<InAppNotificationPayloadModel>,
+  category = NotificationEventCategory.SpaceAdmin
+): InAppNotificationModel => ({
+  id: `notification-${type}`,
+  type,
+  triggeredAt: new Date(),
+  state: NotificationEventInAppState.Unread,
+  category,
+  triggeredBy: {
+    profile: { displayName: 'Ada Lovelace', url: '/user/ada', visual: { uri: 'ada.png' } },
+  },
+  payload: { type: NotificationEventPayload.Space, ...payload } as InAppNotificationPayloadModel,
+});
+
+const hrefOf = (model: InAppNotificationModel) =>
+  mapNotificationToItemData(model, t, NotificationEventInAppState.Unread).href;
+
+describe('resolved notification destinations', () => {
+  it('sends a community application to the community tab of the space settings', () => {
+    const href = hrefOf(
+      notification(NotificationEvent.SpaceAdminCommunityApplication, {
+        type: NotificationEventPayload.SpaceCommunityApplication,
+        space: spacePayload('/my-space'),
+      })
+    );
+
+    // The space home page has no approve/reject surface — the pending memberships
+    // table only exists on the settings Community tab.
+    expect(href).toBe('/my-space/settings/community');
+  });
+
+  it('builds the same settings path for a subspace application', () => {
+    const href = hrefOf(
+      notification(NotificationEvent.SpaceAdminCommunityApplication, {
+        type: NotificationEventPayload.SpaceCommunityApplication,
+        space: spacePayload('/my-space/challenges/my-subspace'),
+      })
+    );
+
+    expect(href).toBe('/my-space/challenges/my-subspace/settings/community');
+  });
+
+  it('leaves an application without a space URL unlinked rather than pointing at /settings/community', () => {
+    const href = hrefOf(
+      notification(NotificationEvent.SpaceAdminCommunityApplication, {
+        type: NotificationEventPayload.SpaceCommunityApplication,
+        space: { id: 'space-1', about: { profile: { displayName: 'My Space' } } },
+      })
+    );
+
+    expect(href).toBeUndefined();
+  });
+
+  it('sends a new-member notification to the contributor who joined', () => {
+    const href = hrefOf(
+      notification(NotificationEvent.SpaceAdminCommunityNewMember, {
+        type: NotificationEventPayload.SpaceCommunityActor,
+        space: spacePayload(),
+        actor: { profile: { displayName: 'Grace Hopper', url: '/user/grace' } },
+      })
+    );
+
+    expect(href).toBe('/user/grace');
+  });
+
+  it('sends calendar notifications to the event, not to the space that also rides along', () => {
+    const calendarEvent = {
+      id: 'event-1',
+      type: CalendarEventType.Event,
+      profile: { displayName: 'Sprint demo', url: '/my-space/calendar/sprint-demo' },
+    };
+
+    const created = hrefOf(
+      notification(NotificationEvent.SpaceCommunityCalendarEventCreated, {
+        type: NotificationEventPayload.SpaceCommunityCalendarEvent,
+        space: spacePayload(),
+        calendarEvent,
+      })
+    );
+    const commented = hrefOf(
+      notification(NotificationEvent.SpaceCommunityCalendarEventComment, {
+        type: NotificationEventPayload.SpaceCommunityCalendarEventComment,
+        space: spacePayload(),
+        calendarEvent,
+      })
+    );
+
+    expect(created).toBe('/my-space/calendar/sprint-demo');
+    expect(commented).toBe('/my-space/calendar/sprint-demo');
+  });
+});
+
+describe('notification types kept on the generic payload fallback', () => {
+  it('sends a callout comment to the commented message', () => {
+    const href = hrefOf(
+      notification(NotificationEvent.SpaceCollaborationCalloutComment, {
+        type: NotificationEventPayload.SpaceCollaborationCalloutComment,
+        space: spacePayload(),
+        callout: { framing: { profile: { displayName: 'A callout', url: '/my-space/callout' } } },
+        messageDetails: {
+          message: 'Nice one',
+          parent: { displayName: 'A callout', url: '/my-space/callout?comment=1' },
+          room: { id: 'room-1' },
+        },
+      })
+    );
+
+    expect(href).toBe('/my-space/callout?comment=1');
+  });
+
+  it('sends a published callout to the callout', () => {
+    const href = hrefOf(
+      notification(NotificationEvent.SpaceCollaborationCalloutPublished, {
+        type: NotificationEventPayload.SpaceCollaborationCallout,
+        space: spacePayload(),
+        callout: { framing: { profile: { displayName: 'A callout', url: '/my-space/callout' } } },
+      })
+    );
+
+    expect(href).toBe('/my-space/callout');
+  });
+
+  it('keeps space-scoped notifications with no better destination on the space home page', () => {
+    const update = hrefOf(
+      notification(NotificationEvent.SpaceCommunicationUpdate, {
+        type: NotificationEventPayload.SpaceCommunicationUpdate,
+        space: spacePayload(),
+        update: 'update-1',
+      })
+    );
+    const invitation = hrefOf(
+      notification(
+        NotificationEvent.UserSpaceCommunityInvitation,
+        { type: NotificationEventPayload.SpaceCommunityInvitation, space: spacePayload() },
+        NotificationEventCategory.User
+      )
+    );
+    const vcInvitationDeclined = hrefOf(
+      notification(NotificationEvent.SpaceAdminVirtualCommunityInvitationDeclined, {
+        type: NotificationEventPayload.VirtualContributor,
+        space: spacePayload(),
+        actor: { profile: { displayName: 'A VC', url: '/vc/a-vc' } },
+      })
+    );
+
+    expect(update).toBe('/my-space');
+    expect(invitation).toBe('/my-space');
+    expect(vcInvitationDeclined).toBe('/my-space');
+  });
+
+  it('sends a forum discussion notification to the discussion', () => {
+    const href = hrefOf(
+      notification(
+        NotificationEvent.PlatformForumDiscussionCreated,
+        {
+          type: NotificationEventPayload.PlatformForumDiscussion,
+          discussion: { id: 'discussion-1', displayName: 'A discussion', url: '/forum/a-discussion' },
+        },
+        NotificationEventCategory.Platform
+      )
+    );
+
+    expect(href).toBe('/forum/a-discussion');
+  });
+
+  it('leaves a payload with no linkable entity without an href', () => {
+    const href = hrefOf(
+      notification(
+        NotificationEvent.PlatformAdminUserProfileRemoved,
+        {
+          type: NotificationEventPayload.PlatformUserProfileRemoved,
+          userEmail: 'someone@example.com',
+          userDisplayName: 'Someone',
+        },
+        NotificationEventCategory.Platform
+      )
+    );
+
+    expect(href).toBeUndefined();
+  });
+});

--- a/src/main/ui/layout/notificationDataMapper.tsx
+++ b/src/main/ui/layout/notificationDataMapper.tsx
@@ -14,13 +14,19 @@
  */
 import type { TFunction } from 'i18next';
 import { Trans } from 'react-i18next';
-import type { ForumDiscussionCategory, NotificationEventInAppState } from '@/core/apollo/generated/graphql-schema';
+import {
+  type ForumDiscussionCategory,
+  NotificationEvent,
+  type NotificationEventInAppState,
+} from '@/core/apollo/generated/graphql-schema';
 import { kebabToConstantCase } from '@/core/utils/string';
 import { InlineMarkdown } from '@/crd/components/common/InlineMarkdown';
 import type { CrdNotificationItemData } from '@/crd/layouts/types';
 import { getInitials } from '@/crd/lib/getInitials';
 import { formatTimeElapsed } from '@/domain/shared/utils/formatTimeElapsed';
 import type { InAppNotificationModel } from '@/main/inAppNotifications/model/InAppNotificationModel';
+import type { InAppNotificationPayloadModel } from '@/main/inAppNotifications/model/InAppNotificationPayloadModel';
+import { buildSettingsTabUrl } from '@/main/routing/urlBuilders';
 
 const TRANS_COMPONENTS = {
   b: <strong />,
@@ -90,11 +96,44 @@ function buildTranslationValues(
 }
 
 /**
+ * Per-type destination overrides, applied before the generic payload fallback below.
+ *
+ * The fallback takes the first URL the payload happens to carry, and almost every
+ * space-scoped payload carries its space — so anything without a callout or a message
+ * lands on the space home page. That is the wrong destination whenever the notification
+ * is about an action to take elsewhere, or about an entity whose own URL the space
+ * would shadow.
+ *
+ * A type absent from this map keeps the generic fallback; only add an entry when the
+ * destination is unambiguous.
+ */
+const URL_OVERRIDES_BY_TYPE: Partial<
+  Record<NotificationEvent, (payload: InAppNotificationPayloadModel) => string | undefined>
+> = {
+  // Applications are reviewed (approved/rejected) on the Community tab of the space
+  // settings, so the space home page leaves the admin with nowhere to act.
+  [NotificationEvent.SpaceAdminCommunityApplication]: payload =>
+    buildSettingsTabUrl(payload.space?.about?.profile?.url, 'community'),
+  // The subject of the notification is the contributor who joined, not the space.
+  [NotificationEvent.SpaceAdminCommunityNewMember]: payload => payload.actor?.profile?.url,
+  // Calendar payloads carry both the event and its space; the space must not win.
+  [NotificationEvent.SpaceCommunityCalendarEventCreated]: payload => payload.calendarEvent?.profile?.url,
+  [NotificationEvent.SpaceCommunityCalendarEventComment]: payload => payload.calendarEvent?.profile?.url,
+};
+
+/**
  * Resolves the URL that clicking a notification should navigate to.
  * Returns a pathname (not an absolute URL) for React Router compatibility.
  */
 function resolveNotificationUrl(notification: InAppNotificationModel): string | undefined {
   const { payload } = notification;
+
+  // An override that cannot build its URL (missing payload fields) falls through to the
+  // generic chain rather than leaving the notification unclickable.
+  const overrideUrl = URL_OVERRIDES_BY_TYPE[notification.type]?.(payload);
+  if (overrideUrl) {
+    return overrideUrl;
+  }
 
   return (
     payload.messageDetails?.parent?.url ??


### PR DESCRIPTION
Fixes alkem-io/client-web#10068

## Problem

Clicking the "<Name> applied to join <Space>" in-app notification took the space admin to the **space home page**. The notification's own description says *"Review the application in the Space settings"*, but the destination it linked to has no approve/reject surface at all, so there was no route from the notification to the action it asks for. Confirmed still reproducible on current `develop`.

## Root cause

`resolveNotificationUrl` in `src/main/ui/layout/notificationDataMapper.tsx` was a **flat `??` chain over the payload with no per-notification-type branching**:

```
messageDetails.parent.url ?? callout.framing.profile.url ?? space.about.profile.url ?? discussion.url ?? calendarEvent.profile.url ?? user.profile.url ?? organization.profile.url
```

Almost every space-scoped payload carries its space, and `space` sits third in that chain. So any notification whose payload has no callout and no message resolves to the space home page, whatever its type. The `SPACE_ADMIN_COMMUNITY_APPLICATION` payload carries only `space` + `application`, so it fell straight through to the space URL.

This is a regression introduced when the MUI notification views were replaced by the CRD data mapper (#9885 / #9892). Before that, each notification type had its own view with an explicit destination — e.g. `InAppSpaceAdminCommunityApplicationView` used `buildSettingsCommunityUrl(spaceUrl)`. Collapsing ~30 per-type views into one generic chain silently dropped those destinations.

## Fix

Introduced a per-type override map (`URL_OVERRIDES_BY_TYPE`) consulted **before** the generic chain, keyed on `notification.type`. Types absent from the map keep the existing fallback byte-for-byte. An override that cannot build its URL (missing payload fields) falls through to the chain rather than leaving the notification unclickable.

The destinations restored are exactly the ones the pre-CRD per-type views used (`git show adb8f15e7^:src/main/inAppNotifications/views/...`):

| Notification type | Before | After | Pre-CRD source of truth |
|---|---|---|---|
| `SPACE_ADMIN_COMMUNITY_APPLICATION` | space home | `<space>/settings/community` | `InAppSpaceAdminCommunityApplicationView` → `buildSettingsCommunityUrl(spaceUrl)` |
| `SPACE_ADMIN_COMMUNITY_NEW_MEMBER` | space home | the contributor who joined (`actor.profile.url`) | `InAppSpaceAdminCommunityNewMemberView` → `payload.actor?.profile?.url` |
| `SPACE_COMMUNITY_CALENDAR_EVENT_CREATED` | space home | the event (`calendarEvent.profile.url`) | `InAppSpaceCommunityCalendarEventCreatedView` |
| `SPACE_COMMUNITY_CALENDAR_EVENT_COMMENT` | space home | the event (`calendarEvent.profile.url`) | `InAppSpaceCommunityCalendarEventCommentView` |

The calendar entries are the same defect: their payload carries both the event *and* its space, and `space` outranks `calendarEvent` in the chain, so the event's own URL was shadowed.

The settings URL is composed with the existing `buildSettingsTabUrl(profileUrl, 'community')` from `src/main/routing/urlBuilders.ts` — not hand-templated, per that file's own comment. **No anchor** is appended: `PendingMembershipsTable` renders as a bare sibling at the top of `SpaceSettingsCommunityView` with no `id` (only `#members` and `#guidelines` exist), and it is the first block on the tab anyway.

Verified the destination actually resolves at every level: `settings/*` is a splat route in both `CrdSpaceRoutes` (L0) and `CrdSubspaceRoutes` (L1/L2), both lazy-load the same `CrdSpaceSettingsPage`, and `community` is a valid tab id visible at **all three levels** (`useSpaceSettingsTab.ts`, `useVisibleSettingsTabs.ts`).

## Deliberately left on the existing fallback

Investigated every notification type against its pre-CRD destination. These were **not** changed, and why:

- **`SPACE_ADMIN_VIRTUAL_COMMUNITY_INVITATION_DECLINED`**, `SPACE_COMMUNITY_INVITATION_USER_PLATFORM`, `USER_SPACE_COMMUNITY_INVITATION`, `USER_SPACE_COMMUNITY_JOINED`, `USER_SPACE_COMMUNITY_APPLICATION_DECLINED` — the pre-CRD views also pointed at the space home. Current behaviour is already correct.
- **`VIRTUAL_ADMIN_SPACE_COMMUNITY_INVITATION`** — pre-CRD used `getInvitationsDialogUrl()` (`/home?dialog=invitations`). That URL still works, but it opens the *recipient's own* pending-invitations dialog, which is a dubious destination for "someone invited a VC to a space you administer". Ambiguous → left on the fallback rather than guessed.
- **`SPACE_COMMUNICATION_UPDATE`** — pre-CRD used `buildUpdatesUrl(spaceUrl)` (`<space>/updates`). Neither the builder nor that route survives in CRD, and `dashboardDataMappers.tsx` explicitly notes updates have no URL of their own and link to the space. Space home is the current intended behaviour.
- **`SPACE_LEAD_COMMUNICATION_MESSAGE`**, `USER_MESSAGE`, `ORGANIZATION_ADMIN_MESSAGE`, `PLATFORM_ADMIN_USER_PROFILE_CREATED`, `USER_SIGN_UP_WELCOME` — pre-CRD used `triggeredBy.profile.url`. Post-messaging-overhaul it is not clear the sender's profile is still the right destination (a conversation would be), and these are not space-home mis-routes. Out of scope → untouched.

## Regression test

New `src/main/ui/layout/notificationDataMapper.test.ts` (10 cases), exercising the public `mapNotificationToItemData`:

- the application notification's `href` is `<space>/settings/community`, for both an L0 URL and a subspace URL;
- an application payload with no space URL stays unlinked rather than emitting a bare `/settings/community`;
- new-member and both calendar types reach their entities;
- untouched types keep their existing behaviour — callout comment → the message, published callout → the callout, update / invitation / VC-declined → the space home, forum discussion → the discussion, and a payload with no linkable entity → no `href`.

Confirmed red before the fix (4 failures, incl. `expected '/my-space' to be '/my-space/settings/community'`) and green after.

## Notes

Client-only. No server, GraphQL document, or codegen changes; no i18n keys added or changed; no restyling of the notification panel. The diff adds code comments — none of them carry a spec, feature, issue, or PR number, per `docs/conventions/code-comments.md`.

## Gates

| Gate | Result |
|---|---|
| `pnpm vitest run` | 296 files / 2491 passed, 2 skipped |
| `pnpm lint` (typecheck + biome + eslint) | exit 0, no findings on the touched files |
| `pnpm build` | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved notification links for community applications, new members, and calendar events.
  * Notifications now direct you to the most relevant destination, including settings and subspaces.

* **Bug Fixes**
  * Added fallback handling when notification links or destination details are unavailable.
  * Improved navigation for forum discussions, callouts, generic space notifications, and unlinked notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->