### PR TITLE
Sidebar graphical tweaks

### DIFF
--- a/src/crd/components/space/sidebar/InfoBlock.tsx
+++ b/src/crd/components/space/sidebar/InfoBlock.tsx
@@ -60,7 +60,7 @@ export function InfoBlock({ description, leads = [], onEditClick, className }: I
   const leadHeading = leads.length === 1 ? t('sidebar.spaceLead') : t('sidebar.spaceLeads');
 
   return (
-    <div className={cn('group relative bg-primary text-primary-foreground rounded-lg p-5', className)}>
+    <div className={cn('group relative bg-primary text-primary-foreground rounded-lg p-5 min-h-[120px]', className)}>
       {description && (
         <>
           <div ref={descriptionRef} className={cn(!isExpanded && 'line-clamp-3')}>

--- a/src/crd/layouts/SpaceShell.test.tsx
+++ b/src/crd/layouts/SpaceShell.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { SpaceShell } from './SpaceShell';
+
+const renderShell = (props: { sidebarCollapsed?: boolean; fullWidth?: boolean; sidebar?: boolean }) =>
+  render(
+    <SpaceShell
+      header={<div>header</div>}
+      sidebar={props.sidebar === false ? undefined : <div data-testid="sidebar-slot" />}
+      sidebarCollapsed={props.sidebarCollapsed}
+      fullWidth={props.fullWidth}
+    >
+      <div data-testid="content" />
+    </SpaceShell>
+  );
+
+describe('SpaceShell sidebar column', () => {
+  test('with a sidebar, the column renders at lg and the content spans 8', () => {
+    renderShell({});
+    const sidebarColumn = screen.getByTestId('sidebar-slot').parentElement as HTMLElement;
+    expect(sidebarColumn.className).toContain('lg:block');
+    expect(sidebarColumn.className).toContain('col-span-2');
+    const content = screen.getByTestId('content').parentElement as HTMLElement;
+    expect(content.className).toContain('lg:col-span-8');
+  });
+
+  test('sidebarCollapsed keeps the slot mounted but hidden, content takes the no-sidebar width', () => {
+    renderShell({ sidebarCollapsed: true });
+    // The slot must stay in the DOM: portals resolve their target element once on mount.
+    const sidebarColumn = screen.getByTestId('sidebar-slot').parentElement as HTMLElement;
+    expect(sidebarColumn.className).toBe('hidden');
+    const content = screen.getByTestId('content').parentElement as HTMLElement;
+    // Same placement as the no-sidebar case (contentColumnClass).
+    expect(content.className).toContain('lg:col-span-10');
+    expect(content.className).not.toContain('lg:col-span-8');
+  });
+
+  test('sidebarCollapsed + fullWidth spans all 12 columns', () => {
+    renderShell({ sidebarCollapsed: true, fullWidth: true });
+    const content = screen.getByTestId('content').parentElement as HTMLElement;
+    expect(content.className).toContain('lg:col-span-12');
+  });
+
+  test('no sidebar at all behaves as before (content in the inset band)', () => {
+    renderShell({ sidebar: false });
+    expect(screen.queryByTestId('sidebar-slot')).not.toBeInTheDocument();
+    const content = screen.getByTestId('content').parentElement as HTMLElement;
+    expect(content.className).toContain('lg:col-span-10');
+  });
+});

--- a/src/crd/layouts/SpaceShell.tsx
+++ b/src/crd/layouts/SpaceShell.tsx
@@ -5,6 +5,14 @@ import { cn } from '@/crd/lib/utils';
 type SpaceShellProps = {
   header: ReactNode;
   sidebar?: ReactNode;
+  /**
+   * Visually collapses the sidebar column while keeping the `sidebar` node mounted:
+   * the column is hidden at every breakpoint and the content takes the full
+   * no-sidebar width. Use when the sidebar is known to render nothing (e.g. a tab
+   * configured with zero widgets) — the slot must stay in the DOM for portals that
+   * resolve their target element once on mount.
+   */
+  sidebarCollapsed?: boolean;
   tabs?: ReactNode;
   children: ReactNode;
   /**
@@ -16,8 +24,19 @@ type SpaceShellProps = {
   className?: string;
 };
 
-export function SpaceShell({ header, sidebar, tabs, children, fullWidth, className }: SpaceShellProps) {
+export function SpaceShell({
+  header,
+  sidebar,
+  sidebarCollapsed,
+  tabs,
+  children,
+  fullWidth,
+  className,
+}: SpaceShellProps) {
   const hasSidebar = !!sidebar;
+  // Collapsed: the node stays mounted (hidden) but the layout behaves as if there
+  // were no sidebar — the content column spans the full no-sidebar width.
+  const showSidebar = hasSidebar && !sidebarCollapsed;
   const hasTabs = !!tabs;
 
   return (
@@ -49,8 +68,11 @@ export function SpaceShell({ header, sidebar, tabs, children, fullWidth, classNa
           {hasSidebar && (
             <div
               className={cn(
-                'hidden lg:block col-span-2 sticky top-[8.5rem] self-start max-h-[calc(100vh-8.5rem)] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-                fullWidth ? 'lg:col-start-1' : 'lg:col-start-2'
+                'hidden',
+                showSidebar && [
+                  'lg:block col-span-2 sticky top-[8.5rem] self-start max-h-[calc(100vh-8.5rem)] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+                  fullWidth ? 'lg:col-start-1' : 'lg:col-start-2',
+                ]
               )}
             >
               {sidebar}
@@ -60,7 +82,7 @@ export function SpaceShell({ header, sidebar, tabs, children, fullWidth, classNa
           <div
             className={cn(
               'col-span-12 min-w-0',
-              hasSidebar ? (fullWidth ? 'lg:col-span-10' : 'lg:col-span-8') : contentColumnClass(fullWidth)
+              showSidebar ? (fullWidth ? 'lg:col-span-10' : 'lg:col-span-8') : contentColumnClass(fullWidth)
             )}
           >
             {children}

--- a/src/main/crdPages/space/hooks/useCrdSpaceTabs.tsx
+++ b/src/main/crdPages/space/hooks/useCrdSpaceTabs.tsx
@@ -23,6 +23,13 @@ type UseCrdSpaceTabsProvided = {
    */
   sectionCount: number;
   showSettings: boolean;
+  /**
+   * Each state's stored `sidebar` (wire enum values), indexed by original position in
+   * the full flow — same indexing as `CrdTabDefinition.index`. Empty while the query
+   * is loading or when the space has no flow states, so `stateSidebars[i]` being
+   * `undefined` means "unknown", never "configured empty".
+   */
+  stateSidebars: ReadonlyArray<readonly string[]>;
 };
 
 const tabsDefaultNames: Record<string, 'tabs.dashboard' | 'tabs.community' | 'tabs.subspaces' | 'tabs.knowledgeBase'> =
@@ -113,5 +120,6 @@ export function useCrdSpaceTabs({
     defaultTabIndex,
     sectionCount,
     showSettings: permissions.canUpdate,
+    stateSidebars: allStates.map(state => state.settings.sidebar),
   };
 }

--- a/src/main/crdPages/space/layout/CrdSpacePageLayout.tsx
+++ b/src/main/crdPages/space/layout/CrdSpacePageLayout.tsx
@@ -54,6 +54,7 @@ import { mapSpaceVisibility } from '../dataMappers/spacePageDataMapper';
 import { CrdSpaceAboutDialogConnector } from '../dialogs/CrdSpaceAboutDialogConnector';
 import { CrdSpaceActivityDialogConnector } from '../dialogs/CrdSpaceActivityDialogConnector';
 import { useCrdSpaceTabs } from '../hooks/useCrdSpaceTabs';
+import { resolveSidebarPlan } from './sidebarWidgetPlan';
 
 export default function CrdSpacePageLayout() {
   const { t } = useTranslation(['crd-space', 'crd-spaceSettings']);
@@ -95,7 +96,7 @@ export default function CrdSpacePageLayout() {
   const isLevelZero = spaceLevel === SpaceLevel.L0;
   usePageTitle(isLevelZero ? space.about.profile.displayName : undefined);
 
-  const { tabs, defaultTabIndex, sectionCount, showSettings } = useCrdSpaceTabs({
+  const { tabs, defaultTabIndex, sectionCount, showSettings, stateSidebars } = useCrdSpaceTabs({
     spaceId,
     skip: !isLevelZero || !permissions.canRead,
   });
@@ -132,6 +133,14 @@ export default function CrdSpacePageLayout() {
   } else if (defaultTabIndex >= 0) {
     activeTabIndex = Math.min(defaultTabIndex, maxTabIndex);
   }
+
+  // A tab configured with zero renderable widgets gets no sidebar column at all — the
+  // content takes the full no-sidebar width (FR-016). Only collapse when the stored list
+  // is KNOWN and resolves empty: while SpaceTabs is loading `stateSidebars` is empty, and
+  // collapsing then would flash the content full-width on every cold load. The mobile
+  // drawer and its triggers (hamburger, bottom bar, edge swipe) stay available regardless.
+  const activeTabSidebar = stateSidebars[activeTabIndex];
+  const sidebarEmpty = activeTabSidebar !== undefined && resolveSidebarPlan(activeTabSidebar).length === 0;
 
   const handleTabChange = (index: number) => {
     const url = buildSpaceSectionUrl(space.about.profile.url ?? '', index + 1);
@@ -235,6 +244,9 @@ export default function CrdSpacePageLayout() {
             )
           }
           sidebar={isOnSettings ? undefined : sidebarSlot}
+          // Empty-configured sidebar: the slot stays mounted (the portal resolves its
+          // target once on mount) but the column collapses and content goes full width.
+          sidebarCollapsed={sidebarEmpty}
           tabs={
             isOnSettings ? (
               // Settings tabs live in the shell's sticky tabs row too, so they


### PR DESCRIPTION
### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop content now expands to full width when the active space tab has no sidebar widgets.
  * Sidebar layouts can collapse while preserving the sidebar for quick restoration.
  * Space tab state now reflects each tab’s configured sidebar settings.

* **Bug Fixes**
  * Improved sidebar sizing and layout consistency with a minimum sidebar information block height.

* **Tests**
  * Added coverage for visible, collapsed, full-width, and absent sidebar layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->