### PR TITLE
fix: derive collaboration origin from platform domain

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,6 @@ VITE_APP_LOG_ERRORS=true
 # ws://<host>/collab/<documentId>?type=memo|whiteboard through the gateway
 # (Traefik/Oathkeeper → collaboration-service). Replaces the legacy Socket.IO
 # (whiteboard) + Hocuspocus (memo) endpoints.
-VITE_APP_COLLAB_URL=http://localhost:3000
 VITE_APP_COLLAB_PATH=/collab
 
 # Opt the Vite dev server back into registering the service worker.

--- a/specs/005-guest-whiteboard-access/data-model.md
+++ b/specs/005-guest-whiteboard-access/data-model.md
@@ -280,7 +280,8 @@ try {
 
 **Connection Parameters**:
 
-- URL: `VITE_APP_COLLAB_URL` (e.g., `http://localhost:3000`)
+- Origin: the first non-empty value of `VITE_APP_ALKEMIO_DOMAIN`, otherwise
+  `window.location.origin` (there is no separate collaboration-origin setting)
 - Path: `VITE_APP_COLLAB_PATH` (e.g., `/api/private/ws/socket.io`)
 - Transport: WebSocket (with polling fallback)
 

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
@@ -95,6 +95,30 @@ describe('UnifiedCollabProvider', () => {
     provider.destroy();
   });
 
+  it('uses the configured platform domain when no base URL override is provided', () => {
+    vi.stubGlobal('window', {
+      _env_: { VITE_APP_ALKEMIO_DOMAIN: 'https://platform.test' },
+      location: { origin: 'https://browser.test' },
+    });
+
+    const provider = new UnifiedCollabProvider({ documentId: 'doc-1', type: 'whiteboard' });
+
+    expect(MockWebSocket.instances[0].url).toBe('wss://platform.test/collab/doc-1?type=whiteboard');
+    provider.destroy();
+  });
+
+  it('uses the browser origin when no platform domain or base URL override is provided', () => {
+    vi.stubGlobal('window', {
+      _env_: {},
+      location: { origin: 'https://browser.test' },
+    });
+
+    const provider = new UnifiedCollabProvider({ documentId: 'doc-1', type: 'memo' });
+
+    expect(MockWebSocket.instances[0].url).toBe('wss://browser.test/collab/doc-1?type=memo');
+    provider.destroy();
+  });
+
   it('passes a guest name through the query string', () => {
     const provider = new UnifiedCollabProvider({ ...baseOptions, type: 'memo', guestName: 'Alice S.' });
     expect(MockWebSocket.instances[0].url).toBe('wss://collab.test/collab/doc-1?type=memo&guestName=Alice+S.');
@@ -435,13 +459,6 @@ describe('UnifiedCollabProvider', () => {
 
     provider.destroy();
     vi.useRealTimers();
-  });
-
-  it('stays inert when no collab base URL is configured', () => {
-    const provider = new UnifiedCollabProvider({ documentId: 'd', type: 'memo' });
-    expect(MockWebSocket.instances).toHaveLength(0);
-    expect(provider.status).toBe('connecting');
-    provider.destroy();
   });
 });
 

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
@@ -119,6 +119,18 @@ describe('UnifiedCollabProvider', () => {
     provider.destroy();
   });
 
+  it('uses the browser origin when the runtime platform domain is empty', () => {
+    vi.stubGlobal('window', {
+      _env_: { VITE_APP_ALKEMIO_DOMAIN: '' },
+      location: { origin: 'https://browser.test' },
+    });
+
+    const provider = new UnifiedCollabProvider({ documentId: 'doc-1', type: 'memo' });
+
+    expect(MockWebSocket.instances[0].url).toBe('wss://browser.test/collab/doc-1?type=memo');
+    provider.destroy();
+  });
+
   it('passes a guest name through the query string', () => {
     const provider = new UnifiedCollabProvider({ ...baseOptions, type: 'memo', guestName: 'Alice S.' });
     expect(MockWebSocket.instances[0].url).toBe('wss://collab.test/collab/doc-1?type=memo&guestName=Alice+S.');

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
@@ -709,7 +709,7 @@ function buildCollabUrl(
   options: Pick<UnifiedCollabProviderOptions, 'documentId' | 'type' | 'baseUrl' | 'path' | 'guestName'>
 ): string | null {
   const baseUrl =
-    options.baseUrl ?? globalThis.window?._env_?.VITE_APP_ALKEMIO_DOMAIN ?? globalThis.window?.location.origin;
+    options.baseUrl || globalThis.window?._env_?.VITE_APP_ALKEMIO_DOMAIN || globalThis.window?.location.origin;
   if (!baseUrl) return null;
 
   const path = options.path ?? globalThis.window?._env_?.VITE_APP_COLLAB_PATH ?? '/collab';

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
@@ -182,7 +182,7 @@ type UnifiedCollabProviderCommonOptions = {
   type: 'memo' | 'whiteboard';
   /** Reuse an existing awareness (e.g. the whiteboard binding's). A fresh one is created when omitted. */
   awareness?: Awareness;
-  /** Override the service base URL (defaults to the configured collab URL). */
+  /** Override the service base URL (defaults to the platform or browser origin). */
   baseUrl?: string;
   /** Override the service path prefix (defaults to `/collab`). */
   path?: string;
@@ -702,13 +702,14 @@ function readRawJsonPayload(decoder: decoding.Decoder): unknown {
 
 /**
  * Build `wss://<host><path>/<documentId>?type=<type>[&guestName=...]` from the
- * configured collab base URL. `http(s)` is upgraded to `ws(s)`. Returns null when
- * the base URL is not configured (the provider then stays inert).
+ * platform origin. `http(s)` is upgraded to `ws(s)`. An explicit `baseUrl`
+ * remains available for tests and non-platform embedding.
  */
 function buildCollabUrl(
   options: Pick<UnifiedCollabProviderOptions, 'documentId' | 'type' | 'baseUrl' | 'path' | 'guestName'>
 ): string | null {
-  const baseUrl = options.baseUrl ?? globalThis.window?._env_?.VITE_APP_COLLAB_URL;
+  const baseUrl =
+    options.baseUrl ?? globalThis.window?._env_?.VITE_APP_ALKEMIO_DOMAIN ?? globalThis.window?.location.origin;
   if (!baseUrl) return null;
 
   const path = options.path ?? globalThis.window?._env_?.VITE_APP_COLLAB_PATH ?? '/collab';

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -5,7 +5,6 @@ declare global {
       VITE_APP_DEBUG_QUERY?: string;
       VITE_APP_LOG_ERRORS?: string;
       VITE_APP_IN_CONTEXT_TRANSLATION?: string;
-      VITE_APP_COLLAB_URL?: string;
       VITE_APP_COLLAB_PATH?: string;
       VITE_APP_ASSISTANT_ENABLED?: string;
       VITE_APP_ASSISTANT_BASE_PATH?: string;


### PR DESCRIPTION
Fixes alkem-io/client-web#10221

## Root cause

Unified collaboration defaulted only to `VITE_APP_COLLAB_URL`, duplicating the platform origin configuration and leaving the provider inert when that extra variable was absent.

## Fix

- Resolve the WebSocket origin in the order: explicit provider `baseUrl`, `VITE_APP_ALKEMIO_DOMAIN`, browser origin.
- Preserve explicit `path`, then `VITE_APP_COLLAB_PATH`, then `/collab`.
- Remove `VITE_APP_COLLAB_URL` from the runtime environment type and local environment file.
- Keep explicit provider overrides for tests and non-platform embedding.

An obsolete deployment variable can remain temporarily without affecting behavior because the client no longer reads it. No retired `VITE_APP_COLLAB_DOC_URL` runtime reference was introduced.

## Regression coverage

- Platform-domain origin takes precedence over browser origin.
- Browser origin is used when no platform domain is configured.
- Existing explicit `baseUrl` coverage remains green.

## Verification

- `pnpm lint` (Node 24.14.0)
- `pnpm vitest run` — 354 files, 3001 passed, 2 skipped
- `pnpm build` (Node 24.14.0)
- Normal pre-commit hook, no bypass — green

Comments changed in this PR carry no issue or specification references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time collaboration connection handling by using the configured platform domain or browser origin when no custom base URL is provided.
  * Preserved support for explicitly configured collaboration base URLs.
* **Chores**
  * Removed the dedicated collaboration URL setting; the collaboration path remains configurable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->