### PR TITLE
fix(a11y): label whiteboard editor dialog

### DIFF
--- a/src/crd/components/whiteboard/WhiteboardEditorShell.spec.tsx
+++ b/src/crd/components/whiteboard/WhiteboardEditorShell.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WhiteboardEditorShell } from './WhiteboardEditorShell';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('WhiteboardEditorShell', () => {
+  it('associates the whiteboard title with the dialog', () => {
+    render(
+      <WhiteboardEditorShell open={true} onClose={vi.fn()} title="Planning board">
+        <div>Canvas</div>
+      </WhiteboardEditorShell>
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Planning board' });
+    const titleId = dialog.getAttribute('aria-labelledby');
+
+    expect(titleId).toBeTruthy();
+    if (!titleId) throw new Error('Expected the dialog to reference its title');
+    expect(document.getElementById(titleId)).toHaveAttribute('data-slot', 'dialog-title');
+  });
+});

--- a/src/crd/components/whiteboard/WhiteboardEditorShell.tsx
+++ b/src/crd/components/whiteboard/WhiteboardEditorShell.tsx
@@ -1,8 +1,8 @@
 import { X } from 'lucide-react';
-import { type ReactNode, useId } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/crd/lib/utils';
-import { Dialog, DialogContentRaw, DialogOverlay, DialogPortal } from '@/crd/primitives/dialog';
+import { Dialog, DialogContentRaw, DialogOverlay, DialogPortal, DialogTitle } from '@/crd/primitives/dialog';
 
 type WhiteboardEditorShellProps = {
   open: boolean;
@@ -39,7 +39,6 @@ export function WhiteboardEditorShell({
   onEscapeKeyDown,
 }: WhiteboardEditorShellProps) {
   const { t } = useTranslation('crd-whiteboard');
-  const titleId = useId();
 
   return (
     <Dialog
@@ -51,7 +50,6 @@ export function WhiteboardEditorShell({
       <DialogPortal>
         <DialogOverlay className="z-[60] bg-background/80 backdrop-blur-sm" />
         <DialogContentRaw
-          aria-labelledby={titleId}
           onInteractOutside={e => e.preventDefault()}
           onPointerDownOutside={e => e.preventDefault()}
           onEscapeKeyDown={e => {
@@ -73,10 +71,12 @@ export function WhiteboardEditorShell({
         >
           {/* Header */}
           <div className="flex items-center gap-2 px-4 py-2 border-b border-border shrink-0">
-            <div id={titleId} className="flex-1 min-w-0 flex items-center gap-2">
-              {title}
-              {titleExtra}
-            </div>
+            <DialogTitle asChild={true}>
+              <div className="flex-1 min-w-0 flex items-center gap-2">
+                {title}
+                {titleExtra}
+              </div>
+            </DialogTitle>
             <div className="flex items-center gap-1 shrink-0">
               {headerActions}
               <button


### PR DESCRIPTION
## Source

Free-text bug, no board story.

## Root cause

The whiteboard editor shell manually connected its visible title with `aria-labelledby`, but it never rendered Radix's required `DialogTitle` component. Radix therefore reported the dialog as untitled whenever a whiteboard opened.

## Fix

- Render the existing visible whiteboard-title container through `DialogTitle` with `asChild`.
- Let Radix generate and own the dialog/title association.
- Remove the redundant local title ID. No hidden duplicate label or new user-facing copy is introduced.

## Regression test

The new `WhiteboardEditorShell` test renders the real Radix dialog, resolves it by the visible whiteboard name, and verifies that its `aria-labelledby` target is the mounted `DialogTitle`. The test fails on `develop` while reproducing the reported Radix warning.

## Verification

- `pnpm vitest run` — 350 files passed; 2,971 tests passed, 2 skipped
- `pnpm build` — passed
- `pnpm lint` — passed (typecheck, Biome, ESLint; existing baseline warnings only)
- Normal signed commit hook — passed, including the full test suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog accessibility by correctly identifying the whiteboard editor title for assistive technologies.
  * Preserved existing dialog title and header content while ensuring the title is properly associated with the dialog.

* **Tests**
  * Added coverage verifying the dialog title and its accessibility labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->