### PR TITLE
fix: restore additive whiteboard template imports

### DIFF
--- a/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.spec.ts
+++ b/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.spec.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const scene = {
+    encodeStateVector: vi.fn(() => new Uint8Array([1])),
+    encodeStateAsUpdate: vi.fn(() => new Uint8Array([2])),
+    applyRemoteUpdate: vi.fn(),
+    onDocUpdate: vi.fn(() => vi.fn()),
+    getElementsIncludingDeleted: vi.fn(() => [{ id: 'template-element' }]),
+    getAssetLocators: vi.fn(() => ({ image: 'source-document' })),
+    getPersistedAppState: vi.fn(() => ({ viewBackgroundColor: '#fff' })),
+    destroy: vi.fn(),
+  };
+
+  class MockScene {
+    encodeStateVector = scene.encodeStateVector;
+    encodeStateAsUpdate = scene.encodeStateAsUpdate;
+    applyRemoteUpdate = scene.applyRemoteUpdate;
+    onDocUpdate = scene.onDocUpdate;
+    getElementsIncludingDeleted = scene.getElementsIncludingDeleted;
+    getAssetLocators = scene.getAssetLocators;
+    getPersistedAppState = scene.getPersistedAppState;
+    destroy = scene.destroy;
+  }
+
+  type Listener = (...args: never[]) => void;
+  class MockProvider {
+    static instance: MockProvider;
+    listeners = new Map<string, Listener>();
+    options: unknown;
+    connect = vi.fn();
+    destroy = vi.fn();
+
+    constructor(options: unknown) {
+      this.options = options;
+      MockProvider.instance = this;
+    }
+
+    on(event: string, listener: Listener) {
+      this.listeners.set(event, listener);
+    }
+
+    off(event: string) {
+      this.listeners.delete(event);
+    }
+
+    emit(event: string, value: unknown) {
+      this.listeners.get(event)?.(value as never);
+    }
+  }
+
+  return { scene, MockScene, MockProvider };
+});
+
+vi.mock('@excalidraw-yjs/excalidraw/headless', () => ({ Scene: h.MockScene }));
+vi.mock('@/domain/collaboration/realTimeCollaboration/unifiedCollabProvider', () => ({
+  UnifiedCollabProvider: h.MockProvider,
+}));
+
+import { loadWhiteboardSceneFromCollaboration } from './loadWhiteboardSceneFromCollaboration';
+
+describe('loadWhiteboardSceneFromCollaboration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads the source through the whiteboard collaboration port and returns a plain scene', async () => {
+    const result = loadWhiteboardSceneFromCollaboration('source-whiteboard');
+    const provider = h.MockProvider.instance;
+
+    expect(provider.options).toMatchObject({
+      documentId: 'source-whiteboard',
+      type: 'whiteboard',
+      connect: false,
+    });
+    expect(provider.connect).toHaveBeenCalledTimes(1);
+
+    provider.emit('synced', true);
+
+    await expect(result).resolves.toEqual({
+      elements: [{ id: 'template-element' }],
+      assets: { image: 'source-document' },
+      appState: { viewBackgroundColor: '#fff' },
+    });
+    expect(provider.destroy).toHaveBeenCalledTimes(1);
+    expect(h.scene.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a terminal source-room refusal without returning an empty template', async () => {
+    const result = loadWhiteboardSceneFromCollaboration('forbidden-source');
+    const provider = h.MockProvider.instance;
+
+    provider.emit('close', { code: 1008, reason: 'forbidden', disposition: 'terminal' });
+
+    await expect(result).rejects.toThrow('Unable to load whiteboard template: forbidden');
+    expect(provider.destroy).toHaveBeenCalledTimes(1);
+    expect(h.scene.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.spec.ts
+++ b/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.spec.ts
@@ -96,4 +96,17 @@ describe('loadWhiteboardSceneFromCollaboration', () => {
     expect(provider.destroy).toHaveBeenCalledTimes(1);
     expect(h.scene.destroy).toHaveBeenCalledTimes(1);
   });
+
+  it('destroys the temporary source provider immediately when the import is cancelled', async () => {
+    const controller = new AbortController();
+    const result = loadWhiteboardSceneFromCollaboration('slow-source', { signal: controller.signal });
+    const provider = h.MockProvider.instance;
+
+    expect(provider.connect).toHaveBeenCalledTimes(1);
+    controller.abort();
+
+    await expect(result).rejects.toThrow('Whiteboard template load cancelled');
+    expect(provider.destroy).toHaveBeenCalledTimes(1);
+    expect(h.scene.destroy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.ts
+++ b/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.ts
@@ -7,7 +7,10 @@ import {
 const LOAD_TIMEOUT_MS = 30_000;
 
 /** Load a whiteboard through the collaboration transport without exposing its Yjs update through GraphQL. */
-export const loadWhiteboardSceneFromCollaboration = (whiteboardId: string): Promise<WhiteboardSnapshot> => {
+export const loadWhiteboardSceneFromCollaboration = (
+  whiteboardId: string,
+  options: { signal?: AbortSignal } = {}
+): Promise<WhiteboardSnapshot> => {
   const scene = new Scene();
   const provider = new UnifiedCollabProvider({
     documentId: whiteboardId,
@@ -23,11 +26,13 @@ export const loadWhiteboardSceneFromCollaboration = (whiteboardId: string): Prom
 
   return new Promise((resolve, reject) => {
     let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
 
     const finish = (result: { scene: WhiteboardSnapshot } | { error: Error }) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeout);
+      if (timeout) clearTimeout(timeout);
+      options.signal?.removeEventListener('abort', handleAbort);
       provider.off('synced', handleSynced);
       provider.off('close', handleClose);
       provider.destroy();
@@ -53,12 +58,18 @@ export const loadWhiteboardSceneFromCollaboration = (whiteboardId: string): Prom
       }
     };
 
-    const timeout = setTimeout(
-      () => finish({ error: new Error('Timed out loading whiteboard template') }),
-      LOAD_TIMEOUT_MS
-    );
+    const handleAbort = () => {
+      finish({ error: new Error('Whiteboard template load cancelled') });
+    };
+
+    timeout = setTimeout(() => finish({ error: new Error('Timed out loading whiteboard template') }), LOAD_TIMEOUT_MS);
     provider.on('synced', handleSynced);
     provider.on('close', handleClose);
+    options.signal?.addEventListener('abort', handleAbort, { once: true });
+    if (options.signal?.aborted) {
+      handleAbort();
+      return;
+    }
     provider.connect();
   });
 };

--- a/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.ts
+++ b/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.ts
@@ -1,0 +1,64 @@
+import { Scene, type WhiteboardSnapshot } from '@excalidraw-yjs/excalidraw/headless';
+import {
+  type CloseVerdict,
+  UnifiedCollabProvider,
+} from '@/domain/collaboration/realTimeCollaboration/unifiedCollabProvider';
+
+const LOAD_TIMEOUT_MS = 30_000;
+
+/** Load a whiteboard through the collaboration transport without exposing its Yjs update through GraphQL. */
+export const loadWhiteboardSceneFromCollaboration = (whiteboardId: string): Promise<WhiteboardSnapshot> => {
+  const scene = new Scene();
+  const provider = new UnifiedCollabProvider({
+    documentId: whiteboardId,
+    type: 'whiteboard',
+    scenePort: {
+      encodeSceneStateVector: () => scene.encodeStateVector(),
+      encodeSceneAsUpdate: (format, targetStateVector) => scene.encodeStateAsUpdate(format, targetStateVector),
+      applyRemoteSceneUpdate: (update, format) => scene.applyRemoteUpdate(update, format),
+      onLocalSceneUpdate: (listener, format) => scene.onDocUpdate(listener, format),
+    },
+    connect: false,
+  });
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const finish = (result: { scene: WhiteboardSnapshot } | { error: Error }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      provider.off('synced', handleSynced);
+      provider.off('close', handleClose);
+      provider.destroy();
+      scene.destroy();
+      if ('scene' in result) resolve(result.scene);
+      else reject(result.error);
+    };
+
+    const handleSynced = (synced: boolean) => {
+      if (!synced) return;
+      finish({
+        scene: {
+          elements: [...scene.getElementsIncludingDeleted()],
+          assets: scene.getAssetLocators(),
+          appState: scene.getPersistedAppState(),
+        },
+      });
+    };
+
+    const handleClose = (verdict: CloseVerdict) => {
+      if (verdict.disposition === 'terminal' || verdict.disposition === 'normal') {
+        finish({ error: new Error(`Unable to load whiteboard template: ${verdict.reason || verdict.code}`) });
+      }
+    };
+
+    const timeout = setTimeout(
+      () => finish({ error: new Error('Timed out loading whiteboard template') }),
+      LOAD_TIMEOUT_MS
+    );
+    provider.on('synced', handleSynced);
+    provider.on('close', handleClose);
+    provider.connect();
+  });
+};

--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
@@ -98,10 +98,22 @@ describe('mergeWhiteboard asset re-homing', () => {
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
-  it('does not require a source locator for deleted image elements', async () => {
+  it('ignores deleted image elements instead of importing their tombstones', async () => {
     h.templateScene = {
       ...makeTemplateScene(),
-      elements: [{ ...makeTemplateScene().elements[0], isDeleted: true }],
+      elements: [
+        { ...makeTemplateScene().elements[0], isDeleted: true },
+        {
+          id: 'visible',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          version: 1,
+          boundElements: null,
+        },
+      ],
       assets: {},
     };
     const api = makeApi({ sceneLocatorsSequence: [{}] });
@@ -111,6 +123,23 @@ describe('mergeWhiteboard asset re-homing', () => {
     expect(api.addFiles).not.toHaveBeenCalled();
     expect(api.flushAssetPublication).not.toHaveBeenCalled();
     expect(api.updateScene).toHaveBeenCalledTimes(1);
+    expect(api.updateScene.mock.calls[0][0].elements).toHaveLength(1);
+    expect(api.updateScene.mock.calls[0][0].elements[0].type).toBe('rectangle');
+  });
+
+  it('rejects a deleted-only template without reporting a visible import', async () => {
+    h.templateScene = {
+      ...makeTemplateScene(),
+      elements: [{ ...makeTemplateScene().elements[0], isDeleted: true }],
+      assets: {},
+    };
+    const api = makeApi({ sceneLocatorsSequence: [{}] });
+
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow(
+      'Template has no visible elements'
+    );
+    expect(api.updateScene).not.toHaveBeenCalled();
+    expect(api.scrollToContent).not.toHaveBeenCalled();
   });
 
   it('resolves the source locator, re-stores into the target bucket (new id), keeps fileId, inserts the element', async () => {
@@ -294,6 +323,53 @@ describe('mergeWhiteboard asset re-homing', () => {
     expect(secondElements[2].id).not.toBe(firstElements[1].id);
     expect(firstElements[1].x).toBeGreaterThan(existing.x + existing.width);
     expect(secondElements[2].x).toBeGreaterThan(firstElements[1].x as number);
+  });
+
+  it('ignores deleted outliers when positioning visible imported content', async () => {
+    h.templateScene = {
+      elements: [
+        {
+          id: 'visible',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          version: 1,
+          boundElements: null,
+        },
+        {
+          id: 'deleted-outlier',
+          type: 'rectangle',
+          x: -100000,
+          y: -100000,
+          width: 10,
+          height: 10,
+          version: 1,
+          isDeleted: true,
+          boundElements: null,
+        },
+      ],
+      assets: {},
+      appState: {},
+    };
+    const existing = {
+      id: 'existing',
+      type: 'rectangle',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      version: 1,
+      boundElements: null,
+    };
+    const api = makeApi({ initialElements: [existing] });
+
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+
+    const inserted = api.updateScene.mock.calls[0][0].elements[1];
+    expect(inserted.x).toBeGreaterThan(existing.x + existing.width);
+    expect(api.updateScene.mock.calls[0][0].elements).toHaveLength(2);
   });
 
   it('regenerates frame, binding, and group relationships within each imported copy', async () => {

--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
@@ -86,6 +86,33 @@ describe('mergeWhiteboard asset re-homing', () => {
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
+  it('rejects a live image whose file id has no source locator before mutating the target', async () => {
+    h.templateScene = { ...makeTemplateScene(), assets: {} };
+    const api = makeApi();
+
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow(
+      'Template images have no source locator: f1'
+    );
+    expect(api.addFiles).not.toHaveBeenCalled();
+    expect(api.flushAssetPublication).not.toHaveBeenCalled();
+    expect(api.updateScene).not.toHaveBeenCalled();
+  });
+
+  it('does not require a source locator for deleted image elements', async () => {
+    h.templateScene = {
+      ...makeTemplateScene(),
+      elements: [{ ...makeTemplateScene().elements[0], isDeleted: true }],
+      assets: {},
+    };
+    const api = makeApi({ sceneLocatorsSequence: [{}] });
+
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+
+    expect(api.addFiles).not.toHaveBeenCalled();
+    expect(api.flushAssetPublication).not.toHaveBeenCalled();
+    expect(api.updateScene).toHaveBeenCalledTimes(1);
+  });
+
   it('resolves the source locator, re-stores into the target bucket (new id), keeps fileId, inserts the element', async () => {
     const api = makeApi();
     const resolve = vi.fn(async () => RESOLVED_BYTES);
@@ -120,9 +147,58 @@ describe('mergeWhiteboard asset re-homing', () => {
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
+  it('aborts before adding resolved files when the editor is invalidated during source resolution', async () => {
+    const api = makeApi();
+    let finishResolve: ((file: typeof RESOLVED_BYTES) => void) | undefined;
+    const resolve = vi.fn(
+      () =>
+        new Promise<typeof RESOLVED_BYTES>(finish => {
+          finishResolve = finish;
+        })
+    );
+    let cancelled = false;
+
+    const merge = mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve), () => cancelled);
+    await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
+    cancelled = true;
+    finishResolve?.(RESOLVED_BYTES);
+
+    await expect(merge).rejects.toThrow('Whiteboard editor changed while importing template');
+    expect(api.addFiles).not.toHaveBeenCalled();
+    expect(api.flushAssetPublication).not.toHaveBeenCalled();
+    expect(api.updateScene).not.toHaveBeenCalled();
+  });
+
   it('aborts and inserts zero elements when a target store fails in the publish flush', async () => {
     const api = makeApi({ flushReport: { published: [], skipped: [], failed: [{ fileId: 'f1', error: 'x' }] } });
     await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow();
+    expect(api.updateScene).not.toHaveBeenCalled();
+  });
+
+  it('does not update the scene when the editor is invalidated during asset publication', async () => {
+    const api = makeApi();
+    let finishFlush:
+      | ((report: {
+          published: string[];
+          skipped: unknown[];
+          failed: Array<{ fileId: string; error: unknown }>;
+        }) => void)
+      | undefined;
+    api.flushAssetPublication.mockImplementationOnce(
+      () =>
+        new Promise(finish => {
+          finishFlush = finish;
+        })
+    );
+    let cancelled = false;
+
+    const merge = mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(), () => cancelled);
+    await vi.waitFor(() => expect(api.flushAssetPublication).toHaveBeenCalledTimes(1));
+    cancelled = true;
+    finishFlush?.({ published: ['f1'], skipped: [], failed: [] });
+
+    await expect(merge).rejects.toThrow('Whiteboard editor changed while importing template');
+    expect(api.addFiles).toHaveBeenCalledTimes(1);
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
@@ -218,5 +294,83 @@ describe('mergeWhiteboard asset re-homing', () => {
     expect(secondElements[2].id).not.toBe(firstElements[1].id);
     expect(firstElements[1].x).toBeGreaterThan(existing.x + existing.width);
     expect(secondElements[2].x).toBeGreaterThan(firstElements[1].x as number);
+  });
+
+  it('regenerates frame, binding, and group relationships within each imported copy', async () => {
+    h.templateScene = {
+      elements: [
+        {
+          id: 'frame',
+          type: 'frame',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          version: 1,
+          groupIds: ['group'],
+          boundElements: [{ id: 'arrow', type: 'arrow' }],
+        },
+        {
+          id: 'rectangle',
+          type: 'rectangle',
+          x: 10,
+          y: 10,
+          width: 20,
+          height: 20,
+          version: 1,
+          frameId: 'frame',
+          groupIds: ['group'],
+          boundElements: [{ id: 'arrow', type: 'arrow' }],
+        },
+        {
+          id: 'arrow',
+          type: 'arrow',
+          x: 20,
+          y: 20,
+          width: 40,
+          height: 40,
+          version: 1,
+          groupIds: ['group'],
+          startBinding: { elementId: 'rectangle' },
+          endBinding: { elementId: 'frame' },
+          boundElements: null,
+        },
+      ],
+      assets: {},
+      appState: {},
+    };
+    const api = makeApi({ sceneLocatorsSequence: [{}] });
+
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+
+    const firstCopy = api.updateScene.mock.calls[0][0].elements as Array<Record<string, unknown>>;
+    const secondScene = api.updateScene.mock.calls[1][0].elements as Array<Record<string, unknown>>;
+    const secondCopy = secondScene.slice(3);
+    const assertCopyRelationships = (copy: Array<Record<string, unknown>>) => {
+      const [frame, rectangle, arrow] = copy as Array<
+        Record<string, unknown> & {
+          id: string;
+          frameId?: string;
+          groupIds: string[];
+          boundElements?: Array<{ id: string }>;
+          startBinding?: { elementId: string };
+          endBinding?: { elementId: string };
+        }
+      >;
+      expect(rectangle.frameId).toBe(frame.id);
+      expect(arrow.startBinding?.elementId).toBe(rectangle.id);
+      expect(arrow.endBinding?.elementId).toBe(frame.id);
+      expect(frame.boundElements?.[0].id).toBe(arrow.id);
+      expect(rectangle.boundElements?.[0].id).toBe(arrow.id);
+      expect(new Set(copy.flatMap(element => (element.groupIds as string[]) ?? []))).toHaveLength(1);
+      expect(frame.groupIds[0]).not.toBe('group');
+      expect([frame.id, rectangle.id, arrow.id]).not.toContain('frame');
+      return frame.groupIds[0];
+    };
+
+    const firstGroup = assertCopyRelationships(firstCopy);
+    const secondGroup = assertCopyRelationships(secondCopy);
+    expect(secondGroup).not.toBe(firstGroup);
   });
 });

--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Control the template scene directly and exercise only the merge/asset-copy
-// logic: the fork snapshot codec + the content parser are stubbed so the test
-// owns `templateScene`, and the lazy fork import returns the stubbed module.
+// logic: the fork snapshot codec is stubbed so the test owns `templateScene`,
+// and the lazy fork import returns the stubbed module.
 const makeTemplateScene = () => ({
   elements: [
     {
@@ -31,9 +31,6 @@ vi.mock('@excalidraw-yjs/excalidraw', () => ({
   hashElementsVersion: () => 1,
   CaptureUpdateAction: { IMMEDIATELY: 'immediately' },
 }));
-vi.mock('@/domain/common/whiteboard/excalidraw/whiteboardContent', () => ({
-  parseWhiteboardContentToScene: () => h.templateScene,
-}));
 vi.mock('@/core/lazyLoading/lazyWithGlobalErrorHandler', () => ({
   lazyImportWithErrorHandler: async (fn: () => Promise<unknown>) => fn(),
 }));
@@ -51,18 +48,22 @@ type ApiOverrides = Partial<{
   getFiles: () => Record<string, unknown>;
   sceneLocatorsSequence: Array<Record<string, string>>;
   flushReport: { published: string[]; skipped: unknown[]; failed: Array<{ fileId: string; error: unknown }> };
+  initialElements: Array<Record<string, unknown>>;
 }>;
 
 const makeApi = (o: ApiOverrides = {}) => {
   const locatorsSeq = o.sceneLocatorsSequence ?? [{}, { f1: 'target-doc-id' }];
   let call = 0;
+  let elements = o.initialElements ?? [];
   return {
     getFiles: vi.fn(o.getFiles ?? (() => ({}))),
     getSceneAssetLocators: vi.fn(() => locatorsSeq[Math.min(call++, locatorsSeq.length - 1)]),
     addFiles: vi.fn(),
     flushAssetPublication: vi.fn(async () => o.flushReport ?? { published: ['f1'], skipped: [], failed: [] }),
-    getSceneElementsIncludingDeleted: vi.fn(() => []),
-    updateScene: vi.fn(),
+    getSceneElementsIncludingDeleted: vi.fn(() => elements),
+    updateScene: vi.fn(({ elements: nextElements }) => {
+      elements = nextElements;
+    }),
     scrollToContent: vi.fn(),
   };
 };
@@ -79,7 +80,7 @@ describe('mergeWhiteboard asset re-homing', () => {
     h.templateScene = { elements: [], assets: {}, appState: {} };
     const api = makeApi();
 
-    await expect(mergeWhiteboard(api as never, 'invalid', makeAdapter())).rejects.toThrow(
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow(
       'Whiteboard verification failed'
     );
     expect(api.updateScene).not.toHaveBeenCalled();
@@ -88,7 +89,7 @@ describe('mergeWhiteboard asset re-homing', () => {
   it('resolves the source locator, re-stores into the target bucket (new id), keeps fileId, inserts the element', async () => {
     const api = makeApi();
     const resolve = vi.fn(async () => RESOLVED_BYTES);
-    await mergeWhiteboard(api as never, 'content', makeAdapter(resolve));
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve));
 
     // resolve is called with the fileId + the SOURCE locator
     expect(resolve).toHaveBeenCalledWith('f1', 'source-doc-id');
@@ -114,28 +115,28 @@ describe('mergeWhiteboard asset re-homing', () => {
     const resolve = vi.fn(async () => {
       throw new Error('gone');
     });
-    await expect(mergeWhiteboard(api as never, 'content', makeAdapter(resolve))).rejects.toThrow();
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve))).rejects.toThrow();
     expect(api.addFiles).not.toHaveBeenCalled();
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
   it('aborts and inserts zero elements when a target store fails in the publish flush', async () => {
     const api = makeApi({ flushReport: { published: [], skipped: [], failed: [{ fileId: 'f1', error: 'x' }] } });
-    await expect(mergeWhiteboard(api as never, 'content', makeAdapter())).rejects.toThrow();
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow();
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
   it('aborts when a resolved file ends up with no committed target locator', async () => {
     // flush reports success but the scene has no locator for f1 (replaced/unmounted mid-merge)
     const api = makeApi({ sceneLocatorsSequence: [{}, {}] });
-    await expect(mergeWhiteboard(api as never, 'content', makeAdapter())).rejects.toThrow();
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow();
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
   it('does not re-upload an image the target already has a locator for', async () => {
     const api = makeApi({ sceneLocatorsSequence: [{ f1: 'existing' }] });
     const resolve = vi.fn(async () => RESOLVED_BYTES);
-    await mergeWhiteboard(api as never, 'content', makeAdapter(resolve));
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve));
 
     expect(resolve).not.toHaveBeenCalled();
     expect(api.addFiles).not.toHaveBeenCalled();
@@ -153,7 +154,7 @@ describe('mergeWhiteboard asset re-homing', () => {
       sceneLocatorsSequence: [{}, { f1: 'target-doc-id' }],
     });
     const resolve = vi.fn(async () => RESOLVED_BYTES);
-    await mergeWhiteboard(api as never, 'content', makeAdapter(resolve));
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve));
 
     expect(resolve).not.toHaveBeenCalled();
     expect(api.addFiles).not.toHaveBeenCalled();
@@ -168,8 +169,54 @@ describe('mergeWhiteboard asset re-homing', () => {
       flushReport: { published: [], skipped: [], failed: [] },
     });
     const resolve = vi.fn(async () => RESOLVED_BYTES);
-    await expect(mergeWhiteboard(api as never, 'content', makeAdapter(resolve))).rejects.toThrow();
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve))).rejects.toThrow();
     expect(resolve).not.toHaveBeenCalled();
     expect(api.updateScene).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing content and inserts a fresh displaced copy every time the same template is applied', async () => {
+    h.templateScene = {
+      elements: [
+        {
+          id: 'template-element',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          version: 1,
+          boundElements: null,
+        },
+      ],
+      assets: {},
+      appState: {},
+    };
+    const existing = {
+      id: 'existing-element',
+      type: 'rectangle',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      version: 1,
+      boundElements: null,
+    };
+    const api = makeApi({ initialElements: [existing] });
+
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+
+    expect(api.updateScene).toHaveBeenCalledTimes(2);
+    const firstElements = api.updateScene.mock.calls[0][0].elements as Array<Record<string, unknown>>;
+    const secondElements = api.updateScene.mock.calls[1][0].elements as Array<Record<string, unknown>>;
+    expect(firstElements[0]).toBe(existing);
+    expect(secondElements[0]).toBe(existing);
+    expect(firstElements).toHaveLength(2);
+    expect(secondElements).toHaveLength(3);
+    expect(firstElements[1].id).not.toBe('template-element');
+    expect(secondElements[2].id).not.toBe('template-element');
+    expect(secondElements[2].id).not.toBe(firstElements[1].id);
+    expect(firstElements[1].x).toBeGreaterThan(existing.x + existing.width);
+    expect(secondElements[2].x).toBeGreaterThan(firstElements[1].x as number);
   });
 });

--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
@@ -8,11 +8,10 @@ import type {
   hashElementsVersion as ExcalidrawHashElementsVersion,
 } from '@excalidraw-yjs/excalidraw/element/index';
 import type { ExcalidrawElement, FileId } from '@excalidraw-yjs/excalidraw/element/types';
-import { decodeSnapshot, encodeSnapshot } from '@excalidraw-yjs/excalidraw/headless';
+import { decodeSnapshot, encodeSnapshot, type WhiteboardSnapshot } from '@excalidraw-yjs/excalidraw/headless';
 import type { AssetAdapter, BinaryFileData, ExcalidrawImperativeAPI } from '@excalidraw-yjs/excalidraw/types';
 import { v4 as uuidv4 } from 'uuid';
 import { lazyImportWithErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
-import { parseWhiteboardContentToScene } from '@/domain/common/whiteboard/excalidraw/whiteboardContent';
 
 const ANIMATION_SPEED = 2000;
 const ANIMATION_ZOOM_FACTOR = 0.75;
@@ -136,7 +135,7 @@ const displaceElements = (displacement: { x: number; y: number }) => (element: E
 
 const mergeWhiteboard = async (
   whiteboardApi: ExcalidrawImperativeAPI,
-  whiteboardContent: string,
+  whiteboardSnapshot: WhiteboardSnapshot,
   assetAdapter: AssetAdapter
 ) => {
   const { hashElementsVersion, CaptureUpdateAction } = await lazyImportWithErrorHandler<ExcalidrawUtils>(
@@ -144,13 +143,13 @@ const mergeWhiteboard = async (
   );
 
   // Normalize the template through the native snapshot round-trip: encode the
-  // parsed template scene into a throwaway Yjs doc and decode it straight back.
+  // loaded template scene into a throwaway Yjs doc and decode it straight back.
   // This routes the template through the single content representation (the doc
   // re-orders by fractional index and strips per-peer reconciliation metadata)
   // and keeps no raw JSON scene as state — only the materialized elements are
   // merged into the live scene below (the editor's own Scene.doc captures the
   // merge via updateScene).
-  const templateScene = decodeSnapshot(encodeSnapshot(parseWhiteboardContentToScene(whiteboardContent)));
+  const templateScene = decodeSnapshot(encodeSnapshot(whiteboardSnapshot));
 
   if (!isWhiteboardLike(templateScene)) {
     throw new WhiteboardMergeError('Whiteboard verification failed');

--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
@@ -7,7 +7,12 @@ import type {
   CaptureUpdateAction as ExcalidrawCaptureUpdateAction,
   hashElementsVersion as ExcalidrawHashElementsVersion,
 } from '@excalidraw-yjs/excalidraw/element/index';
-import type { ExcalidrawElement, FileId } from '@excalidraw-yjs/excalidraw/element/types';
+import type {
+  ExcalidrawElement,
+  ExcalidrawImageElement,
+  FileId,
+  FixedPointBinding,
+} from '@excalidraw-yjs/excalidraw/element/types';
 import { decodeSnapshot, encodeSnapshot, type WhiteboardSnapshot } from '@excalidraw-yjs/excalidraw/headless';
 import type { AssetAdapter, BinaryFileData, ExcalidrawImperativeAPI } from '@excalidraw-yjs/excalidraw/types';
 import { v4 as uuidv4 } from 'uuid';
@@ -16,7 +21,13 @@ import { lazyImportWithErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErr
 const ANIMATION_SPEED = 2000;
 const ANIMATION_ZOOM_FACTOR = 0.75;
 
-type ExcalidrawElementWithContainerId = ExcalidrawElement & { containerId: string | null };
+type ExcalidrawElementWithRelationships = ExcalidrawElement & {
+  containerId?: string | null;
+  frameId?: string | null;
+  groupIds?: readonly string[];
+  startBinding?: FixedPointBinding | null;
+  endBinding?: FixedPointBinding | null;
+};
 type ExcalidrawUtils = {
   CaptureUpdateAction: typeof ExcalidrawCaptureUpdateAction;
   hashElementsVersion: typeof ExcalidrawHashElementsVersion;
@@ -94,10 +105,11 @@ const calculateInsertionPoint = (whiteboardA: BoundingBox, whiteboardB: Bounding
  * @param idsMap
  * @returns a function that can be passed to elements.map
  */
-const generateNewIds = (idsMap: Record<string, string>) => (element: ExcalidrawElement) => ({
-  ...element,
-  id: (idsMap[element.id] = uuidv4()), // Replace the id and store it in the map
-});
+const generateNewIds = (idsMap: Record<string, string>) => (element: ExcalidrawElement) => {
+  const id = uuidv4();
+  idsMap[element.id] = id;
+  return { ...element, id };
+};
 
 /**
  * Returns a function that can be passed to elements.map to replace the version of the elements
@@ -110,18 +122,31 @@ const replaceElementVersion = (version: number) => (element: ExcalidrawElement) 
 /**
  * Returns a function that can be passed to elements.map to replace containerId and boundElements ids
  */
-const replaceBoundElementsIds = (idsMap: Record<string, string>) => {
+const replaceRelationshipIds = (idsMap: Record<string, string>, groupIdsMap: Record<string, string>) => {
   const replace = (id: string | null) => (id ? idsMap[id] || id : id);
   const replaceMultiple = (boundElements: ExcalidrawElement['boundElements']) =>
     boundElements
       ? boundElements.map(boundElement => ({ ...boundElement, id: idsMap[boundElement.id] || boundElement.id }))
       : boundElements;
 
-  return (element: ExcalidrawElement) => ({
-    ...element,
-    containerId: replace((element as ExcalidrawElementWithContainerId).containerId),
-    boundElements: replaceMultiple(element.boundElements),
-  });
+  return (element: ExcalidrawElement) => {
+    const related = element as ExcalidrawElementWithRelationships;
+    const replaceBinding = (binding: FixedPointBinding | null | undefined) =>
+      binding ? { ...binding, elementId: replace(binding.elementId) as string } : binding;
+    return {
+      ...element,
+      containerId: replace(related.containerId ?? null),
+      frameId: replace(related.frameId ?? null),
+      groupIds: related.groupIds?.map(groupId => {
+        const remappedId = groupIdsMap[groupId] ?? uuidv4();
+        groupIdsMap[groupId] = remappedId;
+        return remappedId;
+      }),
+      startBinding: replaceBinding(related.startBinding),
+      endBinding: replaceBinding(related.endBinding),
+      boundElements: replaceMultiple(element.boundElements),
+    } as unknown as ExcalidrawElement;
+  };
 };
 
 /**
@@ -136,11 +161,19 @@ const displaceElements = (displacement: { x: number; y: number }) => (element: E
 const mergeWhiteboard = async (
   whiteboardApi: ExcalidrawImperativeAPI,
   whiteboardSnapshot: WhiteboardSnapshot,
-  assetAdapter: AssetAdapter
+  assetAdapter: AssetAdapter,
+  isCancelled: () => boolean = () => false
 ) => {
+  const assertActive = () => {
+    if (isCancelled()) {
+      throw new WhiteboardMergeError('Whiteboard editor changed while importing template');
+    }
+  };
+
   const { hashElementsVersion, CaptureUpdateAction } = await lazyImportWithErrorHandler<ExcalidrawUtils>(
     () => import('@excalidraw-yjs/excalidraw')
   );
+  assertActive();
 
   // Normalize the template through the native snapshot round-trip: encode the
   // loaded template scene into a throwaway Yjs doc and decode it straight back.
@@ -162,6 +195,23 @@ const mergeWhiteboard = async (
   const templateAssets = templateScene.assets as Readonly<Record<string, string>>;
 
   try {
+    const liveImageElements = templateElements.filter(
+      (element): element is ExcalidrawImageElement => element.type === 'image' && !element.isDeleted
+    );
+    const imagesWithoutFileId = liveImageElements.filter(element => !element.fileId).map(element => element.id);
+    if (imagesWithoutFileId.length > 0) {
+      throw new WhiteboardMergeError(`Template image elements have no file id: ${imagesWithoutFileId.join(', ')}`);
+    }
+    const liveImageFileIds = [
+      ...new Set(
+        liveImageElements.map(element => element.fileId).filter((fileId): fileId is FileId => Boolean(fileId))
+      ),
+    ];
+    const missingSourceLocators = liveImageFileIds.filter(fileId => !templateAssets[fileId]?.trim());
+    if (missingSourceLocators.length > 0) {
+      throw new WhiteboardMergeError(`Template images have no source locator: ${missingSourceLocators.join(', ')}`);
+    }
+
     // 1. Partition the template's images. Readiness is defined ONLY by a committed
     //    target locator — local cache bytes without a durable locator are NOT
     //    persisted, so a prior merge that cached bytes but failed to publish must
@@ -170,7 +220,7 @@ const mergeWhiteboard = async (
     //    cached need a fresh source resolve.
     const currentFiles = whiteboardApi.getFiles();
     const currentLocators = whiteboardApi.getSceneAssetLocators();
-    const unresolvedLocatorIds = Object.keys(templateAssets).filter(fileId => !currentLocators[fileId]);
+    const unresolvedLocatorIds = liveImageFileIds.filter(fileId => !currentLocators[fileId]);
     const toResolveIds = unresolvedLocatorIds.filter(fileId => !currentFiles[fileId]);
 
     // 2. Resolve EVERY still-uncached source locator to bytes BEFORE mutating the
@@ -188,6 +238,7 @@ const mergeWhiteboard = async (
       //    adapter.store into THIS whiteboard's bucket, minting NEW target locators
       //    keyed by the unchanged file ids. Never reuse the source locator or
       //    upload directly.
+      assertActive();
       whiteboardApi.addFiles(resolvedFiles);
     }
 
@@ -197,7 +248,9 @@ const mergeWhiteboard = async (
     //    reports success yet leaves no locator (replaced/unmounted mid-merge), aborts
     //    with zero elements. A remote-won skip is a success — its locator is present.
     if (unresolvedLocatorIds.length > 0) {
+      assertActive();
       const report = await whiteboardApi.flushAssetPublication();
+      assertActive();
       if (report.failed.length > 0) {
         throw new WhiteboardMergeError(`Template image publish failed: ${report.failed.map(f => f.fileId).join(', ')}`);
       }
@@ -218,14 +271,16 @@ const mergeWhiteboard = async (
     const displacement = calculateInsertionPoint(currentElementsBBox, insertedWhiteboardBBox);
 
     const replacedIds: Record<string, string> = {};
+    const replacedGroupIds: Record<string, string> = {};
     // fractional indices does not need overwriting
     const insertedElements = templateElements
       ?.map(generateNewIds(replacedIds))
       .map(replaceElementVersion(sceneVersion + 1))
-      .map(replaceBoundElementsIds(replacedIds))
+      .map(replaceRelationshipIds(replacedIds, replacedGroupIds))
       .map(displaceElements(displacement));
 
     const newElements = [...currentElements, ...insertedElements];
+    assertActive();
     whiteboardApi.updateScene({
       elements: newElements,
       captureUpdate: CaptureUpdateAction.IMMEDIATELY,

--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
@@ -188,7 +188,14 @@ const mergeWhiteboard = async (
     throw new WhiteboardMergeError('Whiteboard verification failed');
   }
 
-  const templateElements = templateScene.elements as unknown as ExcalidrawElement[];
+  // Snapshot tombstones are synchronization history, not template content. Import
+  // only live elements so deleted outliers cannot affect placement or reappear.
+  const templateElements = (templateScene.elements as unknown as ExcalidrawElement[]).filter(
+    element => !element.isDeleted
+  );
+  if (templateElements.length === 0) {
+    throw new WhiteboardMergeError('Template has no visible elements');
+  }
   // Template images are opaque locators pointing at the TEMPLATE's storage bucket,
   // never bytes. They must be re-homed into THIS whiteboard's bucket before the
   // elements referencing them are inserted (see the asset-copy steps below).
@@ -266,7 +273,7 @@ const mergeWhiteboard = async (
     const currentElements = whiteboardApi.getSceneElementsIncludingDeleted();
     const sceneVersion = hashElementsVersion(currentElements);
 
-    const currentElementsBBox = getBoundingBox(currentElements);
+    const currentElementsBBox = getBoundingBox(currentElements.filter(element => !element.isDeleted));
     const insertedWhiteboardBBox = getBoundingBox(templateElements);
     const displacement = calculateInsertionPoint(currentElementsBBox, insertedWhiteboardBBox);
 

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.sessionEnd.spec.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.sessionEnd.spec.tsx
@@ -16,6 +16,8 @@ const h = vi.hoisted(() => ({
   notifications: [] as string[],
   mountCount: { value: 0 },
   editorInvalidatedCount: { value: 0 },
+  publishedApi: { value: null as string | null },
+  apiEvents: [] as string[],
 }));
 
 vi.mock('./collab/useCollab', () => ({
@@ -62,7 +64,18 @@ const wrapper = (whiteboardId = 'wb-1') => (
   <CollaborativeExcalidrawWrapper
     entities={{ whiteboard: { id: whiteboardId }, assetAdapter: {} as never, lastSuccessfulSavedDate: undefined }}
     options={{}}
-    actions={{ onEditorInvalidated: () => (h.editorInvalidatedCount.value += 1) }}
+    actions={{
+      onInitApi: api => {
+        const id = (api as unknown as { id: string }).id;
+        h.publishedApi.value = id;
+        h.apiEvents.push(`api:${id}`);
+      },
+      onEditorInvalidated: () => {
+        h.editorInvalidatedCount.value += 1;
+        h.publishedApi.value = null;
+        h.apiEvents.push('invalidate');
+      },
+    }}
     renderDisconnectNotice={() => null}
   >
     {({ children }) => <>{children}</>}
@@ -82,6 +95,8 @@ describe('CollaborativeExcalidrawWrapper — session-end outcomes', () => {
     h.notifications.length = 0;
     h.mountCount.value = 0;
     h.editorInvalidatedCount.value = 0;
+    h.publishedApi.value = null;
+    h.apiEvents.length = 0;
   });
   afterEach(() => vi.clearAllMocks());
 
@@ -137,11 +152,13 @@ describe('CollaborativeExcalidrawWrapper — session-end outcomes', () => {
     expect(h.notifications).toContain('callout.whiteboard.session.documentDeleted');
   });
 
-  it('invalidates the captured editor when the whiteboard id changes in place', () => {
+  it('invalidates the old editor before publishing the API for a new whiteboard id', () => {
     const view = renderWrapper();
 
     view.rerender(wrapper('wb-2'));
 
     expect(h.editorInvalidatedCount.value).toBe(1);
+    expect(h.apiEvents).toEqual(['api:api-1', 'invalidate', 'api:api-2']);
+    expect(h.publishedApi.value).toBe('api-2');
   });
 });

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.sessionEnd.spec.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.sessionEnd.spec.tsx
@@ -58,17 +58,18 @@ vi.mock('@/domain/community/userCurrent/useCurrentUserContext', () => ({
 vi.mock('@/domain/shared/utils/useCombinedRefs', () => ({ useCombinedRefs: () => ({ current: null }) }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 
-const renderWrapper = () =>
-  render(
-    <CollaborativeExcalidrawWrapper
-      entities={{ whiteboard: { id: 'wb-1' }, assetAdapter: {} as never, lastSuccessfulSavedDate: undefined }}
-      options={{}}
-      actions={{ onEditorInvalidated: () => (h.editorInvalidatedCount.value += 1) }}
-      renderDisconnectNotice={() => null}
-    >
-      {({ children }) => <>{children}</>}
-    </CollaborativeExcalidrawWrapper>
-  );
+const wrapper = (whiteboardId = 'wb-1') => (
+  <CollaborativeExcalidrawWrapper
+    entities={{ whiteboard: { id: whiteboardId }, assetAdapter: {} as never, lastSuccessfulSavedDate: undefined }}
+    options={{}}
+    actions={{ onEditorInvalidated: () => (h.editorInvalidatedCount.value += 1) }}
+    renderDisconnectNotice={() => null}
+  >
+    {({ children }) => <>{children}</>}
+  </CollaborativeExcalidrawWrapper>
+);
+
+const renderWrapper = () => render(wrapper());
 
 const lastActive = () => h.autoReconnectActive[h.autoReconnectActive.length - 1];
 const send = (info: SessionEndInfo) => act(() => h.onSessionEnd.value?.(info));
@@ -134,5 +135,13 @@ describe('CollaborativeExcalidrawWrapper — session-end outcomes', () => {
     send({ code: 'document-deleted', scope: 'document', disposition: 'terminal' });
     expect(lastActive()).toBe(false);
     expect(h.notifications).toContain('callout.whiteboard.session.documentDeleted');
+  });
+
+  it('invalidates the captured editor when the whiteboard id changes in place', () => {
+    const view = renderWrapper();
+
+    view.rerender(wrapper('wb-2'));
+
+    expect(h.editorInvalidatedCount.value).toBe(1);
   });
 });

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
@@ -178,13 +178,6 @@ const CollaborativeExcalidrawWrapper = ({
   const { whiteboard, assetAdapter, imageValidation, lastSuccessfulSavedDate } = entities;
   const previousWhiteboardIdRef = useRef(whiteboard?.id);
 
-  useEffect(() => {
-    if (previousWhiteboardIdRef.current !== whiteboard?.id) {
-      actions.onEditorInvalidated?.();
-      previousWhiteboardIdRef.current = whiteboard?.id;
-    }
-  }, [whiteboard?.id, actions.onEditorInvalidated]);
-
   const whiteboardDefaults = useWhiteboardDefaults();
   const { t } = useTranslation();
   const notify = useNotification();
@@ -422,6 +415,13 @@ const CollaborativeExcalidrawWrapper = ({
 
   const handleInitializeApi = (api: ExcalidrawImperativeAPI | null) => {
     if (!api) return;
+    // The keyed editor for a new whiteboard can publish its API before a passive
+    // parent effect runs. Invalidate the old generation synchronously here, then
+    // publish the new API, so the invalidation can never clear the replacement.
+    if (previousWhiteboardIdRef.current !== whiteboard?.id) {
+      actions.onEditorInvalidated?.();
+      previousWhiteboardIdRef.current = whiteboard?.id;
+    }
     // Pair the api with the whiteboard it was created under (the editor mounted under the
     // current, keyed whiteboard id), so the init effect can require a match.
     setExcalidrawApi({ api, whiteboardId: whiteboard?.id ?? '' });

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
@@ -1,7 +1,7 @@
 import type { AssetAdapter, ExcalidrawImperativeAPI, ExcalidrawProps } from '@excalidraw-yjs/excalidraw/types';
 import { debounce, merge } from 'lodash-es';
 import type React from 'react';
-import { type PropsWithChildren, type Ref, Suspense, useEffect, useMemo, useState } from 'react';
+import { type PropsWithChildren, type Ref, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type TranslationKey from '@/core/i18n/utils/TranslationKey';
 import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
@@ -176,6 +176,14 @@ const CollaborativeExcalidrawWrapper = ({
   const [connectionError, setConnectionError] = useState(false);
 
   const { whiteboard, assetAdapter, imageValidation, lastSuccessfulSavedDate } = entities;
+  const previousWhiteboardIdRef = useRef(whiteboard?.id);
+
+  useEffect(() => {
+    if (previousWhiteboardIdRef.current !== whiteboard?.id) {
+      actions.onEditorInvalidated?.();
+      previousWhiteboardIdRef.current = whiteboard?.id;
+    }
+  }, [whiteboard?.id, actions.onEditorInvalidated]);
 
   const whiteboardDefaults = useWhiteboardDefaults();
   const { t } = useTranslation();

--- a/src/main/crdPages/templates/__tests__/useTemplatePicker.test.tsx
+++ b/src/main/crdPages/templates/__tests__/useTemplatePicker.test.tsx
@@ -143,7 +143,11 @@ const platformMock = (
   },
 });
 
-const whiteboardContentMock = (templateId: string, previewUri?: string): MockedResponse<TemplateContentQuery> => ({
+const whiteboardContentMock = (
+  templateId: string,
+  previewUri?: string,
+  delay?: number
+): MockedResponse<TemplateContentQuery> => ({
   request: {
     query: TemplateContentDocument,
     variables: {
@@ -190,6 +194,7 @@ const whiteboardContentMock = (templateId: string, previewUri?: string): MockedR
       },
     } as unknown as TemplateContentQuery,
   },
+  delay,
 });
 
 // ---------------------------------------------------------------------------
@@ -361,6 +366,34 @@ describe('useTemplatePicker — selection lifecycle', () => {
 
     expect(result.current.selectedTemplateId).toBeNull();
     expect(result.current.selectedTemplateContent).toBeNull();
+  });
+
+  it('keeps the selected id and content paired when an older content request resolves last', async () => {
+    const wrapper = makeWrapper([
+      whiteboardContentMock('template-a', undefined, 50),
+      whiteboardContentMock('template-b', undefined, 1),
+    ]);
+    const { result } = renderHook(() => useTemplatePicker({ allowedTypes: ['whiteboard'] }), { wrapper });
+
+    act(() => {
+      result.current.pickerProps.onSelect('template-a');
+      result.current.pickerProps.onSelect('template-b');
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedTemplateId).toBe('template-b');
+      expect(result.current.selectedTemplateContent).toMatchObject({
+        type: 'whiteboard',
+        sourceWhiteboardId: 'template-b-whiteboard',
+      });
+    });
+    await act(() => new Promise(resolve => setTimeout(resolve, 60)));
+
+    expect(result.current.selectedTemplateId).toBe('template-b');
+    expect(result.current.selectedTemplateContent).toMatchObject({
+      type: 'whiteboard',
+      sourceWhiteboardId: 'template-b-whiteboard',
+    });
   });
 });
 

--- a/src/main/crdPages/templates/useTemplatePicker.ts
+++ b/src/main/crdPages/templates/useTemplatePicker.ts
@@ -68,8 +68,10 @@ export function useTemplatePicker({
     onOpenChange?.(next);
   };
   const [search, setSearch] = useState('');
-  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
-  const [selectedTemplateContent, setSelectedTemplateContent] = useState<TemplateContent | null>(null);
+  const [selectedTemplate, setSelectedTemplate] = useState<{
+    id: string;
+    content: TemplateContent | null;
+  } | null>(null);
   const [previewId, setPreviewId] = useState<string | null>(null);
   const [previewContent, setPreviewContent] = useState<TemplateContent | undefined>(undefined);
   const [previewLoading, setPreviewLoading] = useState(false);
@@ -122,29 +124,11 @@ export function useTemplatePicker({
   if (accountId) sources.push({ key: 'account', templates: accountTemplates, loading: accountLoading });
   sources.push({ key: 'platform', templates: platformTemplates, loading: platformLoading });
 
-  const fetchContent = async (
-    templateId: string,
-    set: (c: TemplateContent | undefined) => void,
-    setLoading: (b: boolean) => void
-  ) => {
-    if (!primaryType) return;
-    setLoading(true);
-    set(undefined);
-    try {
-      const { data } = await getTemplateContent({
-        variables: { templateId, ...templateContentIncludeVars(primaryType) },
-      });
-      const fetched = data?.lookup.template;
-      if (fetched) set(mapTemplateContent(fetched, primaryType));
-    } finally {
-      setLoading(false);
-    }
-  };
-
   // Tracks the latest preview request so a slow response for template A doesn't overwrite the
   // content shown for template B if the user previewed another card mid-fetch. `previewId` drives a
   // committing action (Use/Import) in the preview pane, so a stale overwrite could apply the wrong template.
   const activePreviewIdRef = useRef<string | null>(null);
+  const selectionRequestRef = useRef(0);
 
   const onPreview = (templateId: string) => {
     if (!primaryType) return;
@@ -176,24 +160,30 @@ export function useTemplatePicker({
   };
 
   const onSelect = (templateId: string | null) => {
+    const request = ++selectionRequestRef.current;
     if (templateId === null) {
-      setSelectedTemplateId(null);
-      setSelectedTemplateContent(null);
+      setSelectedTemplate(null);
       setOpen(false);
       return;
     }
-    setSelectedTemplateId(templateId);
+    setSelectedTemplate({ id: templateId, content: null });
     setOpen(false);
-    void fetchContent(
-      templateId,
-      c => setSelectedTemplateContent(c ?? null),
-      () => {}
-    );
+    if (!primaryType) return;
+    void getTemplateContent({
+      variables: { templateId, ...templateContentIncludeVars(primaryType) },
+    }).then(({ data }) => {
+      if (selectionRequestRef.current !== request) return;
+      const fetched = data?.lookup.template;
+      setSelectedTemplate({
+        id: templateId,
+        content: fetched ? mapTemplateContent(fetched, primaryType) : null,
+      });
+    });
   };
 
   const clearSelection = () => {
-    setSelectedTemplateId(null);
-    setSelectedTemplateContent(null);
+    selectionRequestRef.current += 1;
+    setSelectedTemplate(null);
   };
 
   const pickerProps: TemplatePickerSelectProps = {
@@ -225,8 +215,8 @@ export function useTemplatePicker({
       setOpen(true);
     },
     pickerProps,
-    selectedTemplateId,
-    selectedTemplateContent,
+    selectedTemplateId: selectedTemplate?.id ?? null,
+    selectedTemplateContent: selectedTemplate?.content ?? null,
     clearSelection,
   };
 }

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
@@ -55,6 +55,7 @@ import { useSpace } from '@/domain/space/context/useSpace';
 import { useSubSpace } from '@/domain/space/hooks/useSubSpace';
 import { buildLoginUrl } from '@/main/routing/urlBuilders';
 import useUrlResolver from '@/main/routing/urlResolver/useUrlResolver';
+import { useWhiteboardImportLifetime } from './useWhiteboardImportLifetime';
 import { WhiteboardAssistantRailConnector } from './WhiteboardAssistantRailConnector';
 import { WhiteboardTemplatePickerButton } from './WhiteboardTemplatePickerButton';
 import { mapWhiteboardFooterProps } from './whiteboardFooterMapper';
@@ -225,6 +226,7 @@ const CrdWhiteboardDialog = ({
   // (server update-rejected). A close-in-flight compares this to detect a recovery that
   // replaced the editor mid-flush and abort the save (see `hasEditorChanged`).
   const editorGenerationRef = useRef(0);
+  const importLifetime = useWhiteboardImportLifetime(whiteboard?.id, options.show);
   const collabApiRef = useRef<CollabAPI>(null);
   const editModeEnabled = options.canEdit;
 
@@ -278,6 +280,9 @@ const CrdWhiteboardDialog = ({
   };
 
   const onClose = async () => {
+    // A template source may still be loading. Cancel it before awaiting the close
+    // flush/save path so it cannot mutate the editor while the dialog is leaving.
+    importLifetime.cancelActiveImport();
     const shouldSave = !!(editModeEnabled && collabApiRef.current?.isCollaborating() && whiteboard);
     // Snapshot the editor generation now; if a recovery (update-rejected) discards it while
     // the flush is awaited, the captured api is dead and the save must abort.
@@ -322,23 +327,21 @@ const CrdWhiteboardDialog = ({
 
   const handleImportTemplate = async (sourceWhiteboardId: string) => {
     if (!excalidrawAPI) return;
-    const generationAtImport = editorGenerationRef.current;
+    const importToken = importLifetime.beginImport();
     try {
-      const templateScene = await loadWhiteboardSceneFromCollaboration(sourceWhiteboardId);
-      if (editorGenerationRef.current !== generationAtImport) {
-        throw new Error('Whiteboard editor changed while importing template');
-      }
-      await mergeWhiteboard(
-        excalidrawAPI,
-        templateScene,
-        assetAdapter,
-        () => editorGenerationRef.current !== generationAtImport
-      );
+      const templateScene = await loadWhiteboardSceneFromCollaboration(sourceWhiteboardId, {
+        signal: importToken.signal,
+      });
+      if (importToken.isCancelled()) return;
+      await mergeWhiteboard(excalidrawAPI, templateScene, assetAdapter, importToken.isCancelled);
     } catch (err) {
+      if (importToken.isCancelled()) return;
       notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
       logError(new Error(`Error importing whiteboard template: '${err}'`), {
         category: TagCategoryValues.WHITEBOARD,
       });
+    } finally {
+      importLifetime.finishImport(importToken);
     }
   };
 
@@ -407,6 +410,7 @@ const CrdWhiteboardDialog = ({
           onInitApi: setExcalidrawAPI,
           onEditorInvalidated: () => {
             editorGenerationRef.current += 1;
+            importLifetime.cancelActiveImport();
             setExcalidrawAPI(null);
           },
           onRemoteSave: (error?: string) => {

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
@@ -27,6 +27,8 @@ import { WhiteboardDisconnectedDialog } from '@/crd/components/whiteboard/Whiteb
 import { WhiteboardDisplayName } from '@/crd/components/whiteboard/WhiteboardDisplayName';
 import { WhiteboardEditorShell } from '@/crd/components/whiteboard/WhiteboardEditorShell';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/crd/primitives/dialog';
+import { loadWhiteboardSceneFromCollaboration } from '@/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration';
+import mergeWhiteboard from '@/domain/collaboration/whiteboard/utils/mergeWhiteboard';
 import whiteboardValidationSchema, {
   type WhiteboardFormSchema,
 } from '@/domain/collaboration/whiteboard/validation/whiteboardFormSchema';
@@ -318,6 +320,19 @@ const CrdWhiteboardDialog = ({
     });
   };
 
+  const handleImportTemplate = async (sourceWhiteboardId: string) => {
+    if (!excalidrawAPI) return;
+    try {
+      const templateScene = await loadWhiteboardSceneFromCollaboration(sourceWhiteboardId);
+      await mergeWhiteboard(excalidrawAPI, templateScene, assetAdapter);
+    } catch (err) {
+      notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
+      logError(new Error(`Error importing whiteboard template: '${err}'`), {
+        category: TagCategoryValues.WHITEBOARD,
+      });
+    }
+  };
+
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [learnWhyDialogOpen, setLearnWhyDialogOpen] = useState(false);
   const [learnWhyReasonKey, setLearnWhyReasonKey] = useState<
@@ -544,7 +559,7 @@ const CrdWhiteboardDialog = ({
                   }
                   titleExtra={
                     editModeEnabled && mode === 'write' ? (
-                      <WhiteboardTemplatePickerButton whiteboardId={whiteboard.id} disabled={!isSceneInitialized} />
+                      <WhiteboardTemplatePickerButton disabled={!isSceneInitialized} onImport={handleImportTemplate} />
                     ) : undefined
                   }
                   headerActions={options.headerActions?.({ mode, modeReason, collaborating, connecting, isReadOnly })}

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
@@ -322,8 +322,12 @@ const CrdWhiteboardDialog = ({
 
   const handleImportTemplate = async (sourceWhiteboardId: string) => {
     if (!excalidrawAPI) return;
+    const generationAtImport = editorGenerationRef.current;
     try {
       const templateScene = await loadWhiteboardSceneFromCollaboration(sourceWhiteboardId);
+      if (editorGenerationRef.current !== generationAtImport) {
+        throw new Error('Whiteboard editor changed while importing template');
+      }
       await mergeWhiteboard(excalidrawAPI, templateScene, assetAdapter);
     } catch (err) {
       notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
@@ -328,7 +328,12 @@ const CrdWhiteboardDialog = ({
       if (editorGenerationRef.current !== generationAtImport) {
         throw new Error('Whiteboard editor changed while importing template');
       }
-      await mergeWhiteboard(excalidrawAPI, templateScene, assetAdapter);
+      await mergeWhiteboard(
+        excalidrawAPI,
+        templateScene,
+        assetAdapter,
+        () => editorGenerationRef.current !== generationAtImport
+      );
     } catch (err) {
       notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
       logError(new Error(`Error importing whiteboard template: '${err}'`), {
@@ -402,6 +407,7 @@ const CrdWhiteboardDialog = ({
           onInitApi: setExcalidrawAPI,
           onEditorInvalidated: () => {
             editorGenerationRef.current += 1;
+            setExcalidrawAPI(null);
           },
           onRemoteSave: (error?: string) => {
             if (error) {

--- a/src/main/crdPages/whiteboard/WhiteboardTemplatePickerButton.spec.tsx
+++ b/src/main/crdPages/whiteboard/WhiteboardTemplatePickerButton.spec.tsx
@@ -1,0 +1,67 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  selectedTemplateId: null as string | null,
+  selectedTemplateContent: null as { type: 'whiteboard'; sourceWhiteboardId: string } | null,
+  clearSelection: vi.fn(),
+  onImport: vi.fn(async () => {}),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@/core/apollo/generated/apollo-hooks', () => ({
+  useSpaceTemplatesManagerQuery: () => ({ data: undefined }),
+}));
+vi.mock('@/domain/space/context/useSpace', () => ({
+  useSpace: () => ({ space: { accountId: undefined, levelZeroSpaceId: undefined } }),
+}));
+vi.mock('@/main/crdPages/templates/useTemplatePicker', () => ({
+  useTemplatePicker: () => ({
+    selectedTemplateId: h.selectedTemplateId,
+    selectedTemplateContent: h.selectedTemplateContent,
+    clearSelection: h.clearSelection,
+    openPicker: vi.fn(),
+    pickerProps: {},
+  }),
+}));
+vi.mock('@/crd/components/templates/TemplatePicker', () => ({ TemplatePicker: () => null }));
+vi.mock('@/crd/primitives/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+vi.mock('@/crd/primitives/skeleton', () => ({ Skeleton: () => null }));
+
+import { WhiteboardTemplatePickerButton } from './WhiteboardTemplatePickerButton';
+
+describe('WhiteboardTemplatePickerButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.selectedTemplateId = null;
+    h.selectedTemplateContent = null;
+  });
+
+  it('consumes each selection independently, including selecting the same template twice', async () => {
+    const view = render(<WhiteboardTemplatePickerButton onImport={h.onImport} />);
+
+    h.selectedTemplateId = 'template-1';
+    h.selectedTemplateContent = { type: 'whiteboard', sourceWhiteboardId: 'source-whiteboard' };
+    view.rerender(<WhiteboardTemplatePickerButton onImport={h.onImport} />);
+    await waitFor(() => expect(h.onImport).toHaveBeenCalledTimes(1));
+    expect(h.clearSelection).toHaveBeenCalledTimes(1);
+
+    await act(async () => {});
+    h.selectedTemplateId = null;
+    h.selectedTemplateContent = null;
+    view.rerender(<WhiteboardTemplatePickerButton onImport={h.onImport} />);
+
+    h.selectedTemplateId = 'template-1';
+    h.selectedTemplateContent = { type: 'whiteboard', sourceWhiteboardId: 'source-whiteboard' };
+    view.rerender(<WhiteboardTemplatePickerButton onImport={h.onImport} />);
+
+    await waitFor(() => expect(h.onImport).toHaveBeenCalledTimes(2));
+    expect(h.clearSelection).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/main/crdPages/whiteboard/WhiteboardTemplatePickerButton.tsx
+++ b/src/main/crdPages/whiteboard/WhiteboardTemplatePickerButton.tsx
@@ -1,11 +1,6 @@
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  useReplaceWhiteboardContentFromSourceMutation,
-  useSpaceTemplatesManagerQuery,
-} from '@/core/apollo/generated/apollo-hooks';
-import { error as logError, TagCategoryValues } from '@/core/logging/sentry/log';
-import { useNotification } from '@/core/ui/notifications/useNotification';
+import { useSpaceTemplatesManagerQuery } from '@/core/apollo/generated/apollo-hooks';
 import { TemplatePicker } from '@/crd/components/templates/TemplatePicker';
 import { Button } from '@/crd/primitives/button';
 import { Skeleton } from '@/crd/primitives/skeleton';
@@ -13,8 +8,8 @@ import { useSpace } from '@/domain/space/context/useSpace';
 import { useTemplatePicker } from '@/main/crdPages/templates/useTemplatePicker';
 
 type WhiteboardTemplatePickerButtonProps = {
-  whiteboardId: string;
   disabled?: boolean;
+  onImport: (sourceWhiteboardId: string) => Promise<void>;
 };
 
 /**
@@ -25,9 +20,8 @@ type WhiteboardTemplatePickerButtonProps = {
  * outside a space (e.g. the public whiteboard route) `useSpace()` returns its empty default, so only
  * the platform library is offered.
  */
-export function WhiteboardTemplatePickerButton({ whiteboardId, disabled }: WhiteboardTemplatePickerButtonProps) {
+export function WhiteboardTemplatePickerButton({ disabled, onImport }: WhiteboardTemplatePickerButtonProps) {
   const { t } = useTranslation();
-  const notify = useNotification();
   const {
     space: { accountId, levelZeroSpaceId },
   } = useSpace();
@@ -37,26 +31,28 @@ export function WhiteboardTemplatePickerButton({ whiteboardId, disabled }: White
   });
   const spaceTemplatesSetId = tmData?.lookup.space?.templatesManager?.templatesSet?.id;
   const picker = useTemplatePicker({ allowedTypes: ['whiteboard'], accountId, spaceTemplatesSetId });
-  const [replaceFromSource, { loading: importing }] = useReplaceWhiteboardContentFromSourceMutation();
+  const [importing, setImporting] = useState(false);
+  const consumedSelection = useRef<typeof picker.selectedTemplateContent>(null);
 
   const selectedContent = picker.selectedTemplateContent;
   const selectedId = picker.selectedTemplateId;
-  const [appliedFor, setAppliedFor] = useState<string | null>(null);
   useEffect(() => {
-    if (!selectedContent || selectedContent.type !== 'whiteboard' || !selectedId || appliedFor === selectedId) return;
+    if (!selectedContent) {
+      consumedSelection.current = null;
+      return;
+    }
+    if (selectedContent.type !== 'whiteboard' || !selectedId || consumedSelection.current === selectedContent) {
+      return;
+    }
     const sourceWhiteboardID = selectedContent.sourceWhiteboardId;
     if (!sourceWhiteboardID) return;
-    setAppliedFor(selectedId);
-    void replaceFromSource({
-      variables: { input: { targetWhiteboardID: whiteboardId, sourceWhiteboardID } },
-    }).catch(err => {
-      setAppliedFor(null);
-      notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
-      logError(new Error(`Error importing whiteboard template by source id: '${err}'`), {
-        category: TagCategoryValues.WHITEBOARD,
-      });
+    consumedSelection.current = selectedContent;
+    picker.clearSelection();
+    setImporting(true);
+    void onImport(sourceWhiteboardID).finally(() => {
+      setImporting(false);
     });
-  }, [selectedContent, selectedId, appliedFor, replaceFromSource, whiteboardId, notify, t]);
+  }, [selectedContent, selectedId, picker, onImport]);
 
   return (
     // Own Suspense boundary: the template picker pulls in the lazy `crd-templates`

--- a/src/main/crdPages/whiteboard/useWhiteboardImportLifetime.spec.tsx
+++ b/src/main/crdPages/whiteboard/useWhiteboardImportLifetime.spec.tsx
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useWhiteboardImportLifetime } from './useWhiteboardImportLifetime';
+
+const pendingSourceLoad = (signal: AbortSignal) =>
+  new Promise<never>((_, reject) => {
+    signal.addEventListener('abort', () => reject(new Error('source load aborted')), { once: true });
+  });
+
+describe('useWhiteboardImportLifetime', () => {
+  it('cancels a source load as soon as the dialog closes', async () => {
+    const { result, rerender } = renderHook(({ active }) => useWhiteboardImportLifetime('whiteboard-A', active), {
+      initialProps: { active: true },
+    });
+    const token = result.current.beginImport();
+    const loading = pendingSourceLoad(token.signal);
+
+    rerender({ active: false });
+
+    await expect(loading).rejects.toThrow('source load aborted');
+    expect(token.isCancelled()).toBe(true);
+  });
+
+  it('cancels a source load when the dialog unmounts', async () => {
+    const { result, unmount } = renderHook(() => useWhiteboardImportLifetime('whiteboard-A', true));
+    const token = result.current.beginImport();
+    const loading = pendingSourceLoad(token.signal);
+
+    unmount();
+
+    await expect(loading).rejects.toThrow('source load aborted');
+    expect(token.isCancelled()).toBe(true);
+  });
+
+  it('cancels A during the A→B gap without waiting for editor B to publish its API', async () => {
+    const { result, rerender } = renderHook(({ whiteboardId }) => useWhiteboardImportLifetime(whiteboardId, true), {
+      initialProps: { whiteboardId: 'whiteboard-A' },
+    });
+    const tokenA = result.current.beginImport();
+    const loadingA = pendingSourceLoad(tokenA.signal);
+
+    // No replacement editor/API callback occurs here: changing the owning identity
+    // itself must synchronously invalidate the old import generation.
+    rerender({ whiteboardId: 'whiteboard-B' });
+
+    await expect(loadingA).rejects.toThrow('source load aborted');
+    expect(tokenA.isCancelled()).toBe(true);
+    const tokenB = result.current.beginImport();
+    expect(tokenB.signal.aborted).toBe(false);
+    expect(tokenB.isCancelled()).toBe(false);
+  });
+});

--- a/src/main/crdPages/whiteboard/useWhiteboardImportLifetime.ts
+++ b/src/main/crdPages/whiteboard/useWhiteboardImportLifetime.ts
@@ -1,0 +1,49 @@
+import { useLayoutEffect, useRef } from 'react';
+
+export type WhiteboardImportToken = {
+  signal: AbortSignal;
+  isCancelled: () => boolean;
+};
+
+/**
+ * Bind an in-flight template import to the dialog and whiteboard generation that
+ * started it. The layout-effect cleanup runs during unmount / identity changes,
+ * before a replacement editor can publish its API.
+ */
+export const useWhiteboardImportLifetime = (whiteboardId: string | undefined, active: boolean) => {
+  const activeControllerRef = useRef<AbortController | null>(null);
+  const generationRef = useRef(0);
+
+  useLayoutEffect(() => {
+    return () => {
+      generationRef.current += 1;
+      activeControllerRef.current?.abort();
+      activeControllerRef.current = null;
+    };
+  }, [active, whiteboardId]);
+
+  const beginImport = (): WhiteboardImportToken => {
+    activeControllerRef.current?.abort();
+    const controller = new AbortController();
+    activeControllerRef.current = controller;
+    const generation = generationRef.current;
+
+    return {
+      signal: controller.signal,
+      isCancelled: () => controller.signal.aborted || generationRef.current !== generation,
+    };
+  };
+
+  const finishImport = (token: WhiteboardImportToken) => {
+    if (activeControllerRef.current?.signal === token.signal) {
+      activeControllerRef.current = null;
+    }
+  };
+
+  const cancelActiveImport = () => {
+    activeControllerRef.current?.abort();
+    activeControllerRef.current = null;
+  };
+
+  return { beginImport, finishImport, cancelActiveImport };
+};


### PR DESCRIPTION
Fixes alkem-io/client-web#10217

## Root cause

#10198 removed the legacy whiteboard scene from GraphQL template payloads, but also replaced the existing additive client-side merge with a server-side whole-snapshot replacement. Applying a template therefore erased the target drawing.

## Fix

- materialize the selected template through the collaboration transport into a headless scene; no raw Yjs update or scene JSON crosses ordinary GraphQL
- feed the materialized snapshot into the existing additive merge path so target elements remain, imported elements receive fresh IDs, and each copy is displaced next to existing content
- preserve the existing asset re-home and durability gates for template images
- treat every picker selection as a new import, including choosing the same template repeatedly

## Regression coverage

- existing target content is preserved
- repeated application of one template inserts two independent copies with fresh IDs and progressive displacement
- source collaboration materialization returns scene elements/assets and rejects terminal authorization failures
- picker invokes the import for every selection without template-ID deduplication

## Verification

- targeted Vitest: 3 files, 12 tests passed
- `pnpm lint`: passed (existing Biome warning baseline only)
- full Vitest under Node 22.23.2: 356 files, 3004 passed, 2 skipped
- Vite production build under Node 22.23.2: passed
- normal signed commit hook: passed without bypass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Whiteboard templates can be imported into the current whiteboard while preserving existing content.
  - Imports include synced elements, assets, saved settings, and relationships between objects.
  - Import progress is indicated, preventing duplicate actions during processing.

- **Bug Fixes**
  - Improved handling of unavailable, closed, or timed-out template sources.
  - Prevented outdated template responses from replacing newer selections.
  - Import cancellation and editor changes no longer apply stale content.
  - Import failures provide clear notifications without disrupting the current whiteboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->