### PR TITLE
fix(markdown): raise table picker/menu above elevated dialogs (z-[130])

### DIFF
--- a/src/crd/forms/markdown/ToolbarTableOpsMenu.tsx
+++ b/src/crd/forms/markdown/ToolbarTableOpsMenu.tsx
@@ -60,7 +60,7 @@ export function ToolbarTableOpsMenu({ editor }: ToolbarTableOpsMenuProps) {
             <TableIcon className="w-4 h-4" aria-hidden="true" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="z-[70]" align="start">
+        <DropdownMenuContent className="z-[130]" align="start">
           <DropdownMenuItem onClick={() => run(c => c.addColumnBefore())}>
             <ArrowLeftToLine className="w-4 h-4 mr-2" aria-hidden="true" />
             {t('editor.table.addColumnBefore')}

--- a/src/crd/forms/markdown/ToolbarTablePicker.tsx
+++ b/src/crd/forms/markdown/ToolbarTablePicker.tsx
@@ -71,7 +71,7 @@ export function ToolbarTablePicker({ editor }: ToolbarTablePickerProps) {
           <TableIcon className="w-4 h-4" aria-hidden="true" />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="z-[70] w-auto p-2" align="start">
+      <PopoverContent className="z-[130] w-auto p-2" align="start">
         {!customMode ? (
           <>
             {/* biome-ignore lint/a11y/noStaticElementInteractions: mouseLeave only resets hover state — accessible interaction is delegated to per-cell buttons */}


### PR DESCRIPTION
The table insert picker (Popover) and the table operations menu (DropdownMenu) in the markdown toolbar were still pinned at z-[70], so — like the image/embed/link/ emoji pop-ups before them — they opened behind the elevated focused-task edit dialog (z-[120]) and were invisible while editing a task description. Raise both to z-[130], matching the other toolbar pop-ups.

lint + build green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the visibility of table operation menus and table picker popovers by ensuring they appear above overlapping interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->