### PR TITLE
fix(reactions): hide emoji reactions when comments are turned off

### DIFF
--- a/src/crd/components/space/PostCard.test.tsx
+++ b/src/crd/components/space/PostCard.test.tsx
@@ -149,19 +149,34 @@ describe('PostCard reactionsSlot placement', () => {
     expect(reactionsNode.parentElement?.parentElement).toBe(trigger.parentElement);
   });
 
-  it('renders a reactions-only footer when comments are suppressed but reactions exist (edge case)', () => {
-    // commentsEnabled=false AND no existing comments AND no commentsSlot → the
-    // comments footer is suppressed, but reactions still need a home.
+  it('renders no footer and no reactions when comments are turned off and none exist yet', () => {
+    // Reactions follow the comments switch: with commenting off and no existing
+    // messages, the card falls back to its pre-reactions look — no footer row at all.
     const { container } = render(
       <PostCard post={{ ...basePost, commentsEnabled: false, commentCount: 0 }} reactionsSlot={reactions} />
     );
-    const footer = container.querySelector('[data-slot="card-footer"]');
-    expect(footer).toBeTruthy();
-    const reactionsNode = screen.getByTestId('reactions');
-    expect(footer?.contains(reactionsNode)).toBe(true);
-    expect(reactionsNode.parentElement).toHaveClass('ml-auto');
-    // No comments affordance in this minimal footer.
-    expect(screen.queryByRole('button', { name: /Comments/i })).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="card-footer"]')).toBeNull();
+    expect(screen.queryByTestId('reactions')).not.toBeInTheDocument();
+  });
+
+  it('hides reactions but keeps the read-only comments footer when comments are turned off with existing messages', () => {
+    const { container } = render(
+      <PostCard
+        post={{ ...basePost, commentsEnabled: false, commentCount: 3 }}
+        reactionsSlot={reactions}
+        commentsSlot={<div>thread</div>}
+      />
+    );
+    // The existing thread stays reachable, so the footer survives...
+    expect(container.querySelector('[data-slot="card-footer"]')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /expandComments|collapseComments/i })).toBeInTheDocument();
+    // ...but the reactions surface is gone with the comments switch.
+    expect(screen.queryByTestId('reactions')).not.toBeInTheDocument();
+  });
+
+  it('renders reactions when comments are explicitly enabled', () => {
+    render(<PostCard post={{ ...basePost, commentsEnabled: true, commentCount: 0 }} reactionsSlot={reactions} />);
+    expect(screen.getByTestId('reactions')).toBeInTheDocument();
   });
 
   it('renders no footer at all when comments are suppressed and there is no reactions slot', () => {

--- a/src/crd/components/space/PostCard.tsx
+++ b/src/crd/components/space/PostCard.tsx
@@ -231,6 +231,11 @@ export function PostCard({
   const hasCollapsibleComments = commentsSlot !== undefined;
   const [isCommentsOpen, setIsCommentsOpen] = useState(false);
   const showPublishDetails = post.showPublishDetails !== false;
+  // Emoji reactions ride on the same switch as comments. When commenting is turned
+  // off for the callout, the whole reactions surface (picker, total pill, who-reacted)
+  // goes with it; with nothing else to show, the footer row disappears too, so the card
+  // looks exactly as it did before reactions existed.
+  const showReactions = post.commentsEnabled !== false;
 
   const handleCommentsOpenChange = (open: boolean) => {
     setIsCommentsOpen(open);
@@ -549,9 +554,10 @@ export function PostCard({
       {/* Footer is hidden entirely when comments are disabled AND there are no existing messages —
           mirrors the MUI behavior. When messages exist, the thread stays visible (read-only via
           consumer-gated `commentInputSlot`) even after the admin disables further commenting.
-          The reactions widget lives here too, bottom-right of the footer. */}
-      {post.commentsEnabled !== false || (post.commentCount ?? 0) > 0 ? (
-        hasCollapsibleComments ? (
+          The reactions widget lives here too, bottom-right of the footer — but only while
+          commenting is enabled, so a comments-disabled card never keeps a reactions-only row. */}
+      {(post.commentsEnabled !== false || (post.commentCount ?? 0) > 0) &&
+        (hasCollapsibleComments ? (
           <CardFooter className="!p-0 flex-col items-stretch gap-0 border-t bg-muted/5">
             <Collapsible open={isCommentsOpen} onOpenChange={handleCommentsOpenChange}>
               {/* Trigger and reactions are SIBLINGS in this row — the reactions must
@@ -573,7 +579,7 @@ export function PostCard({
                     <span>{commentLabel}</span>
                   </button>
                 </CollapsibleTrigger>
-                {reactionsSlot && <div className="shrink-0">{reactionsSlot}</div>}
+                {showReactions && reactionsSlot && <div className="shrink-0">{reactionsSlot}</div>}
               </div>
               <CollapsibleContent className="px-6 pt-4 pb-4">
                 <div className="flex flex-col gap-3">
@@ -597,18 +603,9 @@ export function PostCard({
               <MessageSquare className="w-4 h-4" aria-hidden="true" />
               <span className="text-caption">{commentLabel}</span>
             </Button>
-            {reactionsSlot && <div className="ml-auto shrink-0">{reactionsSlot}</div>}
+            {showReactions && reactionsSlot && <div className="ml-auto shrink-0">{reactionsSlot}</div>}
           </CardFooter>
-        )
-      ) : (
-        // Comments footer suppressed (disabled + none yet) but reactions still
-        // need a home — render a minimal reactions-only footer, right-aligned.
-        reactionsSlot && (
-          <CardFooter className="!py-3 flex items-center border-t bg-muted/5 px-6">
-            <div className="ml-auto shrink-0">{reactionsSlot}</div>
-          </CardFooter>
-        )
-      )}
+        ))}
     </Card>
   );
 }

--- a/src/main/crdPages/space/callout/CalloutDetailDialogConnector.tsx
+++ b/src/main/crdPages/space/callout/CalloutDetailDialogConnector.tsx
@@ -449,10 +449,13 @@ export function CalloutDetailDialogConnector({
   const spacesFramingSlot = hasSpaces ? <SpaceCollectionConnector calloutId={callout.id} /> : undefined;
 
   // Omit the slot entirely when the callout has no reactions summary (the server
-  // module may not be deployed). The connector renders null in that case, but an
-  // element is still truthy — passing it would render an empty bordered section.
+  // module may not be deployed), or when commenting is turned off for the callout —
+  // reactions share the comments switch, and an omitted slot also drops the bordered
+  // section that hosts them. The framing-level flag is read here rather than from the
+  // dialog's `commentsEnabled` prop, which swaps to the contribution-level switch while
+  // a post contribution is selected and would gate callout reactions on the wrong toggle.
   const reactionsSlot =
-    callout.reactionsSummary == null ? undefined : (
+    callout.reactionsSummary == null || !callout.settings.framing.commentsEnabled ? undefined : (
       <CalloutReactionsConnector
         calloutId={callout.id}
         reactionsSummary={callout.reactionsSummary}


### PR DESCRIPTION
Fixes alkem-io/client-web#8447

## Operator ruling (the issue deliberately left "Expected behavior" open)

The issue asks the team to *decide* whether reactions are tied to the comments
switch. The binding decision taken for this fix:

> **Emoji reactions are available ONLY when the callout setting that enables
> comments is enabled.** When comments are disabled for a callout/post, the
> emoji reactions **and the entire footer row that hosts them** are **hidden** —
> the UI returns to exactly the pre-reactions appearance it had when comments
> were disabled. Not "disabled/greyed out" — hidden.

Recorded here so the previously-open question stays auditable.

## Root cause

The reactions surface shipped as an independent slot with its own home. It was
rendered whenever a reactions summary existed, with no reference to
`callout.settings.framing.commentsEnabled`:

- `PostCard` rendered `reactionsSlot` in the comments footer regardless of
  `commentsEnabled`, and — when the footer was suppressed (comments off, no
  messages) — deliberately fell back to a **reactions-only footer** so the
  reactions "still needed a home". That extra bordered row is the visible
  artifact reported in the issue: a comments-disabled card that used to have no
  footer at all now had one.
- `CalloutDetailDialogConnector` built the dialog's `reactionsSlot` gated only
  on `reactionsSummary == null`, so the bordered reactions section rendered on a
  comments-disabled callout too.

## The fix

Client-web only, presentational. No server change, no GraphQL document,
fragment, or schema change — `callout.settings.framing.commentsEnabled` was
already in the existing query payload (it is what drives the comments footer and
`calloutDataMapper` already maps it onto `PostCardData.commentsEnabled`).

1. **`src/crd/components/space/PostCard.tsx`** — derive
   `showReactions = post.commentsEnabled !== false` and gate both `reactionsSlot`
   renders (collapsible and non-collapsible footer) on it. The reactions-only
   fallback footer branch is removed, so:
   - comments off + no messages → **no footer at all** (pre-reactions look);
   - comments off + existing messages → footer stays for the read-only thread,
     **without** the reactions surface;
   - comments on → unchanged.

2. **`src/main/crdPages/space/callout/CalloutDetailDialogConnector.tsx`** — omit
   the dialog's `reactionsSlot` when the framing-level comments switch is off.
   Omitting the slot (rather than gating inside `CalloutDetailDialog`) also drops
   the bordered `py-3 border-b` section that hosts it, matching the "no empty row
   left behind" requirement, and reuses the existing "omit when no summary"
   precedent right above it.

### Why the dialog gate lives in the connector

`CalloutDetailDialog`'s `commentsEnabled` prop is context-dependent: the
connector swaps it to `settings.contribution.commentsEnabled` while a post
contribution is selected (the comment surface swaps from callout-level to
post-level). Gating the **callout's** reactions on that prop would hide them
whenever a post with commenting off happened to be selected — the wrong toggle.
Reading `callout.settings.framing.commentsEnabled` at the slot construction site
keeps the gate on the callout's own switch.

Since the whole reactions surface — picker, total pill, who-reacted popover — is
composed by `CalloutReactionsBar` behind these slots, gating the slot hides all
of it and prevents the connector from mounting (no wasted reactions queries).

### Scope note

This covers the callout/post reactions shipped with the reactions feature
(#4580). Per-message reactions inside a comment thread are a separate,
pre-existing surface with its own `canComment` gating and are untouched.

## Regression test

`src/crd/components/space/PostCard.test.tsx` — the existing case asserting the
old behavior ("renders a reactions-only footer when comments are suppressed but
reactions exist") is inverted, plus a new case for the messages-exist path:

- `renders no footer and no reactions when comments are turned off and none exist yet`
- `hides reactions but keeps the read-only comments footer when comments are turned off with existing messages`
- `renders reactions when comments are explicitly enabled`

Both new assertions were verified to **fail** against the unmodified
`PostCard.tsx` and pass with the fix.

## Gates

- `pnpm vitest run` — 349 files / 2972 tests pass (2 skipped)
- `pnpm build` — clean
- `pnpm lint` (tsc + Biome + ESLint React Compiler) — exit 0, zero findings on the touched files

Comments added by this diff carry no spec/feature/issue/PR numbers, per the
workspace code-comment convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reactions are now hidden when commenting is disabled.
  - Read-only comment information remains visible when existing comments are present.
  - Removed the reactions-only footer when commenting is disabled and no comments exist.
  - Updated reaction behavior consistently across post cards and callout details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->