### PR TITLE
fix: await whiteboard draft durability before callout creation

### DIFF
--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
@@ -71,6 +71,13 @@ function readFrameType(bytes: Uint8Array): number {
   return decoding.readVarUint(decoding.createDecoder(bytes));
 }
 
+function readRawJsonFrame(bytes: Uint8Array): { type: number; body: unknown } {
+  const decoder = decoding.createDecoder(bytes);
+  const type = decoding.readVarUint(decoder);
+  const body = JSON.parse(new TextDecoder().decode(decoding.readTailAsUint8Array(decoder)));
+  return { type, body };
+}
+
 beforeEach(() => {
   MockWebSocket.instances = [];
   vi.stubGlobal('WebSocket', MockWebSocket);
@@ -284,6 +291,62 @@ describe('UnifiedCollabProvider', () => {
       { kind: 'persisted', requestId: 'req-1' },
       { kind: 'persist-failed', requestId: 'req-1', error: 'store unavailable' },
     ]);
+    provider.destroy();
+  });
+
+  it('requests durability with the raw service wire contract and waits for the matching persisted reply', async () => {
+    const provider = new UnifiedCollabProvider(baseOptions);
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    socket.sent.length = 0;
+
+    const durability = provider.requestDurability();
+    const request = readRawJsonFrame(socket.sent[0]);
+    expect(request.type).toBe(WIRE.DURABILITY_REQUEST);
+    expect(request.body).toEqual({ requestId: expect.stringMatching(/^[a-z0-9]+-[a-z0-9]+$/) });
+
+    let settled = false;
+    void durability.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    socket.receive(
+      encodeServiceControlFrame({ kind: 'persisted', requestId: (request.body as { requestId: string }).requestId })
+    );
+    await expect(durability).resolves.toBeUndefined();
+    provider.destroy();
+  });
+
+  it('coalesces concurrent durability callers and rejects a failed persistence reply', async () => {
+    const provider = new UnifiedCollabProvider(baseOptions);
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    socket.sent.length = 0;
+
+    const first = provider.requestDurability();
+    const second = provider.requestDurability();
+    expect(second).toBe(first);
+    expect(socket.sent).toHaveLength(1);
+    const request = readRawJsonFrame(socket.sent[0]).body as { requestId: string };
+
+    socket.receive(
+      encodeServiceControlFrame({ kind: 'persist-failed', requestId: request.requestId, error: 'store unavailable' })
+    );
+    await expect(first).rejects.toThrow('store unavailable');
+    provider.destroy();
+  });
+
+  it('rejects an outstanding durability request when the connection closes', async () => {
+    const provider = new UnifiedCollabProvider(baseOptions);
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+
+    const durability = provider.requestDurability();
+    socket.serverClose(1006);
+
+    await expect(durability).rejects.toThrow('closed before the draft was persisted');
     provider.destroy();
   });
 

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
@@ -8,6 +8,7 @@ import {
   type CloseVerdict,
   type ControlMessage,
   classifyClose,
+  DURABILITY_REQUEST_TIMEOUT_MS,
   type SceneSyncPort,
   UnifiedCollabProvider,
   WIRE,
@@ -348,6 +349,28 @@ describe('UnifiedCollabProvider', () => {
 
     await expect(durability).rejects.toThrow('closed before the draft was persisted');
     provider.destroy();
+  });
+
+  it('times out a lost durability reply and lets the caller retry', async () => {
+    vi.useFakeTimers();
+    const provider = new UnifiedCollabProvider(baseOptions);
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    socket.sent.length = 0;
+
+    const durability = provider.requestDurability();
+    const timedOut = expect(durability).rejects.toThrow('timed out while persisting the draft');
+    await vi.advanceTimersByTimeAsync(DURABILITY_REQUEST_TIMEOUT_MS);
+    await timedOut;
+
+    const retry = provider.requestDurability();
+    expect(socket.sent).toHaveLength(2);
+    const request = readRawJsonFrame(socket.sent[1]).body as { requestId: string };
+    socket.receive(encodeServiceControlFrame({ kind: 'persisted', requestId: request.requestId }));
+    await expect(retry).resolves.toBeUndefined();
+
+    provider.destroy();
+    vi.useRealTimers();
   });
 
   it('does NOT decode an (invalid) VarString-prefixed control frame — the client reads only the Go raw contract', () => {

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
@@ -320,22 +320,37 @@ describe('UnifiedCollabProvider', () => {
     provider.destroy();
   });
 
-  it('coalesces concurrent durability callers and rejects a failed persistence reply', async () => {
+  it('queues a fresh barrier for a later caller when updates are sent during the first request', async () => {
     const provider = new UnifiedCollabProvider(baseOptions);
     const socket = MockWebSocket.instances[0];
     socket.open();
     socket.sent.length = 0;
 
     const first = provider.requestDurability();
+    const firstRequest = readRawJsonFrame(socket.sent[0]).body as { requestId: string };
+    provider.doc.getMap('scene').set('after-first-barrier', true);
     const second = provider.requestDurability();
-    expect(second).toBe(first);
-    expect(socket.sent).toHaveLength(1);
-    const request = readRawJsonFrame(socket.sent[0]).body as { requestId: string };
+    expect(socket.sent.map(readFrameType)).toEqual([WIRE.DURABILITY_REQUEST, WIRE.SYNC]);
 
+    let secondSettled = false;
+    void second.then(() => {
+      secondSettled = true;
+    });
+    socket.receive(encodeServiceControlFrame({ kind: 'persisted', requestId: firstRequest.requestId }));
+    await expect(first).resolves.toBeUndefined();
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(3));
+    expect(secondSettled).toBe(false);
+
+    const secondRequest = readRawJsonFrame(socket.sent[2]);
+    expect(secondRequest.type).toBe(WIRE.DURABILITY_REQUEST);
+    expect((secondRequest.body as { requestId: string }).requestId).not.toBe(firstRequest.requestId);
     socket.receive(
-      encodeServiceControlFrame({ kind: 'persist-failed', requestId: request.requestId, error: 'store unavailable' })
+      encodeServiceControlFrame({
+        kind: 'persisted',
+        requestId: (secondRequest.body as { requestId: string }).requestId,
+      })
     );
-    await expect(first).rejects.toThrow('store unavailable');
+    await expect(second).resolves.toBeUndefined();
     provider.destroy();
   });
 

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
@@ -215,6 +215,7 @@ export type UnifiedCollabProviderOptions = UnifiedCollabProviderCommonOptions &
   );
 
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
+export const DURABILITY_REQUEST_TIMEOUT_MS = 60_000;
 const NORMAL_CLOSURE = 1000;
 /**
  * WebSocket policy-violation close code (RFC 6455 §7.4.1). The unified collaboration
@@ -274,6 +275,7 @@ export class UnifiedCollabProvider {
         promise: Promise<void>;
         resolve: () => void;
         reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
       }
     | undefined;
 
@@ -430,7 +432,10 @@ export class UnifiedCollabProvider {
       resolve = resolvePromise;
       reject = rejectPromise;
     });
-    this.pendingDurability = { requestId, promise, resolve, reject };
+    const timeout = setTimeout(() => {
+      this.rejectPendingDurability('The collaboration service timed out while persisting the draft');
+    }, DURABILITY_REQUEST_TIMEOUT_MS);
+    this.pendingDurability = { requestId, promise, resolve, reject, timeout };
 
     const encoder = encoding.createEncoder();
     encoding.writeVarUint(encoder, WIRE.DURABILITY_REQUEST);
@@ -539,7 +544,14 @@ export class UnifiedCollabProvider {
 
   private settleDurability(message: ControlMessage): void {
     const pending = this.pendingDurability;
-    if (!pending || message.requestId !== pending.requestId) return;
+    if (
+      !pending ||
+      message.requestId !== pending.requestId ||
+      (message.kind !== 'persisted' && message.kind !== 'persist-failed')
+    ) {
+      return;
+    }
+    clearTimeout(pending.timeout);
     if (message.kind === 'persisted') {
       this.pendingDurability = undefined;
       pending.resolve();
@@ -552,6 +564,7 @@ export class UnifiedCollabProvider {
   private rejectPendingDurability(message: string): void {
     const pending = this.pendingDurability;
     if (!pending) return;
+    clearTimeout(pending.timeout);
     this.pendingDurability = undefined;
     pending.reject(new Error(message));
   }

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
@@ -278,6 +278,8 @@ export class UnifiedCollabProvider {
         timeout: ReturnType<typeof setTimeout>;
       }
     | undefined;
+  /** Serializes callers so every call receives a barrier sent after that call. */
+  private durabilityQueueTail: Promise<void> | undefined;
 
   constructor(options: UnifiedCollabProviderOptions) {
     this.documentId = options.documentId;
@@ -417,10 +419,32 @@ export class UnifiedCollabProvider {
 
   /**
    * Ask the collaboration service to persist every update sent before this frame.
-   * Concurrent callers share the one in-flight request allowed per connection.
+   * The wire allows one in-flight request per connection. A later caller is queued
+   * behind it and receives its own frame, because updates may have been sent after
+   * the earlier barrier.
    */
   requestDurability(): Promise<void> {
-    if (this.pendingDurability) return this.pendingDurability.promise;
+    if (!this.pendingDurability && !this.durabilityQueueTail) {
+      return this.startDurabilityRequest();
+    }
+
+    const predecessor = this.durabilityQueueTail ?? this.pendingDurability?.promise ?? Promise.resolve();
+    const start = () => this.startDurabilityRequest();
+    const queued = predecessor.then(start, start);
+    const settled = queued.then(
+      () => undefined,
+      () => undefined
+    );
+    this.durabilityQueueTail = settled;
+    void settled.then(() => {
+      if (this.durabilityQueueTail === settled) {
+        this.durabilityQueueTail = undefined;
+      }
+    });
+    return queued;
+  }
+
+  private startDurabilityRequest(): Promise<void> {
     if (this.destroyed || this._status !== 'connected' || !this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return Promise.reject(new Error('The collaboration connection is not ready to persist the draft'));
     }

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
@@ -31,6 +31,8 @@ export const WIRE = {
   EPHEMERAL: 2,
   /** Server→client JSON control (saved / save-error / read-only-state / collaborator-mode / room-user-change / update-rejected / session-end). */
   CONTROL: 3,
+  /** Client→server request to persist every preceding update on this connection. */
+  DURABILITY_REQUEST: 4,
 } as const;
 
 /**
@@ -265,6 +267,15 @@ export class UnifiedCollabProvider {
   private readonly controlListeners = new Set<ControlListener>();
   private readonly closeListeners = new Set<CloseListener>();
   private readonly ephemeralListeners = new Set<(event: EphemeralEvent) => void>();
+  private durabilitySequence = 0;
+  private pendingDurability:
+    | {
+        requestId: string;
+        promise: Promise<void>;
+        resolve: () => void;
+        reject: (error: Error) => void;
+      }
+    | undefined;
 
   constructor(options: UnifiedCollabProviderOptions) {
     this.documentId = options.documentId;
@@ -364,6 +375,7 @@ export class UnifiedCollabProvider {
 
   /** Tear down the socket without reconnecting and without destroying the doc. */
   disconnect(): void {
+    this.rejectPendingDurability('The collaboration connection closed before the draft was persisted');
     this.clearReconnect();
     this.teardownSocket(NORMAL_CLOSURE);
     this.setSynced(false);
@@ -374,6 +386,7 @@ export class UnifiedCollabProvider {
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
+    this.rejectPendingDurability('The collaboration editor closed before the draft was persisted');
     this.clearReconnect();
     // Publish the local leave while the socket and awareness listener are still
     // active. The service also cleans up on disconnect; this makes normal client
@@ -398,6 +411,32 @@ export class UnifiedCollabProvider {
 
     if (this.ownsAwareness) this.awareness.destroy();
     if (this.ownsDoc) this.doc.destroy();
+  }
+
+  /**
+   * Ask the collaboration service to persist every update sent before this frame.
+   * Concurrent callers share the one in-flight request allowed per connection.
+   */
+  requestDurability(): Promise<void> {
+    if (this.pendingDurability) return this.pendingDurability.promise;
+    if (this.destroyed || this._status !== 'connected' || !this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error('The collaboration connection is not ready to persist the draft'));
+    }
+
+    const requestId = `${Date.now().toString(36)}-${(++this.durabilitySequence).toString(36)}`;
+    let resolve!: () => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    this.pendingDurability = { requestId, promise, resolve, reject };
+
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, WIRE.DURABILITY_REQUEST);
+    encoding.writeUint8Array(encoder, lib0String.encodeUtf8(JSON.stringify({ requestId })));
+    this.sendFrame(encoding.toUint8Array(encoder));
+    return promise;
   }
 
   private handleOpen = () => {
@@ -465,6 +504,7 @@ export class UnifiedCollabProvider {
       case WIRE.CONTROL: {
         const parsed = readRawJsonPayload(decoder) as ControlMessage | undefined;
         if (parsed && typeof parsed.kind === 'string') {
+          this.settleDurability(parsed);
           this.controlListeners.forEach(listener => listener(parsed));
         }
         break;
@@ -476,6 +516,7 @@ export class UnifiedCollabProvider {
   };
 
   private handleClose = (event: CloseEvent) => {
+    this.rejectPendingDurability('The collaboration connection closed before the draft was persisted');
     this.setSynced(false);
     this.detachSocketListeners();
     this.ws = null;
@@ -495,6 +536,25 @@ export class UnifiedCollabProvider {
       this.scheduleReconnect();
     }
   };
+
+  private settleDurability(message: ControlMessage): void {
+    const pending = this.pendingDurability;
+    if (!pending || message.requestId !== pending.requestId) return;
+    if (message.kind === 'persisted') {
+      this.pendingDurability = undefined;
+      pending.resolve();
+    } else if (message.kind === 'persist-failed') {
+      this.pendingDurability = undefined;
+      pending.reject(new Error(message.error ?? 'The draft could not be persisted'));
+    }
+  }
+
+  private rejectPendingDurability(message: string): void {
+    const pending = this.pendingDurability;
+    if (!pending) return;
+    this.pendingDurability = undefined;
+    pending.reject(new Error(message));
+  }
 
   private handleError = () => {
     // 'close' fires after 'error'; the reconnect is scheduled there.

--- a/src/domain/collaboration/whiteboard/WhiteboardDraft/WhiteboardDraftEditor.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDraft/WhiteboardDraftEditor.tsx
@@ -1,14 +1,21 @@
 import { useWhiteboardDraftDetailsByIdQuery } from '@/core/apollo/generated/apollo-hooks';
 import CrdWhiteboardView from '@/main/crdPages/whiteboard/CrdWhiteboardView';
+import type { WhiteboardDraftLifecycle } from './useWhiteboardDraft';
 
 type WhiteboardDraftEditorProps = {
   whiteboardID: string;
   displayName: string;
   onClose: () => void;
+  draftLifecycle: Pick<WhiteboardDraftLifecycle, 'preparationRef' | 'prepared'>;
 };
 
 /** Opens a draft through the same collaborative editor used by final boards. */
-export const WhiteboardDraftEditor = ({ whiteboardID, displayName, onClose }: WhiteboardDraftEditorProps) => {
+export const WhiteboardDraftEditor = ({
+  whiteboardID,
+  displayName,
+  onClose,
+  draftLifecycle,
+}: WhiteboardDraftEditorProps) => {
   const { data, loading } = useWhiteboardDraftDetailsByIdQuery({ variables: { whiteboardId: whiteboardID } });
   const whiteboard = data?.lookup.whiteboard;
   return (
@@ -21,7 +28,11 @@ export const WhiteboardDraftEditor = ({ whiteboardID, displayName, onClose }: Wh
       readOnlyDisplayName={true}
       preventWhiteboardDeletion={true}
       loadingWhiteboards={loading}
-      backToWhiteboards={onClose}
+      consumptionPreparationRef={draftLifecycle.preparationRef}
+      backToWhiteboards={() => {
+        draftLifecycle.prepared();
+        onClose();
+      }}
     />
   );
 };

--- a/src/domain/collaboration/whiteboard/WhiteboardDraft/useWhiteboardDraft.spec.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDraft/useWhiteboardDraft.spec.tsx
@@ -184,4 +184,89 @@ describe('useWhiteboardDraft', () => {
 
     expect(deleteDraft).toHaveBeenCalledWith({ variables: { whiteboardID: persisted.whiteboardID } });
   });
+
+  it('coalesces an outstanding preparation and retries it after failure without consuming the draft', async () => {
+    const onHandleChange = vi.fn();
+    const { result } = renderHook(() =>
+      useWhiteboardDraft({
+        scope: { type: 'calloutsSet', id: '80c59089-c435-45ae-9862-fda57c0a5a35' },
+        handle: persisted,
+        onHandleChange,
+      })
+    );
+    let resolveFirst!: (prepared: boolean) => void;
+    const prepare = vi
+      .fn()
+      .mockReturnValueOnce(
+        new Promise<boolean>(resolve => {
+          resolveFirst = resolve;
+        })
+      )
+      .mockResolvedValueOnce(true);
+    result.current.preparationRef.current = prepare;
+
+    let first!: Promise<boolean>;
+    let second!: Promise<boolean>;
+    await act(async () => {
+      first = result.current.prepareForConsumption();
+      second = result.current.prepareForConsumption();
+      await Promise.resolve();
+    });
+    expect(second).toBe(first);
+    expect(prepare).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      resolveFirst(false);
+      await expect(first).resolves.toBe(false);
+    });
+    expect(onHandleChange).not.toHaveBeenCalledWith(undefined);
+    expect(deleteDraft).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await expect(result.current.prepareForConsumption()).resolves.toBe(true);
+    });
+    expect(prepare).toHaveBeenCalledTimes(2);
+    expect(onHandleChange).not.toHaveBeenCalledWith(undefined);
+  });
+
+  it('does not prepare again after a successful editor close', async () => {
+    const { result } = renderHook(() =>
+      useWhiteboardDraft({
+        scope: { type: 'calloutsSet', id: '80c59089-c435-45ae-9862-fda57c0a5a35' },
+        handle: persisted,
+        onHandleChange: vi.fn(),
+      })
+    );
+    const prepare = vi.fn(async () => true);
+    result.current.preparationRef.current = prepare;
+
+    act(() => {
+      result.current.preparationRef.current = null;
+      result.current.prepared();
+    });
+    await act(async () => {
+      await expect(result.current.prepareForConsumption()).resolves.toBe(true);
+    });
+
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
+  it('prepares again when an already prepared draft editor is reopened', async () => {
+    const { result } = renderHook(() =>
+      useWhiteboardDraft({
+        scope: { type: 'calloutsSet', id: '80c59089-c435-45ae-9862-fda57c0a5a35' },
+        handle: persisted,
+        onHandleChange: vi.fn(),
+      })
+    );
+    const prepare = vi.fn(async () => true);
+
+    act(() => result.current.prepared());
+    result.current.preparationRef.current = prepare;
+    await act(async () => {
+      await expect(result.current.prepareForConsumption()).resolves.toBe(true);
+    });
+
+    expect(prepare).toHaveBeenCalledOnce();
+  });
 });

--- a/src/domain/collaboration/whiteboard/WhiteboardDraft/useWhiteboardDraft.ts
+++ b/src/domain/collaboration/whiteboard/WhiteboardDraft/useWhiteboardDraft.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { type RefObject, useEffect, useRef, useState } from 'react';
 import {
   useCreateWhiteboardDraftOnCalloutsSetMutation,
   useCreateWhiteboardDraftOnTemplatesSetMutation,
@@ -17,10 +17,15 @@ export type WhiteboardDraftHandle = {
   sourceKey: string;
 };
 
+export type WhiteboardDraftPreparation = () => Promise<boolean>;
+
 export type WhiteboardDraftLifecycle = {
   handle?: WhiteboardDraftHandle;
   loading: boolean;
   materialize: (source?: WhiteboardDraftSource) => Promise<WhiteboardDraftHandle | undefined>;
+  preparationRef: RefObject<WhiteboardDraftPreparation | null>;
+  prepareForConsumption: () => Promise<boolean>;
+  prepared: () => void;
   discard: () => Promise<boolean>;
   consumed: () => void;
 };
@@ -50,10 +55,16 @@ export const useWhiteboardDraft = ({
   source: defaultSource,
 }: UseWhiteboardDraftOptions): WhiteboardDraftLifecycle => {
   const inFlightRef = useRef<Promise<WhiteboardDraftHandle | undefined> | null>(null);
+  const preparationRef = useRef<WhiteboardDraftPreparation | null>(null);
+  const preparationInFlightRef = useRef<Promise<boolean> | null>(null);
+  const preparedRef = useRef(false);
   const handleRef = useRef(handle);
   const lastPropHandleRef = useRef(handle);
   useEffect(() => {
     if (sameHandle(handle, lastPropHandleRef.current)) return;
+    if (handle?.whiteboardID !== lastPropHandleRef.current?.whiteboardID) {
+      preparedRef.current = false;
+    }
     lastPropHandleRef.current = handle;
     handleRef.current = handle;
   }, [handle]);
@@ -72,6 +83,7 @@ export const useWhiteboardDraft = ({
     try {
       await deleteDraft({ variables: { whiteboardID: currentHandle.whiteboardID } });
       handleRef.current = undefined;
+      preparedRef.current = false;
       onHandleChange(undefined);
       return true;
     } catch {
@@ -124,6 +136,7 @@ export const useWhiteboardDraft = ({
           sourceKey: nextSourceKey,
         };
         handleRef.current = next;
+        preparedRef.current = false;
         onHandleChange(next);
         return next;
       } catch {
@@ -140,13 +153,37 @@ export const useWhiteboardDraft = ({
     return promise;
   };
 
+  const prepareForConsumption = (): Promise<boolean> => {
+    if (!handleRef.current) return Promise.resolve(true);
+    if (preparationInFlightRef.current) return preparationInFlightRef.current;
+    const prepare = preparationRef.current;
+    if (!prepare) return Promise.resolve(preparedRef.current);
+
+    const promise = prepare()
+      .then(prepared => {
+        if (prepared) preparedRef.current = true;
+        return prepared;
+      })
+      .finally(() => {
+        preparationInFlightRef.current = null;
+      });
+    preparationInFlightRef.current = promise;
+    return promise;
+  };
+
   return {
     handle,
     loading,
     materialize,
+    preparationRef,
+    prepareForConsumption,
+    prepared: () => {
+      preparedRef.current = true;
+    },
     discard,
     consumed: () => {
       handleRef.current = undefined;
+      preparedRef.current = false;
       onHandleChange(undefined);
     },
   };

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
@@ -251,7 +251,7 @@ const CollaborativeExcalidrawWrapper = ({
     },
   };
 
-  const { UIOptions: externalUIOptions, ...restOptions } = options;
+  const { UIOptions: externalUIOptions, viewModeEnabled: externallyReadOnly, ...restOptions } = options;
 
   const mergedUIOptions = merge(UIOptions, externalUIOptions);
 
@@ -433,7 +433,7 @@ const CollaborativeExcalidrawWrapper = ({
             initialData={whiteboardDefaults}
             UIOptions={mergedUIOptions}
             isCollaborating={collaborating}
-            viewModeEnabled={isReadOnly}
+            viewModeEnabled={isReadOnly || externallyReadOnly}
             assetAdapter={assetAdapter}
             onPointerUpdate={collabApi?.onPointerUpdate}
             onRequestBroadcastEmojiReaction={handleRequestBroadcastEmojiReaction}

--- a/src/domain/common/whiteboard/excalidraw/collab/useCollab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/useCollab.ts
@@ -22,6 +22,8 @@ export type CollabAPI = {
   /** Local pointer move → awareness (the AwarenessRouter owns cursor presence). */
   onPointerUpdate: (payload: PointerUpdatePayload) => void;
   isCollaborating: () => boolean;
+  /** Wait until every preceding scene update is durable in both collaboration stores. */
+  requestDurability: () => Promise<void>;
   /** Broadcast an ephemeral floating emoji to other collaborators (never persisted). */
   broadcastEmojiReaction: (emoji: string, x: number, y: number) => void;
   broadcastCountdownTimer: (remainingSeconds: number, startedBy: string, active: boolean) => void;
@@ -311,6 +313,7 @@ const useCollab = ({
     const collabApi: CollabAPI = {
       onPointerUpdate: payload => awarenessRouter.onPointerUpdate(payload),
       isCollaborating: () => providerRef.current?.status === 'connected',
+      requestDurability: () => provider.requestDurability(),
       broadcastEmojiReaction: (emoji, x, y) => {
         const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
         awarenessRouter.broadcastEmojiReaction({ id, emoji, x, y });

--- a/src/main/crdPages/space/callout/CalloutFormConnector.draftPreparation.spec.ts
+++ b/src/main/crdPages/space/callout/CalloutFormConnector.draftPreparation.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { prepareWhiteboardDraftsForCalloutCreation } from './CalloutFormConnector';
+import { prepareWhiteboardDraftsForCalloutCreation, runCalloutCreationOnce } from './CalloutFormConnector';
 
 const deferred = () => {
   let resolve!: (prepared: boolean) => void;
@@ -51,5 +51,27 @@ describe('prepareWhiteboardDraftsForCalloutCreation', () => {
     expect(prepared).toBe(false);
     expect(createCallout).not.toHaveBeenCalled();
     expect(consumed).not.toHaveBeenCalled();
+  });
+
+  it('keeps the entire preparation and create operation single-flight', async () => {
+    const inFlight = { current: false };
+    const preparation = deferred();
+    const create = vi.fn(async () => {
+      await preparation.promise;
+    });
+    const setPreparing = vi.fn();
+
+    const first = runCalloutCreationOnce(inFlight, setPreparing, create);
+    const second = runCalloutCreationOnce(inFlight, setPreparing, create);
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(setPreparing).toHaveBeenCalledWith(true);
+    await expect(second).resolves.toBeUndefined();
+
+    preparation.resolve(true);
+    await first;
+
+    expect(setPreparing).toHaveBeenLastCalledWith(false);
+    expect(inFlight.current).toBe(false);
   });
 });

--- a/src/main/crdPages/space/callout/CalloutFormConnector.draftPreparation.spec.ts
+++ b/src/main/crdPages/space/callout/CalloutFormConnector.draftPreparation.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { prepareWhiteboardDraftsForCalloutCreation } from './CalloutFormConnector';
+
+const deferred = () => {
+  let resolve!: (prepared: boolean) => void;
+  const promise = new Promise<boolean>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+describe('prepareWhiteboardDraftsForCalloutCreation', () => {
+  it('waits for both framing and response whiteboards before the caller can create the callout', async () => {
+    const framing = deferred();
+    const response = deferred();
+    const prepareFraming = vi.fn(() => framing.promise);
+    const prepareResponse = vi.fn(() => response.promise);
+    const createCallout = vi.fn();
+
+    const submit = (async () => {
+      const prepared = await prepareWhiteboardDraftsForCalloutCreation([
+        { prepareForConsumption: prepareFraming },
+        { prepareForConsumption: prepareResponse },
+      ]);
+      if (prepared) createCallout();
+      return prepared;
+    })();
+
+    framing.resolve(true);
+    await Promise.resolve();
+    expect(createCallout).not.toHaveBeenCalled();
+
+    response.resolve(true);
+    await expect(submit).resolves.toBe(true);
+    expect(createCallout).toHaveBeenCalledOnce();
+  });
+
+  it('blocks creation when either draft is not durable and leaves cleanup to the retry path', async () => {
+    const createCallout = vi.fn();
+    const consumed = vi.fn();
+
+    const prepared = await prepareWhiteboardDraftsForCalloutCreation([
+      { prepareForConsumption: vi.fn(async () => true) },
+      { prepareForConsumption: vi.fn(async () => false) },
+    ]);
+    if (prepared) {
+      createCallout();
+      consumed();
+    }
+
+    expect(prepared).toBe(false);
+    expect(createCallout).not.toHaveBeenCalled();
+    expect(consumed).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/crdPages/space/callout/CalloutFormConnector.tsx
+++ b/src/main/crdPages/space/callout/CalloutFormConnector.tsx
@@ -134,6 +134,22 @@ export async function prepareWhiteboardDraftsForCalloutCreation(
   return prepared.every(Boolean);
 }
 
+export async function runCalloutCreationOnce(
+  inFlight: { current: boolean },
+  setPreparing: (preparing: boolean) => void,
+  create: () => Promise<void>
+): Promise<void> {
+  if (inFlight.current) return;
+  inFlight.current = true;
+  setPreparing(true);
+  try {
+    await create();
+  } finally {
+    inFlight.current = false;
+    setPreparing(false);
+  }
+}
+
 type CalloutFormConnectorProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -526,10 +542,17 @@ function CalloutFormConnectorInner({
   };
 
   // --- Create path -------------------------------------------------------
+  const [preparingCreation, setPreparingCreation] = useState(false);
+  const creationInFlightRef = useRef(false);
   const submitting =
-    creating || updating || mediaGalleryUploading || framingWhiteboardDraft.loading || defaultWhiteboardDraft.loading;
+    creating ||
+    updating ||
+    mediaGalleryUploading ||
+    framingWhiteboardDraft.loading ||
+    defaultWhiteboardDraft.loading ||
+    preparingCreation;
 
-  const createAndUpload = async (visibility: CalloutVisibility) => {
+  const performCreateAndUpload = async (visibility: CalloutVisibility) => {
     const validationErrors = validate();
     if (Object.keys(validationErrors).length > 0) return;
 
@@ -634,6 +657,9 @@ function CalloutFormConnectorInner({
       onOpenChange(false);
     }
   };
+
+  const createAndUpload = (visibility: CalloutVisibility) =>
+    runCalloutCreationOnce(creationInFlightRef, setPreparingCreation, () => performCreateAndUpload(visibility));
 
   // --- Edit path ---------------------------------------------------------
   const pollId = editData?.lookup.callout?.framing.poll?.id ?? values.editMeta?.pollId;

--- a/src/main/crdPages/space/callout/CalloutFormConnector.tsx
+++ b/src/main/crdPages/space/callout/CalloutFormConnector.tsx
@@ -67,7 +67,10 @@ import { buildFlowStateClassificationTagsets } from '@/domain/collaboration/call
 import { useCalloutCreation } from '@/domain/collaboration/calloutsSet/useCalloutCreation/useCalloutCreation';
 import useUploadMediaGalleryVisuals from '@/domain/collaboration/mediaGallery/useUploadMediaGalleryVisuals';
 import { usePollOptionManagement } from '@/domain/collaboration/poll/hooks/usePollOptionManagement';
-import { useWhiteboardDraft } from '@/domain/collaboration/whiteboard/WhiteboardDraft/useWhiteboardDraft';
+import {
+  useWhiteboardDraft,
+  type WhiteboardDraftLifecycle,
+} from '@/domain/collaboration/whiteboard/WhiteboardDraft/useWhiteboardDraft';
 import useUploadWhiteboardVisuals from '@/domain/collaboration/whiteboard/WhiteboardVisuals/useUploadWhiteboardVisuals';
 import { useSpace } from '@/domain/space/context/useSpace';
 import {
@@ -123,6 +126,13 @@ const ADMIN_ONLY_FRAMING_CHIPS: FramingChipId[] = ['contributors', 'spaces'];
 
 /** The title counter stays hidden until the value gets this close to `SMALL_TEXT_LENGTH`. */
 const TITLE_COUNTER_THRESHOLD = SMALL_TEXT_LENGTH - 10;
+
+export async function prepareWhiteboardDraftsForCalloutCreation(
+  drafts: Array<Pick<WhiteboardDraftLifecycle, 'prepareForConsumption'>>
+): Promise<boolean> {
+  const prepared = await Promise.all(drafts.map(draft => draft.prepareForConsumption()));
+  return prepared.every(Boolean);
+}
 
 type CalloutFormConnectorProps = {
   open: boolean;
@@ -201,6 +211,7 @@ function CalloutFormConnectorInner({
   restrictions,
 }: CalloutFormConnectorProps) {
   const { t } = useTranslation('crd-space');
+  const { t: tCommon } = useTranslation();
   const { t: tTaskBoard } = useTranslation('crd-taskBoard');
 
   // Restriction-driven create-mode defaults: any comment toggle that is hidden
@@ -521,6 +532,15 @@ function CalloutFormConnectorInner({
   const createAndUpload = async (visibility: CalloutVisibility) => {
     const validationErrors = validate();
     if (Object.keys(validationErrors).length > 0) return;
+
+    const draftsPrepared = await prepareWhiteboardDraftsForCalloutCreation([
+      framingWhiteboardDraft,
+      defaultWhiteboardDraft,
+    ]);
+    if (!draftsPrepared) {
+      notify(tCommon('callout.whiteboard.saveFailed'), 'error');
+      return;
+    }
 
     // Strip ineligible (stale) selectedIds before serialising — mirrors the update
     // path (tasks T005/T006; the server rejects out-of-scope ids on create too).

--- a/src/main/crdPages/space/callout/FramingEditorConnector.tsx
+++ b/src/main/crdPages/space/callout/FramingEditorConnector.tsx
@@ -399,6 +399,7 @@ export function FramingEditorConnector({
             <WhiteboardDraftEditor
               whiteboardID={whiteboardDraft.handle.whiteboardID}
               displayName={whiteboardTitle || t('callout.whiteboard')}
+              draftLifecycle={whiteboardDraft}
               onClose={() => setWhiteboardEditorOpen(false)}
             />
           )}

--- a/src/main/crdPages/space/callout/FramingEditorConnector.whiteboardDraft.spec.tsx
+++ b/src/main/crdPages/space/callout/FramingEditorConnector.whiteboardDraft.spec.tsx
@@ -32,6 +32,9 @@ const renderWhiteboardFraming = (materialize: () => Promise<undefined>) =>
         handle: undefined,
         loading: false,
         materialize,
+        preparationRef: { current: null },
+        prepareForConsumption: vi.fn().mockResolvedValue(true),
+        prepared: vi.fn(),
         discard: vi.fn().mockResolvedValue(true),
         consumed: vi.fn(),
       }}

--- a/src/main/crdPages/space/callout/ResponseDefaultsConnector.spec.tsx
+++ b/src/main/crdPages/space/callout/ResponseDefaultsConnector.spec.tsx
@@ -158,6 +158,9 @@ describe('ResponseDefaultsConnector template boundaries', () => {
           handle: acceptedDraft,
           loading: false,
           materialize: vi.fn(),
+          preparationRef: { current: null },
+          prepareForConsumption: vi.fn().mockResolvedValue(true),
+          prepared: vi.fn(),
           discard,
           consumed: vi.fn(),
         }}
@@ -187,6 +190,9 @@ describe('ResponseDefaultsConnector template boundaries', () => {
           handle: undefined,
           loading: false,
           materialize: vi.fn().mockResolvedValue(materialized),
+          preparationRef: { current: null },
+          prepareForConsumption: vi.fn().mockResolvedValue(true),
+          prepared: vi.fn(),
           discard,
           consumed: vi.fn(),
         }}
@@ -233,6 +239,9 @@ describe('ResponseDefaultsConnector template boundaries', () => {
           handle: materialized,
           loading: false,
           materialize,
+          preparationRef: { current: null },
+          prepareForConsumption: vi.fn().mockResolvedValue(true),
+          prepared: vi.fn(),
           discard: vi.fn().mockResolvedValue(true),
           consumed: vi.fn(),
         }}

--- a/src/main/crdPages/space/callout/ResponseDefaultsConnector.tsx
+++ b/src/main/crdPages/space/callout/ResponseDefaultsConnector.tsx
@@ -160,6 +160,7 @@ export function ResponseDefaultsConnector({
                 <WhiteboardDraftEditor
                   whiteboardID={whiteboardDraft.handle.whiteboardID}
                   displayName={draft.defaultDisplayName || t('callout.whiteboard')}
+                  draftLifecycle={whiteboardDraft}
                   onClose={() => setWhiteboardEditorSession(undefined)}
                 />
               )}

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.flushOnClose.spec.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.flushOnClose.spec.tsx
@@ -115,6 +115,67 @@ describe('closeCollaborativeWhiteboard — flush-at-collaborative-close gate', (
     expect(order).toEqual(['flush', 'save', 'teardown']);
   });
 
+  it('publishes assets, awaits durability, and only then saves and tears down', async () => {
+    const order: string[] = [];
+    let resolveDurability!: () => void;
+    const durability = new Promise<void>(resolve => {
+      resolveDurability = resolve;
+    });
+    const excalidrawAPI = {
+      flushAssetPublication: vi.fn(async () => {
+        order.push('assets');
+        return cleanReport;
+      }),
+    };
+    const requestDurability = vi.fn(() => {
+      order.push('durability');
+      return durability;
+    });
+    const save = vi.fn(async () => {
+      order.push('save');
+    });
+    const teardown = vi.fn(() => order.push('teardown'));
+
+    const closing = closeCollaborativeWhiteboard({
+      excalidrawAPI,
+      requestDurability,
+      save,
+      onPublishFailed: vi.fn(),
+      teardown,
+    });
+
+    await vi.waitFor(() => expect(requestDurability).toHaveBeenCalledOnce());
+    expect(order).toEqual(['assets', 'durability']);
+    expect(save).not.toHaveBeenCalled();
+    expect(teardown).not.toHaveBeenCalled();
+
+    resolveDurability();
+    await expect(closing).resolves.toBe(true);
+    expect(order).toEqual(['assets', 'durability', 'save', 'teardown']);
+  });
+
+  it('keeps the editor and draft open when durability fails so the user can retry', async () => {
+    const save = vi.fn(async () => {});
+    const teardown = vi.fn();
+    const onDurabilityFailed = vi.fn();
+
+    const proceeded = await closeCollaborativeWhiteboard({
+      excalidrawAPI: { flushAssetPublication: vi.fn(async () => cleanReport) },
+      requestDurability: vi.fn(async () => {
+        throw new Error('store unavailable');
+      }),
+      save,
+      onPublishFailed: vi.fn(),
+      onDurabilityFailed,
+      teardown,
+    });
+
+    expect(proceeded).toBe(false);
+    expect(onDurabilityFailed).toHaveBeenCalledOnce();
+    expect(save).not.toHaveBeenCalled();
+    expect(teardown).not.toHaveBeenCalled();
+  });
+
   it('(b) a still-pending slow store that resolves with a non-empty `failed` does NOT report a clean close', async () => {
     const { promise, resolveWith } = deferredReport();
     const excalidrawAPI = { flushAssetPublication: vi.fn(() => promise) };

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.flushOnClose.spec.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.flushOnClose.spec.tsx
@@ -154,6 +154,49 @@ describe('closeCollaborativeWhiteboard — flush-at-collaborative-close gate', (
     expect(order).toEqual(['assets', 'durability', 'save', 'teardown']);
   });
 
+  it('awaits an in-flight template import before assets, durability, save, and teardown', async () => {
+    const order: string[] = [];
+    let finishImport!: () => void;
+    const importInFlight = new Promise<void>(resolve => {
+      finishImport = () => {
+        order.push('import');
+        resolve();
+      };
+    });
+    const excalidrawAPI = {
+      flushAssetPublication: vi.fn(async () => {
+        order.push('assets');
+        return cleanReport;
+      }),
+    };
+    const requestDurability = vi.fn(async () => {
+      order.push('durability');
+    });
+    const save = vi.fn(async () => {
+      order.push('save');
+    });
+    const teardown = vi.fn(() => order.push('teardown'));
+
+    const closing = closeCollaborativeWhiteboard({
+      excalidrawAPI,
+      waitForPendingWork: () => importInFlight,
+      requestDurability,
+      save,
+      onPublishFailed: vi.fn(),
+      teardown,
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual([]);
+    expect(requestDurability).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+    expect(teardown).not.toHaveBeenCalled();
+
+    finishImport();
+    await expect(closing).resolves.toBe(true);
+    expect(order).toEqual(['import', 'assets', 'durability', 'save', 'teardown']);
+  });
+
   it('keeps the editor and draft open when durability fails so the user can retry', async () => {
     const save = vi.fn(async () => {});
     const teardown = vi.fn();

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.flushOnClose.spec.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.flushOnClose.spec.tsx
@@ -176,6 +176,56 @@ describe('closeCollaborativeWhiteboard — flush-at-collaborative-close gate', (
     expect(teardown).not.toHaveBeenCalled();
   });
 
+  it('keeps a draft open when no live connection can supply its required durability barrier', async () => {
+    const save = vi.fn(async () => {});
+    const teardown = vi.fn();
+    const onDurabilityFailed = vi.fn();
+    const onPreparingChange = vi.fn();
+
+    const proceeded = await closeCollaborativeWhiteboard({
+      excalidrawAPI: { flushAssetPublication: vi.fn(async () => cleanReport) },
+      requireDurability: true,
+      save,
+      onPublishFailed: vi.fn(),
+      onDurabilityFailed,
+      onPreparingChange,
+      teardown,
+    });
+
+    expect(proceeded).toBe(false);
+    expect(onDurabilityFailed).toHaveBeenCalledOnce();
+    expect(save).not.toHaveBeenCalled();
+    expect(teardown).not.toHaveBeenCalled();
+    expect(onPreparingChange.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it('keeps the recovered editor open when its generation changes during durability', async () => {
+    let resolveDurability!: () => void;
+    const durability = new Promise<void>(resolve => {
+      resolveDurability = resolve;
+    });
+    let editorChanged = false;
+    const save = vi.fn(async () => {});
+    const teardown = vi.fn();
+
+    const closing = closeCollaborativeWhiteboard({
+      excalidrawAPI: { flushAssetPublication: vi.fn(async () => cleanReport) },
+      requestDurability: vi.fn(() => durability),
+      save,
+      onPublishFailed: vi.fn(),
+      teardown,
+      hasEditorChanged: () => editorChanged,
+    });
+
+    await vi.waitFor(() => expect(save).not.toHaveBeenCalled());
+    editorChanged = true;
+    resolveDurability();
+
+    await expect(closing).resolves.toBe(false);
+    expect(save).not.toHaveBeenCalled();
+    expect(teardown).not.toHaveBeenCalled();
+  });
+
   it('(b) a still-pending slow store that resolves with a non-empty `failed` does NOT report a clean close', async () => {
     const { promise, resolveWith } = deferredReport();
     const excalidrawAPI = { flushAssetPublication: vi.fn(() => promise) };
@@ -332,5 +382,25 @@ describe('CollaborativeExcalidrawWrapper — asset adapter wiring', () => {
 
     await waitFor(() => expect(h.excalidrawProps).not.toBeNull());
     expect(h.excalidrawProps?.assetAdapter).toBe(assetAdapter);
+  });
+
+  it('puts Excalidraw in view mode while the caller is preparing to close', async () => {
+    render(
+      <CollaborativeExcalidrawWrapper
+        entities={{
+          whiteboard: { id: 'wb-1', profile: { url: '/wb-1' } },
+          assetAdapter: { store: vi.fn(), resolve: vi.fn() } as never,
+          lastSuccessfulSavedDate: undefined,
+        }}
+        options={{ viewModeEnabled: true }}
+        actions={{}}
+        renderDisconnectNotice={() => null}
+      >
+        {({ children }) => children}
+      </CollaborativeExcalidrawWrapper>
+    );
+
+    await waitFor(() => expect(h.excalidrawProps).not.toBeNull());
+    expect(h.excalidrawProps?.viewModeEnabled).toBe(true);
   });
 });

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
@@ -2,7 +2,7 @@ import type { ExportedDataState } from '@excalidraw-yjs/excalidraw/data/types';
 import type { AssetPublishReport, ExcalidrawImperativeAPI } from '@excalidraw-yjs/excalidraw/types';
 import { Formik } from 'formik';
 import type { FormikProps } from 'formik/dist/types';
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode, type Ref, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { AuthorizationPrivilege, ContentUpdatePolicy } from '@/core/apollo/generated/graphql-schema';
@@ -127,6 +127,7 @@ interface CrdWhiteboardDialogProps {
     loadingWhiteboardValue?: boolean;
     changingWhiteboardLockState?: boolean;
   };
+  consumptionPreparationRef?: Ref<(() => Promise<boolean>) | null>;
 }
 
 type RelevantExcalidrawState = Pick<ExportedDataState, 'appState' | 'elements' | 'files'>;
@@ -139,6 +140,10 @@ type CollaborativeCloseParams = {
   save: () => Promise<boolean | void>;
   /** Report that one or more images failed to publish (a non-empty `failed`). */
   onPublishFailed: (report: AssetPublishReport) => void;
+  /** Persist every scene update sent before this request, after asset locators are published. */
+  requestDurability?: () => Promise<void>;
+  /** Report that the collaboration service could not make the scene durable. */
+  onDurabilityFailed?: () => void;
   /** Tear the collaborative session down: evict the cache + run the parent cancel, which unmounts the provider. */
   teardown: () => void;
   /**
@@ -172,6 +177,8 @@ export async function closeCollaborativeWhiteboard({
   excalidrawAPI,
   save,
   onPublishFailed,
+  requestDurability,
+  onDurabilityFailed,
   teardown,
   hasEditorChanged,
 }: CollaborativeCloseParams): Promise<boolean> {
@@ -189,6 +196,14 @@ export async function closeCollaborativeWhiteboard({
   if (hasEditorChanged?.()) {
     return false;
   }
+  if (requestDurability) {
+    try {
+      await requestDurability();
+    } catch {
+      onDurabilityFailed?.();
+      return false;
+    }
+  }
   const saved = await save();
   if (saved === false) {
     return false;
@@ -203,6 +218,7 @@ const CrdWhiteboardDialog = ({
   options,
   state,
   lastSuccessfulSavedDate,
+  consumptionPreparationRef,
 }: CrdWhiteboardDialogProps) => {
   const { t } = useTranslation();
   const { t: tWb } = useTranslation('crd-whiteboard');
@@ -285,6 +301,10 @@ const CrdWhiteboardDialog = ({
     await closeCollaborativeWhiteboard({
       excalidrawAPI,
       hasEditorChanged: () => editorGenerationRef.current !== generationAtClose,
+      requestDurability:
+        shouldSave && collabApiRef.current
+          ? () => collabApiRef.current?.requestDurability() ?? Promise.reject(new Error('Collaboration unavailable'))
+          : undefined,
       save: async () => {
         if (!shouldSave || !whiteboard) return true;
         const excState = excalidrawAPI
@@ -313,12 +333,30 @@ const CrdWhiteboardDialog = ({
       onPublishFailed: () => {
         notify(t('callout.whiteboard.images.uploadFailed'), 'error');
       },
+      onDurabilityFailed: () => {
+        notify(t('callout.whiteboard.saveFailed'), 'error');
+      },
       teardown: () => {
         evictFromCache(whiteboard?.id, 'Whiteboard');
         actions.onCancel();
       },
     });
   };
+
+  useImperativeHandle(consumptionPreparationRef, () => async () => {
+    const collabApi = collabApiRef.current;
+    if (!collabApi?.isCollaborating()) return false;
+    const generationAtPrepare = editorGenerationRef.current;
+    return closeCollaborativeWhiteboard({
+      excalidrawAPI,
+      hasEditorChanged: () => editorGenerationRef.current !== generationAtPrepare,
+      requestDurability: () => collabApi.requestDurability(),
+      save: async () => true,
+      onPublishFailed: () => notify(t('callout.whiteboard.images.uploadFailed'), 'error'),
+      onDurabilityFailed: () => notify(t('callout.whiteboard.saveFailed'), 'error'),
+      teardown: () => {},
+    });
+  });
 
   const handleImportTemplate = async (sourceWhiteboardId: string) => {
     if (!excalidrawAPI) return;

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
@@ -142,8 +142,12 @@ type CollaborativeCloseParams = {
   onPublishFailed: (report: AssetPublishReport) => void;
   /** Persist every scene update sent before this request, after asset locators are published. */
   requestDurability?: () => Promise<void>;
+  /** Refuse to close when no live collaboration connection can supply the durability barrier. */
+  requireDurability?: boolean;
   /** Report that the collaboration service could not make the scene durable. */
   onDurabilityFailed?: () => void;
+  /** Disable canvas mutation for the full flush/durability/save interval. */
+  onPreparingChange?: (preparing: boolean) => void;
   /** Tear the collaborative session down: evict the cache + run the parent cancel, which unmounts the provider. */
   teardown: () => void;
   /**
@@ -178,38 +182,54 @@ export async function closeCollaborativeWhiteboard({
   save,
   onPublishFailed,
   requestDurability,
+  requireDurability,
   onDurabilityFailed,
+  onPreparingChange,
   teardown,
   hasEditorChanged,
 }: CollaborativeCloseParams): Promise<boolean> {
-  if (excalidrawAPI) {
-    const report = await excalidrawAPI.flushAssetPublication();
-    if (report.failed.length > 0) {
-      onPublishFailed(report);
+  onPreparingChange?.(true);
+  try {
+    if (excalidrawAPI) {
+      const report = await excalidrawAPI.flushAssetPublication();
+      if (report.failed.length > 0) {
+        onPublishFailed(report);
+        return false;
+      }
+    }
+    // A recovery (update-rejected) that fired DURING the flush replaced the editor: the
+    // captured api is dead and its scene is stale versus the recovery's server-canonical
+    // resync. Abort BEFORE the save — never read/persist the dead api, and leave the
+    // (recovered) session up rather than tearing it down on this stale intent.
+    if (hasEditorChanged?.()) {
       return false;
     }
-  }
-  // A recovery (update-rejected) that fired DURING the flush replaced the editor: the
-  // captured api is dead and its scene is stale versus the recovery's server-canonical
-  // resync. Abort BEFORE the save — never read/persist the dead api, and leave the
-  // (recovered) session up rather than tearing it down on this stale intent.
-  if (hasEditorChanged?.()) {
-    return false;
-  }
-  if (requestDurability) {
-    try {
-      await requestDurability();
-    } catch {
+    if (!requestDurability && requireDurability) {
       onDurabilityFailed?.();
       return false;
     }
+    if (requestDurability) {
+      try {
+        await requestDurability();
+      } catch {
+        onDurabilityFailed?.();
+        return false;
+      }
+    }
+    // A recovery can also replace the editor while the durability request is in
+    // flight. Never save from the captured API or tear the recovered editor down.
+    if (hasEditorChanged?.()) {
+      return false;
+    }
+    const saved = await save();
+    if (saved === false) {
+      return false;
+    }
+    teardown();
+    return true;
+  } finally {
+    onPreparingChange?.(false);
   }
-  const saved = await save();
-  if (saved === false) {
-    return false;
-  }
-  teardown();
-  return true;
 }
 
 const CrdWhiteboardDialog = ({
@@ -247,6 +267,8 @@ const CrdWhiteboardDialog = ({
   const [_lastSaveError, setLastSaveError] = useState<string | undefined>();
   const [isSceneInitialized, setSceneInitialized] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
+  const [preparingClose, setPreparingClose] = useState(false);
+  const closeInFlightRef = useRef(false);
   const [selectedPreviewMode, setSelectedPreviewMode] = useState<WhiteboardPreviewMode>(
     whiteboard?.previewSettings.mode ?? WhiteboardPreviewMode.Auto
   );
@@ -294,53 +316,63 @@ const CrdWhiteboardDialog = ({
   };
 
   const onClose = async () => {
-    const shouldSave = !!(editModeEnabled && collabApiRef.current?.isCollaborating() && whiteboard);
+    if (closeInFlightRef.current) return;
+    closeInFlightRef.current = true;
+    const collabApi = collabApiRef.current;
+    const shouldSave = !!(editModeEnabled && collabApi?.isCollaborating() && whiteboard);
+    const draftRequiresDurability = consumptionPreparationRef !== undefined;
     // Snapshot the editor generation now; if a recovery (update-rejected) discards it while
     // the flush is awaited, the captured api is dead and the save must abort.
     const generationAtClose = editorGenerationRef.current;
-    await closeCollaborativeWhiteboard({
-      excalidrawAPI,
-      hasEditorChanged: () => editorGenerationRef.current !== generationAtClose,
-      requestDurability:
-        shouldSave && collabApiRef.current
-          ? () => collabApiRef.current?.requestDurability() ?? Promise.reject(new Error('Collaboration unavailable'))
-          : undefined,
-      save: async () => {
-        if (!shouldSave || !whiteboard) return true;
-        const excState = excalidrawAPI
-          ? {
-              elements: excalidrawAPI.getSceneElements(),
-              appState: excalidrawAPI.getAppState(),
-              files: excalidrawAPI.getFiles(),
+    try {
+      await closeCollaborativeWhiteboard({
+        excalidrawAPI,
+        hasEditorChanged: () => editorGenerationRef.current !== generationAtClose,
+        requestDurability:
+          (shouldSave || draftRequiresDurability) && collabApi?.isCollaborating()
+            ? () => collabApi.requestDurability()
+            : undefined,
+        requireDurability: draftRequiresDurability,
+        onPreparingChange: setPreparingClose,
+        save: async () => {
+          if (!shouldSave || !whiteboard) return true;
+          const excState = excalidrawAPI
+            ? {
+                elements: excalidrawAPI.getSceneElements(),
+                appState: excalidrawAPI.getAppState(),
+                files: excalidrawAPI.getFiles(),
+              }
+            : undefined;
+          const result = await prepareWhiteboardForUpdate(whiteboard, excState);
+          if (result.success) {
+            const update = await actions.onUpdate(result.whiteboard, result.previewImages);
+            if (!update.success) {
+              notify(t('callout.whiteboard.saveFailed'), 'error');
+              return false;
             }
-          : undefined;
-        const result = await prepareWhiteboardForUpdate(whiteboard, excState);
-        if (result.success) {
-          const update = await actions.onUpdate(result.whiteboard, result.previewImages);
-          if (!update.success) {
+            return true;
+          } else {
+            logError(new Error('Error preparing whiteboard for update on close'), {
+              category: TagCategoryValues.WHITEBOARD,
+            });
             notify(t('callout.whiteboard.saveFailed'), 'error');
             return false;
           }
-          return true;
-        } else {
-          logError(new Error('Error preparing whiteboard for update on close'), {
-            category: TagCategoryValues.WHITEBOARD,
-          });
+        },
+        onPublishFailed: () => {
+          notify(t('callout.whiteboard.images.uploadFailed'), 'error');
+        },
+        onDurabilityFailed: () => {
           notify(t('callout.whiteboard.saveFailed'), 'error');
-          return false;
-        }
-      },
-      onPublishFailed: () => {
-        notify(t('callout.whiteboard.images.uploadFailed'), 'error');
-      },
-      onDurabilityFailed: () => {
-        notify(t('callout.whiteboard.saveFailed'), 'error');
-      },
-      teardown: () => {
-        evictFromCache(whiteboard?.id, 'Whiteboard');
-        actions.onCancel();
-      },
-    });
+        },
+        teardown: () => {
+          evictFromCache(whiteboard?.id, 'Whiteboard');
+          actions.onCancel();
+        },
+      });
+    } finally {
+      closeInFlightRef.current = false;
+    }
   };
 
   useImperativeHandle(consumptionPreparationRef, () => async () => {
@@ -351,6 +383,8 @@ const CrdWhiteboardDialog = ({
       excalidrawAPI,
       hasEditorChanged: () => editorGenerationRef.current !== generationAtPrepare,
       requestDurability: () => collabApi.requestDurability(),
+      requireDurability: true,
+      onPreparingChange: setPreparingClose,
       save: async () => true,
       onPublishFailed: () => notify(t('callout.whiteboard.images.uploadFailed'), 'error'),
       onDurabilityFailed: () => notify(t('callout.whiteboard.saveFailed'), 'error'),
@@ -435,6 +469,7 @@ const CrdWhiteboardDialog = ({
         collabApiRef={collabApiRef}
         options={{
           UIOptions: { canvasActions: { export: { saveFileToDisk: true } } },
+          viewModeEnabled: preparingClose,
         }}
         actions={{
           onInitApi: setExcalidrawAPI,
@@ -586,7 +621,7 @@ const CrdWhiteboardDialog = ({
                       displayName={whiteboard.profile.displayName}
                       value={values.profile.displayName}
                       onChange={name => setFieldValue('profile.displayName', name)}
-                      readOnly={options.readOnlyDisplayName}
+                      readOnly={options.readOnlyDisplayName || preparingClose}
                       editing={isEditingName}
                       onEdit={() => setIsEditingName(true)}
                       onSave={async () => {
@@ -601,7 +636,10 @@ const CrdWhiteboardDialog = ({
                   }
                   titleExtra={
                     editModeEnabled && mode === 'write' ? (
-                      <WhiteboardTemplatePickerButton disabled={!isSceneInitialized} onImport={handleImportTemplate} />
+                      <WhiteboardTemplatePickerButton
+                        disabled={!isSceneInitialized || preparingClose}
+                        onImport={handleImportTemplate}
+                      />
                     ) : undefined
                   }
                   headerActions={options.headerActions?.({ mode, modeReason, collaborating, connecting, isReadOnly })}

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
@@ -135,6 +135,8 @@ type RelevantExcalidrawState = Pick<ExportedDataState, 'appState' | 'elements' |
 type CollaborativeCloseParams = {
   /** The live editor API, or `null` when the editor is already gone / unmounted. */
   excalidrawAPI: Pick<ExcalidrawImperativeAPI, 'flushAssetPublication'> | null;
+  /** Finish a template import already in progress before taking the close barrier. */
+  waitForPendingWork?: () => Promise<void>;
   /** Persist preview + display name for the collaborative whiteboard (a no-op when not editing). */
   /** Return false when the metadata/preview save failed and the dialog must stay open. */
   save: () => Promise<boolean | void>;
@@ -179,6 +181,7 @@ type CollaborativeCloseParams = {
  */
 export async function closeCollaborativeWhiteboard({
   excalidrawAPI,
+  waitForPendingWork,
   save,
   onPublishFailed,
   requestDurability,
@@ -190,6 +193,10 @@ export async function closeCollaborativeWhiteboard({
 }: CollaborativeCloseParams): Promise<boolean> {
   onPreparingChange?.(true);
   try {
+    await waitForPendingWork?.();
+    if (hasEditorChanged?.()) {
+      return false;
+    }
     if (excalidrawAPI) {
       const report = await excalidrawAPI.flushAssetPublication();
       if (report.failed.length > 0) {
@@ -268,7 +275,13 @@ const CrdWhiteboardDialog = ({
   const [isSceneInitialized, setSceneInitialized] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
   const [preparingClose, setPreparingClose] = useState(false);
+  const preparingCloseRef = useRef(false);
   const closeInFlightRef = useRef(false);
+  const importInFlightRef = useRef<Promise<void> | null>(null);
+  const updatePreparingClose = (preparing: boolean) => {
+    preparingCloseRef.current = preparing;
+    setPreparingClose(preparing);
+  };
   const [selectedPreviewMode, setSelectedPreviewMode] = useState<WhiteboardPreviewMode>(
     whiteboard?.previewSettings.mode ?? WhiteboardPreviewMode.Auto
   );
@@ -327,13 +340,14 @@ const CrdWhiteboardDialog = ({
     try {
       await closeCollaborativeWhiteboard({
         excalidrawAPI,
+        waitForPendingWork: () => importInFlightRef.current ?? Promise.resolve(),
         hasEditorChanged: () => editorGenerationRef.current !== generationAtClose,
         requestDurability:
           (shouldSave || draftRequiresDurability) && collabApi?.isCollaborating()
             ? () => collabApi.requestDurability()
             : undefined,
         requireDurability: draftRequiresDurability,
-        onPreparingChange: setPreparingClose,
+        onPreparingChange: updatePreparingClose,
         save: async () => {
           if (!shouldSave || !whiteboard) return true;
           const excState = excalidrawAPI
@@ -381,10 +395,11 @@ const CrdWhiteboardDialog = ({
     const generationAtPrepare = editorGenerationRef.current;
     return closeCollaborativeWhiteboard({
       excalidrawAPI,
+      waitForPendingWork: () => importInFlightRef.current ?? Promise.resolve(),
       hasEditorChanged: () => editorGenerationRef.current !== generationAtPrepare,
       requestDurability: () => collabApi.requestDurability(),
       requireDurability: true,
-      onPreparingChange: setPreparingClose,
+      onPreparingChange: updatePreparingClose,
       save: async () => true,
       onPublishFailed: () => notify(t('callout.whiteboard.images.uploadFailed'), 'error'),
       onDurabilityFailed: () => notify(t('callout.whiteboard.saveFailed'), 'error'),
@@ -392,26 +407,37 @@ const CrdWhiteboardDialog = ({
     });
   });
 
-  const handleImportTemplate = async (sourceWhiteboardId: string) => {
-    if (!excalidrawAPI) return;
+  const handleImportTemplate = (sourceWhiteboardId: string): Promise<void> => {
+    if (preparingCloseRef.current || !excalidrawAPI) return Promise.resolve();
+    if (importInFlightRef.current) return importInFlightRef.current;
+
     const generationAtImport = editorGenerationRef.current;
-    try {
-      const templateScene = await loadWhiteboardSceneFromCollaboration(sourceWhiteboardId);
-      if (editorGenerationRef.current !== generationAtImport) {
-        throw new Error('Whiteboard editor changed while importing template');
+    const operation = (async () => {
+      try {
+        const templateScene = await loadWhiteboardSceneFromCollaboration(sourceWhiteboardId);
+        if (editorGenerationRef.current !== generationAtImport) {
+          throw new Error('Whiteboard editor changed while importing template');
+        }
+        await mergeWhiteboard(
+          excalidrawAPI,
+          templateScene,
+          assetAdapter,
+          () => editorGenerationRef.current !== generationAtImport
+        );
+      } catch (err) {
+        notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
+        logError(new Error(`Error importing whiteboard template: '${err}'`), {
+          category: TagCategoryValues.WHITEBOARD,
+        });
       }
-      await mergeWhiteboard(
-        excalidrawAPI,
-        templateScene,
-        assetAdapter,
-        () => editorGenerationRef.current !== generationAtImport
-      );
-    } catch (err) {
-      notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
-      logError(new Error(`Error importing whiteboard template: '${err}'`), {
-        category: TagCategoryValues.WHITEBOARD,
-      });
-    }
+    })();
+    importInFlightRef.current = operation;
+    void operation.finally(() => {
+      if (importInFlightRef.current === operation) {
+        importInFlightRef.current = null;
+      }
+    });
+    return operation;
   };
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);

--- a/src/main/crdPages/whiteboard/CrdWhiteboardView.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardView.tsx
@@ -1,5 +1,5 @@
 import { ScanEye } from 'lucide-react';
-import { type ReactNode, Suspense, useState } from 'react';
+import { type ReactNode, type Ref, Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { AuthorizationPrivilege } from '@/core/apollo/generated/graphql-schema';
 import { useFullscreen } from '@/core/ui/fullscreen/useFullscreen';
@@ -30,6 +30,7 @@ export interface CrdWhiteboardViewProps {
   preventWhiteboardDeletion?: boolean;
   backToWhiteboards: () => void;
   onWhiteboardDeleted?: () => void;
+  consumptionPreparationRef?: Ref<(() => Promise<boolean>) | null>;
 }
 
 const CrdWhiteboardView = ({
@@ -44,6 +45,7 @@ const CrdWhiteboardView = ({
   readOnlyDisplayName,
   preventWhiteboardDeletion,
   onWhiteboardDeleted,
+  consumptionPreparationRef,
 }: CrdWhiteboardViewProps) => {
   // aria-label-only use; disable suspense so this hook never suspends above the
   // component's internal <Suspense>, which would tear down the live canvas
@@ -79,6 +81,7 @@ const CrdWhiteboardView = ({
   return (
     <Suspense fallback={<Loading />}>
       <CrdWhiteboardDialog
+        consumptionPreparationRef={consumptionPreparationRef}
         entities={{ whiteboard }}
         lastSuccessfulSavedDate={lastSuccessfulSavedDate}
         actions={{


### PR DESCRIPTION
## Summary

- await asset publication and the collaboration durability barrier before consuming framing and response whiteboard drafts
- coalesce draft preparation on the existing lifecycle and keep failed preparation retryable without consuming or deleting drafts
- preserve the existing successful create cleanup and UI behavior

## Root cause

Callout creation could clone and consume server-side whiteboard drafts while their latest collaborative updates and asset locators were still pending persistence.

## Tests

- exact durability request/control wire handling, coalescing, disconnect, and failure paths
- asset publication -> durability -> save -> teardown ordering
- both framing and response drafts block the create mutation until prepared
- failed preparation leaves both drafts reusable; successful create retains existing consumed cleanup
- controlled sabotage produced four RED tests when the preparation/durability gates were bypassed; restored implementation returned them green
- `pnpm lint`
- `pnpm vitest run` (357 files; 3014 passed, 2 skipped)
- `pnpm build`

Stacked on #10224. New and updated code comments describe behavior only and contain no spec, issue, or PR references. This bugfix deliberately adds no `specs/` artifact.

Fixes alkem-io/client-web#10219