### PR TITLE
fix(templates): stop spurious ENTITY_NOT_FOUND toast when deleting a template

### DIFF
--- a/src/main/crdPages/templates/useTemplatesManager.ts
+++ b/src/main/crdPages/templates/useTemplatesManager.ts
@@ -109,13 +109,26 @@ export function useTemplatesManager({
   // then refetches the now-deleted id and surfaces a spurious ENTITY_NOT_FOUND toast
   // even though the delete succeeded. A one-shot query has no observer to invalidate.
   const apolloClient = useApolloClient();
-  const getTemplateContent = (options: { variables: TemplateContentQueryVariables }) =>
-    apolloClient.query<TemplateContentQuery, TemplateContentQueryVariables>({
-      query: TemplateContentDocument,
-      variables: options.variables,
-      fetchPolicy: 'network-only',
-      errorPolicy: 'all',
-    });
+  const getTemplateContent = async (options: {
+    variables: TemplateContentQueryVariables;
+  }): Promise<{ data: TemplateContentQuery | undefined }> => {
+    // Default errorPolicy ('none') rejects on a GraphQL error, so partial data never
+    // reaches copy/save. `client.query` also rejects on network errors regardless of
+    // policy — we catch both here and surface `{ data: undefined }`, the shape every
+    // caller already treats as "nothing to show" (`if (!fetched) return`, or clearing
+    // the preview spinner). A failed read therefore can neither leave a spinner stuck
+    // nor raise an unhandled rejection from the fire-and-forget callers.
+    try {
+      const result = await apolloClient.query<TemplateContentQuery, TemplateContentQueryVariables>({
+        query: TemplateContentDocument,
+        variables: options.variables,
+        fetchPolicy: 'network-only',
+      });
+      return { data: result.data };
+    } catch {
+      return { data: undefined };
+    }
+  };
   const [createTemplateFromContentSpace] = useCreateTemplateFromContentSpaceMutation({
     refetchQueries: ['AllTemplatesInTemplatesSet'],
   });

--- a/src/main/crdPages/templates/useTemplatesManager.ts
+++ b/src/main/crdPages/templates/useTemplatesManager.ts
@@ -1,13 +1,15 @@
+import { useApolloClient } from '@apollo/client';
 import { useRef, useState } from 'react';
 import {
   refetchAllTemplatesInTemplatesSetQuery,
+  TemplateContentDocument,
   useAllTemplatesInTemplatesSetQuery,
   useCreateTemplateFromContentSpaceMutation,
   useDeleteTemplateMutation,
   useImportTemplateDialogAccountTemplatesQuery,
   useImportTemplateDialogPlatformTemplatesQuery,
-  useTemplateContentLazyQuery,
 } from '@/core/apollo/generated/apollo-hooks';
+import type { TemplateContentQuery, TemplateContentQueryVariables } from '@/core/apollo/generated/graphql-schema';
 import type {
   TemplateAction,
   TemplateCardData,
@@ -100,7 +102,20 @@ export function useTemplatesManager({
 
   // ── create/edit form lifecycle ──
   const form = useTemplateForms({ templatesSetId, spaceId, markdownUpload, referenceUpload });
-  const [getTemplateContent] = useTemplateContentLazyQuery();
+  // One-shot content read for preview / edit / duplicate. Deliberately imperative
+  // (`client.query`) rather than `useTemplateContentLazyQuery`: a lazy query leaves a
+  // standing observer bound to its last `templateId`, and when that template is later
+  // deleted the delete's `cache.evict` + `cache.gc()` invalidates that observer, which
+  // then refetches the now-deleted id and surfaces a spurious ENTITY_NOT_FOUND toast
+  // even though the delete succeeded. A one-shot query has no observer to invalidate.
+  const apolloClient = useApolloClient();
+  const getTemplateContent = (options: { variables: TemplateContentQueryVariables }) =>
+    apolloClient.query<TemplateContentQuery, TemplateContentQueryVariables>({
+      query: TemplateContentDocument,
+      variables: options.variables,
+      fetchPolicy: 'network-only',
+      errorPolicy: 'all',
+    });
   const [createTemplateFromContentSpace] = useCreateTemplateFromContentSpaceMutation({
     refetchQueries: ['AllTemplatesInTemplatesSet'],
   });


### PR DESCRIPTION
## Problem

Deleting a template that had been **previewed, edited, or duplicated** first showed a
`Not able to locate Template with the specified ID` (`ENTITY_NOT_FOUND`, code 10101)
error toast — even though the delete **succeeded** server-side. Found by QA on Space
**Classification** templates (`workspace#024-classifications`), but the cause is generic
and affects every template type.

## Root cause

Template content is loaded via `useTemplateContentLazyQuery`. A lazy query leaves a
**standing observer** bound to its last `templateId`. The delete mutation's `update`
(`cache.evict({ Template })` + `cache.gc()`) invalidates that observer, which then
**refetches the now-deleted id** (`lookup.template`) and raises the 404. The failing
operation in the network log is the `TemplateContent` **query** (`path: ["lookup","template"]`),
not the `DeleteTemplate` mutation — the delete itself is clean.

The lazy query's result object was never read — only its `execute` function is used — so
the standing observer served no purpose beyond triggering this bug.

## Fix

Replace the lazy query with a **one-shot** `apolloClient.query` (`fetchPolicy:
'network-only'`, `errorPolicy: 'all'`). A one-shot query has no standing observer to
invalidate, so a subsequent delete cannot trigger a refetch of the deleted template.
Server delete behaviour is unchanged and already correct.

## Verification

- Reproduced the server side via API: `deleteTemplate` returns the id and the row is gone;
  the post-delete `lookup.template` 404 is the *expected* not-found — the bug was only the
  client refetching it.
- `pnpm run typecheck:native` — passes.
- `biome` clean on the changed file.
- Single-file change; no GraphQL schema/codegen changes.

## Follow-up (not in this PR)

Classification template cards key their value chips by **label** (`TemplateCard.tsx`),
so duplicate value labels emit a React `same key` warning. The correct fix keys by value
`id`, which needs a small prop-type change (`valueLabels: string[]` → values with ids)
across the card + mapper — left out to keep this PR focused on the reported delete bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template content loading by handling GraphQL and network errors gracefully.
  * Prevented failed template content requests from interrupting the application.
  * Ensured unavailable or empty template content continues to follow the existing empty-content behavior.
  * Preserved retrieval of the latest available template data when requests succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->