### PR TITLE
fix: restore additive whiteboard templates and durable drafts

### DIFF
--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.spec.ts
@@ -8,6 +8,7 @@ import {
   type CloseVerdict,
   type ControlMessage,
   classifyClose,
+  DURABILITY_REQUEST_TIMEOUT_MS,
   type SceneSyncPort,
   UnifiedCollabProvider,
   WIRE,
@@ -69,6 +70,13 @@ class MockWebSocket {
 
 function readFrameType(bytes: Uint8Array): number {
   return decoding.readVarUint(decoding.createDecoder(bytes));
+}
+
+function readRawJsonFrame(bytes: Uint8Array): { type: number; body: unknown } {
+  const decoder = decoding.createDecoder(bytes);
+  const type = decoding.readVarUint(decoder);
+  const body = JSON.parse(new TextDecoder().decode(decoding.readTailAsUint8Array(decoder)));
+  return { type, body };
 }
 
 beforeEach(() => {
@@ -321,6 +329,99 @@ describe('UnifiedCollabProvider', () => {
       { kind: 'persist-failed', requestId: 'req-1', error: 'store unavailable' },
     ]);
     provider.destroy();
+  });
+
+  it('requests durability with the raw service wire contract and waits for the matching persisted reply', async () => {
+    const provider = new UnifiedCollabProvider(baseOptions);
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    socket.sent.length = 0;
+
+    const durability = provider.requestDurability();
+    const request = readRawJsonFrame(socket.sent[0]);
+    expect(request.type).toBe(WIRE.DURABILITY_REQUEST);
+    expect(request.body).toEqual({ requestId: expect.stringMatching(/^[a-z0-9]+-[a-z0-9]+$/) });
+
+    let settled = false;
+    void durability.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    socket.receive(
+      encodeServiceControlFrame({ kind: 'persisted', requestId: (request.body as { requestId: string }).requestId })
+    );
+    await expect(durability).resolves.toBeUndefined();
+    provider.destroy();
+  });
+
+  it('queues a fresh barrier for a later caller when updates are sent during the first request', async () => {
+    const provider = new UnifiedCollabProvider(baseOptions);
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    socket.sent.length = 0;
+
+    const first = provider.requestDurability();
+    const firstRequest = readRawJsonFrame(socket.sent[0]).body as { requestId: string };
+    provider.doc.getMap('scene').set('after-first-barrier', true);
+    const second = provider.requestDurability();
+    expect(socket.sent.map(readFrameType)).toEqual([WIRE.DURABILITY_REQUEST, WIRE.SYNC]);
+
+    let secondSettled = false;
+    void second.then(() => {
+      secondSettled = true;
+    });
+    socket.receive(encodeServiceControlFrame({ kind: 'persisted', requestId: firstRequest.requestId }));
+    await expect(first).resolves.toBeUndefined();
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(3));
+    expect(secondSettled).toBe(false);
+
+    const secondRequest = readRawJsonFrame(socket.sent[2]);
+    expect(secondRequest.type).toBe(WIRE.DURABILITY_REQUEST);
+    expect((secondRequest.body as { requestId: string }).requestId).not.toBe(firstRequest.requestId);
+    socket.receive(
+      encodeServiceControlFrame({
+        kind: 'persisted',
+        requestId: (secondRequest.body as { requestId: string }).requestId,
+      })
+    );
+    await expect(second).resolves.toBeUndefined();
+    provider.destroy();
+  });
+
+  it('rejects an outstanding durability request when the connection closes', async () => {
+    const provider = new UnifiedCollabProvider(baseOptions);
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+
+    const durability = provider.requestDurability();
+    socket.serverClose(1006);
+
+    await expect(durability).rejects.toThrow('closed before the draft was persisted');
+    provider.destroy();
+  });
+
+  it('times out a lost durability reply and lets the caller retry', async () => {
+    vi.useFakeTimers();
+    const provider = new UnifiedCollabProvider(baseOptions);
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    socket.sent.length = 0;
+
+    const durability = provider.requestDurability();
+    const timedOut = expect(durability).rejects.toThrow('timed out while persisting the draft');
+    await vi.advanceTimersByTimeAsync(DURABILITY_REQUEST_TIMEOUT_MS);
+    await timedOut;
+
+    const retry = provider.requestDurability();
+    expect(socket.sent).toHaveLength(2);
+    const request = readRawJsonFrame(socket.sent[1]).body as { requestId: string };
+    socket.receive(encodeServiceControlFrame({ kind: 'persisted', requestId: request.requestId }));
+    await expect(retry).resolves.toBeUndefined();
+
+    provider.destroy();
+    vi.useRealTimers();
   });
 
   it('does NOT decode an (invalid) VarString-prefixed control frame — the client reads only the Go raw contract', () => {

--- a/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
+++ b/src/domain/collaboration/realTimeCollaboration/unifiedCollabProvider.ts
@@ -31,6 +31,8 @@ export const WIRE = {
   EPHEMERAL: 2,
   /** Server→client JSON control (saved / save-error / read-only-state / collaborator-mode / room-user-change / update-rejected / session-end). */
   CONTROL: 3,
+  /** Client→server request to persist every preceding update on this connection. */
+  DURABILITY_REQUEST: 4,
 } as const;
 
 /**
@@ -105,8 +107,8 @@ export type ControlMessage = {
     | 'session-end'
     // Durability-barrier replies: each answers ONE `persist-request` by its `requestId`.
     // `persisted` = the requested state reached the configured stores; `persist-failed` =
-    // it could not (with `error`). The client decodes them today over the same raw-JSON
-    // control channel; the durability CALLER that consumes them lands with Stage B.
+    // it could not (with `error`). `requestDurability` below consumes them over the
+    // same raw-JSON control channel.
     | 'persisted'
     | 'persist-failed';
   version?: number;
@@ -213,6 +215,7 @@ export type UnifiedCollabProviderOptions = UnifiedCollabProviderCommonOptions &
   );
 
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
+export const DURABILITY_REQUEST_TIMEOUT_MS = 60_000;
 const NORMAL_CLOSURE = 1000;
 /**
  * WebSocket policy-violation close code (RFC 6455 §7.4.1). The unified collaboration
@@ -265,6 +268,18 @@ export class UnifiedCollabProvider {
   private readonly controlListeners = new Set<ControlListener>();
   private readonly closeListeners = new Set<CloseListener>();
   private readonly ephemeralListeners = new Set<(event: EphemeralEvent) => void>();
+  private durabilitySequence = 0;
+  private pendingDurability:
+    | {
+        requestId: string;
+        promise: Promise<void>;
+        resolve: () => void;
+        reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
+      }
+    | undefined;
+  /** Serializes callers so every call receives a barrier sent after that call. */
+  private durabilityQueueTail: Promise<void> | undefined;
 
   constructor(options: UnifiedCollabProviderOptions) {
     this.documentId = options.documentId;
@@ -364,6 +379,7 @@ export class UnifiedCollabProvider {
 
   /** Tear down the socket without reconnecting and without destroying the doc. */
   disconnect(): void {
+    this.rejectPendingDurability('The collaboration connection closed before the draft was persisted');
     this.clearReconnect();
     this.teardownSocket(NORMAL_CLOSURE);
     this.setSynced(false);
@@ -374,6 +390,7 @@ export class UnifiedCollabProvider {
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
+    this.rejectPendingDurability('The collaboration editor closed before the draft was persisted');
     this.clearReconnect();
     // Publish the local leave while the socket and awareness listener are still
     // active. The service also cleans up on disconnect; this makes normal client
@@ -398,6 +415,57 @@ export class UnifiedCollabProvider {
 
     if (this.ownsAwareness) this.awareness.destroy();
     if (this.ownsDoc) this.doc.destroy();
+  }
+
+  /**
+   * Ask the collaboration service to persist every update sent before this frame.
+   * The wire allows one in-flight request per connection. A later caller is queued
+   * behind it and receives its own frame, because updates may have been sent after
+   * the earlier barrier.
+   */
+  requestDurability(): Promise<void> {
+    if (!this.pendingDurability && !this.durabilityQueueTail) {
+      return this.startDurabilityRequest();
+    }
+
+    const predecessor = this.durabilityQueueTail ?? this.pendingDurability?.promise ?? Promise.resolve();
+    const start = () => this.startDurabilityRequest();
+    const queued = predecessor.then(start, start);
+    const settled = queued.then(
+      () => undefined,
+      () => undefined
+    );
+    this.durabilityQueueTail = settled;
+    void settled.then(() => {
+      if (this.durabilityQueueTail === settled) {
+        this.durabilityQueueTail = undefined;
+      }
+    });
+    return queued;
+  }
+
+  private startDurabilityRequest(): Promise<void> {
+    if (this.destroyed || this._status !== 'connected' || !this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error('The collaboration connection is not ready to persist the draft'));
+    }
+
+    const requestId = `${Date.now().toString(36)}-${(++this.durabilitySequence).toString(36)}`;
+    let resolve!: () => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    const timeout = setTimeout(() => {
+      this.rejectPendingDurability('The collaboration service timed out while persisting the draft');
+    }, DURABILITY_REQUEST_TIMEOUT_MS);
+    this.pendingDurability = { requestId, promise, resolve, reject, timeout };
+
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, WIRE.DURABILITY_REQUEST);
+    encoding.writeUint8Array(encoder, lib0String.encodeUtf8(JSON.stringify({ requestId })));
+    this.sendFrame(encoding.toUint8Array(encoder));
+    return promise;
   }
 
   private handleOpen = () => {
@@ -465,6 +533,7 @@ export class UnifiedCollabProvider {
       case WIRE.CONTROL: {
         const parsed = readRawJsonPayload(decoder) as ControlMessage | undefined;
         if (parsed && typeof parsed.kind === 'string') {
+          this.settleDurability(parsed);
           this.controlListeners.forEach(listener => listener(parsed));
         }
         break;
@@ -476,6 +545,7 @@ export class UnifiedCollabProvider {
   };
 
   private handleClose = (event: CloseEvent) => {
+    this.rejectPendingDurability('The collaboration connection closed before the draft was persisted');
     this.setSynced(false);
     this.detachSocketListeners();
     this.ws = null;
@@ -495,6 +565,33 @@ export class UnifiedCollabProvider {
       this.scheduleReconnect();
     }
   };
+
+  private settleDurability(message: ControlMessage): void {
+    const pending = this.pendingDurability;
+    if (
+      !pending ||
+      message.requestId !== pending.requestId ||
+      (message.kind !== 'persisted' && message.kind !== 'persist-failed')
+    ) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    if (message.kind === 'persisted') {
+      this.pendingDurability = undefined;
+      pending.resolve();
+    } else if (message.kind === 'persist-failed') {
+      this.pendingDurability = undefined;
+      pending.reject(new Error(message.error ?? 'The draft could not be persisted'));
+    }
+  }
+
+  private rejectPendingDurability(message: string): void {
+    const pending = this.pendingDurability;
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    this.pendingDurability = undefined;
+    pending.reject(new Error(message));
+  }
 
   private handleError = () => {
     // 'close' fires after 'error'; the reconnect is scheduled there.

--- a/src/domain/collaboration/whiteboard/WhiteboardDraft/WhiteboardDraftEditor.tsx
+++ b/src/domain/collaboration/whiteboard/WhiteboardDraft/WhiteboardDraftEditor.tsx
@@ -20,6 +20,7 @@ export const WhiteboardDraftEditor = ({ whiteboardID, displayName, onClose }: Wh
       displayName={displayName}
       readOnlyDisplayName={true}
       preventWhiteboardDeletion={true}
+      requireDurableClose={true}
       loadingWhiteboards={loading}
       backToWhiteboards={onClose}
     />

--- a/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.spec.ts
+++ b/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.spec.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const scene = {
+    encodeStateVector: vi.fn(() => new Uint8Array([1])),
+    encodeStateAsUpdate: vi.fn(() => new Uint8Array([2])),
+    applyRemoteUpdate: vi.fn(),
+    onDocUpdate: vi.fn(() => vi.fn()),
+    getElementsIncludingDeleted: vi.fn(() => [{ id: 'template-element' }]),
+    getAssetLocators: vi.fn(() => ({ image: 'source-document' })),
+    getPersistedAppState: vi.fn(() => ({ viewBackgroundColor: '#fff' })),
+    destroy: vi.fn(),
+  };
+
+  class MockScene {
+    encodeStateVector = scene.encodeStateVector;
+    encodeStateAsUpdate = scene.encodeStateAsUpdate;
+    applyRemoteUpdate = scene.applyRemoteUpdate;
+    onDocUpdate = scene.onDocUpdate;
+    getElementsIncludingDeleted = scene.getElementsIncludingDeleted;
+    getAssetLocators = scene.getAssetLocators;
+    getPersistedAppState = scene.getPersistedAppState;
+    destroy = scene.destroy;
+  }
+
+  type Listener = (...args: never[]) => void;
+  class MockProvider {
+    static instance: MockProvider;
+    listeners = new Map<string, Listener>();
+    options: unknown;
+    connect = vi.fn();
+    destroy = vi.fn();
+
+    constructor(options: unknown) {
+      this.options = options;
+      MockProvider.instance = this;
+    }
+
+    on(event: string, listener: Listener) {
+      this.listeners.set(event, listener);
+    }
+
+    off(event: string) {
+      this.listeners.delete(event);
+    }
+
+    emit(event: string, value: unknown) {
+      this.listeners.get(event)?.(value as never);
+    }
+  }
+
+  return { scene, MockScene, MockProvider };
+});
+
+vi.mock('@excalidraw-yjs/excalidraw/headless', () => ({ Scene: h.MockScene }));
+vi.mock('@/domain/collaboration/realTimeCollaboration/unifiedCollabProvider', () => ({
+  UnifiedCollabProvider: h.MockProvider,
+}));
+
+import { loadWhiteboardSceneFromCollaboration } from './loadWhiteboardSceneFromCollaboration';
+
+describe('loadWhiteboardSceneFromCollaboration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads the source through the whiteboard collaboration port and returns a plain scene', async () => {
+    const result = loadWhiteboardSceneFromCollaboration('source-whiteboard');
+    const provider = h.MockProvider.instance;
+
+    expect(provider.options).toMatchObject({
+      documentId: 'source-whiteboard',
+      type: 'whiteboard',
+      connect: false,
+    });
+    expect(provider.connect).toHaveBeenCalledTimes(1);
+
+    provider.emit('synced', true);
+
+    await expect(result).resolves.toEqual({
+      elements: [{ id: 'template-element' }],
+      assets: { image: 'source-document' },
+      appState: { viewBackgroundColor: '#fff' },
+    });
+    expect(provider.destroy).toHaveBeenCalledTimes(1);
+    expect(h.scene.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a terminal source-room refusal without returning an empty template', async () => {
+    const result = loadWhiteboardSceneFromCollaboration('forbidden-source');
+    const provider = h.MockProvider.instance;
+
+    provider.emit('close', { code: 1008, reason: 'forbidden', disposition: 'terminal' });
+
+    await expect(result).rejects.toThrow('Unable to load whiteboard template: forbidden');
+    expect(provider.destroy).toHaveBeenCalledTimes(1);
+    expect(h.scene.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the temporary source provider immediately when the import is cancelled', async () => {
+    const controller = new AbortController();
+    const result = loadWhiteboardSceneFromCollaboration('slow-source', { signal: controller.signal });
+    const provider = h.MockProvider.instance;
+
+    expect(provider.connect).toHaveBeenCalledTimes(1);
+    controller.abort();
+
+    await expect(result).rejects.toThrow('Whiteboard template load cancelled');
+    expect(provider.destroy).toHaveBeenCalledTimes(1);
+    expect(h.scene.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.ts
+++ b/src/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration.ts
@@ -1,0 +1,75 @@
+import { Scene, type WhiteboardSnapshot } from '@excalidraw-yjs/excalidraw/headless';
+import {
+  type CloseVerdict,
+  UnifiedCollabProvider,
+} from '@/domain/collaboration/realTimeCollaboration/unifiedCollabProvider';
+
+const LOAD_TIMEOUT_MS = 30_000;
+
+/** Load a whiteboard through the collaboration transport without exposing its Yjs update through GraphQL. */
+export const loadWhiteboardSceneFromCollaboration = (
+  whiteboardId: string,
+  options: { signal?: AbortSignal } = {}
+): Promise<WhiteboardSnapshot> => {
+  const scene = new Scene();
+  const provider = new UnifiedCollabProvider({
+    documentId: whiteboardId,
+    type: 'whiteboard',
+    scenePort: {
+      encodeSceneStateVector: () => scene.encodeStateVector(),
+      encodeSceneAsUpdate: (format, targetStateVector) => scene.encodeStateAsUpdate(format, targetStateVector),
+      applyRemoteSceneUpdate: (update, format) => scene.applyRemoteUpdate(update, format),
+      onLocalSceneUpdate: (listener, format) => scene.onDocUpdate(listener, format),
+    },
+    connect: false,
+  });
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (result: { scene: WhiteboardSnapshot } | { error: Error }) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      options.signal?.removeEventListener('abort', handleAbort);
+      provider.off('synced', handleSynced);
+      provider.off('close', handleClose);
+      provider.destroy();
+      scene.destroy();
+      if ('scene' in result) resolve(result.scene);
+      else reject(result.error);
+    };
+
+    const handleSynced = (synced: boolean) => {
+      if (!synced) return;
+      finish({
+        scene: {
+          elements: [...scene.getElementsIncludingDeleted()],
+          assets: scene.getAssetLocators(),
+          appState: scene.getPersistedAppState(),
+        },
+      });
+    };
+
+    const handleClose = (verdict: CloseVerdict) => {
+      if (verdict.disposition === 'terminal' || verdict.disposition === 'normal') {
+        finish({ error: new Error(`Unable to load whiteboard template: ${verdict.reason || verdict.code}`) });
+      }
+    };
+
+    const handleAbort = () => {
+      finish({ error: new Error('Whiteboard template load cancelled') });
+    };
+
+    timeout = setTimeout(() => finish({ error: new Error('Timed out loading whiteboard template') }), LOAD_TIMEOUT_MS);
+    provider.on('synced', handleSynced);
+    provider.on('close', handleClose);
+    options.signal?.addEventListener('abort', handleAbort, { once: true });
+    if (options.signal?.aborted) {
+      handleAbort();
+      return;
+    }
+    provider.connect();
+  });
+};

--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
@@ -439,7 +439,7 @@ describe('mergeWhiteboard asset re-homing', () => {
       expect(arrow.endBinding?.elementId).toBe(frame.id);
       expect(frame.boundElements?.[0].id).toBe(arrow.id);
       expect(rectangle.boundElements?.[0].id).toBe(arrow.id);
-      expect(new Set(copy.flatMap(element => (element.groupIds as string[]) ?? []))).toHaveLength(1);
+      expect(new Set(copy.flatMap(element => (element.groupIds as string[]) ?? [])).size).toBe(1);
       expect(frame.groupIds[0]).not.toBe('group');
       expect([frame.id, rectangle.id, arrow.id]).not.toContain('frame');
       return frame.groupIds[0];

--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.spec.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Control the template scene directly and exercise only the merge/asset-copy
-// logic: the fork snapshot codec + the content parser are stubbed so the test
-// owns `templateScene`, and the lazy fork import returns the stubbed module.
+// logic: the fork snapshot codec is stubbed so the test owns `templateScene`,
+// and the lazy fork import returns the stubbed module.
 const makeTemplateScene = () => ({
   elements: [
     {
@@ -31,9 +31,6 @@ vi.mock('@excalidraw-yjs/excalidraw', () => ({
   hashElementsVersion: () => 1,
   CaptureUpdateAction: { IMMEDIATELY: 'immediately' },
 }));
-vi.mock('@/domain/common/whiteboard/excalidraw/whiteboardContent', () => ({
-  parseWhiteboardContentToScene: () => h.templateScene,
-}));
 vi.mock('@/core/lazyLoading/lazyWithGlobalErrorHandler', () => ({
   lazyImportWithErrorHandler: async (fn: () => Promise<unknown>) => fn(),
 }));
@@ -51,18 +48,22 @@ type ApiOverrides = Partial<{
   getFiles: () => Record<string, unknown>;
   sceneLocatorsSequence: Array<Record<string, string>>;
   flushReport: { published: string[]; skipped: unknown[]; failed: Array<{ fileId: string; error: unknown }> };
+  initialElements: Array<Record<string, unknown>>;
 }>;
 
 const makeApi = (o: ApiOverrides = {}) => {
   const locatorsSeq = o.sceneLocatorsSequence ?? [{}, { f1: 'target-doc-id' }];
   let call = 0;
+  let elements = o.initialElements ?? [];
   return {
     getFiles: vi.fn(o.getFiles ?? (() => ({}))),
     getSceneAssetLocators: vi.fn(() => locatorsSeq[Math.min(call++, locatorsSeq.length - 1)]),
     addFiles: vi.fn(),
     flushAssetPublication: vi.fn(async () => o.flushReport ?? { published: ['f1'], skipped: [], failed: [] }),
-    getSceneElementsIncludingDeleted: vi.fn(() => []),
-    updateScene: vi.fn(),
+    getSceneElementsIncludingDeleted: vi.fn(() => elements),
+    updateScene: vi.fn(({ elements: nextElements }) => {
+      elements = nextElements;
+    }),
     scrollToContent: vi.fn(),
   };
 };
@@ -79,16 +80,72 @@ describe('mergeWhiteboard asset re-homing', () => {
     h.templateScene = { elements: [], assets: {}, appState: {} };
     const api = makeApi();
 
-    await expect(mergeWhiteboard(api as never, 'invalid', makeAdapter())).rejects.toThrow(
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow(
       'Whiteboard verification failed'
     );
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
+  it('rejects a live image whose file id has no source locator before mutating the target', async () => {
+    h.templateScene = { ...makeTemplateScene(), assets: {} };
+    const api = makeApi();
+
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow(
+      'Template images have no source locator: f1'
+    );
+    expect(api.addFiles).not.toHaveBeenCalled();
+    expect(api.flushAssetPublication).not.toHaveBeenCalled();
+    expect(api.updateScene).not.toHaveBeenCalled();
+  });
+
+  it('ignores deleted image elements instead of importing their tombstones', async () => {
+    h.templateScene = {
+      ...makeTemplateScene(),
+      elements: [
+        { ...makeTemplateScene().elements[0], isDeleted: true },
+        {
+          id: 'visible',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          version: 1,
+          boundElements: null,
+        },
+      ],
+      assets: {},
+    };
+    const api = makeApi({ sceneLocatorsSequence: [{}] });
+
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+
+    expect(api.addFiles).not.toHaveBeenCalled();
+    expect(api.flushAssetPublication).not.toHaveBeenCalled();
+    expect(api.updateScene).toHaveBeenCalledTimes(1);
+    expect(api.updateScene.mock.calls[0][0].elements).toHaveLength(1);
+    expect(api.updateScene.mock.calls[0][0].elements[0].type).toBe('rectangle');
+  });
+
+  it('rejects a deleted-only template without reporting a visible import', async () => {
+    h.templateScene = {
+      ...makeTemplateScene(),
+      elements: [{ ...makeTemplateScene().elements[0], isDeleted: true }],
+      assets: {},
+    };
+    const api = makeApi({ sceneLocatorsSequence: [{}] });
+
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow(
+      'Template has no visible elements'
+    );
+    expect(api.updateScene).not.toHaveBeenCalled();
+    expect(api.scrollToContent).not.toHaveBeenCalled();
+  });
+
   it('resolves the source locator, re-stores into the target bucket (new id), keeps fileId, inserts the element', async () => {
     const api = makeApi();
     const resolve = vi.fn(async () => RESOLVED_BYTES);
-    await mergeWhiteboard(api as never, 'content', makeAdapter(resolve));
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve));
 
     // resolve is called with the fileId + the SOURCE locator
     expect(resolve).toHaveBeenCalledWith('f1', 'source-doc-id');
@@ -114,28 +171,77 @@ describe('mergeWhiteboard asset re-homing', () => {
     const resolve = vi.fn(async () => {
       throw new Error('gone');
     });
-    await expect(mergeWhiteboard(api as never, 'content', makeAdapter(resolve))).rejects.toThrow();
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve))).rejects.toThrow();
     expect(api.addFiles).not.toHaveBeenCalled();
+    expect(api.updateScene).not.toHaveBeenCalled();
+  });
+
+  it('aborts before adding resolved files when the editor is invalidated during source resolution', async () => {
+    const api = makeApi();
+    let finishResolve: ((file: typeof RESOLVED_BYTES) => void) | undefined;
+    const resolve = vi.fn(
+      () =>
+        new Promise<typeof RESOLVED_BYTES>(finish => {
+          finishResolve = finish;
+        })
+    );
+    let cancelled = false;
+
+    const merge = mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve), () => cancelled);
+    await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
+    cancelled = true;
+    finishResolve?.(RESOLVED_BYTES);
+
+    await expect(merge).rejects.toThrow('Whiteboard editor changed while importing template');
+    expect(api.addFiles).not.toHaveBeenCalled();
+    expect(api.flushAssetPublication).not.toHaveBeenCalled();
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
   it('aborts and inserts zero elements when a target store fails in the publish flush', async () => {
     const api = makeApi({ flushReport: { published: [], skipped: [], failed: [{ fileId: 'f1', error: 'x' }] } });
-    await expect(mergeWhiteboard(api as never, 'content', makeAdapter())).rejects.toThrow();
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow();
+    expect(api.updateScene).not.toHaveBeenCalled();
+  });
+
+  it('does not update the scene when the editor is invalidated during asset publication', async () => {
+    const api = makeApi();
+    let finishFlush:
+      | ((report: {
+          published: string[];
+          skipped: unknown[];
+          failed: Array<{ fileId: string; error: unknown }>;
+        }) => void)
+      | undefined;
+    api.flushAssetPublication.mockImplementationOnce(
+      () =>
+        new Promise(finish => {
+          finishFlush = finish;
+        })
+    );
+    let cancelled = false;
+
+    const merge = mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(), () => cancelled);
+    await vi.waitFor(() => expect(api.flushAssetPublication).toHaveBeenCalledTimes(1));
+    cancelled = true;
+    finishFlush?.({ published: ['f1'], skipped: [], failed: [] });
+
+    await expect(merge).rejects.toThrow('Whiteboard editor changed while importing template');
+    expect(api.addFiles).toHaveBeenCalledTimes(1);
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
   it('aborts when a resolved file ends up with no committed target locator', async () => {
     // flush reports success but the scene has no locator for f1 (replaced/unmounted mid-merge)
     const api = makeApi({ sceneLocatorsSequence: [{}, {}] });
-    await expect(mergeWhiteboard(api as never, 'content', makeAdapter())).rejects.toThrow();
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter())).rejects.toThrow();
     expect(api.updateScene).not.toHaveBeenCalled();
   });
 
   it('does not re-upload an image the target already has a locator for', async () => {
     const api = makeApi({ sceneLocatorsSequence: [{ f1: 'existing' }] });
     const resolve = vi.fn(async () => RESOLVED_BYTES);
-    await mergeWhiteboard(api as never, 'content', makeAdapter(resolve));
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve));
 
     expect(resolve).not.toHaveBeenCalled();
     expect(api.addFiles).not.toHaveBeenCalled();
@@ -153,7 +259,7 @@ describe('mergeWhiteboard asset re-homing', () => {
       sceneLocatorsSequence: [{}, { f1: 'target-doc-id' }],
     });
     const resolve = vi.fn(async () => RESOLVED_BYTES);
-    await mergeWhiteboard(api as never, 'content', makeAdapter(resolve));
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve));
 
     expect(resolve).not.toHaveBeenCalled();
     expect(api.addFiles).not.toHaveBeenCalled();
@@ -168,8 +274,179 @@ describe('mergeWhiteboard asset re-homing', () => {
       flushReport: { published: [], skipped: [], failed: [] },
     });
     const resolve = vi.fn(async () => RESOLVED_BYTES);
-    await expect(mergeWhiteboard(api as never, 'content', makeAdapter(resolve))).rejects.toThrow();
+    await expect(mergeWhiteboard(api as never, h.templateScene as never, makeAdapter(resolve))).rejects.toThrow();
     expect(resolve).not.toHaveBeenCalled();
     expect(api.updateScene).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing content and inserts a fresh displaced copy every time the same template is applied', async () => {
+    h.templateScene = {
+      elements: [
+        {
+          id: 'template-element',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          version: 1,
+          boundElements: null,
+        },
+      ],
+      assets: {},
+      appState: {},
+    };
+    const existing = {
+      id: 'existing-element',
+      type: 'rectangle',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      version: 1,
+      boundElements: null,
+    };
+    const api = makeApi({ initialElements: [existing] });
+
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+
+    expect(api.updateScene).toHaveBeenCalledTimes(2);
+    const firstElements = api.updateScene.mock.calls[0][0].elements as Array<Record<string, unknown>>;
+    const secondElements = api.updateScene.mock.calls[1][0].elements as Array<Record<string, unknown>>;
+    expect(firstElements[0]).toBe(existing);
+    expect(secondElements[0]).toBe(existing);
+    expect(firstElements).toHaveLength(2);
+    expect(secondElements).toHaveLength(3);
+    expect(firstElements[1].id).not.toBe('template-element');
+    expect(secondElements[2].id).not.toBe('template-element');
+    expect(secondElements[2].id).not.toBe(firstElements[1].id);
+    expect(firstElements[1].x).toBeGreaterThan(existing.x + existing.width);
+    expect(secondElements[2].x).toBeGreaterThan(firstElements[1].x as number);
+  });
+
+  it('ignores deleted outliers when positioning visible imported content', async () => {
+    h.templateScene = {
+      elements: [
+        {
+          id: 'visible',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          version: 1,
+          boundElements: null,
+        },
+        {
+          id: 'deleted-outlier',
+          type: 'rectangle',
+          x: -100000,
+          y: -100000,
+          width: 10,
+          height: 10,
+          version: 1,
+          isDeleted: true,
+          boundElements: null,
+        },
+      ],
+      assets: {},
+      appState: {},
+    };
+    const existing = {
+      id: 'existing',
+      type: 'rectangle',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      version: 1,
+      boundElements: null,
+    };
+    const api = makeApi({ initialElements: [existing] });
+
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+
+    const inserted = api.updateScene.mock.calls[0][0].elements[1];
+    expect(inserted.x).toBeGreaterThan(existing.x + existing.width);
+    expect(api.updateScene.mock.calls[0][0].elements).toHaveLength(2);
+  });
+
+  it('regenerates frame, binding, and group relationships within each imported copy', async () => {
+    h.templateScene = {
+      elements: [
+        {
+          id: 'frame',
+          type: 'frame',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          version: 1,
+          groupIds: ['group'],
+          boundElements: [{ id: 'arrow', type: 'arrow' }],
+        },
+        {
+          id: 'rectangle',
+          type: 'rectangle',
+          x: 10,
+          y: 10,
+          width: 20,
+          height: 20,
+          version: 1,
+          frameId: 'frame',
+          groupIds: ['group'],
+          boundElements: [{ id: 'arrow', type: 'arrow' }],
+        },
+        {
+          id: 'arrow',
+          type: 'arrow',
+          x: 20,
+          y: 20,
+          width: 40,
+          height: 40,
+          version: 1,
+          groupIds: ['group'],
+          startBinding: { elementId: 'rectangle' },
+          endBinding: { elementId: 'frame' },
+          boundElements: null,
+        },
+      ],
+      assets: {},
+      appState: {},
+    };
+    const api = makeApi({ sceneLocatorsSequence: [{}] });
+
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+    await mergeWhiteboard(api as never, h.templateScene as never, makeAdapter());
+
+    const firstCopy = api.updateScene.mock.calls[0][0].elements as Array<Record<string, unknown>>;
+    const secondScene = api.updateScene.mock.calls[1][0].elements as Array<Record<string, unknown>>;
+    const secondCopy = secondScene.slice(3);
+    const assertCopyRelationships = (copy: Array<Record<string, unknown>>) => {
+      const [frame, rectangle, arrow] = copy as Array<
+        Record<string, unknown> & {
+          id: string;
+          frameId?: string;
+          groupIds: string[];
+          boundElements?: Array<{ id: string }>;
+          startBinding?: { elementId: string };
+          endBinding?: { elementId: string };
+        }
+      >;
+      expect(rectangle.frameId).toBe(frame.id);
+      expect(arrow.startBinding?.elementId).toBe(rectangle.id);
+      expect(arrow.endBinding?.elementId).toBe(frame.id);
+      expect(frame.boundElements?.[0].id).toBe(arrow.id);
+      expect(rectangle.boundElements?.[0].id).toBe(arrow.id);
+      expect(new Set(copy.flatMap(element => (element.groupIds as string[]) ?? []))).toHaveLength(1);
+      expect(frame.groupIds[0]).not.toBe('group');
+      expect([frame.id, rectangle.id, arrow.id]).not.toContain('frame');
+      return frame.groupIds[0];
+    };
+
+    const firstGroup = assertCopyRelationships(firstCopy);
+    const secondGroup = assertCopyRelationships(secondCopy);
+    expect(secondGroup).not.toBe(firstGroup);
   });
 });

--- a/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
+++ b/src/domain/collaboration/whiteboard/utils/mergeWhiteboard.ts
@@ -7,17 +7,27 @@ import type {
   CaptureUpdateAction as ExcalidrawCaptureUpdateAction,
   hashElementsVersion as ExcalidrawHashElementsVersion,
 } from '@excalidraw-yjs/excalidraw/element/index';
-import type { ExcalidrawElement, FileId } from '@excalidraw-yjs/excalidraw/element/types';
-import { decodeSnapshot, encodeSnapshot } from '@excalidraw-yjs/excalidraw/headless';
+import type {
+  ExcalidrawElement,
+  ExcalidrawImageElement,
+  FileId,
+  FixedPointBinding,
+} from '@excalidraw-yjs/excalidraw/element/types';
+import { decodeSnapshot, encodeSnapshot, type WhiteboardSnapshot } from '@excalidraw-yjs/excalidraw/headless';
 import type { AssetAdapter, BinaryFileData, ExcalidrawImperativeAPI } from '@excalidraw-yjs/excalidraw/types';
 import { v4 as uuidv4 } from 'uuid';
 import { lazyImportWithErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
-import { parseWhiteboardContentToScene } from '@/domain/common/whiteboard/excalidraw/whiteboardContent';
 
 const ANIMATION_SPEED = 2000;
 const ANIMATION_ZOOM_FACTOR = 0.75;
 
-type ExcalidrawElementWithContainerId = ExcalidrawElement & { containerId: string | null };
+type ExcalidrawElementWithRelationships = ExcalidrawElement & {
+  containerId?: string | null;
+  frameId?: string | null;
+  groupIds?: readonly string[];
+  startBinding?: FixedPointBinding | null;
+  endBinding?: FixedPointBinding | null;
+};
 type ExcalidrawUtils = {
   CaptureUpdateAction: typeof ExcalidrawCaptureUpdateAction;
   hashElementsVersion: typeof ExcalidrawHashElementsVersion;
@@ -95,10 +105,11 @@ const calculateInsertionPoint = (whiteboardA: BoundingBox, whiteboardB: Bounding
  * @param idsMap
  * @returns a function that can be passed to elements.map
  */
-const generateNewIds = (idsMap: Record<string, string>) => (element: ExcalidrawElement) => ({
-  ...element,
-  id: (idsMap[element.id] = uuidv4()), // Replace the id and store it in the map
-});
+const generateNewIds = (idsMap: Record<string, string>) => (element: ExcalidrawElement) => {
+  const id = uuidv4();
+  idsMap[element.id] = id;
+  return { ...element, id };
+};
 
 /**
  * Returns a function that can be passed to elements.map to replace the version of the elements
@@ -111,18 +122,31 @@ const replaceElementVersion = (version: number) => (element: ExcalidrawElement) 
 /**
  * Returns a function that can be passed to elements.map to replace containerId and boundElements ids
  */
-const replaceBoundElementsIds = (idsMap: Record<string, string>) => {
+const replaceRelationshipIds = (idsMap: Record<string, string>, groupIdsMap: Record<string, string>) => {
   const replace = (id: string | null) => (id ? idsMap[id] || id : id);
   const replaceMultiple = (boundElements: ExcalidrawElement['boundElements']) =>
     boundElements
       ? boundElements.map(boundElement => ({ ...boundElement, id: idsMap[boundElement.id] || boundElement.id }))
       : boundElements;
 
-  return (element: ExcalidrawElement) => ({
-    ...element,
-    containerId: replace((element as ExcalidrawElementWithContainerId).containerId),
-    boundElements: replaceMultiple(element.boundElements),
-  });
+  return (element: ExcalidrawElement) => {
+    const related = element as ExcalidrawElementWithRelationships;
+    const replaceBinding = (binding: FixedPointBinding | null | undefined) =>
+      binding ? { ...binding, elementId: replace(binding.elementId) as string } : binding;
+    return {
+      ...element,
+      containerId: replace(related.containerId ?? null),
+      frameId: replace(related.frameId ?? null),
+      groupIds: related.groupIds?.map(groupId => {
+        const remappedId = groupIdsMap[groupId] ?? uuidv4();
+        groupIdsMap[groupId] = remappedId;
+        return remappedId;
+      }),
+      startBinding: replaceBinding(related.startBinding),
+      endBinding: replaceBinding(related.endBinding),
+      boundElements: replaceMultiple(element.boundElements),
+    } as unknown as ExcalidrawElement;
+  };
 };
 
 /**
@@ -136,33 +160,65 @@ const displaceElements = (displacement: { x: number; y: number }) => (element: E
 
 const mergeWhiteboard = async (
   whiteboardApi: ExcalidrawImperativeAPI,
-  whiteboardContent: string,
-  assetAdapter: AssetAdapter
+  whiteboardSnapshot: WhiteboardSnapshot,
+  assetAdapter: AssetAdapter,
+  isCancelled: () => boolean = () => false
 ) => {
+  const assertActive = () => {
+    if (isCancelled()) {
+      throw new WhiteboardMergeError('Whiteboard editor changed while importing template');
+    }
+  };
+
   const { hashElementsVersion, CaptureUpdateAction } = await lazyImportWithErrorHandler<ExcalidrawUtils>(
     () => import('@excalidraw-yjs/excalidraw')
   );
+  assertActive();
 
   // Normalize the template through the native snapshot round-trip: encode the
-  // parsed template scene into a throwaway Yjs doc and decode it straight back.
+  // loaded template scene into a throwaway Yjs doc and decode it straight back.
   // This routes the template through the single content representation (the doc
   // re-orders by fractional index and strips per-peer reconciliation metadata)
   // and keeps no raw JSON scene as state — only the materialized elements are
   // merged into the live scene below (the editor's own Scene.doc captures the
   // merge via updateScene).
-  const templateScene = decodeSnapshot(encodeSnapshot(parseWhiteboardContentToScene(whiteboardContent)));
+  const templateScene = decodeSnapshot(encodeSnapshot(whiteboardSnapshot));
 
   if (!isWhiteboardLike(templateScene)) {
     throw new WhiteboardMergeError('Whiteboard verification failed');
   }
 
-  const templateElements = templateScene.elements as unknown as ExcalidrawElement[];
+  // Snapshot tombstones are synchronization history, not template content. Import
+  // only live elements so deleted outliers cannot affect placement or reappear.
+  const templateElements = (templateScene.elements as unknown as ExcalidrawElement[]).filter(
+    element => !element.isDeleted
+  );
+  if (templateElements.length === 0) {
+    throw new WhiteboardMergeError('Template has no visible elements');
+  }
   // Template images are opaque locators pointing at the TEMPLATE's storage bucket,
   // never bytes. They must be re-homed into THIS whiteboard's bucket before the
   // elements referencing them are inserted (see the asset-copy steps below).
   const templateAssets = templateScene.assets as Readonly<Record<string, string>>;
 
   try {
+    const liveImageElements = templateElements.filter(
+      (element): element is ExcalidrawImageElement => element.type === 'image' && !element.isDeleted
+    );
+    const imagesWithoutFileId = liveImageElements.filter(element => !element.fileId).map(element => element.id);
+    if (imagesWithoutFileId.length > 0) {
+      throw new WhiteboardMergeError(`Template image elements have no file id: ${imagesWithoutFileId.join(', ')}`);
+    }
+    const liveImageFileIds = [
+      ...new Set(
+        liveImageElements.map(element => element.fileId).filter((fileId): fileId is FileId => Boolean(fileId))
+      ),
+    ];
+    const missingSourceLocators = liveImageFileIds.filter(fileId => !templateAssets[fileId]?.trim());
+    if (missingSourceLocators.length > 0) {
+      throw new WhiteboardMergeError(`Template images have no source locator: ${missingSourceLocators.join(', ')}`);
+    }
+
     // 1. Partition the template's images. Readiness is defined ONLY by a committed
     //    target locator — local cache bytes without a durable locator are NOT
     //    persisted, so a prior merge that cached bytes but failed to publish must
@@ -171,7 +227,7 @@ const mergeWhiteboard = async (
     //    cached need a fresh source resolve.
     const currentFiles = whiteboardApi.getFiles();
     const currentLocators = whiteboardApi.getSceneAssetLocators();
-    const unresolvedLocatorIds = Object.keys(templateAssets).filter(fileId => !currentLocators[fileId]);
+    const unresolvedLocatorIds = liveImageFileIds.filter(fileId => !currentLocators[fileId]);
     const toResolveIds = unresolvedLocatorIds.filter(fileId => !currentFiles[fileId]);
 
     // 2. Resolve EVERY still-uncached source locator to bytes BEFORE mutating the
@@ -189,6 +245,7 @@ const mergeWhiteboard = async (
       //    adapter.store into THIS whiteboard's bucket, minting NEW target locators
       //    keyed by the unchanged file ids. Never reuse the source locator or
       //    upload directly.
+      assertActive();
       whiteboardApi.addFiles(resolvedFiles);
     }
 
@@ -198,7 +255,9 @@ const mergeWhiteboard = async (
     //    reports success yet leaves no locator (replaced/unmounted mid-merge), aborts
     //    with zero elements. A remote-won skip is a success — its locator is present.
     if (unresolvedLocatorIds.length > 0) {
+      assertActive();
       const report = await whiteboardApi.flushAssetPublication();
+      assertActive();
       if (report.failed.length > 0) {
         throw new WhiteboardMergeError(`Template image publish failed: ${report.failed.map(f => f.fileId).join(', ')}`);
       }
@@ -214,19 +273,21 @@ const mergeWhiteboard = async (
     const currentElements = whiteboardApi.getSceneElementsIncludingDeleted();
     const sceneVersion = hashElementsVersion(currentElements);
 
-    const currentElementsBBox = getBoundingBox(currentElements);
+    const currentElementsBBox = getBoundingBox(currentElements.filter(element => !element.isDeleted));
     const insertedWhiteboardBBox = getBoundingBox(templateElements);
     const displacement = calculateInsertionPoint(currentElementsBBox, insertedWhiteboardBBox);
 
     const replacedIds: Record<string, string> = {};
+    const replacedGroupIds: Record<string, string> = {};
     // fractional indices does not need overwriting
     const insertedElements = templateElements
       ?.map(generateNewIds(replacedIds))
       .map(replaceElementVersion(sceneVersion + 1))
-      .map(replaceBoundElementsIds(replacedIds))
+      .map(replaceRelationshipIds(replacedIds, replacedGroupIds))
       .map(displaceElements(displacement));
 
     const newElements = [...currentElements, ...insertedElements];
+    assertActive();
     whiteboardApi.updateScene({
       elements: newElements,
       captureUpdate: CaptureUpdateAction.IMMEDIATELY,

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.sessionEnd.spec.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.sessionEnd.spec.tsx
@@ -16,6 +16,8 @@ const h = vi.hoisted(() => ({
   notifications: [] as string[],
   mountCount: { value: 0 },
   editorInvalidatedCount: { value: 0 },
+  publishedApi: { value: null as string | null },
+  apiEvents: [] as string[],
 }));
 
 vi.mock('./collab/useCollab', () => ({
@@ -58,17 +60,29 @@ vi.mock('@/domain/community/userCurrent/useCurrentUserContext', () => ({
 vi.mock('@/domain/shared/utils/useCombinedRefs', () => ({ useCombinedRefs: () => ({ current: null }) }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 
-const renderWrapper = () =>
-  render(
-    <CollaborativeExcalidrawWrapper
-      entities={{ whiteboard: { id: 'wb-1' }, assetAdapter: {} as never, lastSuccessfulSavedDate: undefined }}
-      options={{}}
-      actions={{ onEditorInvalidated: () => (h.editorInvalidatedCount.value += 1) }}
-      renderDisconnectNotice={() => null}
-    >
-      {({ children }) => <>{children}</>}
-    </CollaborativeExcalidrawWrapper>
-  );
+const wrapper = (whiteboardId = 'wb-1') => (
+  <CollaborativeExcalidrawWrapper
+    entities={{ whiteboard: { id: whiteboardId }, assetAdapter: {} as never, lastSuccessfulSavedDate: undefined }}
+    options={{}}
+    actions={{
+      onInitApi: api => {
+        const id = (api as unknown as { id: string }).id;
+        h.publishedApi.value = id;
+        h.apiEvents.push(`api:${id}`);
+      },
+      onEditorInvalidated: () => {
+        h.editorInvalidatedCount.value += 1;
+        h.publishedApi.value = null;
+        h.apiEvents.push('invalidate');
+      },
+    }}
+    renderDisconnectNotice={() => null}
+  >
+    {({ children }) => <>{children}</>}
+  </CollaborativeExcalidrawWrapper>
+);
+
+const renderWrapper = () => render(wrapper());
 
 const lastActive = () => h.autoReconnectActive[h.autoReconnectActive.length - 1];
 const send = (info: SessionEndInfo) => act(() => h.onSessionEnd.value?.(info));
@@ -81,6 +95,8 @@ describe('CollaborativeExcalidrawWrapper — session-end outcomes', () => {
     h.notifications.length = 0;
     h.mountCount.value = 0;
     h.editorInvalidatedCount.value = 0;
+    h.publishedApi.value = null;
+    h.apiEvents.length = 0;
   });
   afterEach(() => vi.clearAllMocks());
 
@@ -134,5 +150,15 @@ describe('CollaborativeExcalidrawWrapper — session-end outcomes', () => {
     send({ code: 'document-deleted', scope: 'document', disposition: 'terminal' });
     expect(lastActive()).toBe(false);
     expect(h.notifications).toContain('callout.whiteboard.session.documentDeleted');
+  });
+
+  it('invalidates the old editor before publishing the API for a new whiteboard id', () => {
+    const view = renderWrapper();
+
+    view.rerender(wrapper('wb-2'));
+
+    expect(h.editorInvalidatedCount.value).toBe(1);
+    expect(h.apiEvents).toEqual(['api:api-1', 'invalidate', 'api:api-2']);
+    expect(h.publishedApi.value).toBe('api-2');
   });
 });

--- a/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
+++ b/src/domain/common/whiteboard/excalidraw/CollaborativeExcalidrawWrapper.tsx
@@ -1,7 +1,7 @@
 import type { AssetAdapter, ExcalidrawImperativeAPI, ExcalidrawProps } from '@excalidraw-yjs/excalidraw/types';
 import { debounce, merge } from 'lodash-es';
 import type React from 'react';
-import { type PropsWithChildren, type Ref, Suspense, useEffect, useMemo, useState } from 'react';
+import { type PropsWithChildren, type Ref, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type TranslationKey from '@/core/i18n/utils/TranslationKey';
 import { lazyWithGlobalErrorHandler } from '@/core/lazyLoading/lazyWithGlobalErrorHandler';
@@ -176,6 +176,7 @@ const CollaborativeExcalidrawWrapper = ({
   const [connectionError, setConnectionError] = useState(false);
 
   const { whiteboard, assetAdapter, imageValidation, lastSuccessfulSavedDate } = entities;
+  const previousWhiteboardIdRef = useRef(whiteboard?.id);
 
   const whiteboardDefaults = useWhiteboardDefaults();
   const { t } = useTranslation();
@@ -251,7 +252,7 @@ const CollaborativeExcalidrawWrapper = ({
     },
   };
 
-  const { UIOptions: externalUIOptions, ...restOptions } = options;
+  const { UIOptions: externalUIOptions, viewModeEnabled: externallyReadOnly, ...restOptions } = options;
 
   const mergedUIOptions = merge(UIOptions, externalUIOptions);
 
@@ -414,6 +415,13 @@ const CollaborativeExcalidrawWrapper = ({
 
   const handleInitializeApi = (api: ExcalidrawImperativeAPI | null) => {
     if (!api) return;
+    // The keyed editor for a new whiteboard can publish its API before a passive
+    // parent effect runs. Invalidate the old generation synchronously here, then
+    // publish the new API, so the invalidation can never clear the replacement.
+    if (previousWhiteboardIdRef.current !== whiteboard?.id) {
+      actions.onEditorInvalidated?.();
+      previousWhiteboardIdRef.current = whiteboard?.id;
+    }
     // Pair the api with the whiteboard it was created under (the editor mounted under the
     // current, keyed whiteboard id), so the init effect can require a match.
     setExcalidrawApi({ api, whiteboardId: whiteboard?.id ?? '' });
@@ -433,7 +441,7 @@ const CollaborativeExcalidrawWrapper = ({
             initialData={whiteboardDefaults}
             UIOptions={mergedUIOptions}
             isCollaborating={collaborating}
-            viewModeEnabled={isReadOnly}
+            viewModeEnabled={isReadOnly || externallyReadOnly}
             assetAdapter={assetAdapter}
             onPointerUpdate={collabApi?.onPointerUpdate}
             onRequestBroadcastEmojiReaction={handleRequestBroadcastEmojiReaction}

--- a/src/domain/common/whiteboard/excalidraw/collab/useCollab.spec.tsx
+++ b/src/domain/common/whiteboard/excalidraw/collab/useCollab.spec.tsx
@@ -283,10 +283,27 @@ describe('useCollab — session-end control (validated tuple, idempotent close)'
     const onSessionEnd = vi.fn();
     const onTerminalClose = vi.fn();
     const onCloseConnection = vi.fn();
-    const { result } = renderHook(() => useCollab({ username: 'T', onCloseConnection, onTerminalClose, onSessionEnd }));
+    const onSceneInitChange = vi.fn();
+    const { result } = renderHook(() =>
+      useCollab({ username: 'T', onCloseConnection, onTerminalClose, onSessionEnd, onSceneInitChange })
+    );
     const cleanup = result.current[1]({ excalidrawApi: fakeApi, roomId: 'r' });
-    return { onSessionEnd, onTerminalClose, onCloseConnection, cleanup };
+    return { onSessionEnd, onTerminalClose, onCloseConnection, onSceneInitChange, cleanup };
   };
+
+  it('seals scene consumers immediately when session-end arrives, before the socket closes', () => {
+    const { onSessionEnd, onSceneInitChange, cleanup } = mount();
+    controlHandler?.({
+      kind: 'session-end',
+      code: 'server-shutdown',
+      scope: 'document',
+      disposition: 'transient',
+    } as ControlMessage);
+
+    expect(onSceneInitChange).toHaveBeenLastCalledWith(false);
+    expect(onSceneInitChange.mock.invocationCallOrder[0]).toBeLessThan(onSessionEnd.mock.invocationCallOrder[0] ?? 0);
+    cleanup();
+  });
 
   it.each([
     ['update-rate-exceeded', 'member', 'transient'],

--- a/src/domain/common/whiteboard/excalidraw/collab/useCollab.ts
+++ b/src/domain/common/whiteboard/excalidraw/collab/useCollab.ts
@@ -22,6 +22,8 @@ export type CollabAPI = {
   /** Local pointer move → awareness (the AwarenessRouter owns cursor presence). */
   onPointerUpdate: (payload: PointerUpdatePayload) => void;
   isCollaborating: () => boolean;
+  /** Wait until every preceding scene update is durable in both collaboration stores. */
+  requestDurability: () => Promise<void>;
   /** Broadcast an ephemeral floating emoji to other collaborators (never persisted). */
   broadcastEmojiReaction: (emoji: string, x: number, y: number) => void;
   broadcastCountdownTimer: (remainingSeconds: number, startedBy: string, active: boolean) => void;
@@ -288,6 +290,12 @@ const useCollab = ({
           // control is authoritative over the socket close that follows (idempotence via
           // `sessionEndHandled`). An unknown/inconsistent tuple fails CLOSED to a terminal.
           sessionEndHandled = true;
+          // Seal editor consumers immediately, before the socket close which follows this
+          // control frame. Waiting for the provider's later `synced=false` event leaves a
+          // window where an async template import can still publish into a session the
+          // server has already ended.
+          setIsSceneInitialized(false);
+          onSceneInitChange?.(false);
           const info = classifySessionEnd(message);
           if (info) {
             onSessionEnd?.(info);
@@ -311,6 +319,7 @@ const useCollab = ({
     const collabApi: CollabAPI = {
       onPointerUpdate: payload => awarenessRouter.onPointerUpdate(payload),
       isCollaborating: () => providerRef.current?.status === 'connected',
+      requestDurability: () => provider.requestDurability(),
       broadcastEmojiReaction: (emoji, x, y) => {
         const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
         awarenessRouter.broadcastEmojiReaction({ id, emoji, x, y });

--- a/src/main/crdPages/templates/__tests__/useTemplatePicker.test.tsx
+++ b/src/main/crdPages/templates/__tests__/useTemplatePicker.test.tsx
@@ -197,6 +197,22 @@ const whiteboardContentMock = (
   delay,
 });
 
+const whiteboardContentErrorMock = (templateId: string): MockedResponse<TemplateContentQuery> => ({
+  request: {
+    query: TemplateContentDocument,
+    variables: {
+      templateId,
+      includeCallout: false,
+      includeWhiteboard: true,
+      includePost: false,
+      includeSpace: false,
+      includeCommunityGuidelines: false,
+      includeClassification: false,
+    },
+  },
+  error: new Error('template content unavailable'),
+});
+
 // ---------------------------------------------------------------------------
 // Wrapper
 // ---------------------------------------------------------------------------
@@ -394,6 +410,18 @@ describe('useTemplatePicker — selection lifecycle', () => {
       type: 'whiteboard',
       sourceWhiteboardId: 'template-b-whiteboard',
     });
+  });
+
+  it('clears a transient selection when its content request fails', async () => {
+    const wrapper = makeWrapper([whiteboardContentErrorMock('template-a')]);
+    const { result } = renderHook(() => useTemplatePicker({ allowedTypes: ['whiteboard'] }), { wrapper });
+
+    act(() => result.current.pickerProps.onSelect('template-a'));
+    expect(result.current.selectedTemplateId).toBe('template-a');
+    expect(result.current.selectedTemplateContent).toBeNull();
+
+    await waitFor(() => expect(result.current.selectedTemplateId).toBeNull());
+    expect(result.current.selectedTemplateContent).toBeNull();
   });
 });
 

--- a/src/main/crdPages/templates/__tests__/useTemplatePicker.test.tsx
+++ b/src/main/crdPages/templates/__tests__/useTemplatePicker.test.tsx
@@ -143,7 +143,11 @@ const platformMock = (
   },
 });
 
-const whiteboardContentMock = (templateId: string, previewUri?: string): MockedResponse<TemplateContentQuery> => ({
+const whiteboardContentMock = (
+  templateId: string,
+  previewUri?: string,
+  delay?: number
+): MockedResponse<TemplateContentQuery> => ({
   request: {
     query: TemplateContentDocument,
     variables: {
@@ -190,6 +194,7 @@ const whiteboardContentMock = (templateId: string, previewUri?: string): MockedR
       },
     } as unknown as TemplateContentQuery,
   },
+  delay,
 });
 
 // ---------------------------------------------------------------------------
@@ -361,6 +366,34 @@ describe('useTemplatePicker — selection lifecycle', () => {
 
     expect(result.current.selectedTemplateId).toBeNull();
     expect(result.current.selectedTemplateContent).toBeNull();
+  });
+
+  it('keeps the selected id and content paired when an older content request resolves last', async () => {
+    const wrapper = makeWrapper([
+      whiteboardContentMock('template-a', undefined, 50),
+      whiteboardContentMock('template-b', undefined, 1),
+    ]);
+    const { result } = renderHook(() => useTemplatePicker({ allowedTypes: ['whiteboard'] }), { wrapper });
+
+    act(() => {
+      result.current.pickerProps.onSelect('template-a');
+      result.current.pickerProps.onSelect('template-b');
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedTemplateId).toBe('template-b');
+      expect(result.current.selectedTemplateContent).toMatchObject({
+        type: 'whiteboard',
+        sourceWhiteboardId: 'template-b-whiteboard',
+      });
+    });
+    await act(() => new Promise(resolve => setTimeout(resolve, 60)));
+
+    expect(result.current.selectedTemplateId).toBe('template-b');
+    expect(result.current.selectedTemplateContent).toMatchObject({
+      type: 'whiteboard',
+      sourceWhiteboardId: 'template-b-whiteboard',
+    });
   });
 });
 

--- a/src/main/crdPages/templates/useTemplatePicker.ts
+++ b/src/main/crdPages/templates/useTemplatePicker.ts
@@ -171,14 +171,24 @@ export function useTemplatePicker({
     if (!primaryType) return;
     void getTemplateContent({
       variables: { templateId, ...templateContentIncludeVars(primaryType) },
-    }).then(({ data }) => {
-      if (selectionRequestRef.current !== request) return;
-      const fetched = data?.lookup.template;
-      setSelectedTemplate({
-        id: templateId,
-        content: fetched ? mapTemplateContent(fetched, primaryType) : null,
+    })
+      .then(({ data }) => {
+        if (selectionRequestRef.current !== request) return;
+        const fetched = data?.lookup.template;
+        setSelectedTemplate(
+          fetched
+            ? {
+                id: templateId,
+                content: mapTemplateContent(fetched, primaryType),
+              }
+            : null
+        );
+      })
+      .catch(() => {
+        // Apollo's error link reports the failure. Drop this transient pick so consumers
+        // never observe a permanently half-loaded `{ id, content: null }` selection.
+        if (selectionRequestRef.current === request) setSelectedTemplate(null);
       });
-    });
   };
 
   const clearSelection = () => {

--- a/src/main/crdPages/templates/useTemplatePicker.ts
+++ b/src/main/crdPages/templates/useTemplatePicker.ts
@@ -68,8 +68,10 @@ export function useTemplatePicker({
     onOpenChange?.(next);
   };
   const [search, setSearch] = useState('');
-  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
-  const [selectedTemplateContent, setSelectedTemplateContent] = useState<TemplateContent | null>(null);
+  const [selectedTemplate, setSelectedTemplate] = useState<{
+    id: string;
+    content: TemplateContent | null;
+  } | null>(null);
   const [previewId, setPreviewId] = useState<string | null>(null);
   const [previewContent, setPreviewContent] = useState<TemplateContent | undefined>(undefined);
   const [previewLoading, setPreviewLoading] = useState(false);
@@ -122,29 +124,11 @@ export function useTemplatePicker({
   if (accountId) sources.push({ key: 'account', templates: accountTemplates, loading: accountLoading });
   sources.push({ key: 'platform', templates: platformTemplates, loading: platformLoading });
 
-  const fetchContent = async (
-    templateId: string,
-    set: (c: TemplateContent | undefined) => void,
-    setLoading: (b: boolean) => void
-  ) => {
-    if (!primaryType) return;
-    setLoading(true);
-    set(undefined);
-    try {
-      const { data } = await getTemplateContent({
-        variables: { templateId, ...templateContentIncludeVars(primaryType) },
-      });
-      const fetched = data?.lookup.template;
-      if (fetched) set(mapTemplateContent(fetched, primaryType));
-    } finally {
-      setLoading(false);
-    }
-  };
-
   // Tracks the latest preview request so a slow response for template A doesn't overwrite the
   // content shown for template B if the user previewed another card mid-fetch. `previewId` drives a
   // committing action (Use/Import) in the preview pane, so a stale overwrite could apply the wrong template.
   const activePreviewIdRef = useRef<string | null>(null);
+  const selectionRequestRef = useRef(0);
 
   const onPreview = (templateId: string) => {
     if (!primaryType) return;
@@ -176,24 +160,30 @@ export function useTemplatePicker({
   };
 
   const onSelect = (templateId: string | null) => {
+    const request = ++selectionRequestRef.current;
     if (templateId === null) {
-      setSelectedTemplateId(null);
-      setSelectedTemplateContent(null);
+      setSelectedTemplate(null);
       setOpen(false);
       return;
     }
-    setSelectedTemplateId(templateId);
+    setSelectedTemplate({ id: templateId, content: null });
     setOpen(false);
-    void fetchContent(
-      templateId,
-      c => setSelectedTemplateContent(c ?? null),
-      () => {}
-    );
+    if (!primaryType) return;
+    void getTemplateContent({
+      variables: { templateId, ...templateContentIncludeVars(primaryType) },
+    }).then(({ data }) => {
+      if (selectionRequestRef.current !== request) return;
+      const fetched = data?.lookup.template;
+      setSelectedTemplate({
+        id: templateId,
+        content: fetched ? mapTemplateContent(fetched, primaryType) : null,
+      });
+    });
   };
 
   const clearSelection = () => {
-    setSelectedTemplateId(null);
-    setSelectedTemplateContent(null);
+    selectionRequestRef.current += 1;
+    setSelectedTemplate(null);
   };
 
   const pickerProps: TemplatePickerSelectProps = {
@@ -225,8 +215,8 @@ export function useTemplatePicker({
       setOpen(true);
     },
     pickerProps,
-    selectedTemplateId,
-    selectedTemplateContent,
+    selectedTemplateId: selectedTemplate?.id ?? null,
+    selectedTemplateContent: selectedTemplate?.content ?? null,
     clearSelection,
   };
 }

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.flushOnClose.spec.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.flushOnClose.spec.tsx
@@ -115,6 +115,89 @@ describe('closeCollaborativeWhiteboard — flush-at-collaborative-close gate', (
     expect(order).toEqual(['flush', 'save', 'teardown']);
   });
 
+  it('waits for the editor-owned import, then flushes, persists, saves, and tears down', async () => {
+    const order: string[] = [];
+    let finishImport!: () => void;
+    const pendingImport = new Promise<void>(resolve => {
+      finishImport = resolve;
+    });
+    const excalidrawAPI = {
+      flushAssetPublication: vi.fn(async () => {
+        order.push('flush');
+        return cleanReport;
+      }),
+    };
+    const requestDurability = vi.fn(async () => {
+      order.push('durability');
+    });
+    const save = vi.fn(async () => {
+      order.push('save');
+    });
+    const teardown = vi.fn(() => order.push('teardown'));
+
+    const closing = closeCollaborativeWhiteboard({
+      excalidrawAPI,
+      waitForPendingImport: async () => {
+        order.push('import');
+        await pendingImport;
+      },
+      requestDurability,
+      requireDurability: true,
+      save,
+      onPublishFailed: vi.fn(),
+      teardown,
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(['import']);
+    finishImport();
+    await expect(closing).resolves.toBe(true);
+    expect(order).toEqual(['import', 'flush', 'durability', 'save', 'teardown']);
+  });
+
+  it('keeps a draft editor open when no durability barrier is available', async () => {
+    const save = vi.fn(async () => {});
+    const teardown = vi.fn();
+    const onDurabilityFailed = vi.fn();
+
+    const closed = await closeCollaborativeWhiteboard({
+      excalidrawAPI: { flushAssetPublication: vi.fn(async () => cleanReport) },
+      requireDurability: true,
+      save,
+      onPublishFailed: vi.fn(),
+      onDurabilityFailed,
+      teardown,
+    });
+
+    expect(closed).toBe(false);
+    expect(onDurabilityFailed).toHaveBeenCalledOnce();
+    expect(save).not.toHaveBeenCalled();
+    expect(teardown).not.toHaveBeenCalled();
+  });
+
+  it('keeps the editor open when persistence fails', async () => {
+    const save = vi.fn(async () => {});
+    const teardown = vi.fn();
+    const onDurabilityFailed = vi.fn();
+
+    const closed = await closeCollaborativeWhiteboard({
+      excalidrawAPI: { flushAssetPublication: vi.fn(async () => cleanReport) },
+      requestDurability: vi.fn(async () => {
+        throw new Error('persist failed');
+      }),
+      requireDurability: true,
+      save,
+      onPublishFailed: vi.fn(),
+      onDurabilityFailed,
+      teardown,
+    });
+
+    expect(closed).toBe(false);
+    expect(onDurabilityFailed).toHaveBeenCalledOnce();
+    expect(save).not.toHaveBeenCalled();
+    expect(teardown).not.toHaveBeenCalled();
+  });
+
   it('(b) a still-pending slow store that resolves with a non-empty `failed` does NOT report a clean close', async () => {
     const { promise, resolveWith } = deferredReport();
     const excalidrawAPI = { flushAssetPublication: vi.fn(() => promise) };

--- a/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardDialog.tsx
@@ -27,6 +27,8 @@ import { WhiteboardDisconnectedDialog } from '@/crd/components/whiteboard/Whiteb
 import { WhiteboardDisplayName } from '@/crd/components/whiteboard/WhiteboardDisplayName';
 import { WhiteboardEditorShell } from '@/crd/components/whiteboard/WhiteboardEditorShell';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/crd/primitives/dialog';
+import { loadWhiteboardSceneFromCollaboration } from '@/domain/collaboration/whiteboard/utils/loadWhiteboardSceneFromCollaboration';
+import mergeWhiteboard from '@/domain/collaboration/whiteboard/utils/mergeWhiteboard';
 import whiteboardValidationSchema, {
   type WhiteboardFormSchema,
 } from '@/domain/collaboration/whiteboard/validation/whiteboardFormSchema';
@@ -120,6 +122,8 @@ interface CrdWhiteboardDialogProps {
     readOnlyDisplayName?: boolean;
     editDisplayName?: boolean;
     previewSettingsDialogOpen?: boolean;
+    /** Draft editors may close only after the collaboration service confirms persistence. */
+    requireDurableClose?: boolean;
   };
   state?: {
     loadingWhiteboardValue?: boolean;
@@ -132,11 +136,18 @@ type RelevantExcalidrawState = Pick<ExportedDataState, 'appState' | 'elements' |
 type CollaborativeCloseParams = {
   /** The live editor API, or `null` when the editor is already gone / unmounted. */
   excalidrawAPI: Pick<ExcalidrawImperativeAPI, 'flushAssetPublication'> | null;
+  /** Finish the one editor-owned import before freezing and persisting the scene. */
+  waitForPendingImport?: () => Promise<void>;
   /** Persist preview + display name for the collaborative whiteboard (a no-op when not editing). */
   /** Return false when the metadata/preview save failed and the dialog must stay open. */
   save: () => Promise<boolean | void>;
   /** Report that one or more images failed to publish (a non-empty `failed`). */
   onPublishFailed: (report: AssetPublishReport) => void;
+  /** Persist every update sent before this request. */
+  requestDurability?: () => Promise<void>;
+  /** Refuse to close when a draft has no live durability barrier. */
+  requireDurability?: boolean;
+  onDurabilityFailed?: () => void;
   /** Tear the collaborative session down: evict the cache + run the parent cancel, which unmounts the provider. */
   teardown: () => void;
   /**
@@ -168,11 +179,17 @@ type CollaborativeCloseParams = {
  */
 export async function closeCollaborativeWhiteboard({
   excalidrawAPI,
+  waitForPendingImport,
   save,
   onPublishFailed,
+  requestDurability,
+  requireDurability,
+  onDurabilityFailed,
   teardown,
   hasEditorChanged,
 }: CollaborativeCloseParams): Promise<boolean> {
+  await waitForPendingImport?.();
+  if (hasEditorChanged?.()) return false;
   if (excalidrawAPI) {
     const report = await excalidrawAPI.flushAssetPublication();
     if (report.failed.length > 0) {
@@ -187,6 +204,19 @@ export async function closeCollaborativeWhiteboard({
   if (hasEditorChanged?.()) {
     return false;
   }
+  if (!requestDurability && requireDurability) {
+    onDurabilityFailed?.();
+    return false;
+  }
+  if (requestDurability) {
+    try {
+      await requestDurability();
+    } catch {
+      onDurabilityFailed?.();
+      return false;
+    }
+  }
+  if (hasEditorChanged?.()) return false;
   const saved = await save();
   if (saved === false) {
     return false;
@@ -223,8 +253,14 @@ const CrdWhiteboardDialog = ({
   // (server update-rejected). A close-in-flight compares this to detect a recovery that
   // replaced the editor mid-flush and abort the save (see `hasEditorChanged`).
   const editorGenerationRef = useRef(0);
+  const importInFlightRef = useRef<Promise<void> | null>(null);
+  const importAbortRef = useRef<AbortController | null>(null);
+  const closeInFlightRef = useRef(false);
+  const [closing, setClosing] = useState(false);
   const collabApiRef = useRef<CollabAPI>(null);
   const editModeEnabled = options.canEdit;
+
+  useEffect(() => () => importAbortRef.current?.abort(), [whiteboard?.id]);
 
   const [_lastSaveError, setLastSaveError] = useState<string | undefined>();
   const [isSceneInitialized, setSceneInitialized] = useState(false);
@@ -276,46 +312,89 @@ const CrdWhiteboardDialog = ({
   };
 
   const onClose = async () => {
-    const shouldSave = !!(editModeEnabled && collabApiRef.current?.isCollaborating() && whiteboard);
+    if (closeInFlightRef.current) return;
+    closeInFlightRef.current = true;
+    setClosing(true);
+    const collabApi = collabApiRef.current;
+    const shouldSave = !!(editModeEnabled && collabApi?.isCollaborating() && whiteboard);
     // Snapshot the editor generation now; if a recovery (update-rejected) discards it while
     // the flush is awaited, the captured api is dead and the save must abort.
     const generationAtClose = editorGenerationRef.current;
-    await closeCollaborativeWhiteboard({
-      excalidrawAPI,
-      hasEditorChanged: () => editorGenerationRef.current !== generationAtClose,
-      save: async () => {
-        if (!shouldSave || !whiteboard) return true;
-        const excState = excalidrawAPI
-          ? {
-              elements: excalidrawAPI.getSceneElements(),
-              appState: excalidrawAPI.getAppState(),
-              files: excalidrawAPI.getFiles(),
+    let closed = false;
+    try {
+      closed = await closeCollaborativeWhiteboard({
+        excalidrawAPI,
+        waitForPendingImport: () => importInFlightRef.current ?? Promise.resolve(),
+        hasEditorChanged: () => editorGenerationRef.current !== generationAtClose,
+        requestDurability: shouldSave && collabApi ? () => collabApi.requestDurability() : undefined,
+        requireDurability: options.requireDurableClose,
+        save: async () => {
+          if (!shouldSave || !whiteboard) return true;
+          const excState = excalidrawAPI
+            ? {
+                elements: excalidrawAPI.getSceneElements(),
+                appState: excalidrawAPI.getAppState(),
+                files: excalidrawAPI.getFiles(),
+              }
+            : undefined;
+          const result = await prepareWhiteboardForUpdate(whiteboard, excState);
+          if (result.success) {
+            const update = await actions.onUpdate(result.whiteboard, result.previewImages);
+            if (!update.success) {
+              notify(t('callout.whiteboard.saveFailed'), 'error');
+              return false;
             }
-          : undefined;
-        const result = await prepareWhiteboardForUpdate(whiteboard, excState);
-        if (result.success) {
-          const update = await actions.onUpdate(result.whiteboard, result.previewImages);
-          if (!update.success) {
+            return true;
+          } else {
+            logError(new Error('Error preparing whiteboard for update on close'), {
+              category: TagCategoryValues.WHITEBOARD,
+            });
             notify(t('callout.whiteboard.saveFailed'), 'error');
             return false;
           }
-          return true;
-        } else {
-          logError(new Error('Error preparing whiteboard for update on close'), {
-            category: TagCategoryValues.WHITEBOARD,
-          });
-          notify(t('callout.whiteboard.saveFailed'), 'error');
-          return false;
-        }
-      },
-      onPublishFailed: () => {
-        notify(t('callout.whiteboard.images.uploadFailed'), 'error');
-      },
-      teardown: () => {
-        evictFromCache(whiteboard?.id, 'Whiteboard');
-        actions.onCancel();
-      },
+        },
+        onPublishFailed: () => notify(t('callout.whiteboard.images.uploadFailed'), 'error'),
+        onDurabilityFailed: () => notify(t('callout.whiteboard.saveFailed'), 'error'),
+        teardown: () => {
+          evictFromCache(whiteboard?.id, 'Whiteboard');
+          actions.onCancel();
+        },
+      });
+    } finally {
+      closeInFlightRef.current = false;
+      if (!closed) setClosing(false);
+    }
+  };
+
+  const handleImportTemplate = (sourceWhiteboardId: string): Promise<void> => {
+    if (closing || !excalidrawAPI) return Promise.resolve();
+    if (importInFlightRef.current) return importInFlightRef.current;
+
+    const controller = new AbortController();
+    const generationAtImport = editorGenerationRef.current;
+    importAbortRef.current = controller;
+    const operation = (async () => {
+      try {
+        const templateScene = await loadWhiteboardSceneFromCollaboration(sourceWhiteboardId, {
+          signal: controller.signal,
+        });
+        const cancelled = () => controller.signal.aborted || editorGenerationRef.current !== generationAtImport;
+        if (cancelled()) return;
+        await mergeWhiteboard(excalidrawAPI, templateScene, assetAdapter, cancelled);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
+        logError(new Error(`Error importing whiteboard template: '${err}'`), {
+          category: TagCategoryValues.WHITEBOARD,
+        });
+      }
+    })();
+    importInFlightRef.current = operation;
+    void operation.finally(() => {
+      if (importInFlightRef.current === operation) importInFlightRef.current = null;
+      if (importAbortRef.current === controller) importAbortRef.current = null;
     });
+    return operation;
   };
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -378,11 +457,14 @@ const CrdWhiteboardDialog = ({
         collabApiRef={collabApiRef}
         options={{
           UIOptions: { canvasActions: { export: { saveFileToDisk: true } } },
+          viewModeEnabled: closing,
         }}
         actions={{
           onInitApi: setExcalidrawAPI,
           onEditorInvalidated: () => {
             editorGenerationRef.current += 1;
+            importAbortRef.current?.abort();
+            setExcalidrawAPI(null);
           },
           onRemoteSave: (error?: string) => {
             if (error) {
@@ -394,7 +476,10 @@ const CrdWhiteboardDialog = ({
               actions.setConsecutiveSaveErrors(0);
             }
           },
-          onSceneInitChange: setSceneInitialized,
+          onSceneInitChange: initialized => {
+            setSceneInitialized(initialized);
+            if (!initialized) importAbortRef.current?.abort();
+          },
         }}
         renderDisconnectNotice={({
           open,
@@ -529,7 +614,7 @@ const CrdWhiteboardDialog = ({
                       displayName={whiteboard.profile.displayName}
                       value={values.profile.displayName}
                       onChange={name => setFieldValue('profile.displayName', name)}
-                      readOnly={options.readOnlyDisplayName}
+                      readOnly={options.readOnlyDisplayName || closing}
                       editing={isEditingName}
                       onEdit={() => setIsEditingName(true)}
                       onSave={async () => {
@@ -544,7 +629,10 @@ const CrdWhiteboardDialog = ({
                   }
                   titleExtra={
                     editModeEnabled && mode === 'write' ? (
-                      <WhiteboardTemplatePickerButton whiteboardId={whiteboard.id} disabled={!isSceneInitialized} />
+                      <WhiteboardTemplatePickerButton
+                        disabled={!isSceneInitialized || closing}
+                        onImport={handleImportTemplate}
+                      />
                     ) : undefined
                   }
                   headerActions={options.headerActions?.({ mode, modeReason, collaborating, connecting, isReadOnly })}

--- a/src/main/crdPages/whiteboard/CrdWhiteboardView.tsx
+++ b/src/main/crdPages/whiteboard/CrdWhiteboardView.tsx
@@ -28,6 +28,7 @@ export interface CrdWhiteboardViewProps {
   readOnlyDisplayName?: boolean;
   loadingWhiteboards: boolean;
   preventWhiteboardDeletion?: boolean;
+  requireDurableClose?: boolean;
   backToWhiteboards: () => void;
   onWhiteboardDeleted?: () => void;
 }
@@ -43,6 +44,7 @@ const CrdWhiteboardView = ({
   displayName,
   readOnlyDisplayName,
   preventWhiteboardDeletion,
+  requireDurableClose,
   onWhiteboardDeleted,
 }: CrdWhiteboardViewProps) => {
   // aria-label-only use; disable suspense so this hook never suspends above the
@@ -102,6 +104,7 @@ const CrdWhiteboardView = ({
           readOnlyDisplayName: readOnlyDisplayName || !hasUpdatePrivileges,
           fullscreen: isFullscreen,
           previewSettingsDialogOpen,
+          requireDurableClose,
           headerActions: (collabState: CollabState) => (
             <>
               <ShareButton url={whiteboardShareUrl} disabled={!whiteboardShareUrl}>

--- a/src/main/crdPages/whiteboard/WhiteboardTemplatePickerButton.spec.tsx
+++ b/src/main/crdPages/whiteboard/WhiteboardTemplatePickerButton.spec.tsx
@@ -1,0 +1,67 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  selectedTemplateId: null as string | null,
+  selectedTemplateContent: null as { type: 'whiteboard'; sourceWhiteboardId: string } | null,
+  clearSelection: vi.fn(),
+  onImport: vi.fn(async () => {}),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@/core/apollo/generated/apollo-hooks', () => ({
+  useSpaceTemplatesManagerQuery: () => ({ data: undefined }),
+}));
+vi.mock('@/domain/space/context/useSpace', () => ({
+  useSpace: () => ({ space: { accountId: undefined, levelZeroSpaceId: undefined } }),
+}));
+vi.mock('@/main/crdPages/templates/useTemplatePicker', () => ({
+  useTemplatePicker: () => ({
+    selectedTemplateId: h.selectedTemplateId,
+    selectedTemplateContent: h.selectedTemplateContent,
+    clearSelection: h.clearSelection,
+    openPicker: vi.fn(),
+    pickerProps: {},
+  }),
+}));
+vi.mock('@/crd/components/templates/TemplatePicker', () => ({ TemplatePicker: () => null }));
+vi.mock('@/crd/primitives/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+vi.mock('@/crd/primitives/skeleton', () => ({ Skeleton: () => null }));
+
+import { WhiteboardTemplatePickerButton } from './WhiteboardTemplatePickerButton';
+
+describe('WhiteboardTemplatePickerButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.selectedTemplateId = null;
+    h.selectedTemplateContent = null;
+  });
+
+  it('consumes each selection independently, including selecting the same template twice', async () => {
+    const view = render(<WhiteboardTemplatePickerButton onImport={h.onImport} />);
+
+    h.selectedTemplateId = 'template-1';
+    h.selectedTemplateContent = { type: 'whiteboard', sourceWhiteboardId: 'source-whiteboard' };
+    view.rerender(<WhiteboardTemplatePickerButton onImport={h.onImport} />);
+    await waitFor(() => expect(h.onImport).toHaveBeenCalledTimes(1));
+    expect(h.clearSelection).toHaveBeenCalledTimes(1);
+
+    await act(async () => {});
+    h.selectedTemplateId = null;
+    h.selectedTemplateContent = null;
+    view.rerender(<WhiteboardTemplatePickerButton onImport={h.onImport} />);
+
+    h.selectedTemplateId = 'template-1';
+    h.selectedTemplateContent = { type: 'whiteboard', sourceWhiteboardId: 'source-whiteboard' };
+    view.rerender(<WhiteboardTemplatePickerButton onImport={h.onImport} />);
+
+    await waitFor(() => expect(h.onImport).toHaveBeenCalledTimes(2));
+    expect(h.clearSelection).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/main/crdPages/whiteboard/WhiteboardTemplatePickerButton.tsx
+++ b/src/main/crdPages/whiteboard/WhiteboardTemplatePickerButton.tsx
@@ -1,11 +1,6 @@
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  useReplaceWhiteboardContentFromSourceMutation,
-  useSpaceTemplatesManagerQuery,
-} from '@/core/apollo/generated/apollo-hooks';
-import { error as logError, TagCategoryValues } from '@/core/logging/sentry/log';
-import { useNotification } from '@/core/ui/notifications/useNotification';
+import { useSpaceTemplatesManagerQuery } from '@/core/apollo/generated/apollo-hooks';
 import { TemplatePicker } from '@/crd/components/templates/TemplatePicker';
 import { Button } from '@/crd/primitives/button';
 import { Skeleton } from '@/crd/primitives/skeleton';
@@ -13,8 +8,8 @@ import { useSpace } from '@/domain/space/context/useSpace';
 import { useTemplatePicker } from '@/main/crdPages/templates/useTemplatePicker';
 
 type WhiteboardTemplatePickerButtonProps = {
-  whiteboardId: string;
   disabled?: boolean;
+  onImport: (sourceWhiteboardId: string) => Promise<void>;
 };
 
 /**
@@ -25,9 +20,8 @@ type WhiteboardTemplatePickerButtonProps = {
  * outside a space (e.g. the public whiteboard route) `useSpace()` returns its empty default, so only
  * the platform library is offered.
  */
-export function WhiteboardTemplatePickerButton({ whiteboardId, disabled }: WhiteboardTemplatePickerButtonProps) {
+export function WhiteboardTemplatePickerButton({ disabled, onImport }: WhiteboardTemplatePickerButtonProps) {
   const { t } = useTranslation();
-  const notify = useNotification();
   const {
     space: { accountId, levelZeroSpaceId },
   } = useSpace();
@@ -37,26 +31,28 @@ export function WhiteboardTemplatePickerButton({ whiteboardId, disabled }: White
   });
   const spaceTemplatesSetId = tmData?.lookup.space?.templatesManager?.templatesSet?.id;
   const picker = useTemplatePicker({ allowedTypes: ['whiteboard'], accountId, spaceTemplatesSetId });
-  const [replaceFromSource, { loading: importing }] = useReplaceWhiteboardContentFromSourceMutation();
+  const [importing, setImporting] = useState(false);
+  const consumedSelection = useRef<typeof picker.selectedTemplateContent>(null);
 
   const selectedContent = picker.selectedTemplateContent;
   const selectedId = picker.selectedTemplateId;
-  const [appliedFor, setAppliedFor] = useState<string | null>(null);
   useEffect(() => {
-    if (!selectedContent || selectedContent.type !== 'whiteboard' || !selectedId || appliedFor === selectedId) return;
+    if (!selectedContent) {
+      consumedSelection.current = null;
+      return;
+    }
+    if (selectedContent.type !== 'whiteboard' || !selectedId || consumedSelection.current === selectedContent) {
+      return;
+    }
     const sourceWhiteboardID = selectedContent.sourceWhiteboardId;
     if (!sourceWhiteboardID) return;
-    setAppliedFor(selectedId);
-    void replaceFromSource({
-      variables: { input: { targetWhiteboardID: whiteboardId, sourceWhiteboardID } },
-    }).catch(err => {
-      setAppliedFor(null);
-      notify(t('templateLibrary.whiteboardTemplates.errorImporting'), 'error');
-      logError(new Error(`Error importing whiteboard template by source id: '${err}'`), {
-        category: TagCategoryValues.WHITEBOARD,
-      });
+    consumedSelection.current = selectedContent;
+    picker.clearSelection();
+    setImporting(true);
+    void onImport(sourceWhiteboardID).finally(() => {
+      setImporting(false);
     });
-  }, [selectedContent, selectedId, appliedFor, replaceFromSource, whiteboardId, notify, t]);
+  }, [selectedContent, selectedId, picker, onImport]);
 
   return (
     // Own Suspense boundary: the template picker pulls in the lazy `crd-templates`


### PR DESCRIPTION
Fixes #10217
Fixes #10219

Supersedes #10224 and #10226 with one clean commit based directly on current develop.

## Root cause

The unified-collaboration transition removed the editor-side additive template-import path, while draft whiteboards could be torn down before the collaboration service acknowledged durable persistence. Earlier fixes split ownership across the form and editor, which made the lifecycle harder to reason about.

## Solution

- Keep CrdWhiteboardDialog as the single owner of editing, template import, and close durability.
- Load template scenes through the collaboration transport; no Yjs binary is carried through GraphQL.
- Add template elements to the live scene every time they are selected, including repeated selection of the same template.
- Re-home live image assets into the target whiteboard bucket before inserting elements.
- On draft-editor close: finish any import, flush asset publication, await the collaboration durability acknowledgement, save metadata/preview, then tear down.
- Preserve the existing UI and form lifecycle; no Configure flow, draft state machine, or form-level persistence machinery.

## Verification

- Focused whiteboard/template/concurrency suite: 7 files, 106 tests passed.
- Full Vitest suite: 356 files, 3024 passed, 2 skipped.
- pnpm lint: passed (typecheck, Biome, ESLint).
- pnpm build: passed.
- Normal signed commit hook: passed, no bypass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Whiteboard templates can be imported directly from collaborative scenes.
  - Whiteboard closing waits for pending imports and confirmed persistence when required.
  - Added cancellation and timeout handling for collaborative scene loading.

- **Bug Fixes**
  - Prevented stale template requests from overwriting newer selections.
  - Improved relationship remapping, deleted-element handling, and import cancellation.
  - Editors now invalidate correctly when switching whiteboards or receiving session-end events.
  - Failed persistence now prevents incomplete saves and teardown.

- **Tests**
  - Expanded coverage for collaboration, durability, imports, close flows, and editor lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->