### PR TITLE
fix(subspaces): open Create Subspace from the Subspaces dialog on any tab

### DIFF
--- a/src/main/crdPages/space/tabs/CrdSpaceTabPage.tsx
+++ b/src/main/crdPages/space/tabs/CrdSpaceTabPage.tsx
@@ -61,8 +61,12 @@ export default function CrdSpaceTabPage({ tabPosition, onOpenAbout }: CrdSpaceTa
   // the button. Template queries fire only when the widget is configured on
   // this tab AND the viewer can create subspaces (FR-012/FR-019).
   const sidebarWire = flowStateForNewCallouts?.settings.sidebar ?? [];
-  const hasCreateSubspaceWidget = resolveSidebarPlan(sidebarWire).includes('createSubspace');
-  const canCreateSubspace = hasCreateSubspaceWidget && permissions.canCreateSubspaces;
+  const sidebarPlan = resolveSidebarPlan(sidebarWire);
+  // The Subspaces dialog (opened from the `subspaceLinks` widget's "Show all")
+  // also offers Create Subspace, so the dialog + template queries must be live
+  // for either entry point — not only the dedicated `createSubspace` widget.
+  const hasCreateSubspaceEntry = sidebarPlan.includes('createSubspace') || sidebarPlan.includes('subspaceLinks');
+  const canCreateSubspace = hasCreateSubspaceEntry && permissions.canCreateSubspaces;
   const { data: templatesManagerData } = useSpaceTemplatesManagerQuery({
     // biome-ignore lint/style/noNonNullAssertion: ensured by skip
     variables: { spaceId: spaceId! },


### PR DESCRIPTION
Free-text bug, no board story.

## Root cause

`CrdSpaceTabPage` mounted `CreateSubspaceDialogs` (and fired its two template queries) only when the `createSubspace` **widget** was configured on the active tab's sidebar. But the Subspaces dialog — opened from the `subspaceLinks` widget's "Show all" (#10209) — offers its own Create Subspace footer button, gated only on the `canCreateSubspaces` permission. On a tab with `subspaceLinks` but no `createSubspace` widget, clicking that button flipped the `useCreateSubspace` hook's `open` state while the dialog component wasn't rendered at all: the Subspaces dialog closed and nothing appeared.

## Fix

Activate the dialog mount + template queries when **either** entry point is in the tab's sidebar plan (`createSubspace` or `subspaceLinks`), still gated on the permission. The queries stay eager rather than on-click because `openDialog` reads `defaultTemplateId` synchronously at click time to pre-select the space's default subspace template — lazy loading would silently skip that pre-selection on first open. FR-019's intent holds: the queries fire only for viewers with the privilege, on tabs where one of the two entry points is actually configured.

The subspace-page layout (`CrdSubspacePageLayout`) needs no change — its dialog mount gate already matches its handler gate.

## Regression test

Covered by the existing suite plus manual verification of the flow; `pnpm lint` and all 352 test files (2984 tests) pass. No unit test asserts the mount gate directly — it's a JSX conditional wiring two connectors, exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxLUBLeoKzgX6VJcqzW2Lm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Subspace creation is now available when either the Subspace Creation or Subspace Links sidebar widget is configured.
  - Creation remains restricted to viewers with the required permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->