### PR TITLE
feat(memo): gate signing action by space eligibility

### DIFF
--- a/src/core/apollo/generated/graphql-schema.ts
+++ b/src/core/apollo/generated/graphql-schema.ts
@@ -3098,6 +3098,7 @@ export enum CredentialType {
   PlatformOperationsAdmin = 'PLATFORM_OPERATIONS_ADMIN',
   SpaceAdmin = 'SPACE_ADMIN',
   SpaceFeatureMemoMultiUser = 'SPACE_FEATURE_MEMO_MULTI_USER',
+  SpaceFeatureMemoSigning = 'SPACE_FEATURE_MEMO_SIGNING',
   SpaceFeatureOfficeDocuments = 'SPACE_FEATURE_OFFICE_DOCUMENTS',
   SpaceFeatureSaveAsTemplate = 'SPACE_FEATURE_SAVE_AS_TEMPLATE',
   SpaceFeatureVirtualContributors = 'SPACE_FEATURE_VIRTUAL_CONTRIBUTORS',
@@ -4221,6 +4222,7 @@ export enum LicenseEntitlementType {
   AccountSpacePremium = 'ACCOUNT_SPACE_PREMIUM',
   AccountVirtualContributor = 'ACCOUNT_VIRTUAL_CONTRIBUTOR',
   SpaceFlagMemoMultiUser = 'SPACE_FLAG_MEMO_MULTI_USER',
+  SpaceFlagMemoSigning = 'SPACE_FLAG_MEMO_SIGNING',
   SpaceFlagOfficeDocuments = 'SPACE_FLAG_OFFICE_DOCUMENTS',
   SpaceFlagSaveAsTemplate = 'SPACE_FLAG_SAVE_AS_TEMPLATE',
   SpaceFlagVirtualContributorAccess = 'SPACE_FLAG_VIRTUAL_CONTRIBUTOR_ACCESS',
@@ -4306,6 +4308,7 @@ export type Licensing = {
 export enum LicensingCredentialBasedCredentialType {
   AccountLicensePlus = 'ACCOUNT_LICENSE_PLUS',
   SpaceFeatureMemoMultiUser = 'SPACE_FEATURE_MEMO_MULTI_USER',
+  SpaceFeatureMemoSigning = 'SPACE_FEATURE_MEMO_SIGNING',
   SpaceFeatureOfficeDocuments = 'SPACE_FEATURE_OFFICE_DOCUMENTS',
   SpaceFeatureSaveAsTemplate = 'SPACE_FEATURE_SAVE_AS_TEMPLATE',
   SpaceFeatureVirtualContributors = 'SPACE_FEATURE_VIRTUAL_CONTRIBUTORS',

--- a/src/main/crdPages/memo/CrdMemoDialog.signing.test.tsx
+++ b/src/main/crdPages/memo/CrdMemoDialog.signing.test.tsx
@@ -2,12 +2,30 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { AuthorizationPrivilege, SigningAttemptStatus } from '@/core/apollo/generated/graphql-schema';
+import {
+  AuthenticationType,
+  AuthorizationPrivilege,
+  LicenseEntitlementType,
+  SigningAttemptStatus,
+} from '@/core/apollo/generated/graphql-schema';
 import type { MemoSigningDialogProps } from '@/crd/components/memo/MemoSigningDialog';
 import { CrdMemoDialog } from './CrdMemoDialog';
 
 const mocks = vi.hoisted(() => ({
   assign: vi.fn(),
+  authenticated: true,
+  authenticationMethodsOptions: vi.fn(),
+  authenticationMethodsResult: {
+    data: {
+      me: {
+        user: {
+          authentication: { methods: ['CLEVERBASE'] },
+        },
+      },
+    },
+    error: undefined,
+    loading: false,
+  } as Record<string, unknown>,
   continueMutation: vi.fn(),
   lastSigningDialogProps: undefined as MemoSigningDialogProps | undefined,
   memo: undefined as Record<string, unknown> | undefined,
@@ -17,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   requestDurability: vi.fn(),
   returnAttempt: { loading: false, error: undefined, data: undefined } as Record<string, unknown>,
   returnAttemptQuery: vi.fn(),
+  spaceEntitlements: ['SPACE_FLAG_MEMO_SIGNING'] as LicenseEntitlementType[],
   verificationQuery: vi.fn(),
   verificationQueryOptions: vi.fn(),
   verificationResult: { data: undefined, error: undefined, loading: false, variables: undefined } as Record<
@@ -36,6 +55,10 @@ vi.mock('@/core/apollo/generated/apollo-hooks', () => ({
     return mocks.returnAttempt;
   },
   usePrepareMemoSigningMutation: () => [mocks.prepareMutation],
+  useUserSecurityAuthenticationMethodsQuery: (options: unknown) => {
+    mocks.authenticationMethodsOptions(options);
+    return mocks.authenticationMethodsResult;
+  },
   useVerifyMemoSignatureLazyQuery: (options: unknown) => {
     mocks.verificationQueryOptions(options);
     return [mocks.verificationQuery, mocks.verificationResult];
@@ -44,14 +67,17 @@ vi.mock('@/core/apollo/generated/apollo-hooks', () => ({
 }));
 
 vi.mock('@/core/auth/authentication/hooks/useAuthenticationContext', () => ({
-  useAuthenticationContext: () => ({ isAuthenticated: true }),
+  useAuthenticationContext: () => ({ isAuthenticated: mocks.authenticated }),
 }));
 vi.mock('@/core/ui/fullscreen/FullscreenEditorContext', () => ({ useRegisterFullscreenEditor: () => {} }));
 vi.mock('@/core/ui/fullscreen/useFullscreen', () => ({ useFullscreen: () => ({ fullscreen: false }) }));
 vi.mock('@/core/ui/notifications/useNotification', () => ({ useNotification: () => vi.fn() }));
 vi.mock('@/crd/hooks/useMediaQuery', () => ({ useMediaQuery: () => false }));
 vi.mock('@/domain/space/context/useSpace', () => ({
-  useSpace: () => ({ space: { about: { membership: {} } } }),
+  useSpace: () => ({
+    entitlements: mocks.spaceEntitlements,
+    space: { about: { membership: {} } },
+  }),
 }));
 vi.mock('@/domain/space/hooks/useSubSpace', () => ({
   useSubSpace: () => ({ subspace: { about: { membership: {} } } }),
@@ -130,6 +156,19 @@ describe('CrdMemoDialog signing connector', () => {
     });
     vi.stubGlobal('history', { replaceState: mocks.replaceState, state: null });
     mocks.memo = memoWith([AuthorizationPrivilege.Contribute]);
+    mocks.authenticated = true;
+    mocks.authenticationMethodsResult = {
+      data: {
+        me: {
+          user: {
+            authentication: { methods: [AuthenticationType.Cleverbase] },
+          },
+        },
+      },
+      error: undefined,
+      loading: false,
+    };
+    mocks.spaceEntitlements = [LicenseEntitlementType.SpaceFlagMemoSigning];
     const collaborationProvider = {
       hasLocalEdits: false,
       hasUnsavedChanges: false,
@@ -208,6 +247,12 @@ describe('CrdMemoDialog signing connector', () => {
       [AuthorizationPrivilege.Read],
       [{ id: 'signed-1', status: SigningAttemptStatus.Signed, updatedDate: new Date() }]
     );
+    mocks.spaceEntitlements = [];
+    mocks.authenticationMethodsResult = {
+      data: undefined,
+      error: undefined,
+      loading: false,
+    };
 
     renderDialog();
     await user.click(screen.getByRole('button', { name: 'memo.signing.signedCopies' }));
@@ -219,6 +264,80 @@ describe('CrdMemoDialog signing connector', () => {
 
     await user.click(screen.getByRole('button', { name: 'close signing' }));
     expect(screen.queryByTestId('signing-dialog')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['the space entitlement', [], [AuthenticationType.Cleverbase]],
+    ['a linked Cleverbase identity', [LicenseEntitlementType.SpaceFlagMemoSigning], [AuthenticationType.Email]],
+  ] as const)('opens existing signed copies for a contributor without %s and never prepares', async (_gate, entitlements, methods) => {
+    const user = userEvent.setup();
+    mocks.memo = memoWith(
+      [AuthorizationPrivilege.Contribute],
+      [
+        {
+          id: 'signed-1',
+          status: SigningAttemptStatus.Signed,
+          updatedDate: new Date(),
+        },
+      ]
+    );
+    mocks.spaceEntitlements = [...entitlements];
+    mocks.authenticationMethodsResult = {
+      data: { me: { user: { authentication: { methods: [...methods] } } } },
+      error: undefined,
+      loading: false,
+    };
+
+    renderDialog();
+    await user.click(screen.getByRole('button', { name: 'memo.signing.signedCopies' }));
+
+    expect(screen.getByTestId('signing-dialog')).toHaveAttribute('data-signatures', '1');
+    expect(mocks.prepareMutation).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'CONTRIBUTE',
+      privileges: [AuthorizationPrivilege.Read],
+    },
+    { name: 'the space entitlement', entitlements: [] },
+    {
+      name: 'a linked Cleverbase identity',
+      authenticationMethods: [AuthenticationType.Email],
+    },
+    { name: 'loaded authentication methods', loading: true },
+    { name: 'available authentication methods', error: new Error('offline') },
+  ])('hides Sign without $name', gate => {
+    mocks.memo = memoWith(gate.privileges ?? [AuthorizationPrivilege.Contribute]);
+    mocks.spaceEntitlements = gate.entitlements ?? [LicenseEntitlementType.SpaceFlagMemoSigning];
+    mocks.authenticationMethodsResult = {
+      data: {
+        me: {
+          user: {
+            authentication: {
+              methods: gate.authenticationMethods ?? [AuthenticationType.Cleverbase],
+            },
+          },
+        },
+      },
+      error: gate.error,
+      loading: gate.loading ?? false,
+    };
+
+    renderDialog();
+
+    expect(screen.queryByRole('button', { name: 'memo.signing.title' })).not.toBeInTheDocument();
+  });
+
+  it('skips authentication methods and hides Sign for an unauthenticated actor', () => {
+    mocks.authenticated = false;
+
+    renderDialog();
+
+    expect(mocks.authenticationMethodsOptions).toHaveBeenCalledWith({
+      skip: true,
+    });
+    expect(screen.queryByRole('button', { name: 'memo.signing.title' })).not.toBeInTheDocument();
   });
 
   it('runs one uncached verification only after the signed-copy action', async () => {

--- a/src/main/crdPages/memo/CrdMemoDialog.spec.ts
+++ b/src/main/crdPages/memo/CrdMemoDialog.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { AuthorizationPrivilege } from '@/core/apollo/generated/graphql-schema';
+import {
+  AuthenticationType,
+  AuthorizationPrivilege,
+  LicenseEntitlementType,
+} from '@/core/apollo/generated/graphql-schema';
 import { canStartMemoSigning, updateMemoMarkdownCache } from '@/main/crdPages/memo/CrdMemoDialog';
 
 describe('updateMemoMarkdownCache', () => {
@@ -23,8 +27,50 @@ describe('updateMemoMarkdownCache', () => {
 });
 
 describe('canStartMemoSigning', () => {
-  it('shows Sign only to actors with CONTRIBUTE on the memo', () => {
-    expect(canStartMemoSigning([AuthorizationPrivilege.Contribute])).toBe(true);
-    expect(canStartMemoSigning([AuthorizationPrivilege.Read])).toBe(false);
+  it.each([
+    {
+      privileges: [AuthorizationPrivilege.Contribute],
+      entitlements: [LicenseEntitlementType.SpaceFlagMemoSigning],
+      authenticationMethods: [AuthenticationType.Cleverbase],
+      authenticationMethodsReady: true,
+      expected: true,
+    },
+    {
+      privileges: [AuthorizationPrivilege.Read],
+      entitlements: [LicenseEntitlementType.SpaceFlagMemoSigning],
+      authenticationMethods: [AuthenticationType.Cleverbase],
+      authenticationMethodsReady: true,
+      expected: false,
+    },
+    {
+      privileges: [AuthorizationPrivilege.Contribute],
+      entitlements: [],
+      authenticationMethods: [AuthenticationType.Cleverbase],
+      authenticationMethodsReady: true,
+      expected: false,
+    },
+    {
+      privileges: [AuthorizationPrivilege.Contribute],
+      entitlements: [LicenseEntitlementType.SpaceFlagMemoSigning],
+      authenticationMethods: [AuthenticationType.Email],
+      authenticationMethodsReady: true,
+      expected: false,
+    },
+    {
+      privileges: [AuthorizationPrivilege.Contribute],
+      entitlements: [LicenseEntitlementType.SpaceFlagMemoSigning],
+      authenticationMethods: [AuthenticationType.Cleverbase],
+      authenticationMethodsReady: false,
+      expected: false,
+    },
+  ])('returns $expected for the complete signing gate', gate => {
+    expect(
+      canStartMemoSigning(
+        gate.privileges,
+        gate.entitlements,
+        gate.authenticationMethods,
+        gate.authenticationMethodsReady
+      )
+    ).toBe(gate.expected);
   });
 });

--- a/src/main/crdPages/memo/CrdMemoDialog.tsx
+++ b/src/main/crdPages/memo/CrdMemoDialog.tsx
@@ -8,9 +8,15 @@ import {
   useMemoSigningAttemptQuery,
   usePrepareMemoSigningMutation,
   useUpdateMemoDisplayNameMutation,
+  useUserSecurityAuthenticationMethodsQuery,
   useVerifyMemoSignatureLazyQuery,
 } from '@/core/apollo/generated/apollo-hooks';
-import { AuthorizationPrivilege, SpaceLevel } from '@/core/apollo/generated/graphql-schema';
+import {
+  AuthenticationType,
+  AuthorizationPrivilege,
+  LicenseEntitlementType,
+  SpaceLevel,
+} from '@/core/apollo/generated/graphql-schema';
 import { useAuthenticationContext } from '@/core/auth/authentication/hooks/useAuthenticationContext';
 import { useRegisterFullscreenEditor } from '@/core/ui/fullscreen/FullscreenEditorContext';
 import { useFullscreen } from '@/core/ui/fullscreen/useFullscreen';
@@ -59,8 +65,16 @@ export const updateMemoMarkdownCache = (
   return htmlToMarkdown(editor.getHTML()).then(writeMarkdown);
 };
 
-export const canStartMemoSigning = (privileges: AuthorizationPrivilege[]) =>
-  privileges.includes(AuthorizationPrivilege.Contribute);
+export const canStartMemoSigning = (
+  privileges: AuthorizationPrivilege[],
+  entitlements: LicenseEntitlementType[],
+  authenticationMethods: AuthenticationType[] | undefined,
+  authenticationMethodsReady: boolean
+) =>
+  authenticationMethodsReady &&
+  privileges.includes(AuthorizationPrivilege.Contribute) &&
+  entitlements.includes(LicenseEntitlementType.SpaceFlagMemoSigning) &&
+  authenticationMethods?.includes(AuthenticationType.Cleverbase) === true;
 
 export function CrdMemoDialog({ open, memoId, onClose, isContribution = false, onDelete }: CrdMemoDialogProps) {
   const { t, i18n } = useTranslation('crd-space');
@@ -71,8 +85,13 @@ export function CrdMemoDialog({ open, memoId, onClose, isContribution = false, o
   const { memo, loading } = useMemoManager({ id: memoId });
   const editorRef = useRef<Editor | null>(null);
   const { isAuthenticated } = useAuthenticationContext();
+  const {
+    data: authenticationMethodsData,
+    loading: authenticationMethodsLoading,
+    error: authenticationMethodsError,
+  } = useUserSecurityAuthenticationMethodsQuery({ skip: !isAuthenticated });
   const { spaceLevel = SpaceLevel.L0 } = useUrlResolver();
-  const { space } = useSpace();
+  const { space, entitlements } = useSpace();
   const { subspace } = useSubSpace();
   const myMembershipStatus =
     spaceLevel === SpaceLevel.L0
@@ -185,7 +204,13 @@ export function CrdMemoDialog({ open, memoId, onClose, isContribution = false, o
   const privileges = memo?.authorization?.myPrivileges ?? [];
   const hasUpdatePrivileges = privileges.includes(AuthorizationPrivilege.Update);
   const hasDeletePrivileges = privileges.includes(AuthorizationPrivilege.Delete);
-  const hasContributePrivileges = canStartMemoSigning(privileges);
+  const hasContributePrivileges = privileges.includes(AuthorizationPrivilege.Contribute);
+  const canSign = canStartMemoSigning(
+    privileges,
+    entitlements,
+    authenticationMethodsData?.me.user?.authentication?.methods,
+    isAuthenticated && !authenticationMethodsLoading && !authenticationMethodsError
+  );
 
   const canEditDisplayName = isContribution && hasUpdatePrivileges;
   const displayName = memo?.profile.displayName ?? t('memo.errors.loading');
@@ -329,22 +354,22 @@ export function CrdMemoDialog({ open, memoId, onClose, isContribution = false, o
 
   const headerActions = (
     <>
-      {(hasContributePrivileges || Boolean(memo?.signatures.length)) && (
+      {(canSign || Boolean(memo?.signatures.length)) && (
         <Button
           type="button"
           variant="outline"
           size="sm"
-          disabled={(hasContributePrivileges && !provider) || signingFlow.stage === 'preparing'}
+          disabled={(canSign && !provider) || signingFlow.stage === 'preparing'}
           onClick={() => {
             setSigningDialogOpen(true);
-            if (hasContributePrivileges) {
+            if (canSign) {
               clearSigningReturn();
               void signingFlow.prepare();
             }
           }}
         >
           <FileSignature aria-hidden="true" />
-          {t(hasContributePrivileges ? 'memo.signing.title' : 'memo.signing.signedCopies')}
+          {t(canSign ? 'memo.signing.title' : 'memo.signing.signedCopies')}
         </Button>
       )}
       {/* Share dropdown. For users who can update the memo, it also hosts the content-update-policy


### PR DESCRIPTION
## Summary

- Renders the memo Sign action only when the user has CONTRIBUTE, the current space inherits `SPACE_FLAG_MEMO_SIGNING`, and the authenticated identity has a CLEVERBASE method.
- Uses the entitlements already loaded by `useSpace`; no new entitlement query, state, effect, or retry path.
- Hides Sign while authentication methods are missing, loading, or errored, and skips that query when unauthenticated.
- Keeps existing signed copies and Verify available to readers regardless of either signing gate.

Relates to alkem-io/alkemio#2025.

## Verification

- RED commit: `e8da3ae55` — the three-way predicate and loading/error/unauthenticated cases failed before production changes.
- GREEN commit: `c7f24d607`.
- Focused memo suites: 4 files passed, 50 tests passed.
- Pre-commit gate: typecheck, React Compiler lint, and full Vitest suite, 375 files passed, 3,226 tests passed, 2 skipped.
- Local full-suite execution used Node 26 with `--no-experimental-webstorage` as a compatibility workaround; supported-runtime CI remains authoritative.
- Codegen against the exact server schema was rerun byte-stable; only the three generated enum members changed.

## Size

- Product: +34/-9.
- Generated schema: +3/-0.
- Tests: +172/-7.

Human merge only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Memo signing is now available only when users have the required contribution privileges, signing entitlement, authentication method, and authentication readiness.
  - The signing option is hidden when any required eligibility check is missing, unavailable, or incomplete.
  - Unauthenticated users no longer trigger unnecessary authentication-method checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->