### PR TITLE
fix: show whiteboard template previews

### DIFF
--- a/src/main/crdPages/templates/__tests__/useTemplatePicker.test.tsx
+++ b/src/main/crdPages/templates/__tests__/useTemplatePicker.test.tsx
@@ -20,12 +20,14 @@ import {
   ImportTemplateDialogAccountTemplatesDocument,
   ImportTemplateDialogDocument,
   ImportTemplateDialogPlatformTemplatesDocument,
+  TemplateContentDocument,
 } from '@/core/apollo/generated/apollo-hooks';
 import {
   TemplateType as GqlTemplateType,
   type ImportTemplateDialogAccountTemplatesQuery,
   type ImportTemplateDialogPlatformTemplatesQuery,
   type ImportTemplateDialogQuery,
+  type TemplateContentQuery,
 } from '@/core/apollo/generated/graphql-schema';
 import { useTemplatePicker } from '../useTemplatePicker';
 
@@ -106,7 +108,11 @@ const platformMock = (
 ): MockedResponse<ImportTemplateDialogPlatformTemplatesQuery> => ({
   request: {
     query: ImportTemplateDialogPlatformTemplatesDocument,
-    variables: { templateTypes: allowedTypes, includeCallout: true, includeSpace: false },
+    variables: {
+      templateTypes: allowedTypes,
+      includeCallout: allowedTypes[0] === GqlTemplateType.Callout,
+      includeSpace: allowedTypes[0] === GqlTemplateType.Space,
+    },
   },
   result: {
     data: {
@@ -134,6 +140,55 @@ const platformMock = (
         },
       },
     } as unknown as ImportTemplateDialogPlatformTemplatesQuery,
+  },
+});
+
+const whiteboardContentMock = (templateId: string, previewUri?: string): MockedResponse<TemplateContentQuery> => ({
+  request: {
+    query: TemplateContentDocument,
+    variables: {
+      templateId,
+      includeCallout: false,
+      includeWhiteboard: true,
+      includePost: false,
+      includeSpace: false,
+      includeCommunityGuidelines: false,
+      includeClassification: false,
+    },
+  },
+  result: {
+    data: {
+      lookup: {
+        __typename: 'LookupQueryResults',
+        template: {
+          __typename: 'Template',
+          id: templateId,
+          type: GqlTemplateType.Whiteboard,
+          profile: {
+            __typename: 'Profile',
+            id: `${templateId}-profile`,
+            displayName: 'Whiteboard template',
+            description: '',
+            defaultTagset: { __typename: 'Tagset', id: `${templateId}-tagset`, tags: [] },
+          },
+          whiteboard: {
+            __typename: 'Whiteboard',
+            id: `${templateId}-whiteboard`,
+            profile: {
+              __typename: 'Profile',
+              id: `${templateId}-whiteboard-profile`,
+              displayName: 'Whiteboard template',
+              preview: previewUri ? { __typename: 'Visual', name: 'preview', uri: previewUri } : null,
+            },
+            previewSettings: {
+              __typename: 'WhiteboardPreviewSettings',
+              mode: 'AUTO',
+              coordinates: null,
+            },
+          },
+        },
+      },
+    } as unknown as TemplateContentQuery,
   },
 });
 
@@ -306,5 +361,37 @@ describe('useTemplatePicker — selection lifecycle', () => {
 
     expect(result.current.selectedTemplateId).toBeNull();
     expect(result.current.selectedTemplateContent).toBeNull();
+  });
+});
+
+describe('useTemplatePicker — whiteboard preview', () => {
+  it('uses the template card visual when the nested whiteboard has no preview visual', async () => {
+    const allowedTypes: ['whiteboard'] = ['whiteboard'];
+    const template = tpl('wb-1', GqlTemplateType.Whiteboard, 'Legacy whiteboard');
+    template.profile.visual.uri = 'https://cdn.alkem.io/templates/wb-1.png';
+    const wrapper = makeWrapper([
+      platformMock([GqlTemplateType.Whiteboard], [{ template, packDisplayName: 'Platform' }]),
+      whiteboardContentMock('wb-1'),
+    ]);
+    const { result } = renderHook(() => useTemplatePicker({ allowedTypes }), { wrapper });
+
+    act(() => {
+      result.current.openPicker();
+    });
+    await waitFor(() => {
+      expect(result.current.pickerProps.sources[0]?.templates).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.pickerProps.onPreview('wb-1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.pickerProps.previewContent).toEqual({
+        type: 'whiteboard',
+        sourceWhiteboardId: 'wb-1-whiteboard',
+        previewImageUrl: 'https://cdn.alkem.io/templates/wb-1.png',
+      });
+    });
   });
 });

--- a/src/main/crdPages/templates/useTemplatePicker.ts
+++ b/src/main/crdPages/templates/useTemplatePicker.ts
@@ -148,6 +148,7 @@ export function useTemplatePicker({
 
   const onPreview = (templateId: string) => {
     if (!primaryType) return;
+    const cardPreviewUrl = sources.flatMap(source => source.templates).find(card => card.id === templateId)?.bannerUrl;
     activePreviewIdRef.current = templateId;
     setPreviewId(templateId);
     setPreviewContent(undefined);
@@ -156,7 +157,12 @@ export function useTemplatePicker({
       .then(({ data }) => {
         if (activePreviewIdRef.current !== templateId) return;
         const fetched = data?.lookup.template;
-        setPreviewContent(fetched ? mapTemplateContent(fetched, primaryType) : undefined);
+        const content = fetched ? mapTemplateContent(fetched, primaryType) : undefined;
+        setPreviewContent(
+          content?.type === 'whiteboard' && !content.previewImageUrl && cardPreviewUrl
+            ? { ...content, previewImageUrl: cardPreviewUrl }
+            : content
+        );
       })
       .catch(() => {
         // The request failed (network / auth / GraphQL). Leave the (already-cleared) preview empty


### PR DESCRIPTION
## Summary

- Free-text bug; no board story.
- Preserve the existing template chooser UI while restoring whiteboard previews.
- Fall back to the selected template card visual only when the nested whiteboard preview visual is absent.

## Root cause

The contribution template picker passed only the nested whiteboard preview visual to the preview pane. Legacy whiteboard templates commonly retain a valid template CARD visual but have no nested whiteboard preview, so the picker discarded the usable visual and rendered the generic placeholder. The ordinary template preview path already uses that card visual.

## Fix

The picker now carries the selected card visual into the fetched whiteboard preview only as a fallback. A canonical nested whiteboard preview still takes precedence, and no chooser layout or interaction changes were made.

## Regression coverage

Added a hook-level Apollo regression that reproduces a whiteboard template with a card visual and no nested preview. It failed before the fix (`previewImageUrl` was undefined) and now verifies the card visual reaches the preview pane.

## Verification

- Focused Vitest: 8 passed
- Full Vitest: 352 files, 2,985 passed, 2 skipped
- `pnpm build`: passed
- `pnpm lint` (TypeScript, Biome, ESLint): passed
- Normal pre-commit hook: passed full checks under Node 24.14.0
- Commit signature: verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template previews by using the template card visual when a whiteboard preview image is unavailable.
  * Ensured template previews continue to display correctly across supported content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->